### PR TITLE
fix(passcode): don't open bottom sheets over the lock screen

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/ui/screens/passcode/OnceUnlockedTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/ui/screens/passcode/OnceUnlockedTest.kt
@@ -1,0 +1,146 @@
+package com.vultisig.wallet.ui.screens.passcode
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.screens.home.MonthlyBackupReminder
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Driven through `MonthlyBackupReminder`, the sheet the home screen raises off a background read
+ * with no user action — so its window can be added after the passcode lock's and draw above it.
+ * Composed here the way the home screen composes it: the caller's own condition, then the gate.
+ */
+class OnceUnlockedTest {
+
+    @get:Rule val compose = createComposeRule()
+
+    private var isGateClosed by mutableStateOf(false)
+    private var isReminderWanted by mutableStateOf(false)
+
+    @Test
+    fun theReminderShowsWhileTheGateIsOpen() {
+        start(gateClosed = false)
+
+        wantReminder(true)
+
+        assertReminderShows()
+    }
+
+    @Test
+    fun theReminderIsHeldWhileTheGateIsClosed() {
+        start(gateClosed = true)
+
+        wantReminder(true)
+
+        assertReminderHeld()
+    }
+
+    @Test
+    fun theHeldReminderShowsOnceTheGateOpens() {
+        start(gateClosed = true)
+        wantReminder(true)
+        assertReminderHeld()
+
+        setGateState(closed = false)
+
+        assertReminderShows()
+    }
+
+    /**
+     * The lock's own window covers a sheet that was already up, and dropping it would discard the
+     * screen state behind it.
+     */
+    @Test
+    fun theReminderAlreadyUpWhenTheGateClosesStaysUp() {
+        start(gateClosed = false)
+        wantReminder(true)
+        assertReminderShows()
+
+        setGateState(closed = true)
+
+        assertReminderShows()
+    }
+
+    /** Held, not queued: what is no longer wanted by the time the gate opens is not raised. */
+    @Test
+    fun theHeldReminderIsDroppedWhenItStopsBeingWanted() {
+        start(gateClosed = true)
+        wantReminder(true)
+
+        wantReminder(false)
+        setGateState(closed = false)
+
+        assertReminderHeld()
+    }
+
+    /**
+     * The hold is per showing, so dismissing and being raised again behind the lock still holds.
+     */
+    @Test
+    fun theReminderRaisedAgainAfterTheGateClosesIsHeld() {
+        start(gateClosed = false)
+        wantReminder(true)
+        assertReminderShows()
+        wantReminder(false)
+
+        setGateState(closed = true)
+        wantReminder(true)
+
+        assertReminderHeld()
+    }
+
+    private fun start(gateClosed: Boolean) {
+        isGateClosed = gateClosed
+        compose.setContent {
+            CompositionLocalProvider(LocalIsGateClosed provides isGateClosed) {
+                if (isReminderWanted) {
+                    OnceUnlocked {
+                        MonthlyBackupReminder(onDismiss = {}, onBackup = {}, onDoNotRemind = {})
+                    }
+                }
+            }
+        }
+    }
+
+    private fun wantReminder(wanted: Boolean) {
+        isReminderWanted = wanted
+        compose.waitForIdle()
+    }
+
+    private fun setGateState(closed: Boolean) {
+        isGateClosed = closed
+        compose.waitForIdle()
+    }
+
+    private fun assertReminderShows() {
+        compose.waitUntil(SettleTimeoutMillis) { isReminderComposed() }
+
+        compose.onNodeWithText(reminderTitle).assertExists()
+    }
+
+    private fun assertReminderHeld() {
+        compose.waitForIdle()
+
+        compose.onNodeWithText(reminderTitle).assertDoesNotExist()
+    }
+
+    private fun isReminderComposed(): Boolean =
+        compose.onAllNodesWithText(reminderTitle).fetchSemanticsNodes().isNotEmpty()
+
+    private companion object {
+        val reminderTitle: String =
+            InstrumentationRegistry.getInstrumentation()
+                .targetContext
+                .getString(R.string.monthly_backup_reminder_title)
+
+        const val SettleTimeoutMillis = 5_000L
+    }
+}

--- a/app/src/androidTest/java/com/vultisig/wallet/ui/screens/passcode/OnceUnlockedTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/ui/screens/passcode/OnceUnlockedTest.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.ui.screens.passcode
 
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
@@ -10,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.test.platform.app.InstrumentationRegistry
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.screens.home.MonthlyBackupReminder
+import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test
 
@@ -24,6 +26,9 @@ class OnceUnlockedTest {
 
     private var isGateClosed by mutableStateOf(false)
     private var isReminderWanted by mutableStateOf(false)
+
+    /** Counts entries into composition, so a held reminder can be asserted never to have run. */
+    private var reminderCompositions = 0
 
     @Test
     fun theReminderShowsWhileTheGateIsOpen() {
@@ -69,16 +74,17 @@ class OnceUnlockedTest {
         assertReminderShows()
     }
 
-    /** Held, not queued: what is no longer wanted by the time the gate opens is not raised. */
+    /** Held, not queued: what stops being wanted behind the gate is never raised at all. */
     @Test
-    fun theHeldReminderIsDroppedWhenItStopsBeingWanted() {
+    fun theHeldReminderIsNeverComposedIfItStopsBeingWanted() {
         start(gateClosed = true)
         wantReminder(true)
 
         wantReminder(false)
         setGateState(closed = false)
 
-        assertReminderHeld()
+        compose.waitForIdle()
+        assertEquals(0, reminderCompositions)
     }
 
     /**
@@ -103,6 +109,10 @@ class OnceUnlockedTest {
             CompositionLocalProvider(LocalIsGateClosed provides isGateClosed) {
                 if (isReminderWanted) {
                     OnceUnlocked {
+                        DisposableEffect(Unit) {
+                            reminderCompositions++
+                            onDispose {}
+                        }
                         MonthlyBackupReminder(onDismiss = {}, onBackup = {}, onDoNotRemind = {})
                     }
                 }

--- a/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/activity/components/MainActivityContent.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
@@ -57,6 +58,7 @@ import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.SetupNavGraph
 import com.vultisig.wallet.ui.navigation.route
 import com.vultisig.wallet.ui.screens.home.VaultAccountsScreen
+import com.vultisig.wallet.ui.screens.passcode.LocalIsGateClosed
 import com.vultisig.wallet.ui.screens.passcode.PasscodeGuard
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.SnackbarFlow
@@ -137,12 +139,19 @@ internal fun MainActivityContent(
                 onNavigationReady()
             }
 
-            Box(
-                modifier =
-                    Modifier.fillMaxSize()
-                        .then(if (isGateClosed) Modifier.clearAndSetSemantics {} else Modifier)
-            ) {
-                SetupNavGraph(navController = navController, startDestination = startDestination)
+            // Neither the cover nor the semantics reset below reaches a window of its own, so
+            // content that opens one holds itself back on this instead. See OnceUnlocked.
+            CompositionLocalProvider(LocalIsGateClosed provides isGateClosed) {
+                Box(
+                    modifier =
+                        Modifier.fillMaxSize()
+                            .then(if (isGateClosed) Modifier.clearAndSetSemantics {} else Modifier)
+                ) {
+                    SetupNavGraph(
+                        navController = navController,
+                        startDestination = startDestination,
+                    )
+                }
             }
         },
         overlayContent = {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
@@ -53,6 +53,7 @@ import com.vultisig.wallet.ui.components.v2.visuals.BottomFadeEffect
 import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.VaultAccountsUiModel
 import com.vultisig.wallet.ui.models.VaultAccountsViewModel
+import com.vultisig.wallet.ui.screens.passcode.OnceUnlocked
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.notifications.NotificationsIntroBottomSheet
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.notifications.VaultNotificationOptInBottomSheet
 import com.vultisig.wallet.ui.screens.v2.home.components.AccountList
@@ -87,30 +88,38 @@ internal fun VaultAccountsScreen(viewModel: VaultAccountsViewModel = hiltViewMod
         }
     }
 
+    // These three raise themselves off background work rather than off a tap, so each can open its
+    // window after the passcode lock has opened its own, and land above it.
     if (state.showMonthlyBackupReminder) {
-        MonthlyBackupReminder(
-            onDismiss = viewModel::dismissBackupReminder,
-            onBackup = viewModel::backupVault,
-            onDoNotRemind = viewModel::doNotRemindBackup,
-        )
+        OnceUnlocked {
+            MonthlyBackupReminder(
+                onDismiss = viewModel::dismissBackupReminder,
+                onBackup = viewModel::backupVault,
+                onDoNotRemind = viewModel::doNotRemindBackup,
+            )
+        }
     }
 
     if (state.showNotificationIntroSheet) {
-        NotificationsIntroBottomSheet(
-            onEnable = viewModel::onNotificationEnable,
-            onNotNow = viewModel::onNotificationNotNow,
-            onDismissRequest = viewModel::onNotificationNotNow,
-        )
+        OnceUnlocked {
+            NotificationsIntroBottomSheet(
+                onEnable = viewModel::onNotificationEnable,
+                onNotNow = viewModel::onNotificationNotNow,
+                onDismissRequest = viewModel::onNotificationNotNow,
+            )
+        }
     }
 
     if (state.showNotificationVaultSheet) {
-        VaultNotificationOptInBottomSheet(
-            vaults = state.notificationIntroVaults,
-            onEnableVault = viewModel::onNotificationVaultToggle,
-            onDismissRequest = viewModel::onNotificationVaultSheetDismiss,
-            onEnableAll = viewModel::onEnableAll,
-            onDone = viewModel::onNotificationVaultSheetDone,
-        )
+        OnceUnlocked {
+            VaultNotificationOptInBottomSheet(
+                vaults = state.notificationIntroVaults,
+                onEnableVault = viewModel::onNotificationVaultToggle,
+                onDismissRequest = viewModel::onNotificationVaultSheetDismiss,
+                onEnableAll = viewModel::onEnableAll,
+                onDone = viewModel::onNotificationVaultSheetDone,
+            )
+        }
     }
 
     VaultAccountsScreen(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/OnceUnlocked.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/OnceUnlocked.kt
@@ -1,0 +1,39 @@
+package com.vultisig.wallet.ui.screens.passcode
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Whether the passcode gate is covering the app. Provided over the content it covers.
+ *
+ * Open by default, so a preview or a test composes as it always did.
+ */
+internal val LocalIsGateClosed = compositionLocalOf { false }
+
+/**
+ * Holds [content] back until the passcode gate is open.
+ *
+ * For content that draws in a window of its own — a `ModalBottomSheet`, an `AlertDialog` — and is
+ * raised by background work rather than by a tap: one activity's windows stack in the order they
+ * were added, so a window opened after the lock's draws above it however opaque the lock is. A tap
+ * is the one thing that cannot land while the lock holds focus.
+ *
+ * Latched: once composed, [content] stays through a later lock, whose window covers it anyway.
+ * Callers keep their own condition around this, so one that lapses while the gate is closed raises
+ * nothing once it opens.
+ */
+@Composable
+internal fun OnceUnlocked(content: @Composable () -> Unit) {
+    val isGateClosed = LocalIsGateClosed.current
+    var isReleased by remember { mutableStateOf(!isGateClosed) }
+    LaunchedEffect(isGateClosed) { if (!isGateClosed) isReleased = true }
+
+    if (isReleased) {
+        content()
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/OnceUnlocked.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/OnceUnlocked.kt
@@ -1,7 +1,6 @@
 package com.vultisig.wallet.ui.screens.passcode
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -29,9 +28,8 @@ internal val LocalIsGateClosed = compositionLocalOf { false }
  */
 @Composable
 internal fun OnceUnlocked(content: @Composable () -> Unit) {
-    val isGateClosed = LocalIsGateClosed.current
-    var isReleased by remember { mutableStateOf(!isGateClosed) }
-    LaunchedEffect(isGateClosed) { if (!isGateClosed) isReleased = true }
+    var isReleased by remember { mutableStateOf(false) }
+    if (!LocalIsGateClosed.current) isReleased = true
 
     if (isReleased) {
         content()


### PR DESCRIPTION
Closes #5560.

Windows stack in the order they're added, so a bottom sheet that opens while the app is locked lands on top of the lock. #5554 handled the sheets that were already open and the dialog destinations; what's left is a sheet opened by background work after the lock is already up.

`OnceUnlocked` waits for the passcode gate before composing its content. One that was already open stays put — the lock covers it anyway, and closing it would throw away the screen underneath.

Applied to the three sheets on Home that show up on their own rather than on a tap: the monthly backup reminder and the two notification prompts. The rest either need a tap, which can't land while the lock has focus, or are dialog destinations #5554 already pops. iOS does the same thing in `presentsWhenUnlocked`.

## Before / After

| Before | After | After, once unlocked |
|--------|-------|----------------------|
| ![before](https://i.imgur.com/cUl3ewB.png) | ![after](https://i.imgur.com/OOD9b4R.png) | ![unlocked](https://i.imgur.com/CfHjbPc.png) |

## Testing

- `:app:connectedDebugAndroidTest` for `OnceUnlockedTest` + `PopDialogDestinationsWhileLockedTest` — 10 tests, 0 failures on a Pixel 9 Pro API 35 emulator. The three hold cases fail without the gate.
- `:app:testDebugUnitTest`, `:app:lintDebug`, `:app:ktfmtCheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added passcode-aware handling for backup reminders and notification prompts.
  * Reminders and prompts become available after the wallet is unlocked and remain available if the app is locked again.
  * Prevented gated overlays from remaining accessible while the passcode screen is closed.

* **Tests**
  * Added coverage for reminder visibility, reopening behavior, persistence, and pending reminder handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->