### PR TITLE
feat(swap): Select route picker in the Advanced swap sheet

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -201,6 +201,7 @@ import com.vultisig.wallet.ui.screens.swap.preview.AdvancedExternalRecipientPrev
 import com.vultisig.wallet.ui.screens.swap.preview.AdvancedGasLimitPreview
 import com.vultisig.wallet.ui.screens.swap.preview.AdvancedMenuConfiguredPreview
 import com.vultisig.wallet.ui.screens.swap.preview.AdvancedMenuPreview
+import com.vultisig.wallet.ui.screens.swap.preview.AdvancedSelectRoutePreview
 import com.vultisig.wallet.ui.screens.swap.preview.AdvancedSlippagePreview
 import com.vultisig.wallet.ui.screens.swap.preview.SwapFormProviderPreview
 import com.vultisig.wallet.ui.screens.swap.preview.SwapFormQuoteLoadingPreview
@@ -352,6 +353,7 @@ class PreviewActivity : ComponentActivity() {
                     "swap_advanced_menu_configured" -> AdvancedMenuConfiguredPreview()
                     "swap_advanced_slippage" -> AdvancedSlippagePreview()
                     "swap_advanced_gas_limit" -> AdvancedGasLimitPreview()
+                    "swap_advanced_select_route" -> AdvancedSelectRoutePreview()
                     "swap_advanced_external_recipient" -> AdvancedExternalRecipientPreview()
                     "select_asset_secured_before" -> SelectAssetSecuredPreview(showSecured = false)
                     "select_asset_secured_after" -> SelectAssetSecuredPreview(showSecured = true)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormUiModel.kt
@@ -1,5 +1,7 @@
 package com.vultisig.wallet.ui.models.swap
 
+import com.vultisig.wallet.data.models.ImageModel
+import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.ui.models.send.TokenBalanceUiModel
 import com.vultisig.wallet.ui.screens.settings.TierType
 import com.vultisig.wallet.ui.screens.swap.SwapMode
@@ -38,6 +40,28 @@ internal data class FeeBreakdown(
     // not report price impact (1inch/Kyber/LiFi/Jupiter). Drives the Price Impact row (iOS parity).
     val priceImpactPercent: String? = null,
     val priceImpactLevel: PriceImpactLevel? = null,
+)
+
+/**
+ * One row of the Select-route picker in the Advanced swap sheet: a fetched provider quote the user
+ * can pick over the automatic winner. Rows are ordered best→worst by net destination output, with
+ * the active route pinned to the top.
+ *
+ * @property feeText The provider/swap fee in fiat, or null when the fee is baked into the quoted
+ *   rate (1inch) and there is no separate amount to show.
+ * @property etaText Estimated completion time ("~600s"); only THORChain/Maya expose an estimate, so
+ *   null hides the segment for aggregator routes.
+ * @property outputText Approximate destination output, e.g. "~21.83561311 RUNE".
+ */
+internal data class SwapRouteUiModel(
+    val provider: SwapProvider,
+    val name: UiText,
+    val logo: ImageModel?,
+    val feeText: String?,
+    val etaText: UiText?,
+    val outputText: String,
+    val outputFiatText: String,
+    val isSelected: Boolean,
 )
 
 /** VULT-tier and referral discount info rendered in the fee-details panel. */
@@ -79,6 +103,13 @@ internal data class SwapFormUiModel(
     // Set when [externalRecipient] is not a valid address for the destination chain. Surfaced
     // inline in the recipient sheet and blocks the swap so funds can't go to a malformed address.
     val externalRecipientError: UiText? = null,
+    // Fetched routes for the Select-route picker, active route first then best→worst by output.
+    // Empty when fewer than two routes exist — the row is disabled and there is nothing to pick.
+    val routeOptions: List<SwapRouteUiModel> = emptyList(),
+    // True while the active route is a manual user pick rather than the automatic winner; the
+    // Select route row then shows the provider name instead of "Auto". Reset on every quote
+    // refresh, which re-defaults the route to the best quote.
+    val isRouteManuallySelected: Boolean = false,
     // Whether the Advanced swap sheet is open. Opened only after the VULT Silver-tier gate passes;
     // a below-tier vault sees [advancedSettingsGate] instead (#4858).
     val showAdvancedSettings: Boolean = false,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -1109,6 +1109,14 @@ constructor(
         _uiState.update { it.copy(showAdvancedSettings = false) }
     }
 
+    /**
+     * Applies a manual route pick from the Select-route page of the Advanced sheet: the picked,
+     * already-fetched quote replaces the automatic winner until the next quote refresh.
+     */
+    fun selectRoute(provider: SwapProvider) {
+        quotePipeline.selectRoute(provider)
+    }
+
     fun dismissAdvancedSettingsGate() {
         _uiState.update { it.copy(advancedSettingsGate = null) }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -511,39 +511,60 @@ constructor(
             else selected
         }
 
+        val metric = rankingMetric(successes)
         return RankedQuotes(
             best = selectBestQuote(successes),
+            // Ordered by the same metric the winner is chosen with, so the picker can never rank a
+            // route above the one it puts the check on. The raw amount breaks a tie between two
+            // routes whose fiat rounds to the same figure.
             ranked =
                 successes.sortedWith(
-                    // Fiat first (matches the best-quote metric), then the raw destination amount —
-                    // every candidate quotes the same dst token, so amounts compare directly. The
-                    // tie-break keeps the list output-ordered when the dst token has no price and
-                    // comparableDstFiat collapses to zero for every candidate at once.
-                    compareByDescending<BestQuote> { it.result.comparableDstFiat }
-                        .thenByDescending { it.result.quote.expectedDstValue.decimal }
+                    compareByDescending<BestQuote>(metric).thenByDescending {
+                        it.result.quote.expectedDstValue.decimal
+                    }
                 ),
         )
     }
 
     /**
-     * Picks the winning quote across providers. The ranking metric is net destination output
-     * ([QuoteFetchResult.comparableDstFiat]) — every provider in a candidate set swaps to the same
-     * destination token, so the values are directly comparable. Among quotes within
-     * [PROVIDER_PREFERENCE_BAND] of the best net output (economically tied on rate) a banded
-     * preference picks the winner by the iOS canonical rule: source gas decides only when both
-     * quotes expose it (same-chain EVM aggregators), then provider priority, then higher net
-     * output. Only the aggregators expose gas and their priorities form one contiguous block, so no
-     * gas-unknown provider's priority falls between two gas-exposing ones — the comparator is a
-     * strict weak order for every realizable candidate set and the winner is independent of input
-     * order. Anything outside the band loses on output.
+     * What a candidate set is ranked by: net destination fiat
+     * ([QuoteFetchResult.comparableDstFiat]) whenever any candidate has one, else the raw
+     * destination amount.
+     *
+     * Every candidate quotes the same destination token, so the amount is directly comparable and
+     * says exactly what the fiat would have said. Without the fallback an unpriced destination
+     * collapses every candidate's metric to zero at once, which reads as "every route is
+     * economically tied" and hands the whole decision to provider priority — so the winner could be
+     * a route another one beats outright on output.
+     */
+    private fun rankingMetric(successes: List<BestQuote>): (BestQuote) -> BigDecimal =
+        if (successes.any { it.result.comparableDstFiat.signum() > 0 }) {
+            { it.result.comparableDstFiat }
+        } else {
+            { it.result.quote.expectedDstValue.decimal }
+        }
+
+    /**
+     * Picks the winning quote across providers. The ranking metric is [rankingMetric] — net
+     * destination output, in fiat where the destination has a price and in destination tokens where
+     * it doesn't. Every provider in a candidate set swaps to the same destination token, so the
+     * values are directly comparable either way. Among quotes within [PROVIDER_PREFERENCE_BAND] of
+     * the best net output (economically tied on rate) a banded preference picks the winner by the
+     * iOS canonical rule: source gas decides only when both quotes expose it (same-chain EVM
+     * aggregators), then provider priority, then higher net output. Only the aggregators expose gas
+     * and their priorities form one contiguous block, so no gas-unknown provider's priority falls
+     * between two gas-exposing ones — the comparator is a strict weak order for every realizable
+     * candidate set and the winner is independent of input order. Anything outside the band loses
+     * on output.
      *
      * Assumes [successes] is non-empty (the caller has already surfaced the all-failed case).
      */
     internal fun selectBestQuote(successes: List<BestQuote>): BestQuote {
-        val best = successes.maxBy { it.result.comparableDstFiat }
-        val floor = best.result.comparableDstFiat * (BigDecimal.ONE - PROVIDER_PREFERENCE_BAND)
+        val metric = rankingMetric(successes)
+        val best = successes.maxBy(metric)
+        val floor = metric(best) * (BigDecimal.ONE - PROVIDER_PREFERENCE_BAND)
         return successes
-            .filter { it.result.comparableDstFiat >= floor }
+            .filter { metric(it) >= floor }
             .minWithOrNull(
                 // Source gas decides only when both quotes expose it; otherwise this ties and
                 // selection falls through to provider priority, then higher net output.
@@ -553,7 +574,7 @@ constructor(
                         if (lhsGas != null && rhsGas != null) lhsGas.compareTo(rhsGas) else 0
                     }
                     .thenBy { providerPriority(it.candidate.provider) }
-                    .thenByDescending { it.result.comparableDstFiat }
+                    .thenByDescending(metric)
             ) ?: best
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -513,7 +513,15 @@ constructor(
 
         return RankedQuotes(
             best = selectBestQuote(successes),
-            ranked = successes.sortedByDescending { it.result.comparableDstFiat },
+            ranked =
+                successes.sortedWith(
+                    // Fiat first (matches the best-quote metric), then the raw destination amount —
+                    // every candidate quotes the same dst token, so amounts compare directly. The
+                    // tie-break keeps the list output-ordered when the dst token has no price and
+                    // comparableDstFiat collapses to zero for every candidate at once.
+                    compareByDescending<BestQuote> { it.result.comparableDstFiat }
+                        .thenByDescending { it.result.quote.expectedDstValue.decimal }
+                ),
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -105,13 +105,21 @@ internal data class QuoteCandidate(
 internal data class BestQuote(val candidate: QuoteCandidate, val result: QuoteFetchResult)
 
 /**
+ * Every successfully fetched quote for one request: the banded-preference winner ([best]) plus the
+ * full candidate set ordered best→worst by net destination output ([ranked]). [ranked] always
+ * contains [best]; it drives the Select-route picker, where the user can override the automatic
+ * winner with any other fetched route.
+ */
+internal data class RankedQuotes(val best: BestQuote, val ranked: List<BestQuote>)
+
+/**
  * Outcome of resolving the best quote for a pair: either a [Success] holding the winning
  * [BestQuote], or a [Failure] whose typed swap error has already been mapped to a renderable
  * [Failure.formError] so the ViewModel only has to surface it.
  */
 internal sealed interface QuoteResolution {
-    /** A winning quote was fetched. */
-    data class Success(val best: BestQuote) : QuoteResolution
+    /** A winning quote was fetched; [ranked] is the full output-ordered candidate set. */
+    data class Success(val best: BestQuote, val ranked: List<BestQuote>) : QuoteResolution
 
     /** The fetch failed; [formError] is the mapped message, [cause]/[tag] are for logging. */
     data class Failure(val formError: UiText, val cause: Throwable, val tag: String) :
@@ -432,7 +440,7 @@ constructor(
         amount: BigDecimal,
         slippageBps: Int? = null,
         externalRecipient: String? = null,
-    ): BestQuote {
+    ): RankedQuotes {
         if (candidates.isEmpty()) {
             throw SwapException.SwapIsNotSupported("Swap is not supported for this pair")
         }
@@ -503,7 +511,10 @@ constructor(
             else selected
         }
 
-        return selectBestQuote(successes)
+        return RankedQuotes(
+            best = selectBestQuote(successes),
+            ranked = successes.sortedByDescending { it.result.comparableDstFiat },
+        )
     }
 
     /**
@@ -561,7 +572,7 @@ constructor(
         externalRecipient: String? = null,
     ): QuoteResolution =
         try {
-            QuoteResolution.Success(
+            val fetched =
                 fetchBestQuote(
                     candidates = candidates,
                     src = src,
@@ -575,7 +586,7 @@ constructor(
                     slippageBps = slippageBps,
                     externalRecipient = externalRecipient,
                 )
-            )
+            QuoteResolution.Success(best = fetched.best, ranked = fetched.ranked)
         } catch (e: SwapException) {
             QuoteResolution.Failure(
                 formError = mapSwapExceptionToFormError(e, srcToken, selectedSrcTokenTitle),

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -121,6 +121,10 @@ internal sealed interface SwapQuotePipelineResult {
         val utxoDstAddress: String?,
         val utxoMemo: String?,
         val srcTokenValue: BigInteger,
+        // Full fetched candidate set, best→worst by net output. Drives the Select-route picker;
+        // [quote]/[provider] is one of these (the auto winner, or the user's manual pick when this
+        // Success was rebuilt by a route selection).
+        val rankedQuotes: List<BestQuote> = emptyList(),
     ) : SwapQuotePipelineResult
 }
 
@@ -250,7 +254,7 @@ internal class SwapQuotePipeline(
                 )
             // Map the sealed result: a typed fetch failure becomes a Failure carrying its
             // already-mapped error; only a Success continues into fee processing.
-            val bestQuote =
+            val resolved =
                 when (resolution) {
                     is QuoteResolution.Failure ->
                         return SwapQuotePipelineResult.Failure(
@@ -263,15 +267,16 @@ internal class SwapQuotePipeline(
                             cause = resolution.cause,
                             tag = resolution.tag,
                         )
-                    is QuoteResolution.Success -> resolution.best
+                    is QuoteResolution.Success -> resolution
                 }
 
             buildSuccess(
-                bestQuote = bestQuote,
+                bestQuote = resolved.best,
                 src = src,
                 srcTokenValue = srcTokenValue,
                 tokenValue = tokenValue,
                 currentDiscountInfo = currentDiscountInfo,
+                rankedQuotes = resolved.ranked,
             )
         } catch (e: SwapException) {
             SwapQuotePipelineResult.Failure(
@@ -331,13 +336,18 @@ internal class SwapQuotePipeline(
         }
     }
 
-    /** Builds the display-ready [SwapQuotePipelineResult.Success] from the winning quote. */
+    /**
+     * Builds the display-ready [SwapQuotePipelineResult.Success] from the winning quote.
+     * [rankedQuotes] is passed through untouched so the Select-route picker keeps the full
+     * candidate set both on a fresh fetch and when re-applying a manual route pick.
+     */
     internal suspend fun buildSuccess(
         bestQuote: BestQuote,
         src: SendSrc,
         srcTokenValue: BigInteger,
         tokenValue: TokenValue,
         currentDiscountInfo: DiscountInfo,
+        rankedQuotes: List<BestQuote> = emptyList(),
     ): SwapQuotePipelineResult.Success {
         val quoteResult = bestQuote.result
         val provider = quoteResult.provider
@@ -447,6 +457,7 @@ internal class SwapQuotePipeline(
             utxoDstAddress = utxoFeeData?.first,
             utxoMemo = utxoFeeData?.second,
             srcTokenValue = srcTokenValue,
+            rankedQuotes = rankedQuotes,
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -477,6 +477,7 @@ internal class SwapQuotePipeline(
         gasFee: TokenValue?,
         gasFeeChain: Chain?,
         networkFeeTokenValue: TokenValue?,
+        evmBaselineEstimate: EstimatedGasFee? = null,
     ): NetworkFeeOutcome {
         val srcToken = src.account.token
         // Base state mirrors the display update: UTXO swaps stay disabled until the plan fee lands.
@@ -547,6 +548,18 @@ internal class SwapQuotePipeline(
                     networkFee = rebased.estimated.toNetworkFeeSet()
                     effectiveNetworkFeeTokenValue = rebased.estimated.tokenValue
                 }
+            }
+        } else if (srcToken.chain.standard == TokenStandard.EVM) {
+            // A non-aggregator quote (THORChain/Maya native EVM route) won or was picked: restore
+            // the gas-pass estimate the fee display started from ([evmBaselineEstimate], stamped
+            // by calculateGas). Without this, a fee previously re-based onto an aggregator's route
+            // gas lingers when the active route switches to one it never applied to — the same
+            // route then shows a different Network Fee than when it wins a fresh fetch. Restoring
+            // the stored estimate verbatim keeps it byte-identical to that fresh-fetch display.
+            val baseline = evmBaselineEstimate?.takeIf { gasFeeChain == srcToken.chain }
+            if (baseline != null) {
+                networkFee = baseline.toNetworkFeeSet()
+                effectiveNetworkFeeTokenValue = baseline.tokenValue
             }
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -27,6 +27,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import java.math.BigDecimal
+import java.math.RoundingMode
 import java.text.DecimalFormat
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -154,12 +155,14 @@ constructor(
     // reset cancels this first, keeping exactly one writer of quote state at a time.
     private var selectRouteJob: Job? = null
 
-    private data class RouteContext(val input: QuoteInput, val ranked: List<BestQuote>)
+    // Ticket taken by every writer of quote state — each pipeline apply, each manual pick, each
+    // reset. Cancelling the pick job only protects one direction: a pipeline apply that suspended
+    // in resolveNetworkFee resumes with no idea a pick has landed since, and would stamp its own
+    // network fee and isSwapDisabled over the quote now on screen. Whoever wrote the quote last
+    // owns its fee, so a writer resuming on a stale ticket drops its outcome.
+    private var quoteApplyGeneration = 0
 
-    // Route-row output formatter: full precision with grouping, unlike the display mapper, which
-    // abbreviates above 1e6 and would collapse the differences the picker column compares.
-    // Main-confined like the rest of this class (DecimalFormat is not thread-safe).
-    private val routeOutputFormat = DecimalFormat("#,##0.########")
+    private data class RouteContext(val input: QuoteInput, val ranked: List<BestQuote>)
 
     // Suppresses the quote-refresh timer while the form isn't the foreground screen. The form's
     // scope (= viewModelScope) stays alive on the back stack once the flow proceeds to
@@ -498,6 +501,7 @@ constructor(
 
         val (src, dst) = input.address
 
+        val generation = ++quoteApplyGeneration
         routeContext = RouteContext(input, result.rankedQuotes)
         val routeOptions =
             buildRouteOptions(
@@ -544,7 +548,7 @@ constructor(
             )
         }
 
-        applyNetworkFeeOutcome(
+        val networkFeeOutcome =
             swapQuotePipeline.resolveNetworkFee(
                 result = result,
                 src = src,
@@ -554,7 +558,11 @@ constructor(
                 networkFeeTokenValue = estimatedNetworkFeeTokenValue.value,
                 evmBaselineEstimate = evmBaselineEstimate,
             )
-        )
+        // resolveNetworkFee suspends (plan fetch, balance read). Another writer — a manual pick, a
+        // fresh pipeline result, a reset — may own the quote on screen by now, and it arms its own
+        // fee and timer; this outcome belongs to a quote that is no longer displayed.
+        if (generation != quoteApplyGeneration) return
+        applyNetworkFeeOutcome(networkFeeOutcome)
 
         quoteState.quote?.expiredAt?.let { launchRefreshQuoteTimer(it) }
     }
@@ -603,11 +611,10 @@ constructor(
                             UiText.FormattedText(R.string.swap_route_eta, listOf(it))
                         },
                     // Formatted from the raw quote amount, NOT estimatedDstTokenValue: the display
-                    // formatter abbreviates above 1e6 ("~1.1M"), which collapses the differences
-                    // this column exists to compare (iOS keeps full precision here).
+                    // formatter abbreviates from 1e6 with a single decimal ("~1.1M"), which
+                    // collapses the differences this column exists to compare.
                     outputText =
-                        "~${routeOutputFormat.format(fetch.quote.expectedDstValue.decimal)} " +
-                            dstTicker,
+                        "~${formatRouteOutput(fetch.quote.expectedDstValue.decimal)} $dstTicker",
                     outputFiatText = fetch.estimatedDstFiatValue,
                     isSelected = candidate.candidate.provider == activeProvider,
                 )
@@ -857,6 +864,9 @@ constructor(
         // The context a pending pick was built from is going away with the quote it belonged to.
         selectRouteJob?.cancel()
         selectRouteJob = null
+        // Clearing the quote invalidates any fee still resolving for it, the same way a newer
+        // apply does — otherwise it resumes and writes a network fee onto state with no quote.
+        quoteApplyGeneration++
         quoteState.reset()
         routeContext = null
         uiState.update {
@@ -895,6 +905,9 @@ constructor(
         // The context a pending pick was built from is going away with the quote it belonged to.
         selectRouteJob?.cancel()
         selectRouteJob = null
+        // Clearing the quote invalidates any fee still resolving for it, the same way a newer
+        // apply does — otherwise it resumes and writes a network fee onto state with no quote.
+        quoteApplyGeneration++
         // Clears quote/provider and the swap fee in one place. Resetting swapFeeFiat lets
         // collectTotalFee()'s filterNotNull() short-circuit so a later calculateGas() update can't
         // write a (newGas + staleSwap) combination back into state.totalFee — the same race that
@@ -926,5 +939,43 @@ constructor(
         if (cause != null) {
             Timber.e(cause, tag)
         }
+    }
+}
+
+// The thresholds iOS abbreviates a displayed amount at.
+private val ROUTE_OUTPUT_MILLION: BigDecimal = BigDecimal.ONE.movePointRight(6)
+private val ROUTE_OUTPUT_BILLION: BigDecimal = BigDecimal.ONE.movePointRight(9)
+private val ROUTE_OUTPUT_TRILLION: BigDecimal = BigDecimal.ONE.movePointRight(12)
+
+// Route-row output formatters, mirroring iOS `Decimal.formatForDisplay()`: grouped with up to eight
+// fraction digits below 1e6, abbreviated to two decimals from there up. Full precision where the
+// routes are actually compared digit by digit — the display mapper abbreviates from 1e6 with one
+// decimal and collapses the very differences this column exists to show — but bounded above it,
+// because the output Column carries no weight while the provider name carries weight(1f): an
+// unabbreviated nine-figure amount measures wider than the row's whole two-column budget and
+// squeezes the name to nothing. Truncating, never rounding up, so a row can't advertise more output
+// than the quote pays.
+// Main-confined like the controller that uses them (DecimalFormat is not thread-safe).
+private val routeOutputFormat =
+    DecimalFormat("#,##0.########").apply { roundingMode = RoundingMode.DOWN }
+
+private val routeAbbreviatedOutputFormat =
+    DecimalFormat("#,##0.##").apply { roundingMode = RoundingMode.DOWN }
+
+/**
+ * A Select-route row's output amount, formatted the way iOS formats its own (`formatForDisplay`):
+ * full precision below a million, abbreviated to two decimals from there up so the column stays
+ * inside the row.
+ */
+internal fun formatRouteOutput(amount: BigDecimal): String {
+    val magnitude = amount.abs()
+    return when {
+        magnitude >= ROUTE_OUTPUT_TRILLION ->
+            routeAbbreviatedOutputFormat.format(amount.movePointLeft(12)) + "T"
+        magnitude >= ROUTE_OUTPUT_BILLION ->
+            routeAbbreviatedOutputFormat.format(amount.movePointLeft(9)) + "B"
+        magnitude >= ROUTE_OUTPUT_MILLION ->
+            routeAbbreviatedOutputFormat.format(amount.movePointLeft(6)) + "M"
+        else -> routeOutputFormat.format(amount)
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -6,9 +6,12 @@ import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.getProviderLogo
+import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
@@ -132,6 +135,13 @@ constructor(
     private val refreshQuoteState = MutableStateFlow(0)
 
     private var refreshQuoteJob: Job? = null
+
+    // The input and ranked candidate set of the last applied quote, kept so a Select-route pick can
+    // rebuild and apply another already-fetched candidate without a network round-trip. Cleared on
+    // every reset/supersede path — a pick must never apply a quote for stale input.
+    private var routeContext: RouteContext? = null
+
+    private data class RouteContext(val input: QuoteInput, val ranked: List<BestQuote>)
 
     // Suppresses the quote-refresh timer while the form isn't the foreground screen. The form's
     // scope (= viewModelScope) stays alive on the back stack once the flow proceeds to
@@ -407,6 +417,7 @@ constructor(
     private suspend fun applyQuoteResult(
         input: QuoteInput,
         result: SwapQuotePipelineResult.Success,
+        isManualRoutePick: Boolean = false,
     ) {
         // isAmountFieldEmpty is read once when resolveQuote is called, but the live input can
         // change
@@ -444,7 +455,15 @@ constructor(
             return
         }
 
-        val (src, _) = input.address
+        val (src, dst) = input.address
+
+        routeContext = RouteContext(input, result.rankedQuotes)
+        val routeOptions =
+            buildRouteOptions(
+                ranked = result.rankedQuotes,
+                activeProvider = result.provider,
+                dstTicker = dst.account.token.ticker,
+            )
 
         quoteState.provider = result.provider
         quoteState.quote = result.quote
@@ -478,6 +497,8 @@ constructor(
                 formError = null,
                 isSwapDisabled = result.isUtxoSwap,
                 isLoading = false,
+                routeOptions = routeOptions,
+                isRouteManuallySelected = isManualRoutePick,
             )
         }
 
@@ -493,6 +514,82 @@ constructor(
         )
 
         quoteState.quote?.expiredAt?.let { launchRefreshQuoteTimer(it) }
+    }
+
+    /**
+     * Maps the ranked candidate set onto Select-route picker rows: the active route pinned to the
+     * top, the rest keeping their best→worst net-output order. Fewer than two routes means there is
+     * nothing to pick, so the list stays empty and the Select route row disables.
+     */
+    private suspend fun buildRouteOptions(
+        ranked: List<BestQuote>,
+        activeProvider: SwapProvider,
+        dstTicker: String,
+    ): List<SwapRouteUiModel> {
+        if (ranked.size < 2) return emptyList()
+        return ranked
+            .map { candidate ->
+                val fetch = candidate.result
+                // Only THORChain/Maya expose a completion estimate; aggregator rows render the fee
+                // alone.
+                val etaSeconds =
+                    when (val quote = fetch.quote) {
+                        is SwapQuote.ThorChain -> quote.data.totalSwapSeconds
+                        is SwapQuote.MayaChain -> quote.data.totalSwapSeconds
+                        else -> null
+                    }
+                SwapRouteUiModel(
+                    provider = candidate.candidate.provider,
+                    name = fetch.providerUiText,
+                    logo = getProviderLogo(candidate.candidate.provider.getSwapProviderId()),
+                    // 1inch bakes the affiliate fee into the quoted rate — there is no separate
+                    // amount to show, so the fee segment is dropped rather than showing "$0.00".
+                    feeText =
+                        if (fetch.swapFeeIncludedInRate) null
+                        else fiatValueToString(fetch.swapFeeFiat, asFee = true),
+                    etaText =
+                        etaSeconds?.let {
+                            UiText.FormattedText(R.string.swap_route_eta, listOf(it))
+                        },
+                    outputText = "~${fetch.estimatedDstTokenValue} $dstTicker",
+                    outputFiatText = fetch.estimatedDstFiatValue,
+                    isSelected = candidate.candidate.provider == activeProvider,
+                )
+            }
+            // Stable sort: pins the active route to the top, the rest keep their output ranking.
+            .sortedByDescending { it.isSelected }
+    }
+
+    /**
+     * Applies a manual route pick from the Select-route sheet: rebuilds the display state for the
+     * picked, already-fetched candidate and applies it through the same path as an auto-resolved
+     * quote, so fees, discounts, balance validation, and the refresh timer all follow the pick. No
+     * network fetch — the pick only chooses among the quotes of the last resolution, and the next
+     * refresh re-defaults the route to the automatic best (iOS parity).
+     */
+    fun selectRoute(provider: SwapProvider) {
+        val ctx = routeContext ?: return
+        if (quoteState.provider == provider) return
+        val candidate = ctx.ranked.firstOrNull { it.candidate.provider == provider } ?: return
+        scope.safeLaunch(onError = { Timber.e(it, "selectRoute") }) {
+            val (src, _) = ctx.input.address
+            val amount = ctx.input.amount ?: return@safeLaunch
+            val srcToken = src.account.token
+            val srcTokenValue = amount.movePointRight(srcToken.decimal).toBigInteger()
+            val tokenValue = convertTokenAndValueToTokenValue(srcToken, srcTokenValue)
+            val result =
+                swapQuotePipeline.buildSuccess(
+                    bestQuote = candidate,
+                    src = src,
+                    srcTokenValue = srcTokenValue,
+                    tokenValue = tokenValue,
+                    currentDiscountInfo = uiState.value.discountInfo,
+                    rankedQuotes = ctx.ranked,
+                )
+            // applyQuoteResult re-runs the superseded/quotable guards against the live input, so a
+            // pick that lands after the user changed amount/pair/settings is dropped, not applied.
+            applyQuoteResult(ctx.input, result, isManualRoutePick = true)
+        }
     }
 
     /** Applies the UTXO plan-fee / balance outcome to the network-fee flows and form state. */
@@ -689,6 +786,7 @@ constructor(
         refreshQuoteJob?.cancel()
         refreshQuoteJob = null
         quoteState.reset()
+        routeContext = null
         uiState.update {
             it.copy(
                 srcFiatValue = "0",
@@ -698,6 +796,8 @@ constructor(
                         hasQuote = false,
                         expiredAt = null,
                     ),
+                routeOptions = emptyList(),
+                isRouteManuallySelected = false,
                 feeBreakdown =
                     it.feeBreakdown.copy(
                         fee = "0",
@@ -725,10 +825,13 @@ constructor(
         // write a (newGas + staleSwap) combination back into state.totalFee — the same race that
         // triggers on flipSelectedTokens since selectedSrc changes synchronously.
         quoteState.reset()
+        routeContext = null
         uiState.update {
             it.copy(
                 srcFiatValue = "0",
                 quoteDisplay = QuoteDisplay(),
+                routeOptions = emptyList(),
+                isRouteManuallySelected = false,
                 feeBreakdown =
                     it.feeBreakdown.copy(
                         fee = "0",

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EstimatedGasFee
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapQuote
@@ -26,6 +27,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import java.math.BigDecimal
+import java.text.DecimalFormat
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -132,6 +134,12 @@ constructor(
     val gasFeeChain = MutableStateFlow<Chain?>(null)
     val estimatedNetworkFeeFiatValue = MutableStateFlow<FiatValue?>(null)
 
+    // The last gas-pass display estimate from calculateGas, for the chain in [gasFeeChain]. An
+    // EVM-aggregator quote overwrites the display with a route-gas re-base; this is what
+    // resolveNetworkFee restores when a non-aggregator (THOR/Maya) route becomes active on an EVM
+    // source, so the fee matches what a fresh fetch with that winner shows.
+    private var evmBaselineEstimate: EstimatedGasFee? = null
+
     private val refreshQuoteState = MutableStateFlow(0)
 
     private var refreshQuoteJob: Job? = null
@@ -141,7 +149,17 @@ constructor(
     // every reset/supersede path — a pick must never apply a quote for stale input.
     private var routeContext: RouteContext? = null
 
+    // The in-flight manual route pick. The quote pipeline's collectLatest serializes its own
+    // applies, but a pick runs on an independent coroutine — so every pipeline-owned apply and
+    // reset cancels this first, keeping exactly one writer of quote state at a time.
+    private var selectRouteJob: Job? = null
+
     private data class RouteContext(val input: QuoteInput, val ranked: List<BestQuote>)
+
+    // Route-row output formatter: full precision with grouping, unlike the display mapper, which
+    // abbreviates above 1e6 and would collapse the differences the picker column compares.
+    // Main-confined like the rest of this class (DecimalFormat is not thread-safe).
+    private val routeOutputFormat = DecimalFormat("#,##0.########")
 
     // Suppresses the quote-refresh timer while the form isn't the foreground screen. The form's
     // scope (= viewModelScope) stays alive on the back stack once the flow proceeds to
@@ -224,6 +242,11 @@ constructor(
                     // a slow gas fetch can't overwrite the plan fee with a dust estimate.
                     if (chain.standard != TokenStandard.UTXO || chain == Chain.Cardano) {
                         try {
+                            // Kept as the restore point for non-aggregator EVM routes: an
+                            // aggregator quote re-bases the displayed fee onto its route gas, and
+                            // resolveNetworkFee restores this exact estimate when a THOR/Maya
+                            // route becomes active again.
+                            evmBaselineEstimate = result.estimated
                             estimatedNetworkFeeFiatValue.value = result.estimated.fiatValue
                             estimatedNetworkFeeTokenValue.value = result.estimated.tokenValue
 
@@ -251,6 +274,7 @@ constructor(
                         // selectSrcPercentage() doesn't subtract a cross-chain fee value
                         // (e.g. ETH wei subtracted from ZEC satoshis) before calculateFees()
                         // can compute the correct UTXO plan fee.
+                        evmBaselineEstimate = null
                         estimatedNetworkFeeTokenValue.value = null
                         estimatedNetworkFeeFiatValue.value = null
                         uiState.update {
@@ -435,7 +459,18 @@ constructor(
         // be applied — and then signed with a mismatched memo / slippage floor — over the new one
         // (#5310). Match the source/destination quote endpoints as well: changing to another
         // routable pair with the same amount creates the same pre-debounce landing window.
+        // A pipeline-owned result supersedes any pick still applying: cancel it so a pick
+        // suspended in resolveNetworkFee can't write its network fee / isSwapDisabled over the
+        // quote this fresh result is about to apply.
+        if (!isManualRoutePick) {
+            selectRouteJob?.cancel()
+            selectRouteJob = null
+        }
+
         if (!isLiveInputQuotable) {
+            // A stale pick must not clear the live request's state — the reset for the changed
+            // input already ran (or will) on the pipeline path that owns it.
+            if (isManualRoutePick) return
             resetQuoteState()
             return
         }
@@ -451,6 +486,12 @@ constructor(
                 input.slippageBps != slippageBps.value ||
                 input.externalRecipient != externalRecipient.value
         if (isSuperseded) {
+            // The discard path exists for pipeline-owned results, where this result IS the stale
+            // state on screen. A pick's input was captured at fetch time, so when it trips this
+            // guard the state on screen belongs to a NEWER request — dropping the pick silently is
+            // the only safe move; discarding would strip the newer quote with no error, no spinner
+            // and no armed refresh.
+            if (isManualRoutePick) return
             discardSupersededQuoteResult()
             return
         }
@@ -462,6 +503,7 @@ constructor(
             buildRouteOptions(
                 ranked = result.rankedQuotes,
                 activeProvider = result.provider,
+                srcToken = src.account.token,
                 dstTicker = dst.account.token.ticker,
             )
 
@@ -510,6 +552,7 @@ constructor(
                 gasFee = gasFee.value,
                 gasFeeChain = gasFeeChain.value,
                 networkFeeTokenValue = estimatedNetworkFeeTokenValue.value,
+                evmBaselineEstimate = evmBaselineEstimate,
             )
         )
 
@@ -524,6 +567,7 @@ constructor(
     private suspend fun buildRouteOptions(
         ranked: List<BestQuote>,
         activeProvider: SwapProvider,
+        srcToken: Coin,
         dstTicker: String,
     ): List<SwapRouteUiModel> {
         if (ranked.size < 2) return emptyList()
@@ -538,20 +582,32 @@ constructor(
                         is SwapQuote.MayaChain -> quote.data.totalSwapSeconds
                         else -> null
                     }
+                // Mirrors buildSuccess's fee treatment so a row never advertises a fee that
+                // vanishes from the breakdown the moment the route is picked: SwapKit UTXO-family
+                // deposits surface their cost once as the Network Fee (the wire inbound fee would
+                // double-count it), and 1inch bakes the affiliate fee into the quoted rate — in
+                // both cases there is no separate amount to show, so the segment is dropped.
+                val hidesSwapFee =
+                    fetch.swapFeeIncludedInRate ||
+                        (fetch.quote is SwapQuote.SwapKit &&
+                            srcToken.chain.standard == TokenStandard.UTXO)
                 SwapRouteUiModel(
                     provider = candidate.candidate.provider,
                     name = fetch.providerUiText,
                     logo = getProviderLogo(candidate.candidate.provider.getSwapProviderId()),
-                    // 1inch bakes the affiliate fee into the quoted rate — there is no separate
-                    // amount to show, so the fee segment is dropped rather than showing "$0.00".
                     feeText =
-                        if (fetch.swapFeeIncludedInRate) null
+                        if (hidesSwapFee) null
                         else fiatValueToString(fetch.swapFeeFiat, asFee = true),
                     etaText =
                         etaSeconds?.let {
                             UiText.FormattedText(R.string.swap_route_eta, listOf(it))
                         },
-                    outputText = "~${fetch.estimatedDstTokenValue} $dstTicker",
+                    // Formatted from the raw quote amount, NOT estimatedDstTokenValue: the display
+                    // formatter abbreviates above 1e6 ("~1.1M"), which collapses the differences
+                    // this column exists to compare (iOS keeps full precision here).
+                    outputText =
+                        "~${routeOutputFormat.format(fetch.quote.expectedDstValue.decimal)} " +
+                            dstTicker,
                     outputFiatText = fetch.estimatedDstFiatValue,
                     isSelected = candidate.candidate.provider == activeProvider,
                 )
@@ -571,25 +627,38 @@ constructor(
         val ctx = routeContext ?: return
         if (quoteState.provider == provider) return
         val candidate = ctx.ranked.firstOrNull { it.candidate.provider == provider } ?: return
-        scope.safeLaunch(onError = { Timber.e(it, "selectRoute") }) {
-            val (src, _) = ctx.input.address
-            val amount = ctx.input.amount ?: return@safeLaunch
-            val srcToken = src.account.token
-            val srcTokenValue = amount.movePointRight(srcToken.decimal).toBigInteger()
-            val tokenValue = convertTokenAndValueToTokenValue(srcToken, srcTokenValue)
-            val result =
-                swapQuotePipeline.buildSuccess(
-                    bestQuote = candidate,
-                    src = src,
-                    srcTokenValue = srcTokenValue,
-                    tokenValue = tokenValue,
-                    currentDiscountInfo = uiState.value.discountInfo,
-                    rankedQuotes = ctx.ranked,
-                )
-            // applyQuoteResult re-runs the superseded/quotable guards against the live input, so a
-            // pick that lands after the user changed amount/pair/settings is dropped, not applied.
-            applyQuoteResult(ctx.input, result, isManualRoutePick = true)
+        // A row that lapsed while the sheet was open can no longer be signed at its quoted rate:
+        // don't apply it (Swap would stay enabled against an expired quote) — refresh instead, so
+        // a fresh candidate set replaces the whole list.
+        if (Clock.System.now() >= candidate.result.quote.expiredAt) {
+            refreshQuoteState.value++
+            return
         }
+        selectRouteJob?.cancel()
+        selectRouteJob =
+            scope.safeLaunch(onError = { Timber.e(it, "selectRoute") }) {
+                val (src, _) = ctx.input.address
+                val amount = ctx.input.amount ?: return@safeLaunch
+                val srcToken = src.account.token
+                val srcTokenValue = amount.movePointRight(srcToken.decimal).toBigInteger()
+                val tokenValue = convertTokenAndValueToTokenValue(srcToken, srcTokenValue)
+                val result =
+                    swapQuotePipeline.buildSuccess(
+                        bestQuote = candidate,
+                        src = src,
+                        srcTokenValue = srcTokenValue,
+                        tokenValue = tokenValue,
+                        currentDiscountInfo = uiState.value.discountInfo,
+                        rankedQuotes = ctx.ranked,
+                    )
+                // buildSuccess suspends (discount checks); a refresh or reset may have replaced or
+                // cleared the context meanwhile. That newer state wins — drop the pick.
+                if (routeContext !== ctx) return@safeLaunch
+                // applyQuoteResult re-runs the superseded/quotable guards against the live input;
+                // on the manual path a trip drops the pick silently instead of resetting state
+                // owned by a newer request.
+                applyQuoteResult(ctx.input, result, isManualRoutePick = true)
+            }
     }
 
     /** Applies the UTXO plan-fee / balance outcome to the network-fee flows and form state. */
@@ -785,6 +854,9 @@ constructor(
     private fun discardSupersededQuoteResult() {
         refreshQuoteJob?.cancel()
         refreshQuoteJob = null
+        // The context a pending pick was built from is going away with the quote it belonged to.
+        selectRouteJob?.cancel()
+        selectRouteJob = null
         quoteState.reset()
         routeContext = null
         uiState.update {
@@ -820,6 +892,9 @@ constructor(
         // quote pipeline against the same invalid amount, briefly re-exposing the fee block.
         refreshQuoteJob?.cancel()
         refreshQuoteJob = null
+        // The context a pending pick was built from is going away with the quote it belonged to.
+        selectRouteJob?.cancel()
+        selectRouteJob = null
         // Clears quote/provider and the swap fee in one place. Resetting swapFeeFiat lets
         // collectTotalFee()'s filterNotNull() short-circuit so a later calculateGas() update can't
         // write a (newGas + staleSwap) combination back into state.totalFee — the same race that

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -510,6 +510,11 @@ constructor(
                 srcToken = src.account.token,
                 dstTicker = dst.account.token.ticker,
             )
+        // buildRouteOptions suspends too (fiatValueToString reads the currency from DataStore), so
+        // a writer can be overtaken before the display write below just like across
+        // resolveNetworkFee: without this check it would land its quote/display over the newer
+        // writer's and only its fee would be dropped by the later ticket check.
+        if (generation != quoteApplyGeneration) return
 
         quoteState.provider = result.provider
         quoteState.quote = result.quote

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/SwapScreen.kt
@@ -45,6 +45,7 @@ import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
@@ -119,6 +120,7 @@ internal fun NavGraphBuilder.swapScreen(navController: NavHostController) {
             onSlippageSelected = model::setSlippageBps,
             onGasLimitSelected = model::setGasLimit,
             onExternalRecipientSelected = model::setExternalRecipient,
+            onRouteSelected = model::selectRoute,
             onAdvancedSettingsClick = model::onAdvancedSettingsClicked,
             onDismissAdvancedSettings = model::dismissAdvancedSettings,
             onDismissAdvancedSettingsGate = model::dismissAdvancedSettingsGate,
@@ -155,6 +157,7 @@ internal fun SwapScreen(
     onSlippageSelected: (Int?) -> Unit = {},
     onGasLimitSelected: (Long?) -> Unit = {},
     onExternalRecipientSelected: (String?) -> Unit = {},
+    onRouteSelected: (SwapProvider) -> Unit = {},
     onAdvancedSettingsClick: () -> Unit = {},
     onDismissAdvancedSettings: () -> Unit = {},
     onDismissAdvancedSettingsGate: () -> Unit = {},
@@ -418,6 +421,9 @@ internal fun SwapScreen(
                         externalRecipient = state.externalRecipient,
                         externalRecipientError = state.externalRecipientError?.asString(),
                         onExternalRecipientSelected = onExternalRecipientSelected,
+                        routeOptions = state.routeOptions,
+                        isRouteManuallySelected = state.isRouteManuallySelected,
+                        onRouteSelected = onRouteSelected,
                         onDismiss = onDismissAdvancedSettings,
                     )
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/AdvancedSwapSettings.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/AdvancedSwapSettings.kt
@@ -282,7 +282,7 @@ internal fun SelectRoutePage(
         Column(
             modifier =
                 Modifier.fillMaxWidth()
-                    .clip(RoundedCornerShape(12.dp))
+                    .clip(Theme.v2.radius.md)
                     .background(Theme.v2.colors.backgrounds.secondary)
         ) {
             routeOptions.forEachIndexed { index, route ->

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/AdvancedSwapSettings.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/AdvancedSwapSettings.kt
@@ -25,10 +25,12 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.ui.components.PasteIcon
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.inputs.VsBasicTextField
@@ -37,7 +39,10 @@ import com.vultisig.wallet.ui.components.v2.bottomsheets.V2BottomSheet
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
+import com.vultisig.wallet.ui.models.swap.SwapRouteUiModel
+import com.vultisig.wallet.ui.screens.transaction.components.TokenCircle
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.asString
 import java.math.BigDecimal
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -58,6 +63,7 @@ private enum class AdvancedPage {
     Menu,
     Slippage,
     GasLimit,
+    SelectRoute,
     ExternalRecipient,
 }
 
@@ -79,6 +85,12 @@ private enum class AdvancedPage {
  * @param onGasLimitSelected invoked on confirm with the chosen gas limit (null = Auto).
  * @param externalRecipient the current external recipient address, or null/blank = off.
  * @param onExternalRecipientSelected invoked with the entered address (null/blank = off).
+ * @param routeOptions fetched routes for the Select-route page, active route first; empty when
+ *   fewer than two routes exist, which disables the row.
+ * @param isRouteManuallySelected whether the active route is a manual pick (row shows the provider
+ *   name) rather than the automatic winner (row shows "Auto").
+ * @param onRouteSelected invoked with the picked provider; applied immediately (no staging) since
+ *   the pick only chooses among already-fetched quotes.
  */
 @Composable
 internal fun AdvancedSwapSettingsSheet(
@@ -90,6 +102,9 @@ internal fun AdvancedSwapSettingsSheet(
     externalRecipient: String?,
     externalRecipientError: String?,
     onExternalRecipientSelected: (String?) -> Unit,
+    routeOptions: List<SwapRouteUiModel>,
+    isRouteManuallySelected: Boolean,
+    onRouteSelected: (SwapProvider) -> Unit,
     onDismiss: () -> Unit,
 ) {
     var page by remember { mutableStateOf(AdvancedPage.Menu) }
@@ -114,6 +129,7 @@ internal fun AdvancedSwapSettingsSheet(
                     AdvancedPage.Menu -> R.string.swap_advanced_sheet_title
                     AdvancedPage.Slippage -> R.string.swap_advanced_slippage_page_title
                     AdvancedPage.GasLimit -> R.string.swap_advanced_gas_limit_title
+                    AdvancedPage.SelectRoute -> R.string.swap_advanced_select_route_title
                     AdvancedPage.ExternalRecipient ->
                         R.string.swap_advanced_external_recipient_title
                 }
@@ -153,18 +169,35 @@ internal fun AdvancedSwapSettingsSheet(
                     slippageValue = formatSlippage(stagedSlippageBps) ?: autoLabel,
                     gasLimitValue = stagedGasLimit?.toString() ?: autoLabel,
                     isGasLimitApplicable = isGasLimitApplicable,
+                    routeValue =
+                        if (isRouteManuallySelected)
+                            routeOptions.firstOrNull { it.isSelected }?.name?.asString()
+                                ?: autoLabel
+                        else autoLabel,
+                    isRouteSelectable = routeOptions.isNotEmpty(),
                     externalRecipientValue =
                         if (externalRecipient.isNullOrBlank())
                             stringResource(R.string.swap_advanced_value_off)
                         else stringResource(R.string.swap_advanced_value_on),
                     onSlippageClick = { page = AdvancedPage.Slippage },
                     onGasLimitClick = { page = AdvancedPage.GasLimit },
+                    onSelectRouteClick = { page = AdvancedPage.SelectRoute },
                     onExternalRecipientClick = { page = AdvancedPage.ExternalRecipient },
                 )
             AdvancedPage.Slippage ->
                 SlippagePage(slippageBps = stagedSlippageBps, onSelect = { stagedSlippageBps = it })
             AdvancedPage.GasLimit ->
                 GasLimitPage(gasLimitOverride = stagedGasLimit, onSelect = { stagedGasLimit = it })
+            AdvancedPage.SelectRoute ->
+                SelectRoutePage(
+                    routeOptions = routeOptions,
+                    onSelect = { provider ->
+                        onRouteSelected(provider)
+                        // A pick applies immediately; return to the menu like the iOS sheet so the
+                        // row reflects the new selection.
+                        page = AdvancedPage.Menu
+                    },
+                )
             AdvancedPage.ExternalRecipient ->
                 ExternalRecipientPage(
                     externalRecipient = externalRecipient,
@@ -180,9 +213,12 @@ internal fun AdvancedMenu(
     slippageValue: String,
     gasLimitValue: String,
     isGasLimitApplicable: Boolean,
+    routeValue: String,
+    isRouteSelectable: Boolean,
     externalRecipientValue: String,
     onSlippageClick: () -> Unit,
     onGasLimitClick: () -> Unit,
+    onSelectRouteClick: () -> Unit,
     onExternalRecipientClick: () -> Unit,
 ) {
     Column(
@@ -207,12 +243,142 @@ internal fun AdvancedMenu(
             onClick = onGasLimitClick,
         )
         AdvancedSwapSettingDivider()
+        // Disabled until a quote resolves with more than one fetched route — with a single (or no)
+        // route there is nothing to pick.
+        AdvancedSwapSettingRow(
+            icon = R.drawable.ic_route,
+            title = stringResource(R.string.swap_advanced_select_route_title),
+            value = routeValue,
+            enabled = isRouteSelectable,
+            onClick = onSelectRouteClick,
+        )
+        AdvancedSwapSettingDivider()
         AdvancedSwapSettingRow(
             icon = R.drawable.ic_external_recipient,
             title = stringResource(R.string.swap_advanced_external_recipient_title),
             value = externalRecipientValue,
             onClick = onExternalRecipientClick,
         )
+    }
+}
+
+/**
+ * The Select-route page: every fetched route for the current pair/amount, active route first then
+ * best→worst by net output. Tapping a row applies that provider's quote immediately, overriding the
+ * automatic best until the next quote refresh.
+ */
+@Composable
+internal fun SelectRoutePage(
+    routeOptions: List<SwapRouteUiModel>,
+    onSelect: (SwapProvider) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+        Text(
+            text = stringResource(R.string.swap_select_route_helper),
+            style = Theme.brockmann.body.s.regular,
+            color = Theme.v2.colors.text.tertiary,
+            modifier = Modifier.padding(bottom = 16.dp),
+        )
+
+        Column(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Theme.v2.colors.backgrounds.secondary)
+        ) {
+            routeOptions.forEachIndexed { index, route ->
+                if (index > 0) AdvancedSwapSettingDivider()
+                RouteOptionRow(route = route, onClick = { onSelect(route.provider) })
+            }
+        }
+    }
+}
+
+@Composable
+private fun RouteOptionRow(route: SwapRouteUiModel, onClick: () -> Unit) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .background(
+                    if (route.isSelected) Theme.v2.colors.alerts.success.copy(alpha = 0.05f)
+                    else Color.Transparent
+                )
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        val providerName = route.name.asString()
+        route.logo?.let { logo -> TokenCircle(logo = logo, ticker = providerName, size = 36) }
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp), modifier = Modifier.weight(1f)) {
+            Text(
+                text = providerName,
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.primary,
+                maxLines = 1,
+            )
+            RouteFeeSubtitle(route)
+        }
+        Column(
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = route.outputText,
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.primary,
+                maxLines = 1,
+            )
+            Text(
+                text = route.outputFiatText,
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.text.tertiary,
+                maxLines = 1,
+            )
+        }
+        VsUiCheckbox(checked = route.isSelected, onCheckedChange = { onClick() })
+    }
+}
+
+/**
+ * "Fee $X · ~Ns" subtitle. The fee amount is tinted green on the selected row (per Figma/iOS); the
+ * ETA segment is dropped when the provider exposes no estimate (EVM aggregators), and the fee
+ * segment when it is baked into the quoted rate (1inch).
+ */
+@Composable
+private fun RouteFeeSubtitle(route: SwapRouteUiModel) {
+    val fee = route.feeText
+    val eta = route.etaText?.asString()
+    if (fee == null && eta == null) return
+    Row {
+        if (fee != null) {
+            Text(
+                text = stringResource(R.string.swap_route_fee_prefix) + " ",
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.text.tertiary,
+            )
+            Text(
+                text = fee,
+                style = Theme.brockmann.supplementary.caption,
+                color =
+                    if (route.isSelected) Theme.v2.colors.alerts.success
+                    else Theme.v2.colors.text.tertiary,
+            )
+        }
+        if (fee != null && eta != null) {
+            Text(
+                text = " · ",
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.text.tertiary,
+            )
+        }
+        if (eta != null) {
+            Text(
+                text = eta,
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.text.tertiary,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/preview/AdvancedSwapSettingsPreview.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/preview/AdvancedSwapSettingsPreview.kt
@@ -22,17 +22,23 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.getProviderLogo
+import com.vultisig.wallet.data.models.getSwapProviderId
 import com.vultisig.wallet.ui.components.v2.bottomsheets.DragHandler
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButton
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
 import com.vultisig.wallet.ui.models.swap.SwapFormUiModel
+import com.vultisig.wallet.ui.models.swap.SwapRouteUiModel
 import com.vultisig.wallet.ui.screens.swap.SwapScreen
 import com.vultisig.wallet.ui.screens.swap.components.AdvancedMenu
 import com.vultisig.wallet.ui.screens.swap.components.ExternalRecipientPage
 import com.vultisig.wallet.ui.screens.swap.components.GasLimitPage
+import com.vultisig.wallet.ui.screens.swap.components.SelectRoutePage
 import com.vultisig.wallet.ui.screens.swap.components.SlippagePage
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.UiText
 
 /**
  * Previews for the Advanced swap settings sheet (#4858). The real sheet is a
@@ -53,9 +59,12 @@ internal fun AdvancedMenuPreview() {
             slippageValue = stringResource(R.string.swap_advanced_value_auto),
             gasLimitValue = stringResource(R.string.swap_advanced_value_auto),
             isGasLimitApplicable = true,
+            routeValue = stringResource(R.string.swap_advanced_value_auto),
+            isRouteSelectable = true,
             externalRecipientValue = stringResource(R.string.swap_advanced_value_off),
             onSlippageClick = {},
             onGasLimitClick = {},
+            onSelectRouteClick = {},
             onExternalRecipientClick = {},
         )
     }
@@ -74,10 +83,47 @@ internal fun AdvancedMenuConfiguredPreview() {
             slippageValue = "1%",
             gasLimitValue = stringResource(R.string.swap_advanced_value_auto),
             isGasLimitApplicable = false,
+            routeValue = "THORChain",
+            isRouteSelectable = true,
             externalRecipientValue = stringResource(R.string.swap_advanced_value_on),
             onSlippageClick = {},
             onGasLimitClick = {},
+            onSelectRouteClick = {},
             onExternalRecipientClick = {},
+        )
+    }
+}
+
+// Select-route page mirroring the Figma reference: THORChain (active, pinned first) vs Maya.
+@Preview
+@Composable
+internal fun AdvancedSelectRoutePreview() {
+    PreviewAdvancedSheet(title = stringResource(R.string.swap_advanced_select_route_title)) {
+        SelectRoutePage(
+            routeOptions =
+                listOf(
+                    SwapRouteUiModel(
+                        provider = SwapProvider.THORCHAIN,
+                        name = UiText.DynamicString("THORChain"),
+                        logo = getProviderLogo(SwapProvider.THORCHAIN.getSwapProviderId()),
+                        feeText = "$0.00",
+                        etaText = UiText.DynamicString("~606s"),
+                        outputText = "~21.83561311 RUNE",
+                        outputFiatText = "$9.47",
+                        isSelected = true,
+                    ),
+                    SwapRouteUiModel(
+                        provider = SwapProvider.MAYA,
+                        name = UiText.DynamicString("Maya protocol"),
+                        logo = getProviderLogo(SwapProvider.MAYA.getSwapProviderId()),
+                        feeText = "$0.10",
+                        etaText = UiText.DynamicString("~600s"),
+                        outputText = "~21.610385 RUNE",
+                        outputFiatText = "$9.37",
+                        isSelected = false,
+                    ),
+                ),
+            onSelect = {},
         )
     }
 }

--- a/app/src/main/res/drawable/ic_route.xml
+++ b/app/src/main/res/drawable/ic_route.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M4.333,5.5C5.161,5.5 5.833,4.828 5.833,4C5.833,3.172 5.161,2.5 4.333,2.5C3.505,2.5 2.833,3.172 2.833,4C2.833,4.828 3.505,5.5 4.333,5.5ZM4.333,13.5C5.161,13.5 5.833,12.828 5.833,12C5.833,11.172 5.161,10.5 4.333,10.5C3.505,10.5 2.833,11.172 2.833,12C2.833,12.828 3.505,13.5 4.333,13.5ZM11.667,5.5C12.495,5.5 13.167,4.828 13.167,4C13.167,3.172 12.495,2.5 11.667,2.5C10.839,2.5 10.167,3.172 10.167,4C10.167,4.828 10.839,5.5 11.667,5.5ZM4.333,5.5V10.5M11.666,5.5V6.667C11.666,7.403 11.069,8 10.333,8H5.666C4.93,8 4.333,8.597 4.333,9.333V10.5"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#C9D6E8"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1090,6 +1090,10 @@
     <string name="swap_advanced_slippage_title">Slippage-Toleranz</string>
     <string name="swap_advanced_slippage_page_title">Slippage</string>
     <string name="swap_advanced_gas_limit_title">Gasgrenze</string>
+    <string name="swap_advanced_select_route_title">Route auswählen</string>
+    <string name="swap_select_route_helper">Routen nach Ausgabebetrag sortiert. Die Auswahl einer Route überschreibt Auto.</string>
+    <string name="swap_route_fee_prefix">Gebühr</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">Externen Empfänger verwenden</string>
     <string name="swap_advanced_locked_title">Erweiterte Swap-Einstellungen</string>
     <string name="swap_advanced_locked_subtitle">Feinabstimmung von Slippage, Gas, Routing und Empfänger für jeden Swap.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1088,6 +1088,10 @@
     <string name="swap_advanced_slippage_title">Tolerancia de deslizamiento</string>
     <string name="swap_advanced_slippage_page_title">Deslizamiento</string>
     <string name="swap_advanced_gas_limit_title">Límite de gas</string>
+    <string name="swap_advanced_select_route_title">Seleccionar ruta</string>
+    <string name="swap_select_route_helper">Rutas ordenadas por importe de salida. Seleccionar una ruta anula el modo automático.</string>
+    <string name="swap_route_fee_prefix">Tarifa</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">Usar destinatario externo</string>
     <string name="swap_advanced_locked_title">Ajustes avanzados de swap</string>
     <string name="swap_advanced_locked_subtitle">Ajusta el deslizamiento, el gas, la ruta y el destinatario en cada swap.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1093,6 +1093,10 @@
     <string name="swap_advanced_slippage_title">Tolerancija proklizavanja</string>
     <string name="swap_advanced_slippage_page_title">Proklizavanje</string>
     <string name="swap_advanced_gas_limit_title">Ograničenje plina</string>
+    <string name="swap_advanced_select_route_title">Odaberi rutu</string>
+    <string name="swap_select_route_helper">Rute su poredane prema izlaznom iznosu. Odabir rute poništava automatski odabir.</string>
+    <string name="swap_route_fee_prefix">Naknada</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">Koristi vanjskog primatelja</string>
     <string name="swap_advanced_locked_title">Napredne postavke zamjene</string>
     <string name="swap_advanced_locked_subtitle">Precizno podesite slippage, gas, rutu i primatelja za svaku zamjenu.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1088,6 +1088,10 @@
     <string name="swap_advanced_slippage_title">Tolleranza di slippage</string>
     <string name="swap_advanced_slippage_page_title">Slippage</string>
     <string name="swap_advanced_gas_limit_title">Limite del gas</string>
+    <string name="swap_advanced_select_route_title">Seleziona rotta</string>
+    <string name="swap_select_route_helper">Rotte ordinate per importo in uscita. La selezione di una rotta sostituisce la modalità automatica.</string>
+    <string name="swap_route_fee_prefix">Commissione</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">Usa destinatario esterno</string>
     <string name="swap_advanced_locked_title">Impostazioni avanzate dello swap</string>
     <string name="swap_advanced_locked_subtitle">Regola slippage, gas, percorso e destinatario per ogni swap.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -743,6 +743,10 @@
     <string name="swap_advanced_slippage_title">슬리피지 허용 범위</string>
     <string name="swap_advanced_slippage_page_title">슬리피지</string>
     <string name="swap_advanced_gas_limit_title">가스 한도</string>
+    <string name="swap_advanced_select_route_title">경로 선택</string>
+    <string name="swap_select_route_helper">출력 금액 순으로 정렬된 경로입니다. 경로를 선택하면 자동 선택이 무시됩니다.</string>
+    <string name="swap_route_fee_prefix">수수료</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">외부 수신자 사용</string>
     <string name="swap_advanced_locked_title">고급 스왑 설정</string>
     <string name="swap_advanced_locked_subtitle">모든 스왑에 대해 슬리피지, 가스, 경로, 수신자를 세밀하게 조정하세요.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1085,6 +1085,10 @@
     <string name="swap_advanced_slippage_title">Slippage-tolerantie</string>
     <string name="swap_advanced_slippage_page_title">Slippage</string>
     <string name="swap_advanced_gas_limit_title">Gaslimiet</string>
+    <string name="swap_advanced_select_route_title">Route selecteren</string>
+    <string name="swap_select_route_helper">Routes gesorteerd op uitvoerbedrag. Een route selecteren overschrijft de automatische keuze.</string>
+    <string name="swap_route_fee_prefix">Kosten</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">Externe ontvanger gebruiken</string>
     <string name="swap_advanced_locked_title">Geavanceerde swap-instellingen</string>
     <string name="swap_advanced_locked_subtitle">Stem slippage, gas, routering en ontvanger af voor elke swap.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1087,6 +1087,10 @@
     <string name="swap_advanced_slippage_title">Tolerância de derrapagem</string>
     <string name="swap_advanced_slippage_page_title">Derrapagem</string>
     <string name="swap_advanced_gas_limit_title">Limite de Gás</string>
+    <string name="swap_advanced_select_route_title">Selecionar rota</string>
+    <string name="swap_select_route_helper">Rotas ordenadas por valor de saída. Selecionar uma rota substitui o modo automático.</string>
+    <string name="swap_route_fee_prefix">Taxa</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">Usar destinatário externo</string>
     <string name="swap_advanced_locked_title">Configurações avançadas de swap</string>
     <string name="swap_advanced_locked_subtitle">Ajuste slippage, gas, rota e destinatário em cada swap.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1093,6 +1093,10 @@
     <string name="swap_advanced_slippage_title">Допустимое проскальзывание</string>
     <string name="swap_advanced_slippage_page_title">Проскальзывание</string>
     <string name="swap_advanced_gas_limit_title">Предел газа</string>
+    <string name="swap_advanced_select_route_title">Выбрать маршрут</string>
+    <string name="swap_select_route_helper">Маршруты отсортированы по сумме на выходе. Выбор маршрута отменяет автоматический режим.</string>
+    <string name="swap_route_fee_prefix">Комиссия</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">Использовать внешнего получателя</string>
     <string name="swap_advanced_locked_title">Расширенные настройки обмена</string>
     <string name="swap_advanced_locked_subtitle">Точная настройка проскальзывания, газа, маршрута и получателя для каждого обмена.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1419,6 +1419,10 @@
     <string name="swap_advanced_slippage_title">滑点容差</string>
     <string name="swap_advanced_slippage_page_title">滑点</string>
     <string name="swap_advanced_gas_limit_title">燃料限制</string>
+    <string name="swap_advanced_select_route_title">选择路线</string>
+    <string name="swap_select_route_helper">路线按输出金额排序。选择路线将覆盖自动选择。</string>
+    <string name="swap_route_fee_prefix">手续费</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">使用外部接收方</string>
     <string name="swap_advanced_locked_title">高级兑换设置</string>
     <string name="swap_advanced_locked_subtitle">为每次兑换精细调整滑点、Gas、路由和收款人。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -754,6 +754,10 @@
     <string name="swap_advanced_slippage_title">Slippage Tolerance</string>
     <string name="swap_advanced_slippage_page_title">Slippage</string>
     <string name="swap_advanced_gas_limit_title">Gas Limit</string>
+    <string name="swap_advanced_select_route_title">Select route</string>
+    <string name="swap_select_route_helper">Routes ranked by output amount. Selecting a route overrides auto.</string>
+    <string name="swap_route_fee_prefix">Fee</string>
+    <string name="swap_route_eta">~%1$ds</string>
     <string name="swap_advanced_external_recipient_title">Use External Recipient</string>
     <string name="swap_advanced_locked_title">Advanced Swap Settings</string>
     <string name="swap_advanced_locked_subtitle">Fine-tune slippage, gas, routing, and recipient for every swap.</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/RouteOutputFormatTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/RouteOutputFormatTest.kt
@@ -1,0 +1,51 @@
+package com.vultisig.wallet.ui.models.swap
+
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * The Select-route output column. It compares routes digit by digit, so it keeps full precision
+ * where that is readable — but the column carries no layout weight while the provider name does, so
+ * an unbounded amount would squeeze the name out of the row entirely. iOS draws the same line at a
+ * million ([`Decimal.formatForDisplay`]).
+ */
+internal class RouteOutputFormatTest {
+
+    @Test
+    fun `keeps every quoted digit below a million`() {
+        // The whole point of the column: two routes that differ in the eighth decimal must still
+        // read as different rows.
+        assertEquals("21.83561311", formatRouteOutput(BigDecimal("21.83561311")))
+        assertEquals("21.83561312", formatRouteOutput(BigDecimal("21.83561312")))
+    }
+
+    @Test
+    fun `groups thousands and drops trailing zeros`() {
+        assertEquals("999,999.5", formatRouteOutput(BigDecimal("999999.50000000")))
+        assertEquals("1,234", formatRouteOutput(BigDecimal("1234")))
+    }
+
+    @Test
+    fun `abbreviates from a million up so the row stays inside its budget`() {
+        // The unabbreviated form ("375,000,000.12345678") measures wider than the row's whole
+        // two-column budget at 360dp and leaves the provider name nothing to render in.
+        assertEquals("375M", formatRouteOutput(BigDecimal("375000000.12345678")))
+        assertEquals("1M", formatRouteOutput(BigDecimal("1000000")))
+        assertEquals("1.23M", formatRouteOutput(BigDecimal("1234567")))
+        assertEquals("2.5B", formatRouteOutput(BigDecimal("2500000000")))
+        assertEquals("1.5T", formatRouteOutput(BigDecimal("1500000000000")))
+    }
+
+    @Test
+    fun `truncates rather than rounding up`() {
+        // A row must never advertise more output than the quote actually pays.
+        assertEquals("1.99M", formatRouteOutput(BigDecimal("1999999")))
+        assertEquals("0.99999999", formatRouteOutput(BigDecimal("0.999999999")))
+    }
+
+    @Test
+    fun `just below the abbreviation threshold stays exact`() {
+        assertEquals("999,999.99999999", formatRouteOutput(BigDecimal("999999.99999999")))
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -4198,25 +4198,28 @@ internal class SwapFormViewModelTest {
         swapFeeFiat: FiatValue = FiatValue(BigDecimal.ZERO, "USD"),
         outboundFeeText: String? = null,
         swapFeePercent: String? = null,
-    ): BestQuote =
-        BestQuote(
-            candidate =
-                QuoteCandidate(provider = provider, vultBPSDiscount = null, referral = null),
-            result =
-                QuoteFetchResult(
-                    quote = quote,
-                    provider = provider,
-                    providerUiText = providerUiText,
-                    srcFiatValueText = srcFiatValueText,
-                    estimatedDstTokenValue = estimatedDstTokenValue,
-                    estimatedDstFiatValue = estimatedDstFiatValue,
-                    comparableDstFiat = comparableDstFiat,
-                    feeText = feeText,
-                    swapFeeFiat = swapFeeFiat,
-                    outboundFeeText = outboundFeeText,
-                    swapFeePercent = swapFeePercent,
-                ),
-        )
+    ): RankedQuotes {
+        val best =
+            BestQuote(
+                candidate =
+                    QuoteCandidate(provider = provider, vultBPSDiscount = null, referral = null),
+                result =
+                    QuoteFetchResult(
+                        quote = quote,
+                        provider = provider,
+                        providerUiText = providerUiText,
+                        srcFiatValueText = srcFiatValueText,
+                        estimatedDstTokenValue = estimatedDstTokenValue,
+                        estimatedDstFiatValue = estimatedDstFiatValue,
+                        comparableDstFiat = comparableDstFiat,
+                        feeText = feeText,
+                        swapFeeFiat = swapFeeFiat,
+                        outboundFeeText = outboundFeeText,
+                        swapFeePercent = swapFeePercent,
+                    ),
+            )
+        return RankedQuotes(best = best, ranked = listOf(best))
+    }
 
     private fun createThorChainQuote(
         expectedDstValue: TokenValue = TokenValue(value = BigInteger("95000000"), token = USDC_COIN)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -460,6 +460,18 @@ internal class SwapQuoteManagerTest {
     }
 
     @Test
+    fun `fetchBestQuote wins on token amount when the dst token has no price`() = runTest {
+        // The winner must use the same fallback the ranked list does. On the fiat metric alone an
+        // unpriced destination reads as "every route is economically tied", so the band swallows
+        // the whole set and provider priority hands it to THORChain's 100 — while the picker draws
+        // SwapKit's 200 on the row above, checkmark pointing at the smaller output.
+        val fetched = rankTwoProviders(thorFiat = "0", swapKitFiat = "0")
+
+        assertEquals(SwapProvider.SWAPKIT, fetched.best.candidate.provider)
+        assertEquals(fetched.ranked.first().candidate.provider, fetched.best.candidate.provider)
+    }
+
+    @Test
     fun `fetchBestQuote keeps the materially-better quote when it is outside the 50bps band`() =
         runTest {
             // THORChain prices 0.8% below SwapKit (99.2 vs 100, floor = 99.5), outside the band, so

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -304,6 +304,7 @@ internal class SwapQuoteManagerTest {
                     currency = AppCurrency.USD,
                     amount = BigDecimal.ONE,
                 )
+                .best
 
         assertEquals(SwapProvider.SWAPKIT, best.candidate.provider)
         assertEquals(BigDecimal("200"), best.result.comparableDstFiat)
@@ -425,10 +426,24 @@ internal class SwapQuoteManagerTest {
             // THORChain (priority 0) prices the dst slightly lower than SwapKit (priority 2), but
             // within the 50bps band (99.7 vs 100, floor = 99.5). Both are in-band, so the banded
             // layer tilts to the higher-priority THORChain instead of the marginally larger output.
-            val best = rankTwoProviders(thorFiat = "99.7", swapKitFiat = "100")
+            val best = rankTwoProviders(thorFiat = "99.7", swapKitFiat = "100").best
 
             assertEquals(SwapProvider.THORCHAIN, best.candidate.provider)
             assertEquals(BigDecimal("99.7"), best.result.comparableDstFiat)
+        }
+
+    @Test
+    fun `fetchBestQuote ranks the full candidate set by net output regardless of the winner`() =
+        runTest {
+            // The banded preference makes THORChain the auto winner, but the Select-route list
+            // stays ordered by raw net output — SwapKit (100) above THORChain (99.7).
+            val fetched = rankTwoProviders(thorFiat = "99.7", swapKitFiat = "100")
+
+            assertEquals(SwapProvider.THORCHAIN, fetched.best.candidate.provider)
+            assertEquals(
+                listOf(SwapProvider.SWAPKIT, SwapProvider.THORCHAIN),
+                fetched.ranked.map { it.candidate.provider },
+            )
         }
 
     @Test
@@ -436,7 +451,7 @@ internal class SwapQuoteManagerTest {
         runTest {
             // THORChain prices 0.8% below SwapKit (99.2 vs 100, floor = 99.5), outside the band, so
             // the priority preference does not apply and the better-rate SwapKit wins.
-            val best = rankTwoProviders(thorFiat = "99.2", swapKitFiat = "100")
+            val best = rankTwoProviders(thorFiat = "99.2", swapKitFiat = "100").best
 
             assertEquals(SwapProvider.SWAPKIT, best.candidate.provider)
             assertEquals(BigDecimal("100"), best.result.comparableDstFiat)
@@ -448,7 +463,7 @@ internal class SwapQuoteManagerTest {
      * respectively. The raw dst token amounts are arbitrary; ranking is driven purely by the mocked
      * fiat values.
      */
-    private suspend fun rankTwoProviders(thorFiat: String, swapKitFiat: String): BestQuote {
+    private suspend fun rankTwoProviders(thorFiat: String, swapKitFiat: String): RankedQuotes {
         val btc = coin(Chain.Bitcoin, "BTC", address = "bc1qsrc", decimals = 8)
         val eth = coin(Chain.Ethereum, "ETH", address = "0xdst", decimals = 18)
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -447,6 +447,19 @@ internal class SwapQuoteManagerTest {
         }
 
     @Test
+    fun `fetchBestQuote ranks by token amount when the dst token has no price`() = runTest {
+        // An unpriced destination collapses comparableDstFiat to zero for every candidate at
+        // once; the ranked list must fall back to the raw destination amount (SwapKit's dst is
+        // 200 raw units vs THORChain's 100 in the helper) instead of provider-table order.
+        val fetched = rankTwoProviders(thorFiat = "0", swapKitFiat = "0")
+
+        assertEquals(
+            listOf(SwapProvider.SWAPKIT, SwapProvider.THORCHAIN),
+            fetched.ranked.map { it.candidate.provider },
+        )
+    }
+
+    @Test
     fun `fetchBestQuote keeps the materially-better quote when it is outside the 50bps band`() =
         runTest {
             // THORChain prices 0.8% below SwapKit (99.2 vs 100, floor = 99.5), outside the band, so

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineNetworkFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineNetworkFeeTest.kt
@@ -139,6 +139,47 @@ internal class SwapQuotePipelineNetworkFeeTest {
     }
 
     @Test
+    fun `restores the gas-pass estimate for a THOR quote on an EVM source`() = runTest {
+        // An aggregator quote re-bases the displayed fee onto its route gas; when a THOR/Maya
+        // route becomes active on the same EVM source (fresh win or manual route pick), the
+        // gas-pass baseline must come back — otherwise the aggregator's re-based fee lingers on a
+        // route it never applied to.
+        val ethCoin = coin(Chain.Ethereum)
+        val baseline = gasResult(ethCoin, BigInteger.valueOf(6_000_000)).estimated
+
+        val outcome =
+            pipeline.resolveNetworkFee(
+                result = success(thorQuote(ethCoin)),
+                src = sendSrc(ethCoin),
+                vaultId = "vault",
+                gasFee = TokenValue(BigInteger.valueOf(6_000_000), ethCoin),
+                gasFeeChain = Chain.Ethereum,
+                networkFeeTokenValue = TokenValue(BigInteger.valueOf(2_861_460), ethCoin),
+                evmBaselineEstimate = baseline,
+            )
+
+        val set = assertIs<NetworkFeeUpdate.Set>(outcome.networkFee)
+        assertEquals(BigInteger.valueOf(6_000_000), set.tokenValue.value)
+        coVerify(exactly = 0) { swapGasCalculator.rebaseEvmSwapNetworkFee(any(), any(), any()) }
+    }
+
+    @Test
+    fun `leaves the fee untouched for a THOR quote on EVM without a stored baseline`() = runTest {
+        val ethCoin = coin(Chain.Ethereum)
+        val outcome =
+            pipeline.resolveNetworkFee(
+                result = success(thorQuote(ethCoin)),
+                src = sendSrc(ethCoin),
+                vaultId = "vault",
+                gasFee = TokenValue(BigInteger.valueOf(6_000_000), ethCoin),
+                gasFeeChain = Chain.Ethereum,
+                networkFeeTokenValue = TokenValue(BigInteger.valueOf(6_000_000), ethCoin),
+            )
+
+        assertNull(outcome.networkFee)
+    }
+
+    @Test
     fun `clears the stale fee when the gas fee lags the source chain`() = runTest {
         val ethCoin = coin(Chain.Ethereum)
         val outcome =
@@ -188,6 +229,15 @@ internal class SwapQuotePipelineNetworkFeeTest {
                 ),
             provider = "SwapKit",
             subProvider = "FLASHNET",
+        )
+
+    private fun thorQuote(dstToken: Coin) =
+        SwapQuote.ThorChain(
+            expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
+            fees = TokenValue(BigInteger.valueOf(9), dstToken),
+            expiredAt = Clock.System.now(),
+            recommendedMinTokenValue = TokenValue(BigInteger.ONE, dstToken),
+            data = mockk(relaxed = true),
         )
 
     private fun oneInchQuote(dstToken: Coin, routeGas: Long) =


### PR DESCRIPTION
## What

Adds the missing **Select route** feature to the Advanced swap sheet, porting the route picker from the iOS Advanced Swap work (vultisig-ios#4570).

The Advanced swap sheet gains a **Select route** row (between Gas Limit and Use External Recipient) that opens a page listing **every fetched provider quote**, ranked by net output amount with the active route pinned to the top. Each row shows the provider logo and name, a "Fee $X · ~Ns" subtitle, the approximate destination output with its fiat value, and a green check on the active route. Tapping a route applies it immediately and returns to the menu.

### Transaction hash
https://etherscan.io/tx/0xfc087edcefc819690f0c321f271cf04715193b972050e3b767feb42891701a80

## Behavior

- **Ranking**: routes are ordered best→worst by the same net-output metric (`comparableDstFiat`) the auto-selection ranks on, so the top row always shows the largest output. The auto winner can differ from the top row when the banded provider preference applies — the list order deliberately stays output-ranked.
- **Override semantics (iOS parity)**: a manual pick overrides the automatic best until the next quote refresh (expiry / amount / pair / slippage / recipient change), which resets the route to Auto. The menu row reads "Auto" until a manual pick is made, then the provider name.
- **No extra fetch**: the per-provider fan-out already fetched every candidate and discarded the losers. Picking a route rebuilds display state for the already-fetched candidate and re-applies it through the same `applyQuoteResult` path — fees, discounts, UTXO plan-fee verification, balance validation, and the refresh timer all follow the pick. Picks that land after the input changed are dropped by the existing superseded guards.
- **Row details**: the ETA segment only renders for THORChain/Maya (the only providers exposing `total_swap_seconds`); the fee segment is dropped for 1inch, whose affiliate fee is baked into the quoted rate. The row is disabled while fewer than two routes exist.
- The row lives inside the Advanced sheet, so it inherits the existing Silver-tier gate.

## Changes

- `SwapQuoteManager.fetchBestQuote` returns `RankedQuotes(best, ranked)`; `QuoteResolution.Success` / `SwapQuotePipelineResult.Success` carry the ranked candidate set through `buildSuccess`.
- `SwapQuotePipelineController`: keeps a `RouteContext(input, ranked)`, builds `SwapRouteUiModel` rows, and exposes `selectRoute(provider)`; route state clears on every reset/supersede path.
- `SwapFormUiModel` gains `routeOptions` + `isRouteManuallySelected`; `SwapFormViewModel.selectRoute` delegates to the controller.
- `AdvancedSwapSettingsSheet`: new `SelectRoute` page + menu row; new `ic_route.xml` vector (ported from the iOS `route.svg` asset).
- Strings added to English and all 9 locale files, matching each locale's established route/fee terminology.
- Preview: `AdvancedSelectRoutePreview` + PreviewActivity `swap_advanced_select_route` entry.

## UI (verified on emulator, described in text)

- **Before**: Advanced swap menu shows Slippage Tolerance / Gas Limit / Use External Recipient only.
- **After**: a fourth "Select route — Auto ›" row with the route icon appears between Gas Limit and Use External Recipient; the Select route page renders the ranked list (e.g. THORChain pinned first with green check, "Fee $0.00 · ~606s", "~21.83561311 RUNE / $9.47"; Maya protocol below with an empty radio), matching the reference design.

## Tests

- New: `fetchBestQuote ranks the full candidate set by net output regardless of the winner` — pins that the picker list stays output-ordered even when the banded preference selects a lower-output provider as best.
- Updated `SwapQuoteManagerTest` / `SwapFormViewModelTest` for the `RankedQuotes` return shape.
- `:app:testDebugUnitTest` swap package: 332 tests green. `:app:lintDebug` + `:data:lintDebug` green. ktfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added advanced swap route selection in Advanced Swap Settings.
- Compare providers by output amount, fees, and estimated completion time.
- Select a preferred route without refetching quotes.
- Routes are ranked by expected destination value with provider branding and selection states.
- Added localized route-selection text across supported languages.

## Tests
- Expanded coverage for route ranking, provider selection, output formatting, and network-fee handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->