### PR TITLE
feat(defi): Kamino Earn vaults on the Solana DeFi tab

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -4033,6 +4033,7 @@ private val KAMINO_PREVIEW_ROWS =
             pnlDisplay = "0 USDC",
             pnlDirection = KaminoEarnRow.PnlDirection.FLAT,
             fiatValue = java.math.BigDecimal.ZERO,
+            hasPosition = false,
         ),
     )
 
@@ -4071,7 +4072,7 @@ private fun SolanaDeFiPreview(tab: DeFiTab, hasEnabledVaults: Boolean = true) {
                 isLoading = false,
                 hasEnabledVaults = hasEnabledVaults,
                 rows = if (hasEnabledVaults) KAMINO_PREVIEW_ROWS else emptyList(),
-                totalFiat = "$1,054.22",
+                totalFiat = if (hasEnabledVaults) "$1,054.22" else "$0.00",
                 isBalanceVisible = true,
             ),
         selectedTab = tab,

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -48,6 +48,8 @@ import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimBlockedReason
 import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimError
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakeState
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
@@ -145,6 +147,9 @@ import com.vultisig.wallet.ui.models.send.GasSettingsUiModel
 import com.vultisig.wallet.ui.models.send.SendFormUiModel
 import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.models.send.TokenBalanceUiModel
+import com.vultisig.wallet.ui.models.solanastaking.KaminoAmountUiState
+import com.vultisig.wallet.ui.models.solanastaking.SolanaStakePositionRow
+import com.vultisig.wallet.ui.models.solanastaking.SolanaStakingPositionsUiState
 import com.vultisig.wallet.ui.models.swap.LimitExpiryOption
 import com.vultisig.wallet.ui.models.swap.LimitFormSection
 import com.vultisig.wallet.ui.models.swap.LimitOrderUiModel
@@ -214,8 +219,13 @@ import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfo
 import com.vultisig.wallet.ui.screens.transaction.UiTransactionInfoType
 import com.vultisig.wallet.ui.screens.transaction.toUiTransactionInfo
 import com.vultisig.wallet.ui.screens.v2.chaintokens.ChainTokensScreen
+import com.vultisig.wallet.ui.screens.v2.defi.DeFiTab
 import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoAmountContent
+import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnRow
+import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnUiModel
+import com.vultisig.wallet.ui.screens.v2.defi.solana.SolanaStakingPositionsContent
 import com.vultisig.wallet.ui.screens.v2.home.components.AccountList
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionButton
@@ -297,6 +307,12 @@ class PreviewActivity : ComponentActivity() {
                     "join_limit_order_confirm_after" ->
                         JoinLimitOrderConfirmPreview(recognizesLimitOrder = true)
                     "limit_order_done" -> LimitOrderDonePreview()
+                    "solana_defi_earn" -> SolanaDeFiPreview(tab = DeFiTab.EARN)
+                    "solana_defi_earn_empty" ->
+                        SolanaDeFiPreview(tab = DeFiTab.EARN, hasEnabledVaults = false)
+                    "solana_defi_staked" -> SolanaDeFiPreview(tab = DeFiTab.STAKED)
+                    "kamino_deposit_form" -> KaminoAmountPreview(isWithdraw = false)
+                    "kamino_withdraw_form" -> KaminoAmountPreview(isWithdraw = true)
                     "swap_confirm" -> SwapConfirmPreview()
                     "swap_confirm_chain" -> SwapChainIndicatorPreview()
                     "swap_confirm_disabled" -> SwapConfirmPreview(allConsents = false)
@@ -3966,5 +3982,113 @@ private fun WithdrawUsdcCirclePreview() {
         operatorFeeFieldState = rememberTextFieldState(),
         providerFieldState = rememberTextFieldState(),
         slippageFieldState = rememberTextFieldState(),
+    )
+}
+
+private val KAMINO_PREVIEW_ROWS =
+    listOf(
+        KaminoEarnRow(
+            vaultAddress = "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",
+            name = "Steakhouse USDC",
+            curator = "Steakhouse Financial",
+            riskTier = KaminoRiskTier.CONSERVATIVE,
+            tokenLogo = "usdc",
+            tokenTicker = "USDC",
+            depositedDisplay = "1054.427822 USDC",
+            depositedFiat = "$1,054.22",
+            apyDisplay = "4.00%",
+            pnlDisplay = "54.427822 USDC",
+            pnlDirection = KaminoEarnRow.PnlDirection.UP,
+            fiatValue = java.math.BigDecimal("1054.22"),
+        ),
+        KaminoEarnRow(
+            vaultAddress = "A1so1bPD3W1TfeFwboDh8yfAAVaVtcdAYBYCjhg2mJQ",
+            name = "Allez SOL",
+            curator = "Allez Labs",
+            riskTier = KaminoRiskTier.CONSERVATIVE,
+            tokenLogo = "sol",
+            tokenTicker = "SOL",
+            depositedDisplay = "0 SOL",
+            depositedFiat = "$0.00",
+            apyDisplay = "5.14%",
+            pnlDisplay = "0 SOL",
+            pnlDirection = KaminoEarnRow.PnlDirection.FLAT,
+            fiatValue = java.math.BigDecimal.ZERO,
+        ),
+        KaminoEarnRow(
+            vaultAddress = "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",
+            name = "RWA USDC",
+            curator = "RockawayX",
+            riskTier = KaminoRiskTier.PRIVATE_CREDIT,
+            tokenLogo = "usdc",
+            tokenTicker = "USDC",
+            depositedDisplay = "0 USDC",
+            depositedFiat = "$0.00",
+            apyDisplay = "5.88%",
+            pnlDisplay = "0 USDC",
+            pnlDirection = KaminoEarnRow.PnlDirection.FLAT,
+            fiatValue = java.math.BigDecimal.ZERO,
+        ),
+    )
+
+@Composable
+private fun SolanaDeFiPreview(tab: DeFiTab, hasEnabledVaults: Boolean = true) {
+    SolanaStakingPositionsContent(
+        state =
+            SolanaStakingPositionsUiState(
+                isLoading = false,
+                isBalanceVisible = true,
+                totalStakedFiatDisplay = "$1,240.50",
+                totalStakedSolDisplay = "12.5 SOL",
+                positions =
+                    listOf(
+                        SolanaStakePositionRow(
+                            stakePubkey = "CrqEZ1u6vJb1sV9V4XkKZ6mQx8mUqk5vN7oPzYtWbK1P",
+                            validatorName = "Helius",
+                            validatorAddressDisplay = "CrqE...bK1P",
+                            validatorLogoUrl = null,
+                            votePubkey = "CrqEZ1u6vJb1sV9V4XkKZ6mQx8mUqk5vN7oPzYtWbK1P",
+                            stakedDisplay = "12.5 SOL",
+                            stakedFiatDisplay = "$2,450.00",
+                            rentReserveDisplay = "0.00228 SOL",
+                            state = SolanaStakeState.Active,
+                            stateLabel = UiText.DynamicString("Active"),
+                            apyDisplay = "7.1%",
+                            canManage = true,
+                            canUnstake = true,
+                            canWithdraw = false,
+                            accountLamports = java.math.BigInteger("12500000000"),
+                        )
+                    ),
+            ),
+        kaminoState =
+            KaminoEarnUiModel(
+                isLoading = false,
+                hasEnabledVaults = hasEnabledVaults,
+                rows = if (hasEnabledVaults) KAMINO_PREVIEW_ROWS else emptyList(),
+                totalFiat = "$1,054.22",
+                isBalanceVisible = true,
+            ),
+        selectedTab = tab,
+    )
+}
+
+@Composable
+private fun KaminoAmountPreview(isWithdraw: Boolean) {
+    KaminoAmountContent(
+        state =
+            KaminoAmountUiState(
+                isWithdraw = isWithdraw,
+                vaultName = "Steakhouse USDC",
+                ticker = "USDC",
+                available =
+                    if (isWithdraw) java.math.BigDecimal("1054.427822")
+                    else java.math.BigDecimal("2500"),
+                minimum = java.math.BigDecimal(if (isWithdraw) "0.001" else "0.1"),
+                isLoading = false,
+            ),
+        amountFieldState = rememberTextFieldState(if (isWithdraw) "500" else "1000"),
+        onPercentage = {},
+        onSubmit = {},
     )
 }

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -4000,6 +4000,7 @@ private val KAMINO_PREVIEW_ROWS =
             pnlDisplay = "54.427822 USDC",
             pnlDirection = KaminoEarnRow.PnlDirection.UP,
             fiatValue = java.math.BigDecimal("1054.22"),
+            hasPosition = true,
         ),
         KaminoEarnRow(
             vaultAddress = "A1so1bPD3W1TfeFwboDh8yfAAVaVtcdAYBYCjhg2mJQ",
@@ -4014,6 +4015,8 @@ private val KAMINO_PREVIEW_ROWS =
             pnlDisplay = "0 SOL",
             pnlDirection = KaminoEarnRow.PnlDirection.FLAT,
             fiatValue = java.math.BigDecimal.ZERO,
+            // Read, and holds nothing: the card drops its figure rows and offers only Deposit.
+            hasPosition = false,
         ),
         KaminoEarnRow(
             vaultAddress = "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
@@ -53,6 +53,13 @@ internal data class DepositTransactionUiModel(
     val pairedAddress: String = "",
     val pool: String = "",
     val validatorName: String = "",
+    /**
+     * Base64 raw transactions when the deposit carries pre-built Solana bytes (Kamino Earn, native
+     * staking). Rendered as a decoded instruction list, so the device approving the transaction —
+     * either device, in a co-signed vault — can see what it actually does rather than only its
+     * amount and destination.
+     */
+    val signSolana: List<String> = emptyList(),
     @StringRes val titleRes: Int = R.string.verify_deposit_sending,
     /**
      * `SRC → TGT` of the limit order a `m=<` cancel closes, parsed straight out of the memo. Null

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
@@ -4,6 +4,8 @@ import androidx.annotation.StringRes
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.mappers.SuspendMapperFunc
 import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_WITHDRAW
 import com.vultisig.wallet.data.models.OPERATION_UNBOND
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
@@ -35,6 +37,8 @@ internal interface DepositTransactionToUiModelMapper :
 internal fun depositVerifyTitleRes(operation: String, memo: String = ""): Int =
     when {
         LimitOrderCancelPresentation.isCancel(memo) -> R.string.verify_limit_order_cancel_title
+        operation == OPERATION_KAMINO_DEPOSIT -> R.string.verify_deposit_depositing
+        operation == OPERATION_KAMINO_WITHDRAW -> R.string.verify_deposit_withdrawing
         operation == OPERATION_UNBOND -> R.string.verify_deposit_unbonding
         else -> R.string.verify_deposit_sending
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
@@ -85,6 +85,7 @@ constructor(
             pairedAddress = from.pairedAddress,
             pool = from.pool,
             validatorName = from.validatorName.orEmpty(),
+            signSolana = from.signSolana?.rawTransactions.orEmpty(),
             titleRes = depositVerifyTitleRes(from.operation, from.memo),
             limitCancelPair = LimitOrderCancelPresentation.pairCaption(from.memo),
             limitCancelDonatesDust =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -250,7 +250,7 @@ constructor(
 
         val metrics = runCatching { kaminoApi.getVaultMetrics(vault.address) }.getOrNull()
         val rate = KaminoRate.parse(metrics?.tokensPerShare)
-        val held = eligibility.withdrawableShares
+        val held = eligibility.withdrawableShares?.maximum
 
         val maximum =
             if (held != null && rate != null) {
@@ -435,15 +435,13 @@ constructor(
         val eligibility = _state.value.eligibility
         check(eligibility is KaminoWithdrawEligibility.Withdrawable) {
             when (eligibility) {
-                is KaminoWithdrawEligibility.FarmStaked ->
-                    "These shares are staked in the vault's farm and cannot be withdrawn yet"
                 KaminoWithdrawEligibility.Empty -> "There is nothing to withdraw from this vault"
                 else -> "This position could not be read, so no withdraw can be sized safely"
             }
         }
 
         val rate = checkNotNull(withdrawRate) { "The vault's share rate is unavailable" }
-        val held = eligibility.shares
+        val held = eligibility.shares.maximum
         val maximum = checkNotNull(withdrawMaximumTokens) { "The withdrawable balance is unknown" }
 
         val requested =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -27,6 +27,8 @@ import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_WITHDRAW
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.repositories.BalanceRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
@@ -402,6 +404,10 @@ constructor(
                     estimatedFees = gasFee,
                     estimateFeesFiat = "",
                     blockChainSpecific = specific.blockChainSpecific,
+                    operation =
+                        if (route.isWithdraw) OPERATION_KAMINO_WITHDRAW
+                        else OPERATION_KAMINO_DEPOSIT,
+                    // Shown on verify as the destination vault, not as a validator.
                     validatorName = _state.value.vaultName,
                     signSolana = keysignPayload.signSolana,
                 )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.models.solanastaking
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
@@ -53,6 +54,26 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import timber.log.Timber
+
+/**
+ * Why a Kamino form refused to build a transaction.
+ *
+ * A typed reason rather than an exception message: the message is for the log, and the user needs
+ * the same fact in their own language. Each case maps to one string resource.
+ */
+internal enum class KaminoAmountRefusal(@StringRes val messageRes: Int) {
+    BELOW_SMALLEST_UNIT(R.string.kamino_refusal_below_smallest_unit),
+    EXCEEDS_AVAILABLE(R.string.kamino_amount_exceeds_available),
+    BELOW_MINIMUM(R.string.kamino_refusal_below_minimum),
+    NOTHING_TO_WITHDRAW(R.string.kamino_withdraw_nothing),
+    POSITION_UNREADABLE(R.string.kamino_withdraw_unreadable),
+    RATE_UNAVAILABLE(R.string.kamino_refusal_rate_unavailable),
+    LARGER_THAN_POSITION(R.string.kamino_refusal_larger_than_position),
+}
+
+/** Thrown to carry a [KaminoAmountRefusal] out to the state, where it becomes localised text. */
+internal class KaminoAmountRefused(val refusal: KaminoAmountRefusal) :
+    IllegalStateException(refusal.name)
 
 internal data class KaminoAmountUiState(
     val isWithdraw: Boolean = false,
@@ -339,11 +360,14 @@ constructor(
                         // transaction means the app declined to sign something, which the user
                         // should be able to read. An exception carrying no message would otherwise
                         // render as a blank line.
+                        // A typed refusal carries its own localised text. Anything else is a fault
+                        // rather than a rejection, so it gets the generic message — with the real
+                        // exception already in the log above.
                         error =
-                            throwable.message
-                                ?.takeIf { message -> message.isNotBlank() }
-                                ?.let(UiText::DynamicString)
-                                ?: UiText.StringResource(R.string.kamino_error_build_failed),
+                            UiText.StringResource(
+                                (throwable as? KaminoAmountRefused)?.refusal?.messageRes
+                                    ?: R.string.kamino_error_build_failed
+                            ),
                     )
                 }
             }
@@ -353,14 +377,10 @@ constructor(
             // Sending an unrounded 1.0000009 while displaying 1.000000 would sign one thing and
             // show another.
             val amount = rawAmount.setScale(coin.decimal, RoundingMode.DOWN)
-            require(amount.signum() > 0) {
-                "Amount is smaller than the smallest unit of ${coin.ticker}"
-            }
-            require(amount <= _state.value.available) { "Amount exceeds the available balance" }
+            if (amount.signum() <= 0) refuse(KaminoAmountRefusal.BELOW_SMALLEST_UNIT)
+            if (amount > _state.value.available) refuse(KaminoAmountRefusal.EXCEEDS_AVAILABLE)
             _state.value.minimum?.let { minimum ->
-                require(amount >= minimum) {
-                    "Minimum is ${minimum.stripTrailingZeros().toPlainString()} ${coin.ticker}"
-                }
+                if (amount < minimum) refuse(KaminoAmountRefusal.BELOW_MINIMUM)
             }
 
             // The denomination the endpoint expects, sized here rather than anywhere downstream.
@@ -438,16 +458,19 @@ constructor(
      */
     private fun withdrawShares(amount: BigDecimal, coin: Coin): String {
         val eligibility = _state.value.eligibility
-        check(eligibility is KaminoWithdrawEligibility.Withdrawable) {
-            when (eligibility) {
-                KaminoWithdrawEligibility.Empty -> "There is nothing to withdraw from this vault"
-                else -> "This position could not be read, so no withdraw can be sized safely"
-            }
+        if (eligibility !is KaminoWithdrawEligibility.Withdrawable) {
+            refuse(
+                if (eligibility == KaminoWithdrawEligibility.Empty) {
+                    KaminoAmountRefusal.NOTHING_TO_WITHDRAW
+                } else {
+                    KaminoAmountRefusal.POSITION_UNREADABLE
+                }
+            )
         }
 
-        val rate = checkNotNull(withdrawRate) { "The vault's share rate is unavailable" }
+        val rate = withdrawRate ?: refuse(KaminoAmountRefusal.RATE_UNAVAILABLE)
         val held = eligibility.shares.maximum
-        val maximum = checkNotNull(withdrawMaximumTokens) { "The withdrawable balance is unknown" }
+        val maximum = withdrawMaximumTokens ?: refuse(KaminoAmountRefusal.RATE_UNAVAILABLE)
 
         val requested =
             KaminoTokenAmount(
@@ -463,10 +486,10 @@ constructor(
                 rate = rate,
                 shareDecimals = vault?.sharesDecimals ?: held.decimals,
             )
-        checkNotNull(shares) { "That amount is larger than this position" }
-        check(shares.baseUnits <= held.baseUnits) {
-            // Belt and braces on the one invariant that matters: never request more than is held.
-            "Refusing to request more shares than the position holds"
+        if (shares == null || shares.baseUnits > held.baseUnits) {
+            // The second half is belt and braces on the one invariant that matters: never request
+            // more shares than the position holds.
+            refuse(KaminoAmountRefusal.LARGER_THAN_POSITION)
         }
         return shares.apiString()
     }
@@ -491,6 +514,8 @@ constructor(
             _state.update { it.copy(liquidity = liquidity) }
         }
     }
+
+    private fun refuse(refusal: KaminoAmountRefusal): Nothing = throw KaminoAmountRefused(refusal)
 
     fun dismissError() {
         _state.update { it.copy(error = null) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -14,8 +14,14 @@ import com.vultisig.wallet.data.blockchain.solana.kamino.BuildKaminoKeysignPaylo
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoComputeBudget
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoPositionMath
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRate
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoShareAmount
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoTokenAmount
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVault
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawEligibility
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawLiquidity
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawMath
 import com.vultisig.wallet.data.blockchain.solana.kamino.coin
 import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.models.Chain
@@ -60,6 +66,18 @@ internal data class KaminoAmountUiState(
     val isLoading: Boolean = true,
     val isSubmitting: Boolean = false,
     val error: UiText? = null,
+    /**
+     * Why a withdraw is or is not possible. Null for a deposit. `FarmStaked` is a real, expected
+     * state rather than a failure: every deposit auto-stakes, and the transaction that spends
+     * staked shares has never been observed, so the app refuses it by name instead of guessing a
+     * layout.
+     */
+    val eligibility: KaminoWithdrawEligibility? = null,
+    /**
+     * Whether the requested withdraw fits the vault's liquid buffer. Ordinary information, not an
+     * error — the buffer is well under 1% of assets, so exceeding it is the common case.
+     */
+    val liquidity: KaminoWithdrawLiquidity = KaminoWithdrawLiquidity.Instant,
 )
 
 /**
@@ -101,6 +119,13 @@ constructor(
 
     private var tokenCoin: Coin? = null
 
+    // Withdraw sizing state, read at load and reused at submit so the form's maximum, its gate and
+    // the amount actually sent cannot disagree.
+    private var withdrawRate: KaminoRate? = null
+    private var withdrawHeldShares: KaminoShareAmount? = null
+    private var withdrawMaximumTokens: KaminoTokenAmount? = null
+    private var liquidBuffer: KaminoTokenAmount? = null
+
     private val action: KaminoAction
         get() = if (route.isWithdraw) KaminoAction.WITHDRAW else KaminoAction.DEPOSIT
 
@@ -138,17 +163,13 @@ constructor(
             val coin = resolveCoin(vault)
             tokenCoin = coin
 
-            val available =
-                if (route.isWithdraw) withdrawableAmount(vault, coin)
-                else spendableBalance(vault, coin)
+            if (route.isWithdraw) {
+                loadWithdrawState(vault, coin)
+                return@safeLaunch
+            }
 
+            val available = spendableBalance(vault, coin)
             val vaultState = runCatching { kaminoApi.getVaultState(vault.address) }.getOrNull()
-            val minimumField =
-                if (route.isWithdraw) {
-                    vaultState?.state?.minWithdrawAmount
-                } else {
-                    vaultState?.state?.minDepositAmount
-                }
 
             _state.update {
                 it.copy(
@@ -158,9 +179,12 @@ constructor(
                             ?: vault.fallbackName,
                     ticker = coin.ticker,
                     available = available,
-                    // The one Kamino field in base units rather than decimals.
+                    // Token base units for a deposit — the endpoint's own denomination.
                     minimum =
-                        KaminoPositionMath.baseUnitsToDecimal(minimumField, vault.tokenDecimals),
+                        KaminoPositionMath.baseUnitsToDecimal(
+                            vaultState?.state?.minDepositAmount,
+                            vault.tokenDecimals,
+                        ),
                 )
             }
         }
@@ -202,22 +226,73 @@ constructor(
             .movePointLeft(coin.decimal)
     }
 
-    /** What the position is actually worth in tokens — shares times the live share ratio. */
-    private suspend fun withdrawableAmount(vault: KaminoVault, coin: Coin): BigDecimal {
-        val walletAddress = coin.address
-        val position =
-            runCatching { kaminoApi.getUserPositions(walletAddress) }
-                .getOrNull()
-                .orEmpty()
-                .firstOrNull { it.vaultAddress == vault.address }
-        val shares = KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
-        if (shares.signum() == 0) return BigDecimal.ZERO
+    /**
+     * Resolves what the withdraw form may offer, in shares first and tokens only as a projection.
+     *
+     * Shares are the primary unit throughout: the endpoint takes shares, the vault's minimum is in
+     * shares, and a full withdraw must send the exact held share count. The token figure the form
+     * is denominated in is derived from those, never the other way round.
+     */
+    private suspend fun loadWithdrawState(vault: KaminoVault, coin: Coin) {
+        val positions = runCatching { kaminoApi.getUserPositions(coin.address) }.getOrNull()
+        val eligibility =
+            if (positions == null) {
+                // A failed read is neither "nothing to withdraw" nor "everything": refuse it.
+                KaminoWithdrawEligibility.Unreadable
+            } else {
+                KaminoWithdrawEligibility.resolve(
+                    response = positions.firstOrNull { it.vaultAddress == vault.address },
+                    shareDecimals = vault.sharesDecimals,
+                )
+            }
 
         val metrics = runCatching { kaminoApi.getVaultMetrics(vault.address) }.getOrNull()
-        val tokensPerShare =
-            KaminoPositionMath.decimalOrNull(metrics?.tokensPerShare) ?: return BigDecimal.ZERO
-        return KaminoPositionMath.tokenAmount(shares, tokensPerShare, vault.tokenDecimals)
+        val rate = KaminoRate.parse(metrics?.tokensPerShare)
+        val held = eligibility.withdrawableShares
+
+        val maximum =
+            if (held != null && rate != null) {
+                KaminoWithdrawMath.maximumTokens(held, rate, vault.tokenDecimals)
+            } else {
+                null
+            }
+
+        val vaultState = runCatching { kaminoApi.getVaultState(vault.address) }.getOrNull()
+        // Share base units, not token — comparing it against a token amount would be wrong by the
+        // whole share rate (about 930x on the SOL vault).
+        val minimumShares =
+            vaultState?.state?.minWithdrawAmount?.let { raw ->
+                runCatching { KaminoShareAmount(BigInteger(raw), vault.sharesDecimals) }.getOrNull()
+            }
+        val minimum =
+            if (minimumShares != null && rate != null) {
+                KaminoWithdrawMath.minimumTokens(minimumShares, rate, vault.tokenDecimals)
+            } else {
+                null
+            }
+
+        withdrawRate = rate
+        withdrawHeldShares = held
+        withdrawMaximumTokens = maximum
+        liquidBuffer = KaminoTokenAmount.parse(metrics?.tokensAvailable, vault.tokenDecimals)
+
+        _state.update {
+            it.copy(
+                isLoading = false,
+                vaultName =
+                    vaultState?.state?.name?.takeIf { name -> name.isNotBlank() }
+                        ?: vault.fallbackName,
+                ticker = coin.ticker,
+                available = maximum.toDecimalOrZero(vault.tokenDecimals),
+                minimum = minimum?.let { m -> BigDecimal(m.baseUnits).movePointLeft(m.decimals) },
+                eligibility = eligibility,
+            )
+        }
     }
+
+    private fun KaminoTokenAmount?.toDecimalOrZero(decimals: Int): BigDecimal =
+        if (this == null) BigDecimal.ZERO.setScale(decimals)
+        else BigDecimal(baseUnits).movePointLeft(this.decimals)
 
     private suspend fun resolveCoin(vault: KaminoVault): Coin {
         val template =
@@ -243,7 +318,7 @@ constructor(
     fun submit() {
         val vault = vault ?: return
         val coin = tokenCoin ?: return
-        val amount = amountFieldState.text.toString().toBigDecimalOrNull() ?: return
+        val rawAmount = amountFieldState.text.toString().toBigDecimalOrNull() ?: return
 
         _state.update { it.copy(isSubmitting = true, error = null) }
 
@@ -255,19 +330,36 @@ constructor(
                         isSubmitting = false,
                         // Surface the refusal reason rather than a generic failure: a rejected
                         // transaction means the app declined to sign something, which the user
-                        // should be able to read.
-                        error = UiText.DynamicString(throwable.message ?: ""),
+                        // should be able to read. An exception carrying no message would otherwise
+                        // render as a blank line.
+                        error =
+                            throwable.message
+                                ?.takeIf { message -> message.isNotBlank() }
+                                ?.let(UiText::DynamicString)
+                                ?: UiText.StringResource(R.string.kamino_error_build_failed),
                     )
                 }
             }
         ) {
-            require(amount.signum() > 0) { "Amount must be greater than zero" }
+            // Quantised to the token's own precision first, so the amount sent, the amount shown on
+            // the verify screen and the amount checked against the balance are the same number.
+            // Sending an unrounded 1.0000009 while displaying 1.000000 would sign one thing and
+            // show another.
+            val amount = rawAmount.setScale(coin.decimal, RoundingMode.DOWN)
+            require(amount.signum() > 0) {
+                "Amount is smaller than the smallest unit of ${coin.ticker}"
+            }
             require(amount <= _state.value.available) { "Amount exceeds the available balance" }
             _state.value.minimum?.let { minimum ->
                 require(amount >= minimum) {
                     "Minimum is ${minimum.stripTrailingZeros().toPlainString()} ${coin.ticker}"
                 }
             }
+
+            // The denomination the endpoint expects, sized here rather than anywhere downstream.
+            val apiAmount =
+                if (route.isWithdraw) withdrawShares(amount, coin)
+                else amount.stripTrailingZeros().toPlainString()
 
             val storedVault =
                 vaultRepository.get(route.vaultId) ?: error("Vault ${route.vaultId} not found")
@@ -289,7 +381,8 @@ constructor(
                 buildKeysignPayload(
                     vault = vault,
                     action = action,
-                    amount = amount,
+                    apiAmount = apiAmount,
+                    tokenAmount = amount,
                     coin = coin,
                     blockChainSpecific = specific.blockChainSpecific,
                     vaultPublicKeyECDSA = storedVault.pubKeyECDSA,
@@ -319,6 +412,74 @@ constructor(
             navigator.route(
                 Route.VerifyDeposit(vaultId = route.vaultId, transactionId = depositTx.id)
             )
+        }
+    }
+
+    /**
+     * Converts the entered token amount into the share quantity the withdraw endpoint expects.
+     *
+     * Everything hazardous about a withdraw lives here. The endpoint validates nothing: naming more
+     * shares than the wallet holds is silently rewritten to `u64::MAX`, meaning *withdraw
+     * everything*. So an over-request by a single base unit turns a partial withdraw into a full
+     * exit, which is why an amount above the maximum is refused outright rather than clamped, and
+     * why a withdraw of exactly the maximum sends the held balance verbatim instead of a number
+     * round-tripped through tokens.
+     */
+    private fun withdrawShares(amount: BigDecimal, coin: Coin): String {
+        val eligibility = _state.value.eligibility
+        check(eligibility is KaminoWithdrawEligibility.Withdrawable) {
+            when (eligibility) {
+                is KaminoWithdrawEligibility.FarmStaked ->
+                    "These shares are staked in the vault's farm and cannot be withdrawn yet"
+                KaminoWithdrawEligibility.Empty -> "There is nothing to withdraw from this vault"
+                else -> "This position could not be read, so no withdraw can be sized safely"
+            }
+        }
+
+        val rate = checkNotNull(withdrawRate) { "The vault's share rate is unavailable" }
+        val held = eligibility.shares
+        val maximum = checkNotNull(withdrawMaximumTokens) { "The withdrawable balance is unknown" }
+
+        val requested =
+            KaminoTokenAmount(
+                baseUnits = amount.movePointRight(coin.decimal).toBigIntegerExact(),
+                decimals = coin.decimal,
+            )
+
+        val shares =
+            KaminoWithdrawMath.sharesForTokens(
+                tokens = requested,
+                held = held,
+                maximumTokens = maximum,
+                rate = rate,
+                shareDecimals = vault?.sharesDecimals ?: held.decimals,
+            )
+        checkNotNull(shares) { "That amount is larger than this position" }
+        check(shares.baseUnits <= held.baseUnits) {
+            // Belt and braces on the one invariant that matters: never request more than is held.
+            "Refusing to request more shares than the position holds"
+        }
+        return shares.apiString()
+    }
+
+    /** Recomputes whether the entered amount fits the vault's liquid buffer. */
+    fun onAmountChanged(amount: BigDecimal?) {
+        if (!route.isWithdraw) return
+        val decimals = tokenCoin?.decimal ?: return
+        val requested =
+            amount
+                ?.takeIf { it.signum() > 0 }
+                ?.let {
+                    runCatching {
+                            KaminoTokenAmount(it.movePointRight(decimals).toBigInteger(), decimals)
+                        }
+                        .getOrNull()
+                }
+        val liquidity =
+            if (requested == null) KaminoWithdrawLiquidity.Instant
+            else KaminoWithdrawLiquidity.resolve(requested, liquidBuffer)
+        if (liquidity != _state.value.liquidity) {
+            _state.update { it.copy(liquidity = liquidity) }
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -217,8 +217,13 @@ constructor(
             )
         val wrappedSolRent =
             if (vault.tokenMint == KaminoVaultRegistry.WRAPPED_SOL_MINT) {
+                // Falling back to zero would quietly hand the whole balance to a Max deposit that
+                // then cannot fund the account it creates. The 165-byte token-account rent is a
+                // network constant in practice, so the known value is a far better answer than
+                // none.
                 runCatching { solanaApi.getMinimumBalanceForRentExemption() }
-                    .getOrElse { BigInteger.ZERO }
+                    .getOrNull()
+                    ?.takeIf { it.signum() > 0 } ?: SPL_TOKEN_ACCOUNT_RENT_LAMPORTS
             } else {
                 BigInteger.ZERO
             }
@@ -496,6 +501,12 @@ constructor(
     }
 
     private companion object {
+        /**
+         * Rent-exempt minimum for a 165-byte SPL token account. Used only when the live read fails
+         * — reserving nothing would be worse than reserving a value that has not moved in practice.
+         */
+        val SPL_TOKEN_ACCOUNT_RENT_LAMPORTS: BigInteger = BigInteger.valueOf(2_039_280)
+
         val ONE_HUNDRED = BigDecimal(100)
         const val DEFAULT_SCALE = 6
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -1,0 +1,337 @@
+package com.vultisig.wallet.ui.models.solanastaking
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.blockchain.solana.kamino.BuildKaminoKeysignPayloadUseCase
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoComputeBudget
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoPositionMath
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVault
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.blockchain.solana.kamino.coin
+import com.vultisig.wallet.data.chains.helpers.SolanaHelper
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.BalanceRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.navigation.back
+import com.vultisig.wallet.ui.utils.UiText
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+import java.util.UUID
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
+
+internal data class KaminoAmountUiState(
+    val isWithdraw: Boolean = false,
+    val vaultName: String = "",
+    val ticker: String = "",
+    /**
+     * What the entered amount is capped against: wallet balance to deposit, position to withdraw.
+     */
+    val available: BigDecimal = BigDecimal.ZERO,
+    /** Per-vault floor from live vault state, or null when it could not be read. */
+    val minimum: BigDecimal? = null,
+    val percentageSelected: Int = -1,
+    val isLoading: Boolean = true,
+    val isSubmitting: Boolean = false,
+    val error: UiText? = null,
+)
+
+/**
+ * Amount entry for a Kamino Earn deposit or withdraw.
+ *
+ * One ViewModel covers both directions because the forms differ only in what caps the amount —
+ * wallet balance going in, the position's token value coming out — and in the labels. The
+ * transaction itself is built at submit time, never earlier: Kamino bakes a recent blockhash into
+ * it that expires in about a minute, and an MPC ceremony can outlast that.
+ */
+@HiltViewModel
+internal class KaminoAmountViewModel
+@Inject
+constructor(
+    savedStateHandle: SavedStateHandle,
+    private val kaminoApi: KaminoApi,
+    private val solanaApi: SolanaApi,
+    private val vaultRepository: VaultRepository,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val balanceRepository: BalanceRepository,
+    private val blockChainSpecificRepository: BlockChainSpecificRepository,
+    private val buildKeysignPayload: BuildKaminoKeysignPayloadUseCase,
+    private val depositTransactionRepository: DepositTransactionRepository,
+    private val navigator: Navigator<Destination>,
+) : ViewModel() {
+
+    private val route = savedStateHandle.toRoute<Route.KaminoAmount>()
+
+    val amountFieldState = TextFieldState()
+
+    private val _state = MutableStateFlow(KaminoAmountUiState(isWithdraw = route.isWithdraw))
+    val state: StateFlow<KaminoAmountUiState> = _state.asStateFlow()
+
+    /**
+     * Resolved from the local allow-list rather than taken from the navigation argument, so a
+     * malformed or stale route cannot aim the flow at a vault the app does not curate.
+     */
+    private val vault: KaminoVault? = KaminoVaultRegistry.vaultFor(route.vaultAddress)
+
+    private var tokenCoin: Coin? = null
+
+    private val action: KaminoAction
+        get() = if (route.isWithdraw) KaminoAction.WITHDRAW else KaminoAction.DEPOSIT
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        val vault = vault
+        if (vault == null) {
+            _state.update {
+                it.copy(
+                    isLoading = false,
+                    error = UiText.StringResource(R.string.kamino_error_unknown_vault),
+                )
+            }
+            return
+        }
+
+        _state.update {
+            it.copy(vaultName = vault.fallbackName, ticker = vault.coin?.ticker.orEmpty())
+        }
+
+        viewModelScope.safeLaunch(
+            onError = { throwable ->
+                Timber.e(throwable, "Failed to load Kamino amount form")
+                _state.update {
+                    it.copy(
+                        isLoading = false,
+                        error = UiText.StringResource(R.string.kamino_error_load_failed),
+                    )
+                }
+            }
+        ) {
+            val coin = resolveCoin(vault)
+            tokenCoin = coin
+
+            val available =
+                if (route.isWithdraw) withdrawableAmount(vault, coin)
+                else spendableBalance(vault, coin)
+
+            val vaultState = runCatching { kaminoApi.getVaultState(vault.address) }.getOrNull()
+            val minimumField =
+                if (route.isWithdraw) {
+                    vaultState?.state?.minWithdrawAmount
+                } else {
+                    vaultState?.state?.minDepositAmount
+                }
+
+            _state.update {
+                it.copy(
+                    isLoading = false,
+                    vaultName =
+                        vaultState?.state?.name?.takeIf { name -> name.isNotBlank() }
+                            ?: vault.fallbackName,
+                    ticker = coin.ticker,
+                    available = available,
+                    // The one Kamino field in base units rather than decimals.
+                    minimum =
+                        KaminoPositionMath.baseUnitsToDecimal(minimumField, vault.tokenDecimals),
+                )
+            }
+        }
+    }
+
+    /**
+     * Wallet balance less everything the deposit itself has to pay for, so a Max amount produces a
+     * transaction that can actually land.
+     *
+     * For the SOL vault that is three things, not one: the base fee, the priority fee this
+     * transaction will be charged (price × the compute limit, far from negligible at these limits),
+     * and the rent-exempt reserve for the **wrapped-SOL account the deposit has to create** — the
+     * vault's underlying is wSOL, not native SOL. Reserving only the base fee, as this first did,
+     * leaves a Max deposit unable to fund that account and it fails on chain. The native staking
+     * flow reserves rent the same way.
+     *
+     * A token deposit pays all of that in SOL, so the token balance is spendable in full.
+     */
+    private suspend fun spendableBalance(vault: KaminoVault, coin: Coin): BigDecimal {
+        val balance = balanceRepository.getTokenValue(coin.address, coin).first().value
+        if (!coin.isNativeToken) return BigDecimal(balance).movePointLeft(coin.decimal)
+
+        val priorityFee =
+            KaminoComputeBudget.priorityFeeLamports(
+                vault = vault,
+                action = KaminoAction.DEPOSIT,
+                networkPrice = null,
+            )
+        val wrappedSolRent =
+            if (vault.tokenMint == KaminoVaultRegistry.WRAPPED_SOL_MINT) {
+                runCatching { solanaApi.getMinimumBalanceForRentExemption() }
+                    .getOrElse { BigInteger.ZERO }
+            } else {
+                BigInteger.ZERO
+            }
+
+        val headroom = SolanaHelper.DefaultFeeInLamports + priorityFee + wrappedSolRent
+        return BigDecimal((balance - headroom).coerceAtLeast(BigInteger.ZERO))
+            .movePointLeft(coin.decimal)
+    }
+
+    /** What the position is actually worth in tokens — shares times the live share ratio. */
+    private suspend fun withdrawableAmount(vault: KaminoVault, coin: Coin): BigDecimal {
+        val walletAddress = coin.address
+        val position =
+            runCatching { kaminoApi.getUserPositions(walletAddress) }
+                .getOrNull()
+                .orEmpty()
+                .firstOrNull { it.vaultAddress == vault.address }
+        val shares = KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
+        if (shares.signum() == 0) return BigDecimal.ZERO
+
+        val metrics = runCatching { kaminoApi.getVaultMetrics(vault.address) }.getOrNull()
+        val tokensPerShare =
+            KaminoPositionMath.decimalOrNull(metrics?.tokensPerShare) ?: return BigDecimal.ZERO
+        return KaminoPositionMath.tokenAmount(shares, tokensPerShare, vault.tokenDecimals)
+    }
+
+    private suspend fun resolveCoin(vault: KaminoVault): Coin {
+        val template =
+            vault.coin ?: error("No wallet coin maps to ${vault.fallbackName}'s underlying token")
+        val storedVault =
+            vaultRepository.get(route.vaultId) ?: error("Vault ${route.vaultId} not found")
+        val (address, publicKey) =
+            chainAccountAddressRepository.getAddress(Chain.Solana, storedVault)
+        return template.copy(address = address, hexPublicKey = publicKey)
+    }
+
+    fun onPercentageChange(percentage: Int) {
+        val available = _state.value.available
+        val amount =
+            available
+                .multiply(BigDecimal(percentage))
+                .divide(ONE_HUNDRED)
+                .setScale(tokenCoin?.decimal ?: DEFAULT_SCALE, RoundingMode.DOWN)
+        amountFieldState.setTextAndPlaceCursorAtEnd(amount.stripTrailingZeros().toPlainString())
+        _state.update { it.copy(percentageSelected = percentage) }
+    }
+
+    fun submit() {
+        val vault = vault ?: return
+        val coin = tokenCoin ?: return
+        val amount = amountFieldState.text.toString().toBigDecimalOrNull() ?: return
+
+        _state.update { it.copy(isSubmitting = true, error = null) }
+
+        viewModelScope.safeLaunch(
+            onError = { throwable ->
+                Timber.e(throwable, "Failed to build Kamino transaction")
+                _state.update {
+                    it.copy(
+                        isSubmitting = false,
+                        // Surface the refusal reason rather than a generic failure: a rejected
+                        // transaction means the app declined to sign something, which the user
+                        // should be able to read.
+                        error = UiText.DynamicString(throwable.message ?: ""),
+                    )
+                }
+            }
+        ) {
+            require(amount.signum() > 0) { "Amount must be greater than zero" }
+            require(amount <= _state.value.available) { "Amount exceeds the available balance" }
+            _state.value.minimum?.let { minimum ->
+                require(amount >= minimum) {
+                    "Minimum is ${minimum.stripTrailingZeros().toPlainString()} ${coin.ticker}"
+                }
+            }
+
+            val storedVault =
+                vaultRepository.get(route.vaultId) ?: error("Vault ${route.vaultId} not found")
+
+            val gasFee = TokenValue(value = SolanaHelper.DefaultFeeInLamports, token = coin)
+            val specific =
+                blockChainSpecificRepository.getSpecific(
+                    chain = Chain.Solana,
+                    address = coin.address,
+                    token = coin,
+                    gasFee = gasFee,
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                )
+
+            // Built here, at submit, so the blockhash inside it is as fresh as possible.
+            val keysignPayload =
+                buildKeysignPayload(
+                    vault = vault,
+                    action = action,
+                    amount = amount,
+                    coin = coin,
+                    blockChainSpecific = specific.blockChainSpecific,
+                    vaultPublicKeyECDSA = storedVault.pubKeyECDSA,
+                    vaultLocalPartyID = storedVault.localPartyID,
+                    libType = storedVault.libType,
+                )
+
+            val depositTx =
+                DepositTransaction(
+                    id = UUID.randomUUID().toString(),
+                    vaultId = route.vaultId,
+                    srcToken = coin,
+                    srcAddress = coin.address,
+                    srcTokenValue = TokenValue(value = keysignPayload.toAmount, token = coin),
+                    memo = "",
+                    dstAddress = vault.address,
+                    estimatedFees = gasFee,
+                    estimateFeesFiat = "",
+                    blockChainSpecific = specific.blockChainSpecific,
+                    validatorName = _state.value.vaultName,
+                    signSolana = keysignPayload.signSolana,
+                )
+            depositTransactionRepository.addTransaction(depositTx)
+
+            amountFieldState.clearText()
+            _state.update { it.copy(isSubmitting = false) }
+            navigator.route(
+                Route.VerifyDeposit(vaultId = route.vaultId, transactionId = depositTx.id)
+            )
+        }
+    }
+
+    fun dismissError() {
+        _state.update { it.copy(error = null) }
+    }
+
+    fun back() {
+        viewModelScope.safeLaunch(onError = { Timber.w(it, "back failed") }) { navigator.back() }
+    }
+
+    private companion object {
+        val ONE_HUNDRED = BigDecimal(100)
+        const val DEFAULT_SCALE = 6
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
@@ -221,6 +221,10 @@ internal fun SetupNavGraph(navController: NavHostController, startDestination: A
             com.vultisig.wallet.ui.screens.v2.defi.solana.SolanaDelegateScreen()
         }
 
+        composable<Route.KaminoAmount> {
+            com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoAmountScreen()
+        }
+
         composable<Route.SolanaUnstake> {
             com.vultisig.wallet.ui.screens.v2.defi.solana.SolanaUnstakeScreen()
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
@@ -472,6 +472,16 @@ internal sealed class Route {
     @Serializable data class SolanaDelegate(val vaultId: String)
 
     /**
+     * Kamino Earn deposit or withdraw: enter an amount for one curated vault.
+     *
+     * [vaultAddress] is the kVault, resolved against the local allow-list rather than trusted from
+     * the argument. [isWithdraw] picks the direction, since the two forms differ only in which
+     * balance they cap against and which label they carry.
+     */
+    @Serializable
+    data class KaminoAmount(val vaultId: String, val vaultAddress: String, val isWithdraw: Boolean)
+
+    /**
      * Solana "Unstake SOL" confirmation: read-only source stake account + a cooldown notice.
      * Continue deactivates the account (~1-epoch cooldown before withdraw). [delegatedStake] is the
      * account's delegated lamports (raw), shown as the amount on verify.

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -32,6 +32,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_WITHDRAW
 import com.vultisig.wallet.data.models.OPERATION_MINT
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
@@ -213,7 +215,20 @@ internal fun VerifyDepositScreen(
 
                     if (tx.validatorName.isNotEmpty()) {
                         VerifyCardDetails(
-                            title = stringResource(R.string.solana_delegate_validator),
+                            // The same field carries a validator for native staking and a vault
+                            // name
+                            // for Kamino Earn; labelling both "Validator" would misname the vault.
+                            title =
+                                stringResource(
+                                    if (
+                                        tx.operation == OPERATION_KAMINO_DEPOSIT ||
+                                            tx.operation == OPERATION_KAMINO_WITHDRAW
+                                    ) {
+                                        R.string.kamino_verify_vault
+                                    } else {
+                                        R.string.solana_delegate_validator
+                                    }
+                                ),
                             subtitle = tx.validatorName,
                         )
                         VerifyCardDivider(0.dp)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -37,6 +37,7 @@ import com.vultisig.wallet.data.models.OPERATION_KAMINO_WITHDRAW
 import com.vultisig.wallet.data.models.OPERATION_MINT
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
+import com.vultisig.wallet.ui.components.SignSolanaDisplayView
 import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
@@ -246,6 +247,17 @@ internal fun VerifyDepositScreen(
                         VerifyCardDetails(title = stringResource(R.string.pool), subtitle = tx.pool)
                         VerifyCardDivider(0.dp)
                     }
+                    // A pre-built Solana transaction — Kamino Earn, native staking — does its work
+                    // in
+                    // instructions the amount and destination rows say nothing about. Decoding them
+                    // here is what lets the person approving it, on either device of a co-signed
+                    // vault, see which programs it invokes.
+                    tx.signSolana
+                        .takeIf { it.isNotEmpty() }
+                        ?.let { rawTransactions ->
+                            SignSolanaDisplayView(rawTransactions = rawTransactions)
+                            VerifyCardDivider(0.dp)
+                        }
                     // Unbond sets dstAddress and nodeAddress to the same node address, so it
                     // already
                     // renders as the "To" row above; only show the Node address row when it adds a

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/BaseDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/BaseDeFiPositionsScreen.kt
@@ -102,6 +102,7 @@ fun BaseDeFiPositionsScreenContent(
 
 /** Tabs available in DeFi position screens. */
 enum class DeFiTab(@androidx.annotation.StringRes val displayNameRes: Int) {
+    EARN(R.string.defi_tab_earn),
     DEPOSITED(R.string.defi_tab_deposited),
     STAKED(R.string.defi_tab_staked),
     BONDED(R.string.defi_tab_bonded),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
@@ -68,9 +68,9 @@ internal fun KaminoAmountContent(
 ) {
     val amount = amountFieldState.text.toString().toBigDecimalOrNull()
 
-    // Whether the request fits the vault's liquid buffer depends on the amount, so it is recomputed
-    // as the user types rather than only at submit.
-    LaunchedEffect(amount) { onAmountChanged(amount) }
+    // Recomputed as the user types, and again when the vault's figures land: keying only on the
+    // amount left a notice decided against a buffer that had not loaded yet.
+    LaunchedEffect(amount, state.isLoading, state.available) { onAmountChanged(amount) }
 
     // A staked position is withdrawable — Kamino releases the shares from the farm as part of the
     // transaction. What remains is about the read: nothing held, or figures that cannot be trusted.
@@ -87,6 +87,9 @@ internal fun KaminoAmountContent(
         when {
             amount == null -> null
             amount.signum() <= 0 -> null
+            // While the form is loading `available` is still zero, so validating against it would
+            // tell the user every amount exceeds their balance.
+            state.isLoading -> null
             amount > state.available -> stringResource(R.string.kamino_amount_exceeds_available)
             state.minimum != null && amount < state.minimum ->
                 stringResource(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
@@ -72,12 +72,10 @@ internal fun KaminoAmountContent(
     // as the user types rather than only at submit.
     LaunchedEffect(amount) { onAmountChanged(amount) }
 
-    // A withdraw is only possible from unstaked shares. Every other state is a fact about the
-    // position, not a validation failure, so it reads as a message rather than an error.
+    // A staked position is withdrawable — Kamino releases the shares from the farm as part of the
+    // transaction. What remains is about the read: nothing held, or figures that cannot be trusted.
     val blockingReason: String? =
         when (state.eligibility) {
-            is KaminoWithdrawEligibility.FarmStaked ->
-                stringResource(R.string.kamino_withdraw_farm_staked)
             KaminoWithdrawEligibility.Empty -> stringResource(R.string.kamino_withdraw_nothing)
             KaminoWithdrawEligibility.Unreadable ->
                 stringResource(R.string.kamino_withdraw_unreadable)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
@@ -1,0 +1,126 @@
+package com.vultisig.wallet.ui.screens.v2.defi.solana
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.components.buttons.VsButtonState
+import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
+import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
+import com.vultisig.wallet.ui.models.solanastaking.KaminoAmountUiState
+import com.vultisig.wallet.ui.models.solanastaking.KaminoAmountViewModel
+import com.vultisig.wallet.ui.screens.cosmosstaking.StakingAmountCard
+import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.asString
+
+/**
+ * Amount entry for a Kamino Earn deposit or withdraw: the shared amount card with 25/50/75/Max
+ * chips over the available balance, then Continue. On Continue the ViewModel builds the transaction
+ * — memo and compute budget included — validates it, and routes to the verify screen.
+ */
+@Composable
+internal fun KaminoAmountScreen(viewModel: KaminoAmountViewModel = hiltViewModel()) {
+    val state by viewModel.state.collectAsState()
+
+    V2Scaffold(
+        title =
+            stringResource(
+                if (state.isWithdraw) R.string.kamino_withdraw_title
+                else R.string.kamino_deposit_title
+            ),
+        onBackClick = viewModel::back,
+    ) {
+        KaminoAmountContent(
+            state = state,
+            amountFieldState = viewModel.amountFieldState,
+            onPercentage = viewModel::onPercentageChange,
+            onSubmit = viewModel::submit,
+        )
+    }
+}
+
+@Composable
+internal fun KaminoAmountContent(
+    state: KaminoAmountUiState,
+    amountFieldState: TextFieldState,
+    onPercentage: (Int) -> Unit,
+    onSubmit: () -> Unit,
+) {
+    val amount = amountFieldState.text.toString().toBigDecimalOrNull()
+
+    // Over-balance first, then the vault's own floor — the order the user hits them in.
+    val validationError: String? =
+        when {
+            amount == null -> null
+            amount.signum() <= 0 -> null
+            amount > state.available -> stringResource(R.string.kamino_amount_exceeds_available)
+            state.minimum != null && amount < state.minimum ->
+                stringResource(
+                    R.string.kamino_amount_below_minimum,
+                    state.minimum.stripTrailingZeros().toPlainString(),
+                    state.ticker,
+                )
+            else -> null
+        }
+
+    val canContinue =
+        amount != null &&
+            amount.signum() > 0 &&
+            validationError == null &&
+            !state.isSubmitting &&
+            !state.isLoading
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier.fillMaxSize().padding(16.dp).padding(bottom = 80.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = state.vaultName,
+                style = Theme.brockmann.body.m.medium,
+                color = Theme.v2.colors.text.primary,
+            )
+
+            StakingAmountCard(
+                ticker = state.ticker,
+                amountFieldState = amountFieldState,
+                available = state.available,
+                percentageSelected = state.percentageSelected,
+                onPercentage = onPercentage,
+                modifier = Modifier.weight(1f),
+            )
+
+            (validationError ?: state.error?.asString())?.let { error ->
+                Text(
+                    text = error,
+                    style = Theme.brockmann.supplementary.caption,
+                    color = Theme.v2.colors.alerts.error,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+                )
+            }
+        }
+
+        VsButton(
+            label = stringResource(R.string.cosmos_staking_continue),
+            variant = VsButtonVariant.CTA,
+            state = if (canContinue) VsButtonState.Enabled else VsButtonState.Disabled,
+            isLoading = state.isSubmitting,
+            onClick = onSubmit,
+            modifier = Modifier.align(Alignment.BottomCenter).fillMaxWidth().padding(16.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -17,6 +18,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawEligibility
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawLiquidity
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
@@ -26,6 +29,7 @@ import com.vultisig.wallet.ui.models.solanastaking.KaminoAmountViewModel
 import com.vultisig.wallet.ui.screens.cosmosstaking.StakingAmountCard
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
+import java.math.BigDecimal
 
 /**
  * Amount entry for a Kamino Earn deposit or withdraw: the shared amount card with 25/50/75/Max
@@ -48,6 +52,7 @@ internal fun KaminoAmountScreen(viewModel: KaminoAmountViewModel = hiltViewModel
             state = state,
             amountFieldState = viewModel.amountFieldState,
             onPercentage = viewModel::onPercentageChange,
+            onAmountChanged = viewModel::onAmountChanged,
             onSubmit = viewModel::submit,
         )
     }
@@ -58,9 +63,26 @@ internal fun KaminoAmountContent(
     state: KaminoAmountUiState,
     amountFieldState: TextFieldState,
     onPercentage: (Int) -> Unit,
+    onAmountChanged: (BigDecimal?) -> Unit = {},
     onSubmit: () -> Unit,
 ) {
     val amount = amountFieldState.text.toString().toBigDecimalOrNull()
+
+    // Whether the request fits the vault's liquid buffer depends on the amount, so it is recomputed
+    // as the user types rather than only at submit.
+    LaunchedEffect(amount) { onAmountChanged(amount) }
+
+    // A withdraw is only possible from unstaked shares. Every other state is a fact about the
+    // position, not a validation failure, so it reads as a message rather than an error.
+    val blockingReason: String? =
+        when (state.eligibility) {
+            is KaminoWithdrawEligibility.FarmStaked ->
+                stringResource(R.string.kamino_withdraw_farm_staked)
+            KaminoWithdrawEligibility.Empty -> stringResource(R.string.kamino_withdraw_nothing)
+            KaminoWithdrawEligibility.Unreadable ->
+                stringResource(R.string.kamino_withdraw_unreadable)
+            else -> null
+        }
 
     // Over-balance first, then the vault's own floor — the order the user hits them in.
     val validationError: String? =
@@ -81,6 +103,7 @@ internal fun KaminoAmountContent(
         amount != null &&
             amount.signum() > 0 &&
             validationError == null &&
+            blockingReason == null &&
             !state.isSubmitting &&
             !state.isLoading
 
@@ -104,11 +127,30 @@ internal fun KaminoAmountContent(
                 modifier = Modifier.weight(1f),
             )
 
-            (validationError ?: state.error?.asString())?.let { error ->
+            (blockingReason ?: validationError ?: state.error?.asString())?.let { message ->
                 Text(
-                    text = error,
+                    text = message,
                     style = Theme.brockmann.supplementary.caption,
                     color = Theme.v2.colors.alerts.error,
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+                )
+            }
+
+            // Ordinary information about the vault, not a failure: the liquid buffer is well under
+            // 1% of assets, so a withdraw exceeding it is the common case.
+            (state.liquidity as? KaminoWithdrawLiquidity.Delayed)?.let { delayed ->
+                Text(
+                    text =
+                        stringResource(
+                            R.string.kamino_withdraw_delayed,
+                            BigDecimal(delayed.available.baseUnits)
+                                .movePointLeft(delayed.available.decimals)
+                                .stripTrailingZeros()
+                                .toPlainString(),
+                            state.ticker,
+                        ),
+                    style = Theme.brockmann.supplementary.caption,
+                    color = Theme.v2.colors.alerts.warning,
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
                 )
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
@@ -1,0 +1,464 @@
+package com.vultisig.wallet.ui.screens.v2.defi.solana
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.models.getCoinLogo
+import com.vultisig.wallet.ui.components.TokenLogo
+import com.vultisig.wallet.ui.components.UiHorizontalDivider
+import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
+import com.vultisig.wallet.ui.screens.v2.defi.ActionButton
+import com.vultisig.wallet.ui.screens.v2.defi.FIAT_VALUE_UNAVAILABLE
+import com.vultisig.wallet.ui.screens.v2.defi.InfoItem
+import com.vultisig.wallet.ui.theme.Theme
+import java.math.BigDecimal
+
+private val HIDE_BALANCE_CHARS = "• ".repeat(6).trim()
+
+/**
+ * Picker for which curated vaults the Earn tab shows.
+ *
+ * Without this the tab has no way to be populated at all — the opt-in gates every card, so the
+ * feature is unreachable until the user can turn a vault on.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun KaminoVaultPickerSheet(
+    selected: Set<String>,
+    onToggle: (String, Boolean) -> Unit,
+    onDone: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+        containerColor = Theme.v2.colors.backgrounds.primary,
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.kamino_earn_title),
+                style = Theme.brockmann.headings.title3,
+                color = Theme.v2.colors.text.primary,
+            )
+
+            KaminoVaultRegistry.ALLOW_LIST.forEach { vault ->
+                val isSelected = vault.address in selected
+                Row(
+                    modifier =
+                        Modifier.fillMaxWidth()
+                            .kaminoCard()
+                            .clickable { onToggle(vault.address, !isSelected) }
+                            .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = vault.fallbackName,
+                            style = Theme.brockmann.body.m.medium,
+                            color = Theme.v2.colors.text.primary,
+                        )
+                        Text(
+                            text = stringResource(R.string.kamino_earn_curated_by, vault.curator),
+                            style = Theme.brockmann.body.s.medium,
+                            color = Theme.v2.colors.text.tertiary,
+                        )
+                    }
+
+                    Text(
+                        text = stringResource(vault.riskTier.labelRes),
+                        style = Theme.brockmann.supplementary.caption,
+                        color = vault.riskTier.labelColor(),
+                    )
+
+                    UiSpacer(12.dp)
+
+                    Checkbox(checked = isSelected, onCheckedChange = null)
+                }
+            }
+
+            VsButton(
+                label = stringResource(R.string.save_changes),
+                onClick = onDone,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+/** The Kamino Earn segment: a total across enabled vaults, then one card each. */
+@Composable
+internal fun KaminoEarnTabContent(
+    state: KaminoEarnUiModel,
+    onDeposit: (String) -> Unit,
+    onWithdraw: (String) -> Unit,
+    emptyState: @Composable () -> Unit,
+) {
+    when {
+        state.rows.isNotEmpty() || state.hasEnabledVaults ->
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                KaminoEarnTotalCard(
+                    totalFiat = state.totalFiat,
+                    isLoading = state.isLoading && state.totalFiat == null,
+                    isBalanceVisible = state.isBalanceVisible,
+                )
+
+                state.rows.forEach { row ->
+                    KaminoVaultCard(
+                        row = row,
+                        isLoading = state.isLoading,
+                        isBalanceVisible = state.isBalanceVisible,
+                        onDeposit = { onDeposit(row.vaultAddress) },
+                        onWithdraw = { onWithdraw(row.vaultAddress) },
+                    )
+                }
+            }
+
+        else -> emptyState()
+    }
+}
+
+@Composable
+private fun KaminoEarnTotalCard(totalFiat: String?, isLoading: Boolean, isBalanceVisible: Boolean) {
+    Column(modifier = Modifier.kaminoCard().padding(16.dp)) {
+        Text(
+            text = stringResource(R.string.kamino_earn_title),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.tertiary,
+        )
+
+        UiSpacer(2.dp)
+
+        when {
+            isLoading ->
+                UiPlaceholderLoader(modifier = Modifier.size(width = 120.dp, height = 28.dp))
+            else ->
+                Text(
+                    text =
+                        when {
+                            !isBalanceVisible -> HIDE_BALANCE_CHARS
+                            else -> totalFiat ?: FIAT_VALUE_UNAVAILABLE
+                        },
+                    style = Theme.brockmann.headings.title1,
+                    color = Theme.v2.colors.text.primary,
+                )
+        }
+    }
+}
+
+@Composable
+private fun KaminoVaultCard(
+    row: KaminoEarnRow,
+    isLoading: Boolean,
+    isBalanceVisible: Boolean,
+    onDeposit: () -> Unit,
+    onWithdraw: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.kaminoCard().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        VaultIdentityRow(row)
+
+        UiHorizontalDivider()
+
+        DepositedRow(row = row, isBalanceVisible = isBalanceVisible)
+
+        ApyRow(apyDisplay = row.apyDisplay, isLoading = isLoading)
+
+        PnlRow(row = row, isLoading = isLoading, isBalanceVisible = isBalanceVisible)
+
+        VaultActions(
+            hasPosition = row.fiatValue.signum() > 0,
+            onDeposit = onDeposit,
+            onWithdraw = onWithdraw,
+        )
+    }
+}
+
+@Composable
+private fun VaultIdentityRow(row: KaminoEarnRow) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        TokenLogo(
+            // The row carries the logo *name*; Coil needs it resolved to a drawable or it renders
+            // nothing at all.
+            logo = getCoinLogo(row.tokenLogo),
+            title = row.tokenTicker,
+            modifier = Modifier.size(36.dp),
+            errorLogoModifier = Modifier.size(36.dp).clip(Theme.v2.radius.pill),
+        )
+
+        UiSpacer(12.dp)
+
+        Column(modifier = Modifier.weight(1f)) {
+            // The risk tier shares the name's line rather than the curator's. "Curated by
+            // Steakhouse Financial" needs nearly the full width, so pairing the tier with it
+            // truncated the curator while the name line beside it sat half empty. The tier is two
+            // short fixed strings, so the name is the one that yields.
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = row.name,
+                    style = Theme.brockmann.body.m.medium,
+                    color = Theme.v2.colors.text.primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+
+                UiSpacer(8.dp)
+
+                Text(
+                    text = stringResource(row.riskTier.labelRes),
+                    style = Theme.brockmann.supplementary.caption,
+                    color = row.riskTier.labelColor(),
+                    maxLines = 1,
+                )
+            }
+
+            UiSpacer(2.dp)
+
+            Text(
+                text = stringResource(R.string.kamino_earn_curated_by, row.curator),
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.tertiary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun DepositedRow(row: KaminoEarnRow, isBalanceVisible: Boolean) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = stringResource(R.string.kamino_earn_deposited),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.tertiary,
+        )
+
+        UiSpacer(1f)
+
+        // A deposit of zero is a real value, so this is never placeheld — unlike APY and PnL, which
+        // are genuinely absent until their calls answer.
+        Column(horizontalAlignment = Alignment.End) {
+            Text(
+                text = if (isBalanceVisible) row.depositedDisplay else HIDE_BALANCE_CHARS,
+                style = Theme.brockmann.body.m.medium,
+                color = Theme.v2.colors.text.primary,
+                textAlign = TextAlign.End,
+            )
+
+            Text(
+                text =
+                    when {
+                        !isBalanceVisible -> HIDE_BALANCE_CHARS
+                        else -> row.depositedFiat ?: FIAT_VALUE_UNAVAILABLE
+                    },
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.text.tertiary,
+                textAlign = TextAlign.End,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ApyRow(apyDisplay: String?, isLoading: Boolean) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        InfoItem(
+            icon = R.drawable.ic_icon_percentage,
+            label = stringResource(R.string.kamino_earn_apy_30d),
+            value = null,
+        )
+
+        UiSpacer(1f)
+
+        when {
+            apyDisplay != null ->
+                Text(
+                    text = apyDisplay,
+                    style = Theme.brockmann.body.m.medium,
+                    color = Theme.v2.colors.alerts.success,
+                )
+            // Sized to the value it stands in for, so the row does not resize when the number
+            // lands.
+            isLoading ->
+                UiPlaceholderLoader(modifier = Modifier.size(width = 54.dp, height = 14.dp))
+            else ->
+                Text(
+                    text = FIAT_VALUE_UNAVAILABLE,
+                    style = Theme.brockmann.body.m.medium,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+        }
+    }
+}
+
+@Composable
+private fun PnlRow(row: KaminoEarnRow, isLoading: Boolean, isBalanceVisible: Boolean) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = stringResource(R.string.kamino_earn_pnl),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.tertiary,
+        )
+
+        UiSpacer(1f)
+
+        when {
+            row.pnlDisplay != null ->
+                Text(
+                    text = if (isBalanceVisible) row.pnlDisplay else HIDE_BALANCE_CHARS,
+                    style = Theme.brockmann.supplementary.caption,
+                    color = row.pnlDirection.color(),
+                )
+            isLoading ->
+                UiPlaceholderLoader(modifier = Modifier.size(width = 72.dp, height = 14.dp))
+            else ->
+                Text(
+                    text = FIAT_VALUE_UNAVAILABLE,
+                    style = Theme.brockmann.supplementary.caption,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+        }
+    }
+}
+
+@Composable
+private fun VaultActions(hasPosition: Boolean, onDeposit: () -> Unit, onWithdraw: () -> Unit) {
+    // Withdraw only appears once there is something to withdraw; an untouched vault offers the one
+    // action that makes sense, across the full width.
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        if (hasPosition) {
+            ActionButton(
+                title = stringResource(R.string.withdraw),
+                icon = R.drawable.circle_minus,
+                background = Theme.v2.colors.backgrounds.tertiary,
+                contentColor = Theme.v2.colors.text.primary,
+                iconCircleColor = Theme.v2.colors.backgrounds.secondary,
+                modifier = Modifier.weight(1f),
+                onClick = onWithdraw,
+            )
+        }
+
+        ActionButton(
+            title = stringResource(R.string.kamino_earn_deposit),
+            icon = R.drawable.circle_plus,
+            background = Theme.v2.colors.primary.accent4,
+            contentColor = Theme.v2.colors.text.primary,
+            iconCircleColor = Theme.v2.colors.primary.accent3,
+            modifier = Modifier.weight(1f),
+            onClick = onDeposit,
+        )
+    }
+}
+
+@Composable
+private fun Modifier.kaminoCard(): Modifier =
+    fillMaxWidth()
+        .clip(Theme.v2.radius.xl)
+        .background(Theme.v2.colors.backgrounds.secondary)
+        .border(width = 1.dp, color = Theme.v2.colors.border.light, shape = Theme.v2.radius.xl)
+
+private val KaminoRiskTier.labelRes: Int
+    get() =
+        when (this) {
+            KaminoRiskTier.CONSERVATIVE -> R.string.kamino_earn_risk_conservative
+            KaminoRiskTier.PRIVATE_CREDIT -> R.string.kamino_earn_risk_private_credit
+        }
+
+@Composable
+private fun KaminoRiskTier.labelColor(): Color =
+    when (this) {
+        KaminoRiskTier.CONSERVATIVE -> Theme.v2.colors.text.tertiary
+        // Lending against tokenized private credit is a materially different risk and must not read
+        // as the same product as the plain lending vaults.
+        KaminoRiskTier.PRIVATE_CREDIT -> Theme.v2.colors.alerts.warning
+    }
+
+@Composable
+private fun KaminoEarnRow.PnlDirection.color(): Color =
+    when (this) {
+        KaminoEarnRow.PnlDirection.UP -> Theme.v2.colors.alerts.success
+        KaminoEarnRow.PnlDirection.DOWN -> Theme.v2.colors.alerts.error
+        // Every vault the user never deposited into sits at zero; green would read as a gain.
+        KaminoEarnRow.PnlDirection.FLAT -> Theme.v2.colors.text.primary
+    }
+
+@Preview(showBackground = true)
+@Composable
+private fun KaminoEarnTabContentPreview() {
+    KaminoEarnTabContent(
+        state =
+            KaminoEarnUiModel(
+                hasEnabledVaults = true,
+                totalFiat = "$3,010.77",
+                rows =
+                    listOf(
+                        KaminoEarnRow(
+                            vaultAddress = "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",
+                            name = "Steakhouse USDC",
+                            curator = "Steakhouse Financial",
+                            riskTier = KaminoRiskTier.CONSERVATIVE,
+                            tokenLogo = "usdc",
+                            tokenTicker = "USDC",
+                            depositedDisplay = "1000 USDC",
+                            depositedFiat = "$1,000.23",
+                            apyDisplay = "4.00%",
+                            pnlDisplay = "200 USDC",
+                            pnlDirection = KaminoEarnRow.PnlDirection.UP,
+                            fiatValue = BigDecimal("1000.23"),
+                        ),
+                        KaminoEarnRow(
+                            vaultAddress = "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",
+                            name = "RWA USDC",
+                            curator = "RockawayX",
+                            riskTier = KaminoRiskTier.PRIVATE_CREDIT,
+                            tokenLogo = "usdc",
+                            tokenTicker = "USDC",
+                            depositedDisplay = "0 USDC",
+                            depositedFiat = "$0.00",
+                            apyDisplay = "5.88%",
+                            pnlDisplay = "0 USDC",
+                            pnlDirection = KaminoEarnRow.PnlDirection.FLAT,
+                            fiatValue = BigDecimal.ZERO,
+                        ),
+                    ),
+            ),
+        onDeposit = {},
+        onWithdraw = {},
+        emptyState = {},
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
@@ -337,7 +337,17 @@ private fun ApyRow(apyDisplay: String?, isLoading: Boolean) {
 private fun PnlRow(row: KaminoEarnRow, isLoading: Boolean, isBalanceVisible: Boolean) {
     Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
         Text(
-            text = stringResource(R.string.kamino_earn_pnl),
+            // Below zero this reads "Lost", not "Earned": the source is totalPnl, which goes
+            // negative, and "Earned: -3 USDC" asserts the loss was earned and leaves the colour to
+            // correct it.
+            text =
+                stringResource(
+                    if (row.pnlDirection == KaminoEarnRow.PnlDirection.DOWN) {
+                        R.string.kamino_earn_lost
+                    } else {
+                        R.string.kamino_earn_pnl
+                    }
+                ),
             style = Theme.brockmann.body.s.medium,
             color = Theme.v2.colors.text.tertiary,
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
@@ -2,13 +2,13 @@ package com.vultisig.wallet.ui.screens.v2.defi.solana
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -76,7 +77,11 @@ internal fun KaminoVaultPickerSheet(
                     modifier =
                         Modifier.fillMaxWidth()
                             .kaminoCard()
-                            .clickable { onToggle(vault.address, !isSelected) }
+                            .toggleable(
+                                value = isSelected,
+                                role = Role.Checkbox,
+                                onValueChange = { onToggle(vault.address, it) },
+                            )
                             .padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -200,7 +205,9 @@ private fun KaminoVaultCard(
         PnlRow(row = row, isLoading = isLoading, isBalanceVisible = isBalanceVisible)
 
         VaultActions(
-            hasPosition = row.fiatValue.signum() > 0,
+            // Gated on the position itself, not its fiat value: a failed price lookup leaves
+            // fiatValue at zero, and hiding Withdraw then would strand a real balance.
+            hasPosition = row.hasPosition,
             onDeposit = onDeposit,
             onWithdraw = onWithdraw,
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
@@ -198,11 +198,19 @@ private fun KaminoVaultCard(
 
         UiHorizontalDivider()
 
-        DepositedRow(row = row, isBalanceVisible = isBalanceVisible)
+        // A vault read as holding nothing describes no position, and rows of zeros describe nothing
+        // — so the figures go and Deposit takes the full width, as the design draws an empty card.
+        // An *unread* position keeps them: not knowing is not the same as knowing there is nothing.
+        if (row.hasPosition) {
+            DepositedRow(row = row, isBalanceVisible = isBalanceVisible)
+        }
 
+        // APY is a property of the vault rather than of the position, so it stays either way.
         ApyRow(apyDisplay = row.apyDisplay, isLoading = isLoading)
 
-        PnlRow(row = row, isLoading = isLoading, isBalanceVisible = isBalanceVisible)
+        if (row.hasPosition) {
+            PnlRow(row = row, isLoading = isLoading, isBalanceVisible = isBalanceVisible)
+        }
 
         VaultActions(
             // Gated on the position itself, not its fiat value: a failed price lookup leaves

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
@@ -139,6 +139,15 @@ internal fun KaminoEarnTabContent(
                     isBalanceVisible = state.isBalanceVisible,
                 )
 
+                if (state.loadFailed) {
+                    Text(
+                        text = stringResource(R.string.kamino_earn_load_failed),
+                        style = Theme.brockmann.supplementary.caption,
+                        color = Theme.v2.colors.alerts.warning,
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp),
+                    )
+                }
+
                 state.rows.forEach { row ->
                     KaminoVaultCard(
                         row = row,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
@@ -17,6 +17,8 @@ data class KaminoEarnUiModel(
     /** Summed across vaults in the user's currency; null while unresolved. */
     val totalFiat: String? = null,
     val isBalanceVisible: Boolean = true,
+    /** Whether the last load stopped on an error, so the tab can say so rather than look empty. */
+    val loadFailed: Boolean = false,
     val isShowingPicker: Boolean = false,
     /**
      * The selection being edited in the picker, which only becomes the saved one on Done — so

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
@@ -1,0 +1,66 @@
+package com.vultisig.wallet.ui.screens.v2.defi.solana
+
+import androidx.compose.runtime.Immutable
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
+import java.math.BigDecimal
+
+/** State of the Kamino Earn segment of the Solana DeFi tab. */
+@Immutable
+data class KaminoEarnUiModel(
+    val isLoading: Boolean = false,
+    /**
+     * Whether the user has switched any vault on. Distinct from [rows] being empty: an enabled
+     * vault the user has never deposited into still gets a card showing a zero balance.
+     */
+    val hasEnabledVaults: Boolean = false,
+    val rows: List<KaminoEarnRow> = emptyList(),
+    /** Summed across vaults in the user's currency; null while unresolved. */
+    val totalFiat: String? = null,
+    val isBalanceVisible: Boolean = true,
+    val isShowingPicker: Boolean = false,
+    /**
+     * The selection being edited in the picker, which only becomes the saved one on Done — so
+     * dismissing the sheet leaves the enabled vaults untouched.
+     */
+    val pendingSelection: Set<String> = emptySet(),
+)
+
+/** One curated vault's card. */
+@Immutable
+data class KaminoEarnRow(
+    val vaultAddress: String,
+    /** Live vault name when the API answered, otherwise the pinned fallback. */
+    val name: String,
+    val curator: String,
+    val riskTier: KaminoRiskTier,
+    val tokenLogo: String,
+    val tokenTicker: String,
+    /**
+     * Deposited amount with its ticker. Always present — a position of zero is a real value, so
+     * this is never placeheld the way [apyDisplay] and [pnlDisplay] are.
+     */
+    val depositedDisplay: String,
+    val depositedFiat: String?,
+    /** 30-day APY, already a percentage. Null while the metrics call is outstanding or failed. */
+    val apyDisplay: String?,
+    /** Lifetime profit in token terms. Null while the PnL call is outstanding or failed. */
+    val pnlDisplay: String?,
+    val pnlDirection: PnlDirection,
+    /**
+     * The row's fiat value, kept alongside its formatted form so the screen total can be summed
+     * without re-parsing display strings. Zero when the position or its price is unresolved.
+     */
+    val fiatValue: BigDecimal = BigDecimal.ZERO,
+) {
+    /**
+     * Which way the position moved, kept out of the view so the zero case is decided once.
+     *
+     * Zero is deliberately its own state rather than folded into positive: every vault the user has
+     * never deposited into sits at zero, and painting that green reads as a gain.
+     */
+    enum class PnlDirection {
+        UP,
+        DOWN,
+        FLAT,
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
@@ -51,6 +51,12 @@ data class KaminoEarnRow(
      * without re-parsing display strings. Zero when the position or its price is unresolved.
      */
     val fiatValue: BigDecimal = BigDecimal.ZERO,
+    /**
+     * Whether the wallet actually holds shares here. Kept separate from [fiatValue] because a
+     * failed price lookup leaves that at zero, and a position must not disappear because it could
+     * not be priced.
+     */
+    val hasPosition: Boolean = false,
 ) {
     /**
      * Which way the position moved, kept out of the view so the zero case is decided once.

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -321,7 +321,9 @@ constructor(
             apyDisplay = apy?.let { "${it.toPlainString()}%" },
             pnlDisplay =
                 pnlToken?.let {
-                    val amount = it.setScale(vault.tokenDecimals, RoundingMode.DOWN)
+                    // Unsigned: the row's label already says whether this was earned or lost, so a
+                    // minus sign in front of "Lost" would state it twice.
+                    val amount = it.abs().setScale(vault.tokenDecimals, RoundingMode.DOWN)
                     "${amount.stripTrailingZeros().toPlainString()} ${coin?.ticker.orEmpty()}"
                         .trim()
                 },
@@ -335,8 +337,14 @@ constructor(
             fiatValue =
                 tokenAmount?.let { amount -> coin?.let { fiatValueOrNull(amount, it) } }
                     ?: BigDecimal.ZERO,
-            // Derived from the shares, so a vault that could not be priced still offers Withdraw.
-            hasPosition = (shares?.signum() ?: 0) > 0,
+            // Two different claims live in a zero here: "read, and holds nothing" and "not read
+            // yet". Only the first may remove Withdraw. Hiding it on an unread position strands a
+            // user who deposited on another device, or whose refresh failed right after depositing
+            // —
+            // the way out of a position is never removed on the strength of a read that has not
+            // happened. The withdraw form reads the position itself and can say "nothing to
+            // withdraw" truthfully.
+            hasPosition = shares == null || shares.signum() > 0,
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -21,6 +21,7 @@ import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.FIAT_VALUE_UNAVAILABLE
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -206,7 +207,8 @@ constructor(
                                         buildRow(
                                             vault = vault,
                                             walletAddress = walletAddress,
-                                            position = positions[vault.address],
+                                            position = positions?.get(vault.address),
+                                            positionsAreKnown = positions != null,
                                         )
                                     }
                                     .getOrElse { throwable ->
@@ -227,8 +229,12 @@ constructor(
                     current.copy(
                         isLoading = false,
                         // Keep the previous rows if every vault failed, rather than blanking
-                        // positions the user holds because one refresh did not land.
-                        rows = resolved.ifEmpty { current.rows },
+                        // positions the user holds because one refresh did not land — but only for
+                        // vaults still enabled, or disabling one would leave its card on screen.
+                        rows =
+                            resolved.ifEmpty {
+                                current.rows.filter { row -> row.vaultAddress in enabled }
+                            },
                         totalFiat =
                             resolved
                                 .takeIf { it.isNotEmpty() }
@@ -243,20 +249,27 @@ constructor(
      * Positions for the whole wallet in one call, keyed by vault. An address holding nothing
      * returns an empty list, which is a real answer rather than a failure.
      */
-    private suspend fun fetchPositions(walletAddress: String): Map<String, KaminoUserPositionJson> =
+    private suspend fun fetchPositions(
+        walletAddress: String
+    ): Map<String, KaminoUserPositionJson>? =
         withContext(ioDispatcher) {
+            // Null, not empty: an empty list is the wallet genuinely holding nothing, while a
+            // failed
+            // call is not knowing. Collapsing the two would render a real position as "0 USDC",
+            // which reads as a lost deposit.
             runCatching { kaminoApi.getUserPositions(walletAddress) }
                 .getOrElse { throwable ->
                     Timber.e(throwable, "Failed to load Kamino positions")
-                    emptyList()
+                    null
                 }
-                .associateBy { it.vaultAddress }
+                ?.associateBy { it.vaultAddress }
         }
 
     private suspend fun buildRow(
         vault: KaminoVault,
         walletAddress: String,
         position: KaminoUserPositionJson?,
+        positionsAreKnown: Boolean,
     ): KaminoEarnRow = supervisorScope {
         val stateDeferred = async {
             runCatching { kaminoApi.getVaultState(vault.address) }.getOrNull()
@@ -272,11 +285,18 @@ constructor(
         val metrics = metricsDeferred.await()
         val pnl = pnlDeferred.await()
 
-        val shares = KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
+        // A position that could not be read is not a zero one. Null keeps the balance blank rather
+        // than asserting "0", which on a real deposit reads as though it had gone.
+        val shares =
+            if (positionsAreKnown) {
+                KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
+            } else {
+                null
+            }
         val tokensPerShare = KaminoPositionMath.decimalOrNull(metrics?.tokensPerShare)
         val tokenAmount =
-            if (tokensPerShare == null) {
-                BigDecimal.ZERO.setScale(vault.tokenDecimals)
+            if (tokensPerShare == null || shares == null) {
+                null
             } else {
                 KaminoPositionMath.tokenAmount(shares, tokensPerShare, vault.tokenDecimals)
             }
@@ -294,9 +314,10 @@ constructor(
             tokenLogo = coin?.logo.orEmpty(),
             tokenTicker = coin?.ticker.orEmpty(),
             depositedDisplay =
-                "${tokenAmount.stripTrailingZeros().toPlainString()} ${coin?.ticker.orEmpty()}"
-                    .trim(),
-            depositedFiat = coin?.let { fiatOrNull(tokenAmount, it) },
+                tokenAmount?.let {
+                    "${it.stripTrailingZeros().toPlainString()} ${coin?.ticker.orEmpty()}".trim()
+                } ?: FIAT_VALUE_UNAVAILABLE,
+            depositedFiat = tokenAmount?.let { amount -> coin?.let { fiatOrNull(amount, it) } },
             apyDisplay = apy?.let { "${it.toPlainString()}%" },
             pnlDisplay =
                 pnlToken?.let {
@@ -311,7 +332,11 @@ constructor(
                     pnlToken.signum() < 0 -> KaminoEarnRow.PnlDirection.DOWN
                     else -> KaminoEarnRow.PnlDirection.FLAT
                 },
-            fiatValue = coin?.let { fiatValueOrNull(tokenAmount, it) } ?: BigDecimal.ZERO,
+            fiatValue =
+                tokenAmount?.let { amount -> coin?.let { fiatValueOrNull(amount, it) } }
+                    ?: BigDecimal.ZERO,
+            // Derived from the shares, so a vault that could not be priced still offers Withdraw.
+            hasPosition = (shares?.signum() ?: 0) > 0,
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -72,8 +72,32 @@ constructor(
 
     fun setData(vaultId: String) {
         this.vaultId = vaultId
+        forgetStoredShareTokens()
         loadBalanceVisibility()
         observeSelection()
+    }
+
+    /**
+     * Removes any vault-share token a previous version auto-discovered as a wallet balance.
+     *
+     * Filtering discovery stops new ones arriving, but a wallet that already held shares when it
+     * last scanned has them saved — and left there they count the same deposit twice, once as a
+     * position and once as a token. Idempotent, and a no-op for everyone who never had one.
+     */
+    private fun forgetStoredShareTokens() {
+        viewModelScope.safeLaunch(
+            onError = { Timber.w(it, "Could not sweep stored Kamino share tokens") }
+        ) {
+            withContext(ioDispatcher) {
+                val vault = vaultRepository.get(vaultId) ?: return@withContext
+                vault.coins
+                    .filter { coin ->
+                        coin.chain == Chain.Solana &&
+                            coin.contractAddress in KaminoVaultRegistry.SHARES_MINTS
+                    }
+                    .forEach { coin -> vaultRepository.deleteTokenFromVault(vaultId, coin) }
+            }
+        }
     }
 
     fun refresh() {
@@ -173,7 +197,9 @@ constructor(
             viewModelScope.safeLaunch(
                 onError = { throwable ->
                     Timber.e(throwable, "Failed to load Kamino Earn positions")
-                    _state.update { it.copy(isLoading = false) }
+                    // Said on screen, not only in the log: a silent stop leaves the tab looking as
+                    // though the vaults simply hold nothing.
+                    _state.update { it.copy(isLoading = false, loadFailed = true) }
                 }
             ) {
                 val enabled = selected ?: selectionRepository.getSelectedVaults(vaultId).first()
@@ -191,7 +217,9 @@ constructor(
                     return@safeLaunch
                 }
 
-                _state.update { it.copy(isLoading = true, hasEnabledVaults = true) }
+                _state.update {
+                    it.copy(isLoading = true, hasEnabledVaults = true, loadFailed = false)
+                }
 
                 val walletAddress = resolveSolanaAddress()
                 val positions = fetchPositions(walletAddress)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -1,0 +1,359 @@
+package com.vultisig.wallet.ui.screens.v2.defi.solana
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vultisig.wallet.data.IoDispatcher
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoPositionMath
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVault
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.blockchain.solana.kamino.coin
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.KaminoVaultSelectionRepository
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import dagger.hilt.android.lifecycle.HiltViewModel
+import java.math.BigDecimal
+import java.math.RoundingMode
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Drives the Kamino Earn segment of the Solana DeFi tab.
+ *
+ * Cards are gated on the per-vault opt-in and, once enabled, always render: a vault with no deposit
+ * still gets a card at zero. A refresh replaces values in place rather than clearing them first, so
+ * a failed poll leaves the last known figures on screen instead of blanking a position the user
+ * holds.
+ */
+@HiltViewModel
+internal class KaminoEarnViewModel
+@Inject
+constructor(
+    private val navigator: Navigator<Destination>,
+    private val kaminoApi: KaminoApi,
+    private val selectionRepository: KaminoVaultSelectionRepository,
+    private val vaultRepository: VaultRepository,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val tokenPriceRepository: TokenPriceRepository,
+    private val appCurrencyRepository: AppCurrencyRepository,
+    private val balanceVisibilityRepository: BalanceVisibilityRepository,
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(KaminoEarnUiModel())
+    val state: StateFlow<KaminoEarnUiModel> = _state.asStateFlow()
+
+    private lateinit var vaultId: String
+    private var loadJob: Job? = null
+    private var selectionJob: Job? = null
+
+    fun setData(vaultId: String) {
+        this.vaultId = vaultId
+        loadBalanceVisibility()
+        observeSelection()
+    }
+
+    fun refresh() {
+        if (::vaultId.isInitialized) load()
+    }
+
+    /** Opens the vault picker, seeded with whatever is currently enabled. */
+    fun openPicker() {
+        viewModelScope.safeLaunch {
+            val current = selectionRepository.getSelectedVaults(vaultId).first()
+            _state.update { it.copy(isShowingPicker = true, pendingSelection = current) }
+        }
+    }
+
+    /** Dismisses the picker without saving. */
+    fun closePicker() {
+        _state.update { it.copy(isShowingPicker = false) }
+    }
+
+    fun onVaultToggled(vaultAddress: String, isSelected: Boolean) {
+        if (!KaminoVaultRegistry.isAllowed(vaultAddress)) return
+        _state.update { current ->
+            current.copy(
+                pendingSelection =
+                    if (isSelected) current.pendingSelection + vaultAddress
+                    else current.pendingSelection - vaultAddress
+            )
+        }
+    }
+
+    /**
+     * Persists the edited selection. Saving an empty set is how the user turns Kamino Earn off, and
+     * the repository records that as a real choice rather than falling back to the default.
+     */
+    fun savePicker() {
+        val pending = _state.value.pendingSelection
+        _state.update { it.copy(isShowingPicker = false) }
+        viewModelScope.safeLaunch {
+            withContext(ioDispatcher) { selectionRepository.saveSelectedVaults(vaultId, pending) }
+            // The selection flow re-emits and reloads, so nothing else has to be refreshed here.
+        }
+    }
+
+    /** Opens the deposit form for [vaultAddress]. */
+    fun onDeposit(vaultId: String, vaultAddress: String) =
+        openAmountForm(vaultId, vaultAddress, isWithdraw = false)
+
+    /** Opens the withdraw form for [vaultAddress]. */
+    fun onWithdraw(vaultId: String, vaultAddress: String) =
+        openAmountForm(vaultId, vaultAddress, isWithdraw = true)
+
+    private fun openAmountForm(vaultId: String, vaultAddress: String, isWithdraw: Boolean) {
+        // Refuse to route at all for a vault the app does not curate, rather than letting the form
+        // open and fail there.
+        if (!KaminoVaultRegistry.isAllowed(vaultAddress)) {
+            Timber.e("Refusing to open a Kamino form for uncurated vault %s", vaultAddress)
+            return
+        }
+        viewModelScope.safeLaunch {
+            navigator.route(
+                Route.KaminoAmount(
+                    vaultId = vaultId,
+                    vaultAddress = vaultAddress,
+                    isWithdraw = isWithdraw,
+                )
+            )
+        }
+    }
+
+    private fun loadBalanceVisibility() {
+        viewModelScope.safeLaunch {
+            val isVisible =
+                withContext(ioDispatcher) { balanceVisibilityRepository.getVisibility(vaultId) }
+            _state.update { it.copy(isBalanceVisible = isVisible) }
+        }
+    }
+
+    /**
+     * Reloads whenever the opt-in changes, so toggling a vault under Manage positions takes effect
+     * without leaving the screen.
+     */
+    private fun observeSelection() {
+        selectionJob?.cancel()
+        selectionJob =
+            viewModelScope.safeLaunch {
+                selectionRepository.getSelectedVaults(vaultId).distinctUntilChanged().collect {
+                    selected ->
+                    _state.update { it.copy(hasEnabledVaults = selected.isNotEmpty()) }
+                    load(selected)
+                }
+            }
+    }
+
+    private fun load(selected: Set<String>? = null) {
+        loadJob?.cancel()
+        loadJob =
+            viewModelScope.safeLaunch(
+                onError = { throwable ->
+                    Timber.e(throwable, "Failed to load Kamino Earn positions")
+                    _state.update { it.copy(isLoading = false) }
+                }
+            ) {
+                val enabled = selected ?: selectionRepository.getSelectedVaults(vaultId).first()
+                val vaults = KaminoVaultRegistry.ALLOW_LIST.filter { it.address in enabled }
+
+                if (vaults.isEmpty()) {
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            hasEnabledVaults = false,
+                            rows = emptyList(),
+                            totalFiat = null,
+                        )
+                    }
+                    return@safeLaunch
+                }
+
+                _state.update { it.copy(isLoading = true, hasEnabledVaults = true) }
+
+                val walletAddress = resolveSolanaAddress()
+                val positions = fetchPositions(walletAddress)
+                val currencyFormat =
+                    withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
+
+                // Each vault is independent: one failing call must not empty the other cards.
+                val rows = supervisorScope {
+                    vaults
+                        .map { vault ->
+                            async(ioDispatcher) {
+                                runCatching {
+                                        buildRow(
+                                            vault = vault,
+                                            walletAddress = walletAddress,
+                                            position = positions[vault.address],
+                                        )
+                                    }
+                                    .getOrElse { throwable ->
+                                        Timber.e(
+                                            throwable,
+                                            "Failed to build Kamino row for %s",
+                                            vault.address,
+                                        )
+                                        null
+                                    }
+                            }
+                        }
+                        .awaitAll()
+                }
+
+                val resolved = rows.filterNotNull()
+                _state.update { current ->
+                    current.copy(
+                        isLoading = false,
+                        // Keep the previous rows if every vault failed, rather than blanking
+                        // positions the user holds because one refresh did not land.
+                        rows = resolved.ifEmpty { current.rows },
+                        totalFiat =
+                            resolved
+                                .takeIf { it.isNotEmpty() }
+                                ?.let { currencyFormat.format(totalFiatValue(it)) }
+                                ?: current.totalFiat,
+                    )
+                }
+            }
+    }
+
+    /**
+     * Positions for the whole wallet in one call, keyed by vault. An address holding nothing
+     * returns an empty list, which is a real answer rather than a failure.
+     */
+    private suspend fun fetchPositions(walletAddress: String): Map<String, KaminoUserPositionJson> =
+        withContext(ioDispatcher) {
+            runCatching { kaminoApi.getUserPositions(walletAddress) }
+                .getOrElse { throwable ->
+                    Timber.e(throwable, "Failed to load Kamino positions")
+                    emptyList()
+                }
+                .associateBy { it.vaultAddress }
+        }
+
+    private suspend fun buildRow(
+        vault: KaminoVault,
+        walletAddress: String,
+        position: KaminoUserPositionJson?,
+    ): KaminoEarnRow = supervisorScope {
+        val stateDeferred = async {
+            runCatching { kaminoApi.getVaultState(vault.address) }.getOrNull()
+        }
+        val metricsDeferred = async {
+            runCatching { kaminoApi.getVaultMetrics(vault.address) }.getOrNull()
+        }
+        val pnlDeferred = async {
+            runCatching { kaminoApi.getPositionPnl(walletAddress, vault.address) }.getOrNull()
+        }
+
+        val vaultState = stateDeferred.await()
+        val metrics = metricsDeferred.await()
+        val pnl = pnlDeferred.await()
+
+        val shares = KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
+        val tokensPerShare = KaminoPositionMath.decimalOrNull(metrics?.tokensPerShare)
+        val tokenAmount =
+            if (tokensPerShare == null) {
+                BigDecimal.ZERO.setScale(vault.tokenDecimals)
+            } else {
+                KaminoPositionMath.tokenAmount(shares, tokensPerShare, vault.tokenDecimals)
+            }
+
+        val coin = vault.coin
+        val apy =
+            KaminoPositionMath.decimalOrNull(metrics?.apy30d)?.let(KaminoPositionMath::apyPercent)
+        val pnlToken = KaminoPositionMath.decimalOrNull(pnl?.totalPnl?.token)
+
+        KaminoEarnRow(
+            vaultAddress = vault.address,
+            name = vaultState?.state?.name?.takeIf { it.isNotBlank() } ?: vault.fallbackName,
+            curator = vault.curator,
+            riskTier = vault.riskTier,
+            tokenLogo = coin?.logo.orEmpty(),
+            tokenTicker = coin?.ticker.orEmpty(),
+            depositedDisplay =
+                "${tokenAmount.stripTrailingZeros().toPlainString()} ${coin?.ticker.orEmpty()}"
+                    .trim(),
+            depositedFiat = coin?.let { fiatOrNull(tokenAmount, it) },
+            apyDisplay = apy?.let { "${it.toPlainString()}%" },
+            pnlDisplay =
+                pnlToken?.let {
+                    val amount = it.setScale(vault.tokenDecimals, RoundingMode.DOWN)
+                    "${amount.stripTrailingZeros().toPlainString()} ${coin?.ticker.orEmpty()}"
+                        .trim()
+                },
+            pnlDirection =
+                when {
+                    pnlToken == null -> KaminoEarnRow.PnlDirection.FLAT
+                    pnlToken.signum() > 0 -> KaminoEarnRow.PnlDirection.UP
+                    pnlToken.signum() < 0 -> KaminoEarnRow.PnlDirection.DOWN
+                    else -> KaminoEarnRow.PnlDirection.FLAT
+                },
+            fiatValue = coin?.let { fiatValueOrNull(tokenAmount, it) } ?: BigDecimal.ZERO,
+        )
+    }
+
+    /**
+     * Fiat goes through the app's own price pipeline rather than Kamino's USD figures, because the
+     * user may not be reading in dollars.
+     */
+    private suspend fun fiatValueOrNull(amount: BigDecimal, coin: Coin): BigDecimal? {
+        if (amount.signum() == 0) return BigDecimal.ZERO
+        val currency = appCurrencyRepository.currency.first()
+        val price =
+            runCatching {
+                    tokenPriceRepository.getCachedPrice(tokenId = coin.id, appCurrency = currency)
+                        ?: tokenPriceRepository.getPriceByContactAddress(
+                            coin.chain.id,
+                            coin.contractAddress,
+                        )
+                }
+                .getOrNull() ?: return null
+        return amount.multiply(price).setScale(2, RoundingMode.DOWN)
+    }
+
+    private suspend fun fiatOrNull(amount: BigDecimal, coin: Coin): String? {
+        val value = fiatValueOrNull(amount, coin) ?: return null
+        return runCatching { appCurrencyRepository.getCurrencyFormat().format(value) }.getOrNull()
+    }
+
+    /**
+     * Summed per row, because the vaults do not share an underlying token — dollars and SOL cannot
+     * be added before each has been priced.
+     */
+    private fun totalFiatValue(rows: List<KaminoEarnRow>): BigDecimal =
+        rows.fold(BigDecimal.ZERO) { running, row -> running.add(row.fiatValue) }
+
+    private suspend fun resolveSolanaAddress(): String {
+        val vault =
+            withContext(ioDispatcher) { vaultRepository.get(vaultId) }
+                ?: error("Vault $vaultId not found")
+        val (address, _) =
+            withContext(ioDispatcher) {
+                chainAccountAddressRepository.getAddress(Chain.Solana, vault)
+            }
+        return address
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -22,6 +22,9 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
@@ -48,43 +51,73 @@ import com.vultisig.wallet.ui.models.solanastaking.SolanaStakingPositionsViewMod
 import com.vultisig.wallet.ui.screens.cosmosstaking.ValidatorAvatar
 import com.vultisig.wallet.ui.screens.v2.defi.ActionButton
 import com.vultisig.wallet.ui.screens.v2.defi.ApyInfoItem
+import com.vultisig.wallet.ui.screens.v2.defi.DeFiTab
 import com.vultisig.wallet.ui.screens.v2.defi.FIAT_VALUE_UNAVAILABLE
 import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
 import com.vultisig.wallet.ui.screens.v2.defi.InfoItem
+import com.vultisig.wallet.ui.screens.v2.defi.ManagePositionsButton
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
 private val HIDE_BALANCE_CHARS = "• ".repeat(6).trim()
+
+/** Earn leads, matching the design: yield is the reason most users open this tab. */
+private val SOLANA_DEFI_TABS = listOf(DeFiTab.EARN, DeFiTab.STAKED)
 
 /** Entry point for the Solana native-staking positions screen. */
 @Composable
 internal fun SolanaStakingPositionsScreen(
     vaultId: VaultId,
     viewModel: SolanaStakingPositionsViewModel = hiltViewModel(),
+    kaminoViewModel: KaminoEarnViewModel = hiltViewModel(),
 ) {
     val state by viewModel.state.collectAsState()
+    val kaminoState by kaminoViewModel.state.collectAsState()
+    var selectedTab by rememberSaveable { mutableStateOf(DeFiTab.EARN) }
 
     LifecycleResumeEffect(vaultId) {
         viewModel.setData(vaultId)
+        kaminoViewModel.setData(vaultId)
         onPauseOrDispose {}
     }
 
     SolanaStakingPositionsContent(
         state = state,
+        kaminoState = kaminoState,
+        selectedTab = selectedTab,
+        onTabSelected = { selectedTab = it },
         isRefreshing = state.isReloading,
-        onRefresh = viewModel::refresh,
+        onRefresh = {
+            viewModel.refresh()
+            kaminoViewModel.refresh()
+        },
         onStake = viewModel::onStake,
         onMove = viewModel::onMove,
         onFinishMove = viewModel::onFinishMove,
         onDeactivate = viewModel::onDeactivate,
         onWithdraw = viewModel::onWithdraw,
+        onKaminoDeposit = { kaminoViewModel.onDeposit(vaultId, it) },
+        onKaminoWithdraw = { kaminoViewModel.onWithdraw(vaultId, it) },
+        onManagePositions = kaminoViewModel::openPicker,
     )
+
+    if (kaminoState.isShowingPicker) {
+        KaminoVaultPickerSheet(
+            selected = kaminoState.pendingSelection,
+            onToggle = kaminoViewModel::onVaultToggled,
+            onDone = kaminoViewModel::savePicker,
+            onDismiss = kaminoViewModel::closePicker,
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun SolanaStakingPositionsContent(
     state: SolanaStakingPositionsUiState,
+    kaminoState: KaminoEarnUiModel = KaminoEarnUiModel(),
+    selectedTab: DeFiTab = DeFiTab.EARN,
+    onTabSelected: (DeFiTab) -> Unit = {},
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     onStake: () -> Unit = {},
@@ -92,6 +125,9 @@ internal fun SolanaStakingPositionsContent(
     onFinishMove: (String) -> Unit = {},
     onDeactivate: (String) -> Unit = {},
     onWithdraw: (String) -> Unit = {},
+    onKaminoDeposit: (String) -> Unit = {},
+    onKaminoWithdraw: (String) -> Unit = {},
+    onManagePositions: () -> Unit = {},
 ) {
     PullToRefreshBox(isRefreshing = isRefreshing, onRefresh = onRefresh) {
         // One scroll surface for the whole screen: the banner and tab row scroll away with the
@@ -112,50 +148,124 @@ internal fun SolanaStakingPositionsContent(
 
             UiSpacer(16.dp)
 
-            Box(modifier = Modifier.fillMaxWidth()) {
-                VsTabGroup(index = 0) {
-                    tab { VsTab(label = stringResource(R.string.defi_tab_staked), onClick = {}) }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                VsTabGroup(index = SOLANA_DEFI_TABS.indexOf(selectedTab).coerceAtLeast(0)) {
+                    SOLANA_DEFI_TABS.forEach { tab ->
+                        tab {
+                            VsTab(
+                                label = stringResource(tab.displayNameRes),
+                                onClick = { onTabSelected(tab) },
+                            )
+                        }
+                    }
+                }
+
+                // Only Earn has anything to manage; native staking has no per-position opt-in.
+                if (selectedTab == DeFiTab.EARN) {
+                    ManagePositionsButton(onClick = onManagePositions)
                 }
             }
 
             UiSpacer(16.dp)
 
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                HeaderDeFiWidget(
-                    title = stringResource(R.string.solana_staking_total_staked_sol),
-                    iconRes = R.drawable.solana,
-                    buttonText = stringResource(R.string.solana_delegate_new_validator),
-                    onClickAction = onStake,
-                    totalAmount = state.totalStakedSolDisplay,
-                    totalPrice = state.totalStakedFiatDisplay,
-                    isLoading = state.isLoading,
-                    isBalanceVisible = state.isBalanceVisible,
+            if (selectedTab == DeFiTab.EARN) {
+                KaminoEarnTabContent(
+                    state = kaminoState,
+                    onDeposit = onKaminoDeposit,
+                    onWithdraw = onKaminoWithdraw,
+                    emptyState = { KaminoEarnEmptyState() },
                 )
-
-                if (state.positions.isNotEmpty()) {
-                    StakeAccountsWidget(
-                        positions = state.positions,
-                        isBalanceVisible = state.isBalanceVisible,
-                        onDeactivate = onDeactivate,
-                        onWithdraw = onWithdraw,
-                        onMove = onMove,
-                        onFinishMove = onFinishMove,
-                        onStake = onStake,
-                    )
-                }
-
-                state.error?.let {
-                    Text(
-                        text = it.asString(),
-                        style = Theme.brockmann.supplementary.caption,
-                        color = Theme.v2.colors.alerts.error,
-                    )
-                }
+            } else {
+                StakedTabContent(
+                    state = state,
+                    onStake = onStake,
+                    onMove = onMove,
+                    onFinishMove = onFinishMove,
+                    onDeactivate = onDeactivate,
+                    onWithdraw = onWithdraw,
+                )
             }
         }
+    }
+}
+
+/** Native SOL staking: the total, then one card per stake account. */
+@Composable
+private fun StakedTabContent(
+    state: SolanaStakingPositionsUiState,
+    onStake: () -> Unit,
+    onMove: (String) -> Unit,
+    onFinishMove: (String) -> Unit,
+    onDeactivate: (String) -> Unit,
+    onWithdraw: (String) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        HeaderDeFiWidget(
+            title = stringResource(R.string.solana_staking_total_staked_sol),
+            iconRes = R.drawable.solana,
+            buttonText = stringResource(R.string.solana_delegate_new_validator),
+            onClickAction = onStake,
+            totalAmount = state.totalStakedSolDisplay,
+            totalPrice = state.totalStakedFiatDisplay,
+            isLoading = state.isLoading,
+            isBalanceVisible = state.isBalanceVisible,
+        )
+
+        if (state.positions.isNotEmpty()) {
+            StakeAccountsWidget(
+                positions = state.positions,
+                isBalanceVisible = state.isBalanceVisible,
+                onDeactivate = onDeactivate,
+                onWithdraw = onWithdraw,
+                onMove = onMove,
+                onFinishMove = onFinishMove,
+                onStake = onStake,
+            )
+        }
+
+        state.error?.let {
+            Text(
+                text = it.asString(),
+                style = Theme.brockmann.supplementary.caption,
+                color = Theme.v2.colors.alerts.error,
+            )
+        }
+    }
+}
+
+/** Shown until the user switches a Kamino vault on under Manage positions. */
+@Composable
+private fun KaminoEarnEmptyState() {
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(Theme.v2.radius.xl)
+                .background(Theme.v2.colors.backgrounds.secondary)
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.border.light,
+                    shape = Theme.v2.radius.xl,
+                )
+                .padding(16.dp),
+        horizontalAlignment = CenterHorizontally,
+    ) {
+        Text(
+            text = stringResource(R.string.kamino_earn_empty_title),
+            style = Theme.brockmann.body.m.medium,
+            color = Theme.v2.colors.text.primary,
+        )
+
+        UiSpacer(4.dp)
+
+        Text(
+            text = stringResource(R.string.kamino_earn_empty_description),
+            style = Theme.brockmann.supplementary.caption,
+            color = Theme.v2.colors.text.tertiary,
+        )
     }
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -539,6 +539,9 @@
     <string name="kamino_amount_below_minimum">Mindestens %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Dieser Vault wird von der App nicht unterstützt</string>
     <string name="kamino_error_load_failed">Dieser Vault konnte gerade nicht geladen werden</string>
+    <string name="verify_deposit_depositing">Du zahlst ein</string>
+    <string name="verify_deposit_withdrawing">Du hebst ab</string>
+    <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Diese Transaktion konnte nicht vorbereitet werden</string>
     <string name="kamino_withdraw_farm_staked">Diese Anteile sind in der Farm des Vaults gestaked und können noch nicht abgehoben werden</string>
     <string name="kamino_withdraw_nothing">Aus diesem Vault gibt es nichts abzuheben</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -543,7 +543,6 @@
     <string name="verify_deposit_withdrawing">Du hebst ab</string>
     <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Diese Transaktion konnte nicht vorbereitet werden</string>
-    <string name="kamino_withdraw_farm_staked">Diese Anteile sind in der Farm des Vaults gestaked und können noch nicht abgehoben werden</string>
     <string name="kamino_withdraw_nothing">Aus diesem Vault gibt es nichts abzuheben</string>
     <string name="kamino_withdraw_unreadable">Diese Position konnte nicht gelesen werden, daher ist keine Abhebung möglich</string>
     <string name="kamino_withdraw_delayed">Über der Sofort-Liquidität des Vaults von %1$s %2$s. Diese Abhebung kann sich verzögern.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -518,9 +518,27 @@
     <string name="defi_tab_staked">Gestaked</string>
     <string name="defi_tab_bonded">Gebondet</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">Verdienen</string>
     <string name="defi_bond">Bond</string>
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Liquiditätspool</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">Kuratiert von %1$s</string>
+    <string name="kamino_earn_deposited">Eingezahlt</string>
+    <string name="kamino_earn_apy_30d">APY (30 Tage)</string>
+    <string name="kamino_earn_pnl">Gewinn &amp; Verlust</string>
+    <string name="kamino_earn_risk_conservative">Konservativ</string>
+    <string name="kamino_earn_risk_private_credit">Privatkredite</string>
+    <string name="kamino_earn_deposit">Einzahlen</string>
+    <string name="kamino_earn_empty_title">Keine Earn-Positionen aktiviert</string>
+    <string name="kamino_earn_empty_description">Aktiviere einen Kamino-Vault unter „Positionen verwalten“, um mit deinen Solana-Assets Erträge zu erzielen.</string>
+    <string name="kamino_deposit_title">Einzahlen</string>
+    <string name="kamino_withdraw_title">Abheben</string>
+    <string name="kamino_amount_exceeds_available">Betrag übersteigt das verfügbare Guthaben</string>
+    <string name="kamino_amount_below_minimum">Mindestens %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">Dieser Vault wird von der App nicht unterstützt</string>
+    <string name="kamino_error_load_failed">Dieser Vault konnte gerade nicht geladen werden</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Einfrieren</string>
     <string name="tron_defi_unfreeze">Entfrieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -541,6 +541,10 @@
     <string name="kamino_amount_below_minimum">Mindestens %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Dieser Vault wird von der App nicht unterstützt</string>
     <string name="kamino_error_load_failed">Dieser Vault konnte gerade nicht geladen werden</string>
+    <string name="kamino_refusal_below_smallest_unit">Betrag ist kleiner als die kleinste Einheit dieses Assets</string>
+    <string name="kamino_refusal_below_minimum">Betrag liegt unter dem Minimum dieses Vaults</string>
+    <string name="kamino_refusal_rate_unavailable">Der Anteilskurs dieses Vaults ist derzeit nicht verfügbar</string>
+    <string name="kamino_refusal_larger_than_position">Dieser Betrag ist größer als diese Position</string>
     <string name="verify_deposit_depositing">Du zahlst ein</string>
     <string name="verify_deposit_withdrawing">Du hebst ab</string>
     <string name="kamino_verify_vault">Vault</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -539,6 +539,11 @@
     <string name="kamino_amount_below_minimum">Mindestens %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Dieser Vault wird von der App nicht unterstützt</string>
     <string name="kamino_error_load_failed">Dieser Vault konnte gerade nicht geladen werden</string>
+    <string name="kamino_error_build_failed">Diese Transaktion konnte nicht vorbereitet werden</string>
+    <string name="kamino_withdraw_farm_staked">Diese Anteile sind in der Farm des Vaults gestaked und können noch nicht abgehoben werden</string>
+    <string name="kamino_withdraw_nothing">Aus diesem Vault gibt es nichts abzuheben</string>
+    <string name="kamino_withdraw_unreadable">Diese Position konnte nicht gelesen werden, daher ist keine Abhebung möglich</string>
+    <string name="kamino_withdraw_delayed">Über der Sofort-Liquidität des Vaults von %1$s %2$s. Diese Abhebung kann sich verzögern.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Einfrieren</string>
     <string name="tron_defi_unfreeze">Entfrieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -529,6 +529,7 @@
     <string name="kamino_earn_apy_30d">APY (30 Tage)</string>
     <string name="kamino_earn_pnl">Gewinn &amp; Verlust</string>
     <string name="kamino_earn_lost">Verloren</string>
+    <string name="kamino_earn_load_failed">Diese Vaults konnten gerade nicht aktualisiert werden</string>
     <string name="kamino_earn_risk_conservative">Konservativ</string>
     <string name="kamino_earn_risk_private_credit">Privatkredite</string>
     <string name="kamino_earn_deposit">Einzahlen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -528,6 +528,7 @@
     <string name="kamino_earn_deposited">Eingezahlt</string>
     <string name="kamino_earn_apy_30d">APY (30 Tage)</string>
     <string name="kamino_earn_pnl">Gewinn &amp; Verlust</string>
+    <string name="kamino_earn_lost">Verloren</string>
     <string name="kamino_earn_risk_conservative">Konservativ</string>
     <string name="kamino_earn_risk_private_credit">Privatkredite</string>
     <string name="kamino_earn_deposit">Einzahlen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -541,6 +541,10 @@
     <string name="kamino_amount_below_minimum">El mínimo es %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Este vault no es compatible con la app</string>
     <string name="kamino_error_load_failed">No se pudo cargar este vault ahora mismo</string>
+    <string name="kamino_refusal_below_smallest_unit">El importe es menor que la unidad mínima de este activo</string>
+    <string name="kamino_refusal_below_minimum">El importe está por debajo del mínimo de este vault</string>
+    <string name="kamino_refusal_rate_unavailable">La tasa por participación de este vault no está disponible ahora</string>
+    <string name="kamino_refusal_larger_than_position">Ese importe es mayor que esta posición</string>
     <string name="verify_deposit_depositing">Estás depositando</string>
     <string name="verify_deposit_withdrawing">Estás retirando</string>
     <string name="kamino_verify_vault">Vault</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -518,9 +518,27 @@
     <string name="defi_tab_staked">Staking</string>
     <string name="defi_tab_bonded">Bondeado</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">Ganar</string>
     <string name="defi_bond">Bond</string>
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Pool de liquidez</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">Curado por %1$s</string>
+    <string name="kamino_earn_deposited">Depositado</string>
+    <string name="kamino_earn_apy_30d">APY (30 d)</string>
+    <string name="kamino_earn_pnl">Ganancias y pérdidas</string>
+    <string name="kamino_earn_risk_conservative">Conservador</string>
+    <string name="kamino_earn_risk_private_credit">Crédito privado</string>
+    <string name="kamino_earn_deposit">Depositar</string>
+    <string name="kamino_earn_empty_title">No hay posiciones de Earn activadas</string>
+    <string name="kamino_earn_empty_description">Activa un vault de Kamino en «Gestionar Posiciones» para empezar a generar rendimiento con tus activos de Solana.</string>
+    <string name="kamino_deposit_title">Depositar</string>
+    <string name="kamino_withdraw_title">Retirar</string>
+    <string name="kamino_amount_exceeds_available">El importe supera el saldo disponible</string>
+    <string name="kamino_amount_below_minimum">El mínimo es %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">Este vault no es compatible con la app</string>
+    <string name="kamino_error_load_failed">No se pudo cargar este vault ahora mismo</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Congelar</string>
     <string name="tron_defi_unfreeze">Descongelar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -539,6 +539,9 @@
     <string name="kamino_amount_below_minimum">El mínimo es %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Este vault no es compatible con la app</string>
     <string name="kamino_error_load_failed">No se pudo cargar este vault ahora mismo</string>
+    <string name="verify_deposit_depositing">Estás depositando</string>
+    <string name="verify_deposit_withdrawing">Estás retirando</string>
+    <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">No se pudo preparar esta transacción</string>
     <string name="kamino_withdraw_farm_staked">Estas participaciones están en staking en la granja del vault y aún no se pueden retirar</string>
     <string name="kamino_withdraw_nothing">No hay nada que retirar de este vault</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -528,6 +528,7 @@
     <string name="kamino_earn_deposited">Depositado</string>
     <string name="kamino_earn_apy_30d">APY (30 d)</string>
     <string name="kamino_earn_pnl">Ganancias y pérdidas</string>
+    <string name="kamino_earn_lost">Perdido</string>
     <string name="kamino_earn_risk_conservative">Conservador</string>
     <string name="kamino_earn_risk_private_credit">Crédito privado</string>
     <string name="kamino_earn_deposit">Depositar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -529,6 +529,7 @@
     <string name="kamino_earn_apy_30d">APY (30 d)</string>
     <string name="kamino_earn_pnl">Ganancias y pérdidas</string>
     <string name="kamino_earn_lost">Perdido</string>
+    <string name="kamino_earn_load_failed">No se pudieron actualizar estos vaults ahora</string>
     <string name="kamino_earn_risk_conservative">Conservador</string>
     <string name="kamino_earn_risk_private_credit">Crédito privado</string>
     <string name="kamino_earn_deposit">Depositar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -543,7 +543,6 @@
     <string name="verify_deposit_withdrawing">Estás retirando</string>
     <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">No se pudo preparar esta transacción</string>
-    <string name="kamino_withdraw_farm_staked">Estas participaciones están en staking en la granja del vault y aún no se pueden retirar</string>
     <string name="kamino_withdraw_nothing">No hay nada que retirar de este vault</string>
     <string name="kamino_withdraw_unreadable">No se pudo leer esta posición, así que no se puede preparar el retiro</string>
     <string name="kamino_withdraw_delayed">Por encima de la liquidez inmediata del vault de %1$s %2$s. Este retiro puede demorarse.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -539,6 +539,11 @@
     <string name="kamino_amount_below_minimum">El mínimo es %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Este vault no es compatible con la app</string>
     <string name="kamino_error_load_failed">No se pudo cargar este vault ahora mismo</string>
+    <string name="kamino_error_build_failed">No se pudo preparar esta transacción</string>
+    <string name="kamino_withdraw_farm_staked">Estas participaciones están en staking en la granja del vault y aún no se pueden retirar</string>
+    <string name="kamino_withdraw_nothing">No hay nada que retirar de este vault</string>
+    <string name="kamino_withdraw_unreadable">No se pudo leer esta posición, así que no se puede preparar el retiro</string>
+    <string name="kamino_withdraw_delayed">Por encima de la liquidez inmediata del vault de %1$s %2$s. Este retiro puede demorarse.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Congelar</string>
     <string name="tron_defi_unfreeze">Descongelar</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -540,6 +540,9 @@
     <string name="kamino_amount_below_minimum">Minimum je %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Aplikacija ne podržava ovaj vault</string>
     <string name="kamino_error_load_failed">Trenutno nije moguće učitati ovaj vault</string>
+    <string name="verify_deposit_depositing">Deponirate</string>
+    <string name="verify_deposit_withdrawing">Povlačite</string>
+    <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Ovu transakciju nije bilo moguće pripremiti</string>
     <string name="kamino_withdraw_farm_staked">Ovi udjeli uloženi su u farmu vaulta i još se ne mogu povući</string>
     <string name="kamino_withdraw_nothing">Iz ovog vaulta nema se što povući</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -544,7 +544,6 @@
     <string name="verify_deposit_withdrawing">Povlačite</string>
     <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Ovu transakciju nije bilo moguće pripremiti</string>
-    <string name="kamino_withdraw_farm_staked">Ovi udjeli uloženi su u farmu vaulta i još se ne mogu povući</string>
     <string name="kamino_withdraw_nothing">Iz ovog vaulta nema se što povući</string>
     <string name="kamino_withdraw_unreadable">Ovu poziciju nije bilo moguće pročitati, pa se povlačenje ne može pripremiti</string>
     <string name="kamino_withdraw_delayed">Iznad trenutne likvidnosti vaulta od %1$s %2$s. Ovo povlačenje može biti odgođeno.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -540,6 +540,11 @@
     <string name="kamino_amount_below_minimum">Minimum je %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Aplikacija ne podržava ovaj vault</string>
     <string name="kamino_error_load_failed">Trenutno nije moguće učitati ovaj vault</string>
+    <string name="kamino_error_build_failed">Ovu transakciju nije bilo moguće pripremiti</string>
+    <string name="kamino_withdraw_farm_staked">Ovi udjeli uloženi su u farmu vaulta i još se ne mogu povući</string>
+    <string name="kamino_withdraw_nothing">Iz ovog vaulta nema se što povući</string>
+    <string name="kamino_withdraw_unreadable">Ovu poziciju nije bilo moguće pročitati, pa se povlačenje ne može pripremiti</string>
+    <string name="kamino_withdraw_delayed">Iznad trenutne likvidnosti vaulta od %1$s %2$s. Ovo povlačenje može biti odgođeno.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Zamrzni</string>
     <string name="tron_defi_unfreeze">Odmrzni</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -530,6 +530,7 @@
     <string name="kamino_earn_apy_30d">APY (30 d)</string>
     <string name="kamino_earn_pnl">Dobit i gubitak</string>
     <string name="kamino_earn_lost">Izgubljeno</string>
+    <string name="kamino_earn_load_failed">Ove vaultove trenutno nije moguće osvježiti</string>
     <string name="kamino_earn_risk_conservative">Konzervativno</string>
     <string name="kamino_earn_risk_private_credit">Privatni krediti</string>
     <string name="kamino_earn_deposit">Deponiraj</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -542,6 +542,10 @@
     <string name="kamino_amount_below_minimum">Minimum je %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Aplikacija ne podržava ovaj vault</string>
     <string name="kamino_error_load_failed">Trenutno nije moguće učitati ovaj vault</string>
+    <string name="kamino_refusal_below_smallest_unit">Iznos je manji od najmanje jedinice ove imovine</string>
+    <string name="kamino_refusal_below_minimum">Iznos je ispod minimuma ovog vaulta</string>
+    <string name="kamino_refusal_rate_unavailable">Stopa po udjelu ovog vaulta trenutno nije dostupna</string>
+    <string name="kamino_refusal_larger_than_position">Taj iznos je veći od ove pozicije</string>
     <string name="verify_deposit_depositing">Deponirate</string>
     <string name="verify_deposit_withdrawing">Povlačite</string>
     <string name="kamino_verify_vault">Vault</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -519,9 +519,27 @@
     <string name="defi_tab_staked">Uloženo</string>
     <string name="defi_tab_bonded">Vezano</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">Zarada</string>
     <string name="defi_bond">Bond</string>
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Pool likvidnosti</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">Kurirao %1$s</string>
+    <string name="kamino_earn_deposited">Deponirano</string>
+    <string name="kamino_earn_apy_30d">APY (30 d)</string>
+    <string name="kamino_earn_pnl">Dobit i gubitak</string>
+    <string name="kamino_earn_risk_conservative">Konzervativno</string>
+    <string name="kamino_earn_risk_private_credit">Privatni krediti</string>
+    <string name="kamino_earn_deposit">Deponiraj</string>
+    <string name="kamino_earn_empty_title">Nema aktiviranih Earn pozicija</string>
+    <string name="kamino_earn_empty_description">Aktivirajte Kamino vault u „Upravljanje Pozicijama“ kako biste počeli zarađivati na svojoj Solana imovini.</string>
+    <string name="kamino_deposit_title">Deponiraj</string>
+    <string name="kamino_withdraw_title">Povući</string>
+    <string name="kamino_amount_exceeds_available">Iznos premašuje dostupno stanje</string>
+    <string name="kamino_amount_below_minimum">Minimum je %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">Aplikacija ne podržava ovaj vault</string>
+    <string name="kamino_error_load_failed">Trenutno nije moguće učitati ovaj vault</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Zamrzni</string>
     <string name="tron_defi_unfreeze">Odmrzni</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -529,6 +529,7 @@
     <string name="kamino_earn_deposited">Deponirano</string>
     <string name="kamino_earn_apy_30d">APY (30 d)</string>
     <string name="kamino_earn_pnl">Dobit i gubitak</string>
+    <string name="kamino_earn_lost">Izgubljeno</string>
     <string name="kamino_earn_risk_conservative">Konzervativno</string>
     <string name="kamino_earn_risk_private_credit">Privatni krediti</string>
     <string name="kamino_earn_deposit">Deponiraj</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -518,9 +518,27 @@
     <string name="defi_tab_staked">Staking</string>
     <string name="defi_tab_bonded">Vincolato</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">Guadagna</string>
     <string name="defi_bond">Bond</string>
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Pool di liquidità</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">Curato da %1$s</string>
+    <string name="kamino_earn_deposited">Depositato</string>
+    <string name="kamino_earn_apy_30d">APY (30 g)</string>
+    <string name="kamino_earn_pnl">Profitti e perdite</string>
+    <string name="kamino_earn_risk_conservative">Conservativo</string>
+    <string name="kamino_earn_risk_private_credit">Credito privato</string>
+    <string name="kamino_earn_deposit">Deposita</string>
+    <string name="kamino_earn_empty_title">Nessuna posizione Earn attivata</string>
+    <string name="kamino_earn_empty_description">Attiva un vault Kamino in «Gestisci Posizioni» per iniziare a generare rendimento sui tuoi asset Solana.</string>
+    <string name="kamino_deposit_title">Deposita</string>
+    <string name="kamino_withdraw_title">Prelevare</string>
+    <string name="kamino_amount_exceeds_available">L\'importo supera il saldo disponibile</string>
+    <string name="kamino_amount_below_minimum">Il minimo è %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">Questo vault non è supportato dall\'app</string>
+    <string name="kamino_error_load_failed">Impossibile caricare questo vault in questo momento</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Congela</string>
     <string name="tron_defi_unfreeze">Scongela</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -541,6 +541,10 @@
     <string name="kamino_amount_below_minimum">Il minimo è %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Questo vault non è supportato dall\'app</string>
     <string name="kamino_error_load_failed">Impossibile caricare questo vault in questo momento</string>
+    <string name="kamino_refusal_below_smallest_unit">L\'importo è inferiore all\'unità minima di questo asset</string>
+    <string name="kamino_refusal_below_minimum">L\'importo è inferiore al minimo di questo vault</string>
+    <string name="kamino_refusal_rate_unavailable">Il tasso per quota di questo vault non è disponibile ora</string>
+    <string name="kamino_refusal_larger_than_position">Questo importo è superiore a questa posizione</string>
     <string name="verify_deposit_depositing">Stai depositando</string>
     <string name="verify_deposit_withdrawing">Stai prelevando</string>
     <string name="kamino_verify_vault">Vault</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -528,6 +528,7 @@
     <string name="kamino_earn_deposited">Depositato</string>
     <string name="kamino_earn_apy_30d">APY (30 g)</string>
     <string name="kamino_earn_pnl">Profitti e perdite</string>
+    <string name="kamino_earn_lost">Perso</string>
     <string name="kamino_earn_risk_conservative">Conservativo</string>
     <string name="kamino_earn_risk_private_credit">Credito privato</string>
     <string name="kamino_earn_deposit">Deposita</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -529,6 +529,7 @@
     <string name="kamino_earn_apy_30d">APY (30 g)</string>
     <string name="kamino_earn_pnl">Profitti e perdite</string>
     <string name="kamino_earn_lost">Perso</string>
+    <string name="kamino_earn_load_failed">Impossibile aggiornare questi vault in questo momento</string>
     <string name="kamino_earn_risk_conservative">Conservativo</string>
     <string name="kamino_earn_risk_private_credit">Credito privato</string>
     <string name="kamino_earn_deposit">Deposita</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -539,6 +539,9 @@
     <string name="kamino_amount_below_minimum">Il minimo è %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Questo vault non è supportato dall\'app</string>
     <string name="kamino_error_load_failed">Impossibile caricare questo vault in questo momento</string>
+    <string name="verify_deposit_depositing">Stai depositando</string>
+    <string name="verify_deposit_withdrawing">Stai prelevando</string>
+    <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Impossibile preparare questa transazione</string>
     <string name="kamino_withdraw_farm_staked">Queste quote sono in staking nella farm del vault e non possono ancora essere prelevate</string>
     <string name="kamino_withdraw_nothing">Non c\'è nulla da prelevare da questo vault</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -543,7 +543,6 @@
     <string name="verify_deposit_withdrawing">Stai prelevando</string>
     <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Impossibile preparare questa transazione</string>
-    <string name="kamino_withdraw_farm_staked">Queste quote sono in staking nella farm del vault e non possono ancora essere prelevate</string>
     <string name="kamino_withdraw_nothing">Non c\'è nulla da prelevare da questo vault</string>
     <string name="kamino_withdraw_unreadable">Impossibile leggere questa posizione, quindi il prelievo non può essere preparato</string>
     <string name="kamino_withdraw_delayed">Oltre la liquidità immediata del vault di %1$s %2$s. Questo prelievo potrebbe subire ritardi.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -539,6 +539,11 @@
     <string name="kamino_amount_below_minimum">Il minimo è %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Questo vault non è supportato dall\'app</string>
     <string name="kamino_error_load_failed">Impossibile caricare questo vault in questo momento</string>
+    <string name="kamino_error_build_failed">Impossibile preparare questa transazione</string>
+    <string name="kamino_withdraw_farm_staked">Queste quote sono in staking nella farm del vault e non possono ancora essere prelevate</string>
+    <string name="kamino_withdraw_nothing">Non c\'è nulla da prelevare da questo vault</string>
+    <string name="kamino_withdraw_unreadable">Impossibile leggere questa posizione, quindi il prelievo non può essere preparato</string>
+    <string name="kamino_withdraw_delayed">Oltre la liquidità immediata del vault di %1$s %2$s. Questo prelievo potrebbe subire ritardi.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Congela</string>
     <string name="tron_defi_unfreeze">Scongela</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -86,6 +86,10 @@
     <string name="kamino_amount_below_minimum">최소 %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">앱이 지원하지 않는 볼트입니다</string>
     <string name="kamino_error_load_failed">지금은 이 볼트를 불러올 수 없습니다</string>
+    <string name="kamino_refusal_below_smallest_unit">금액이 이 자산의 최소 단위보다 작습니다</string>
+    <string name="kamino_refusal_below_minimum">금액이 이 볼트의 최소 금액보다 적습니다</string>
+    <string name="kamino_refusal_rate_unavailable">이 볼트의 지분 비율을 지금은 가져올 수 없습니다</string>
+    <string name="kamino_refusal_larger_than_position">이 금액은 보유 포지션보다 큽니다</string>
     <string name="verify_deposit_depositing">예치 중</string>
     <string name="verify_deposit_withdrawing">출금 중</string>
     <string name="kamino_verify_vault">볼트</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -63,9 +63,27 @@
     <string name="defi_tab_staked">스테이킹됨</string>
     <string name="defi_tab_bonded">본딩됨</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">수익</string>
     <string name="defi_bond">본딩</string>
     <string name="defi_stake">스테이킹</string>
     <string name="liquidity_pool">유동성 풀</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">%1$s 큐레이션</string>
+    <string name="kamino_earn_deposited">예치됨</string>
+    <string name="kamino_earn_apy_30d">APY (30일)</string>
+    <string name="kamino_earn_pnl">손익</string>
+    <string name="kamino_earn_risk_conservative">보수적</string>
+    <string name="kamino_earn_risk_private_credit">사모 신용</string>
+    <string name="kamino_earn_deposit">예치</string>
+    <string name="kamino_earn_empty_title">활성화된 Earn 포지션 없음</string>
+    <string name="kamino_earn_empty_description">‘포지션 관리’에서 Kamino 볼트를 활성화하면 Solana 자산으로 수익을 얻을 수 있습니다.</string>
+    <string name="kamino_deposit_title">예치</string>
+    <string name="kamino_withdraw_title">출금</string>
+    <string name="kamino_amount_exceeds_available">금액이 사용 가능한 잔액을 초과합니다</string>
+    <string name="kamino_amount_below_minimum">최소 %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">앱이 지원하지 않는 볼트입니다</string>
+    <string name="kamino_error_load_failed">지금은 이 볼트를 불러올 수 없습니다</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">동결</string>
     <string name="tron_defi_unfreeze">동결 해제</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -74,6 +74,7 @@
     <string name="kamino_earn_apy_30d">APY (30일)</string>
     <string name="kamino_earn_pnl">손익</string>
     <string name="kamino_earn_lost">손실</string>
+    <string name="kamino_earn_load_failed">지금은 이 볼트를 새로 고칠 수 없습니다</string>
     <string name="kamino_earn_risk_conservative">보수적</string>
     <string name="kamino_earn_risk_private_credit">사모 신용</string>
     <string name="kamino_earn_deposit">예치</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -73,6 +73,7 @@
     <string name="kamino_earn_deposited">예치됨</string>
     <string name="kamino_earn_apy_30d">APY (30일)</string>
     <string name="kamino_earn_pnl">손익</string>
+    <string name="kamino_earn_lost">손실</string>
     <string name="kamino_earn_risk_conservative">보수적</string>
     <string name="kamino_earn_risk_private_credit">사모 신용</string>
     <string name="kamino_earn_deposit">예치</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -84,6 +84,9 @@
     <string name="kamino_amount_below_minimum">최소 %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">앱이 지원하지 않는 볼트입니다</string>
     <string name="kamino_error_load_failed">지금은 이 볼트를 불러올 수 없습니다</string>
+    <string name="verify_deposit_depositing">예치 중</string>
+    <string name="verify_deposit_withdrawing">출금 중</string>
+    <string name="kamino_verify_vault">볼트</string>
     <string name="kamino_error_build_failed">이 거래를 준비할 수 없습니다</string>
     <string name="kamino_withdraw_farm_staked">이 지분은 볼트 팜에 스테이킹되어 있어 아직 출금할 수 없습니다</string>
     <string name="kamino_withdraw_nothing">이 볼트에서 출금할 것이 없습니다</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -88,7 +88,6 @@
     <string name="verify_deposit_withdrawing">출금 중</string>
     <string name="kamino_verify_vault">볼트</string>
     <string name="kamino_error_build_failed">이 거래를 준비할 수 없습니다</string>
-    <string name="kamino_withdraw_farm_staked">이 지분은 볼트 팜에 스테이킹되어 있어 아직 출금할 수 없습니다</string>
     <string name="kamino_withdraw_nothing">이 볼트에서 출금할 것이 없습니다</string>
     <string name="kamino_withdraw_unreadable">이 포지션을 읽을 수 없어 출금을 준비할 수 없습니다</string>
     <string name="kamino_withdraw_delayed">볼트의 즉시 유동성 %1$s %2$s을(를) 초과합니다. 이 출금은 지연될 수 있습니다.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -84,6 +84,11 @@
     <string name="kamino_amount_below_minimum">최소 %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">앱이 지원하지 않는 볼트입니다</string>
     <string name="kamino_error_load_failed">지금은 이 볼트를 불러올 수 없습니다</string>
+    <string name="kamino_error_build_failed">이 거래를 준비할 수 없습니다</string>
+    <string name="kamino_withdraw_farm_staked">이 지분은 볼트 팜에 스테이킹되어 있어 아직 출금할 수 없습니다</string>
+    <string name="kamino_withdraw_nothing">이 볼트에서 출금할 것이 없습니다</string>
+    <string name="kamino_withdraw_unreadable">이 포지션을 읽을 수 없어 출금을 준비할 수 없습니다</string>
+    <string name="kamino_withdraw_delayed">볼트의 즉시 유동성 %1$s %2$s을(를) 초과합니다. 이 출금은 지연될 수 있습니다.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">동결</string>
     <string name="tron_defi_unfreeze">동결 해제</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -536,6 +536,9 @@
     <string name="kamino_amount_below_minimum">Minimum is %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Deze vault wordt niet ondersteund door de app</string>
     <string name="kamino_error_load_failed">Kan deze vault nu niet laden</string>
+    <string name="verify_deposit_depositing">Je stort</string>
+    <string name="verify_deposit_withdrawing">Je neemt op</string>
+    <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Kan deze transactie niet voorbereiden</string>
     <string name="kamino_withdraw_farm_staked">Deze aandelen staan gestaked in de farm van de vault en kunnen nog niet worden opgenomen</string>
     <string name="kamino_withdraw_nothing">Er is niets op te nemen uit deze vault</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -536,6 +536,11 @@
     <string name="kamino_amount_below_minimum">Minimum is %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Deze vault wordt niet ondersteund door de app</string>
     <string name="kamino_error_load_failed">Kan deze vault nu niet laden</string>
+    <string name="kamino_error_build_failed">Kan deze transactie niet voorbereiden</string>
+    <string name="kamino_withdraw_farm_staked">Deze aandelen staan gestaked in de farm van de vault en kunnen nog niet worden opgenomen</string>
+    <string name="kamino_withdraw_nothing">Er is niets op te nemen uit deze vault</string>
+    <string name="kamino_withdraw_unreadable">Deze positie kon niet worden gelezen, dus er kan geen opname worden voorbereid</string>
+    <string name="kamino_withdraw_delayed">Boven de directe liquiditeit van de vault van %1$s %2$s. Deze opname kan vertraging oplopen.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Bevriezen</string>
     <string name="tron_defi_unfreeze">Ontdooien</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -525,6 +525,7 @@
     <string name="kamino_earn_deposited">Gestort</string>
     <string name="kamino_earn_apy_30d">APY (30 d)</string>
     <string name="kamino_earn_pnl">Winst &amp; verlies</string>
+    <string name="kamino_earn_lost">Verloren</string>
     <string name="kamino_earn_risk_conservative">Conservatief</string>
     <string name="kamino_earn_risk_private_credit">Privaat krediet</string>
     <string name="kamino_earn_deposit">Storten</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -540,7 +540,6 @@
     <string name="verify_deposit_withdrawing">Je neemt op</string>
     <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Kan deze transactie niet voorbereiden</string>
-    <string name="kamino_withdraw_farm_staked">Deze aandelen staan gestaked in de farm van de vault en kunnen nog niet worden opgenomen</string>
     <string name="kamino_withdraw_nothing">Er is niets op te nemen uit deze vault</string>
     <string name="kamino_withdraw_unreadable">Deze positie kon niet worden gelezen, dus er kan geen opname worden voorbereid</string>
     <string name="kamino_withdraw_delayed">Boven de directe liquiditeit van de vault van %1$s %2$s. Deze opname kan vertraging oplopen.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -515,9 +515,27 @@
     <string name="defi_tab_staked">Gestaked</string>
     <string name="defi_tab_bonded">Gebonden</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">Verdienen</string>
     <string name="defi_bond">Bond</string>
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Liquiditeitspool</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">Samengesteld door %1$s</string>
+    <string name="kamino_earn_deposited">Gestort</string>
+    <string name="kamino_earn_apy_30d">APY (30 d)</string>
+    <string name="kamino_earn_pnl">Winst &amp; verlies</string>
+    <string name="kamino_earn_risk_conservative">Conservatief</string>
+    <string name="kamino_earn_risk_private_credit">Privaat krediet</string>
+    <string name="kamino_earn_deposit">Storten</string>
+    <string name="kamino_earn_empty_title">Geen Earn-posities geactiveerd</string>
+    <string name="kamino_earn_empty_description">Activeer een Kamino-vault onder ‘Posities Beheren’ om rendement te behalen op je Solana-assets.</string>
+    <string name="kamino_deposit_title">Storten</string>
+    <string name="kamino_withdraw_title">Opnemen</string>
+    <string name="kamino_amount_exceeds_available">Bedrag is hoger dan het beschikbare saldo</string>
+    <string name="kamino_amount_below_minimum">Minimum is %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">Deze vault wordt niet ondersteund door de app</string>
+    <string name="kamino_error_load_failed">Kan deze vault nu niet laden</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Bevriezen</string>
     <string name="tron_defi_unfreeze">Ontdooien</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -538,6 +538,10 @@
     <string name="kamino_amount_below_minimum">Minimum is %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Deze vault wordt niet ondersteund door de app</string>
     <string name="kamino_error_load_failed">Kan deze vault nu niet laden</string>
+    <string name="kamino_refusal_below_smallest_unit">Bedrag is kleiner dan de kleinste eenheid van dit asset</string>
+    <string name="kamino_refusal_below_minimum">Bedrag ligt onder het minimum van deze vault</string>
+    <string name="kamino_refusal_rate_unavailable">De koers per aandeel van deze vault is nu niet beschikbaar</string>
+    <string name="kamino_refusal_larger_than_position">Dat bedrag is groter dan deze positie</string>
     <string name="verify_deposit_depositing">Je stort</string>
     <string name="verify_deposit_withdrawing">Je neemt op</string>
     <string name="kamino_verify_vault">Vault</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -526,6 +526,7 @@
     <string name="kamino_earn_apy_30d">APY (30 d)</string>
     <string name="kamino_earn_pnl">Winst &amp; verlies</string>
     <string name="kamino_earn_lost">Verloren</string>
+    <string name="kamino_earn_load_failed">Kan deze vaults nu niet verversen</string>
     <string name="kamino_earn_risk_conservative">Conservatief</string>
     <string name="kamino_earn_risk_private_credit">Privaat krediet</string>
     <string name="kamino_earn_deposit">Storten</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -516,9 +516,27 @@
     <string name="defi_tab_staked">Staking</string>
     <string name="defi_tab_bonded">Vinculado</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">Ganhar</string>
     <string name="defi_bond">Bond</string>
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Pool de liquidez</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">Curado por %1$s</string>
+    <string name="kamino_earn_deposited">Depositado</string>
+    <string name="kamino_earn_apy_30d">APY (30 d)</string>
+    <string name="kamino_earn_pnl">Lucros e perdas</string>
+    <string name="kamino_earn_risk_conservative">Conservador</string>
+    <string name="kamino_earn_risk_private_credit">Crédito privado</string>
+    <string name="kamino_earn_deposit">Depositar</string>
+    <string name="kamino_earn_empty_title">Nenhuma posição Earn ativada</string>
+    <string name="kamino_earn_empty_description">Ative um vault da Kamino em «Gerenciar Posições» para começar a render com seus ativos Solana.</string>
+    <string name="kamino_deposit_title">Depositar</string>
+    <string name="kamino_withdraw_title">Retirar</string>
+    <string name="kamino_amount_exceeds_available">O valor excede o saldo disponível</string>
+    <string name="kamino_amount_below_minimum">O mínimo é %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">Este vault não é suportado pelo app</string>
+    <string name="kamino_error_load_failed">Não foi possível carregar este vault agora</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Congelar</string>
     <string name="tron_defi_unfreeze">Descongelar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -541,7 +541,6 @@
     <string name="verify_deposit_withdrawing">Você está retirando</string>
     <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Não foi possível preparar esta transação</string>
-    <string name="kamino_withdraw_farm_staked">Estas cotas estão em staking na farm do vault e ainda não podem ser retiradas</string>
     <string name="kamino_withdraw_nothing">Não há nada a retirar deste vault</string>
     <string name="kamino_withdraw_unreadable">Não foi possível ler esta posição, então a retirada não pode ser preparada</string>
     <string name="kamino_withdraw_delayed">Acima da liquidez imediata do vault de %1$s %2$s. Esta retirada pode demorar.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -537,6 +537,9 @@
     <string name="kamino_amount_below_minimum">O mínimo é %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Este vault não é suportado pelo app</string>
     <string name="kamino_error_load_failed">Não foi possível carregar este vault agora</string>
+    <string name="verify_deposit_depositing">Você está depositando</string>
+    <string name="verify_deposit_withdrawing">Você está retirando</string>
+    <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Não foi possível preparar esta transação</string>
     <string name="kamino_withdraw_farm_staked">Estas cotas estão em staking na farm do vault e ainda não podem ser retiradas</string>
     <string name="kamino_withdraw_nothing">Não há nada a retirar deste vault</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -526,6 +526,7 @@
     <string name="kamino_earn_deposited">Depositado</string>
     <string name="kamino_earn_apy_30d">APY (30 d)</string>
     <string name="kamino_earn_pnl">Lucros e perdas</string>
+    <string name="kamino_earn_lost">Perdido</string>
     <string name="kamino_earn_risk_conservative">Conservador</string>
     <string name="kamino_earn_risk_private_credit">Crédito privado</string>
     <string name="kamino_earn_deposit">Depositar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -537,6 +537,11 @@
     <string name="kamino_amount_below_minimum">O mínimo é %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Este vault não é suportado pelo app</string>
     <string name="kamino_error_load_failed">Não foi possível carregar este vault agora</string>
+    <string name="kamino_error_build_failed">Não foi possível preparar esta transação</string>
+    <string name="kamino_withdraw_farm_staked">Estas cotas estão em staking na farm do vault e ainda não podem ser retiradas</string>
+    <string name="kamino_withdraw_nothing">Não há nada a retirar deste vault</string>
+    <string name="kamino_withdraw_unreadable">Não foi possível ler esta posição, então a retirada não pode ser preparada</string>
+    <string name="kamino_withdraw_delayed">Acima da liquidez imediata do vault de %1$s %2$s. Esta retirada pode demorar.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Congelar</string>
     <string name="tron_defi_unfreeze">Descongelar</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -539,6 +539,10 @@
     <string name="kamino_amount_below_minimum">O mínimo é %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Este vault não é suportado pelo app</string>
     <string name="kamino_error_load_failed">Não foi possível carregar este vault agora</string>
+    <string name="kamino_refusal_below_smallest_unit">O valor é menor que a menor unidade deste ativo</string>
+    <string name="kamino_refusal_below_minimum">O valor está abaixo do mínimo deste vault</string>
+    <string name="kamino_refusal_rate_unavailable">A taxa por cota deste vault não está disponível agora</string>
+    <string name="kamino_refusal_larger_than_position">Esse valor é maior que esta posição</string>
     <string name="verify_deposit_depositing">Você está depositando</string>
     <string name="verify_deposit_withdrawing">Você está retirando</string>
     <string name="kamino_verify_vault">Vault</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -527,6 +527,7 @@
     <string name="kamino_earn_apy_30d">APY (30 d)</string>
     <string name="kamino_earn_pnl">Lucros e perdas</string>
     <string name="kamino_earn_lost">Perdido</string>
+    <string name="kamino_earn_load_failed">Não foi possível atualizar estes vaults agora</string>
     <string name="kamino_earn_risk_conservative">Conservador</string>
     <string name="kamino_earn_risk_private_credit">Crédito privado</string>
     <string name="kamino_earn_deposit">Depositar</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -538,6 +538,9 @@
     <string name="kamino_amount_below_minimum">Минимум — %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Этот vault не поддерживается приложением</string>
     <string name="kamino_error_load_failed">Сейчас не удалось загрузить этот vault</string>
+    <string name="verify_deposit_depositing">Вы вносите</string>
+    <string name="verify_deposit_withdrawing">Вы выводите</string>
+    <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Не удалось подготовить эту транзакцию</string>
     <string name="kamino_withdraw_farm_staked">Эти доли размещены в фарме vault‑а и пока не могут быть выведены</string>
     <string name="kamino_withdraw_nothing">Из этого vault‑а нечего выводить</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -528,6 +528,7 @@
     <string name="kamino_earn_apy_30d">APY (30 дн.)</string>
     <string name="kamino_earn_pnl">Прибыль и убыток</string>
     <string name="kamino_earn_lost">Убыток</string>
+    <string name="kamino_earn_load_failed">Сейчас не удалось обновить эти vault‑ы</string>
     <string name="kamino_earn_risk_conservative">Консервативный</string>
     <string name="kamino_earn_risk_private_credit">Частный кредит</string>
     <string name="kamino_earn_deposit">Внести</string>
@@ -541,7 +542,7 @@
     <string name="kamino_error_load_failed">Сейчас не удалось загрузить этот vault</string>
     <string name="verify_deposit_depositing">Вы вносите</string>
     <string name="verify_deposit_withdrawing">Вы выводите</string>
-    <string name="kamino_verify_vault">Vault</string>
+    <string name="kamino_verify_vault">Vault Kamino</string>
     <string name="kamino_error_build_failed">Не удалось подготовить эту транзакцию</string>
     <string name="kamino_withdraw_nothing">Из этого vault‑а нечего выводить</string>
     <string name="kamino_withdraw_unreadable">Не удалось прочитать эту позицию, поэтому вывод невозможно подготовить</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -542,7 +542,6 @@
     <string name="verify_deposit_withdrawing">Вы выводите</string>
     <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Не удалось подготовить эту транзакцию</string>
-    <string name="kamino_withdraw_farm_staked">Эти доли размещены в фарме vault‑а и пока не могут быть выведены</string>
     <string name="kamino_withdraw_nothing">Из этого vault‑а нечего выводить</string>
     <string name="kamino_withdraw_unreadable">Не удалось прочитать эту позицию, поэтому вывод невозможно подготовить</string>
     <string name="kamino_withdraw_delayed">Превышает мгновенную ликвидность vault‑а %1$s %2$s. Этот вывод может задержаться.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -540,6 +540,10 @@
     <string name="kamino_amount_below_minimum">Минимум — %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">Этот vault не поддерживается приложением</string>
     <string name="kamino_error_load_failed">Сейчас не удалось загрузить этот vault</string>
+    <string name="kamino_refusal_below_smallest_unit">Сумма меньше минимальной единицы этого актива</string>
+    <string name="kamino_refusal_below_minimum">Сумма ниже минимума этого vault‑а</string>
+    <string name="kamino_refusal_rate_unavailable">Курс доли этого vault‑а сейчас недоступен</string>
+    <string name="kamino_refusal_larger_than_position">Эта сумма больше вашей позиции</string>
     <string name="verify_deposit_depositing">Вы вносите</string>
     <string name="verify_deposit_withdrawing">Вы выводите</string>
     <string name="kamino_verify_vault">Vault Kamino</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -531,13 +531,18 @@
     <string name="kamino_earn_risk_private_credit">Частный кредит</string>
     <string name="kamino_earn_deposit">Внести</string>
     <string name="kamino_earn_empty_title">Нет активных позиций Earn</string>
-    <string name="kamino_earn_empty_description">Включите хранилище Kamino в разделе «Управление Позициями», чтобы начать получать доход от своих активов Solana.</string>
+    <string name="kamino_earn_empty_description">Включите vault Kamino в разделе «Управление Позициями», чтобы начать получать доход от своих активов Solana.</string>
     <string name="kamino_deposit_title">Внести</string>
     <string name="kamino_withdraw_title">Вывести</string>
     <string name="kamino_amount_exceeds_available">Сумма превышает доступный баланс</string>
     <string name="kamino_amount_below_minimum">Минимум — %1$s %2$s</string>
-    <string name="kamino_error_unknown_vault">Это хранилище не поддерживается приложением</string>
-    <string name="kamino_error_load_failed">Сейчас не удалось загрузить это хранилище</string>
+    <string name="kamino_error_unknown_vault">Этот vault не поддерживается приложением</string>
+    <string name="kamino_error_load_failed">Сейчас не удалось загрузить этот vault</string>
+    <string name="kamino_error_build_failed">Не удалось подготовить эту транзакцию</string>
+    <string name="kamino_withdraw_farm_staked">Эти доли размещены в фарме vault‑а и пока не могут быть выведены</string>
+    <string name="kamino_withdraw_nothing">Из этого vault‑а нечего выводить</string>
+    <string name="kamino_withdraw_unreadable">Не удалось прочитать эту позицию, поэтому вывод невозможно подготовить</string>
+    <string name="kamino_withdraw_delayed">Превышает мгновенную ликвидность vault‑а %1$s %2$s. Этот вывод может задержаться.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Заморозить</string>
     <string name="tron_defi_unfreeze">Разморозить</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -527,6 +527,7 @@
     <string name="kamino_earn_deposited">Депонировано</string>
     <string name="kamino_earn_apy_30d">APY (30 дн.)</string>
     <string name="kamino_earn_pnl">Прибыль и убыток</string>
+    <string name="kamino_earn_lost">Убыток</string>
     <string name="kamino_earn_risk_conservative">Консервативный</string>
     <string name="kamino_earn_risk_private_credit">Частный кредит</string>
     <string name="kamino_earn_deposit">Внести</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -517,9 +517,27 @@
     <string name="defi_tab_staked">стейкинге</string>
     <string name="defi_tab_bonded">Забондено</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">Доход</string>
     <string name="defi_bond">Бонд</string>
     <string name="defi_stake">Стейк</string>
     <string name="liquidity_pool">Пул ликвидности</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">Куратор: %1$s</string>
+    <string name="kamino_earn_deposited">Депонировано</string>
+    <string name="kamino_earn_apy_30d">APY (30 дн.)</string>
+    <string name="kamino_earn_pnl">Прибыль и убыток</string>
+    <string name="kamino_earn_risk_conservative">Консервативный</string>
+    <string name="kamino_earn_risk_private_credit">Частный кредит</string>
+    <string name="kamino_earn_deposit">Внести</string>
+    <string name="kamino_earn_empty_title">Нет активных позиций Earn</string>
+    <string name="kamino_earn_empty_description">Включите хранилище Kamino в разделе «Управление Позициями», чтобы начать получать доход от своих активов Solana.</string>
+    <string name="kamino_deposit_title">Внести</string>
+    <string name="kamino_withdraw_title">Вывести</string>
+    <string name="kamino_amount_exceeds_available">Сумма превышает доступный баланс</string>
+    <string name="kamino_amount_below_minimum">Минимум — %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">Это хранилище не поддерживается приложением</string>
+    <string name="kamino_error_load_failed">Сейчас не удалось загрузить это хранилище</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Заморозить</string>
     <string name="tron_defi_unfreeze">Разморозить</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -83,7 +83,6 @@
     <string name="verify_deposit_withdrawing">正在提取</string>
     <string name="kamino_verify_vault">金库</string>
     <string name="kamino_error_build_failed">无法准备此交易</string>
-    <string name="kamino_withdraw_farm_staked">这些份额已质押在金库的farm中，暂时无法提取</string>
     <string name="kamino_withdraw_nothing">该金库没有可提取的资产</string>
     <string name="kamino_withdraw_unreadable">无法读取该仓位，因此无法准备提取</string>
     <string name="kamino_withdraw_delayed">超出金库的即时流动性 %1$s %2$s。此次提取可能会延迟。</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -69,6 +69,7 @@
     <string name="kamino_earn_apy_30d">年化收益率（30天）</string>
     <string name="kamino_earn_pnl">盈亏</string>
     <string name="kamino_earn_lost">亏损</string>
+    <string name="kamino_earn_load_failed">暂时无法刷新这些金库</string>
     <string name="kamino_earn_risk_conservative">保守型</string>
     <string name="kamino_earn_risk_private_credit">私募信贷</string>
     <string name="kamino_earn_deposit">存入</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,6 +79,11 @@
     <string name="kamino_amount_below_minimum">最低 %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">应用不支持该金库</string>
     <string name="kamino_error_load_failed">暂时无法加载该金库</string>
+    <string name="kamino_error_build_failed">无法准备此交易</string>
+    <string name="kamino_withdraw_farm_staked">这些份额已质押在金库的farm中，暂时无法提取</string>
+    <string name="kamino_withdraw_nothing">该金库没有可提取的资产</string>
+    <string name="kamino_withdraw_unreadable">无法读取该仓位，因此无法准备提取</string>
+    <string name="kamino_withdraw_delayed">超出金库的即时流动性 %1$s %2$s。此次提取可能会延迟。</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">冻结</string>
     <string name="tron_defi_unfreeze">解冻</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -79,6 +79,9 @@
     <string name="kamino_amount_below_minimum">最低 %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">应用不支持该金库</string>
     <string name="kamino_error_load_failed">暂时无法加载该金库</string>
+    <string name="verify_deposit_depositing">正在存入</string>
+    <string name="verify_deposit_withdrawing">正在提取</string>
+    <string name="kamino_verify_vault">金库</string>
     <string name="kamino_error_build_failed">无法准备此交易</string>
     <string name="kamino_withdraw_farm_staked">这些份额已质押在金库的farm中，暂时无法提取</string>
     <string name="kamino_withdraw_nothing">该金库没有可提取的资产</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -68,6 +68,7 @@
     <string name="kamino_earn_deposited">已存入</string>
     <string name="kamino_earn_apy_30d">年化收益率（30天）</string>
     <string name="kamino_earn_pnl">盈亏</string>
+    <string name="kamino_earn_lost">亏损</string>
     <string name="kamino_earn_risk_conservative">保守型</string>
     <string name="kamino_earn_risk_private_credit">私募信贷</string>
     <string name="kamino_earn_deposit">存入</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -81,6 +81,10 @@
     <string name="kamino_amount_below_minimum">最低 %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">应用不支持该金库</string>
     <string name="kamino_error_load_failed">暂时无法加载该金库</string>
+    <string name="kamino_refusal_below_smallest_unit">金额小于该资产的最小单位</string>
+    <string name="kamino_refusal_below_minimum">金额低于该金库的最低限额</string>
+    <string name="kamino_refusal_rate_unavailable">暂时无法获取该金库的份额价格</string>
+    <string name="kamino_refusal_larger_than_position">该金额大于当前仓位</string>
     <string name="verify_deposit_depositing">正在存入</string>
     <string name="verify_deposit_withdrawing">正在提取</string>
     <string name="kamino_verify_vault">金库</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -58,9 +58,27 @@
     <string name="defi_tab_staked">已质押</string>
     <string name="defi_tab_bonded">已绑定</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">赚币</string>
     <string name="defi_bond">绑定</string>
     <string name="defi_stake">质押</string>
     <string name="liquidity_pool">流动性池</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">由 %1$s 策划</string>
+    <string name="kamino_earn_deposited">已存入</string>
+    <string name="kamino_earn_apy_30d">年化收益率（30天）</string>
+    <string name="kamino_earn_pnl">盈亏</string>
+    <string name="kamino_earn_risk_conservative">保守型</string>
+    <string name="kamino_earn_risk_private_credit">私募信贷</string>
+    <string name="kamino_earn_deposit">存入</string>
+    <string name="kamino_earn_empty_title">未启用任何赚币仓位</string>
+    <string name="kamino_earn_empty_description">在“管理仓位”中启用 Kamino 金库，即可开始用您的 Solana 资产赚取收益。</string>
+    <string name="kamino_deposit_title">存入</string>
+    <string name="kamino_withdraw_title">提取</string>
+    <string name="kamino_amount_exceeds_available">金额超出可用余额</string>
+    <string name="kamino_amount_below_minimum">最低 %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">应用不支持该金库</string>
+    <string name="kamino_error_load_failed">暂时无法加载该金库</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">冻结</string>
     <string name="tron_defi_unfreeze">解冻</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -89,6 +89,10 @@
     <string name="kamino_amount_below_minimum">Minimum is %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">This vault is not one the app supports</string>
     <string name="kamino_error_load_failed">Could not load this vault right now</string>
+    <string name="kamino_refusal_below_smallest_unit">Amount is smaller than the smallest unit of this asset</string>
+    <string name="kamino_refusal_below_minimum">Amount is below this vault\'s minimum</string>
+    <string name="kamino_refusal_rate_unavailable">This vault\'s share rate is unavailable right now</string>
+    <string name="kamino_refusal_larger_than_position">That amount is larger than this position</string>
     <string name="verify_deposit_depositing">You\'re depositing</string>
     <string name="verify_deposit_withdrawing">You\'re withdrawing</string>
     <string name="kamino_verify_vault">Vault</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,11 @@
     <string name="kamino_amount_below_minimum">Minimum is %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">This vault is not one the app supports</string>
     <string name="kamino_error_load_failed">Could not load this vault right now</string>
+    <string name="kamino_error_build_failed">Couldn\'t prepare this transaction</string>
+    <string name="kamino_withdraw_farm_staked">These shares are staked in the vault\'s farm and can\'t be withdrawn yet</string>
+    <string name="kamino_withdraw_nothing">Nothing to withdraw from this vault</string>
+    <string name="kamino_withdraw_unreadable">This position couldn\'t be read, so no withdrawal can be prepared</string>
+    <string name="kamino_withdraw_delayed">Above the vault\'s instant liquidity of %1$s %2$s. This withdrawal may settle with a delay.</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Freeze</string>
     <string name="tron_defi_unfreeze">Unfreeze</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,9 +66,27 @@
     <string name="defi_tab_staked">Staked</string>
     <string name="defi_tab_bonded">Bonded</string>
     <string name="defi_tab_lp">LP</string>
+    <string name="defi_tab_earn">Earn</string>
     <string name="defi_bond">Bond</string>
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Liquidity Pool</string>
+    <!-- Kamino Earn -->
+    <string name="kamino_earn_title">Kamino Earn</string>
+    <string name="kamino_earn_curated_by">Curated by %1$s</string>
+    <string name="kamino_earn_deposited">Deposited</string>
+    <string name="kamino_earn_apy_30d">APY (30d)</string>
+    <string name="kamino_earn_pnl">Profit &amp; Loss</string>
+    <string name="kamino_earn_risk_conservative">Conservative</string>
+    <string name="kamino_earn_risk_private_credit">Private Credit</string>
+    <string name="kamino_earn_deposit">Deposit</string>
+    <string name="kamino_earn_empty_title">No Earn positions enabled</string>
+    <string name="kamino_earn_empty_description">Enable a Kamino vault under Manage positions to start earning on your Solana assets.</string>
+    <string name="kamino_deposit_title">Deposit</string>
+    <string name="kamino_withdraw_title">Withdraw</string>
+    <string name="kamino_amount_exceeds_available">Amount exceeds the available balance</string>
+    <string name="kamino_amount_below_minimum">Minimum is %1$s %2$s</string>
+    <string name="kamino_error_unknown_vault">This vault is not one the app supports</string>
+    <string name="kamino_error_load_failed">Could not load this vault right now</string>
     <!-- Tron DeFi -->
     <string name="tron_defi_freeze">Freeze</string>
     <string name="tron_defi_unfreeze">Unfreeze</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="kamino_earn_deposited">Deposited</string>
     <string name="kamino_earn_apy_30d">APY (30d)</string>
     <string name="kamino_earn_pnl">Profit &amp; Loss</string>
+    <string name="kamino_earn_lost">Lost</string>
     <string name="kamino_earn_risk_conservative">Conservative</string>
     <string name="kamino_earn_risk_private_credit">Private Credit</string>
     <string name="kamino_earn_deposit">Deposit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -77,6 +77,7 @@
     <string name="kamino_earn_apy_30d">APY (30d)</string>
     <string name="kamino_earn_pnl">Profit &amp; Loss</string>
     <string name="kamino_earn_lost">Lost</string>
+    <string name="kamino_earn_load_failed">Couldn\'t refresh these vaults just now</string>
     <string name="kamino_earn_risk_conservative">Conservative</string>
     <string name="kamino_earn_risk_private_credit">Private Credit</string>
     <string name="kamino_earn_deposit">Deposit</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -91,7 +91,6 @@
     <string name="verify_deposit_withdrawing">You\'re withdrawing</string>
     <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Couldn\'t prepare this transaction</string>
-    <string name="kamino_withdraw_farm_staked">These shares are staked in the vault\'s farm and can\'t be withdrawn yet</string>
     <string name="kamino_withdraw_nothing">Nothing to withdraw from this vault</string>
     <string name="kamino_withdraw_unreadable">This position couldn\'t be read, so no withdrawal can be prepared</string>
     <string name="kamino_withdraw_delayed">Above the vault\'s instant liquidity of %1$s %2$s. This withdrawal may settle with a delay.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -87,6 +87,9 @@
     <string name="kamino_amount_below_minimum">Minimum is %1$s %2$s</string>
     <string name="kamino_error_unknown_vault">This vault is not one the app supports</string>
     <string name="kamino_error_load_failed">Could not load this vault right now</string>
+    <string name="verify_deposit_depositing">You\'re depositing</string>
+    <string name="verify_deposit_withdrawing">You\'re withdrawing</string>
+    <string name="kamino_verify_vault">Vault</string>
     <string name="kamino_error_build_failed">Couldn\'t prepare this transaction</string>
     <string name="kamino_withdraw_farm_staked">These shares are staked in the vault\'s farm and can\'t be withdrawn yet</string>
     <string name="kamino_withdraw_nothing">Nothing to withdraw from this vault</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.models.solanastaking
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.KaminoApi
 import com.vultisig.wallet.data.api.KaminoUserPositionJson
 import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
@@ -25,6 +26,7 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -294,10 +296,9 @@ internal class KaminoAmountViewModelTest {
     }
 
     @Test
-    fun `a withdraw of farm-staked shares is refused by name, not attempted`() = runTest {
-        // Every launch-vault deposit auto-stakes, and the transaction that spends staked shares has
-        // never been observed, so this is a named state rather than a guess at an instruction
-        // layout.
+    fun `a farm-staked position is offered, because Kamino releases it from the farm`() = runTest {
+        // Every launch-vault deposit auto-stakes, so refusing this would block the only withdraw
+        // path that exists in practice. The transaction releases the shares from the farm itself.
         givenTokenBalance("0")
         coEvery { kaminoApi.getUserPositions(WALLET) } returns
             listOf(
@@ -379,6 +380,27 @@ internal class KaminoAmountViewModelTest {
         assertEquals(OPERATION_KAMINO_DEPOSIT, captured.captured.operation)
         assertEquals("Steakhouse USDC", captured.captured.validatorName)
         assertEquals(STEAKHOUSE.address, captured.captured.dstAddress)
+    }
+
+    @Test
+    fun `a refusal reaches the user as a localised resource, not an exception message`() = runTest {
+        // The message belongs in the log; the user needs the same fact in their own language. A
+        // DynamicString carrying English prose reaches every locale untranslated.
+        givenTokenBalance("2500000000")
+
+        val vm = viewModel()
+        vm.amountFieldState.setTextAndPlaceCursorAtEnd("999999")
+        vm.submit()
+
+        val error = vm.state.value.error
+        assertTrue(
+            error is UiText.StringResource,
+            "expected a string resource, was ${error?.let { it::class.simpleName }}",
+        )
+        assertEquals(
+            R.string.kamino_amount_exceeds_available,
+            (error as UiText.StringResource).resId,
+        )
     }
 
     private companion object {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -1,0 +1,309 @@
+package com.vultisig.wallet.ui.models.solanastaking
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
+import com.vultisig.wallet.data.api.KaminoVaultStateJson
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.blockchain.solana.kamino.BuildKaminoKeysignPayloadUseCase
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.BalanceRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class KaminoAmountViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var kaminoApi: KaminoApi
+    private lateinit var solanaApi: SolanaApi
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
+    private lateinit var balanceRepository: BalanceRepository
+    private lateinit var blockChainSpecificRepository: BlockChainSpecificRepository
+    private lateinit var buildKeysignPayload: BuildKaminoKeysignPayloadUseCase
+    private lateinit var depositTransactionRepository: DepositTransactionRepository
+    private lateinit var navigator: Navigator<Destination>
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        // `toRoute` reaches into android.os.Bundle, which is not available to JVM tests, so the
+        // route is stubbed the same way the other route-carrying ViewModel tests do it.
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+        kaminoApi = mockk(relaxed = true)
+        solanaApi = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        chainAccountAddressRepository = mockk(relaxed = true)
+        balanceRepository = mockk(relaxed = true)
+        blockChainSpecificRepository = mockk(relaxed = true)
+        buildKeysignPayload = mockk(relaxed = true)
+        depositTransactionRepository = mockk(relaxed = true)
+        navigator = mockk(relaxed = true)
+
+        // 165-byte SPL token account rent-exempt reserve, the real mainnet figure.
+        coEvery { solanaApi.getMinimumBalanceForRentExemption() } returns BigInteger("2039280")
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
+        coEvery { chainAccountAddressRepository.getAddress(Chain.Solana, VAULT) } returns
+            (WALLET to "pubkey")
+        coEvery { kaminoApi.getVaultState(any()) } returns
+            KaminoVaultStateJson(
+                address = STEAKHOUSE.address,
+                state =
+                    KaminoVaultStateJson.State(
+                        name = "Steakhouse USDC",
+                        tokenMint = STEAKHOUSE.tokenMint,
+                        tokenDecimals = 6,
+                        sharesMint = STEAKHOUSE.sharesMint,
+                        sharesDecimals = 6,
+                        minDepositAmount = "100000",
+                        minWithdrawAmount = "1000",
+                    ),
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel(
+        vaultAddress: String = STEAKHOUSE.address,
+        isWithdraw: Boolean = false,
+    ): KaminoAmountViewModel {
+        every { any<SavedStateHandle>().toRoute<Route.KaminoAmount>() } returns
+            Route.KaminoAmount(
+                vaultId = VAULT_ID,
+                vaultAddress = vaultAddress,
+                isWithdraw = isWithdraw,
+            )
+        return KaminoAmountViewModel(
+            savedStateHandle = mockk(relaxed = true),
+            kaminoApi = kaminoApi,
+            solanaApi = solanaApi,
+            vaultRepository = vaultRepository,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            balanceRepository = balanceRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            buildKeysignPayload = buildKeysignPayload,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+        )
+    }
+
+    private fun givenTokenBalance(baseUnits: String) {
+        coEvery { balanceRepository.getTokenValue(any(), any()) } returns
+            flowOf(TokenValue(value = BigInteger(baseUnits), token = COIN))
+    }
+
+    @Test
+    fun `a deposit caps against the wallet token balance`() = runTest {
+        givenTokenBalance("2500000000") // 2,500 USDC at 6 decimals
+
+        val state = viewModel().state.value
+
+        assertFalse(state.isWithdraw)
+        assertEquals(0, BigDecimal("2500").compareTo(state.available))
+        assertEquals("Steakhouse USDC", state.vaultName)
+        assertEquals("USDC", state.ticker)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `the deposit minimum comes from vault state, converted out of base units`() = runTest {
+        givenTokenBalance("2500000000")
+
+        // 100000 base units at 6 decimals is 0.1 USDC — not 100,000.
+        assertEquals(0, BigDecimal("0.1").compareTo(viewModel().state.value.minimum!!))
+    }
+
+    @Test
+    fun `a withdraw caps against the position, not the wallet`() = runTest {
+        givenTokenBalance("0") // nothing in the wallet; the position is what matters
+        coEvery { kaminoApi.getUserPositions(WALLET) } returns
+            listOf(
+                KaminoUserPositionJson(
+                    vaultAddress = STEAKHOUSE.address,
+                    stakedShares = "1000",
+                    totalShares = "1000",
+                )
+            )
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0544278224860290217")
+
+        val state = viewModel(isWithdraw = true).state.value
+
+        assertTrue(state.isWithdraw)
+        // 1000 shares × 1.0544278224860290217, rounded down to the token's 6 decimals.
+        assertEquals(0, BigDecimal("1054.427822").compareTo(state.available))
+        assertEquals(0, BigDecimal("0.001").compareTo(state.minimum!!))
+    }
+
+    @Test
+    fun `a withdraw with no position offers nothing rather than the wallet balance`() = runTest {
+        givenTokenBalance("2500000000")
+        coEvery { kaminoApi.getUserPositions(WALLET) } returns emptyList()
+
+        assertEquals(
+            0,
+            BigDecimal.ZERO.compareTo(viewModel(isWithdraw = true).state.value.available),
+        )
+    }
+
+    @Test
+    fun `an uncurated vault address is refused before anything is fetched`() = runTest {
+        // The route argument is not trusted: only the local allow-list decides.
+        val state =
+            viewModel(vaultAddress = "2Z6C84pCc2ri8t39jvRCXnTGFQqUJf1mMpUMtpeFfhyB").state.value
+
+        assertNotNull(state.error)
+        assertFalse(state.isLoading)
+        assertEquals(0, BigDecimal.ZERO.compareTo(state.available))
+    }
+
+    @Test
+    fun `percentage chips scale the available balance and round down`() = runTest {
+        givenTokenBalance("2500000000")
+
+        val vm = viewModel()
+        vm.onPercentageChange(50)
+
+        assertEquals("1250", vm.amountFieldState.text.toString())
+        assertEquals(50, vm.state.value.percentageSelected)
+    }
+
+    @Test
+    fun `a max chip on a native SOL vault leaves room for the network fee`() = runTest {
+        // 1 SOL exactly; the fee buffer must come off the top or the deposit cannot pay for itself.
+        coEvery { balanceRepository.getTokenValue(any(), any()) } returns
+            flowOf(TokenValue(value = BigInteger("1000000000"), token = COIN))
+        coEvery { kaminoApi.getVaultState(any()) } returns
+            KaminoVaultStateJson(
+                address = ALLEZ.address,
+                state =
+                    KaminoVaultStateJson.State(
+                        name = "Allez SOL",
+                        tokenMint = ALLEZ.tokenMint,
+                        tokenDecimals = 9,
+                        sharesMint = ALLEZ.sharesMint,
+                        sharesDecimals = 6,
+                        minDepositAmount = "10000000",
+                    ),
+            )
+
+        val available = viewModel(vaultAddress = ALLEZ.address).state.value.available
+
+        assertTrue(available < BigDecimal.ONE, "expected less than a whole SOL, was $available")
+        assertTrue(
+            available > BigDecimal("0.99"),
+            "expected most of the balance to remain, was $available",
+        )
+    }
+
+    @Test
+    fun `submitting nothing does not build a transaction`() = runTest {
+        givenTokenBalance("2500000000")
+
+        val vm = viewModel()
+        vm.submit() // empty field
+
+        assertNull(vm.state.value.error)
+        assertFalse(vm.state.value.isSubmitting)
+    }
+
+    @Test
+    fun `a max SOL deposit reserves the wrapped-SOL account rent it has to create`() = runTest {
+        // The vault's underlying is wSOL, so the deposit creates a token account. Without reserving
+        // its rent a Max deposit cannot fund that account and fails on chain.
+        coEvery { balanceRepository.getTokenValue(any(), any()) } returns
+            flowOf(TokenValue(value = BigInteger("1000000000"), token = COIN))
+        coEvery { kaminoApi.getVaultState(any()) } returns
+            KaminoVaultStateJson(
+                address = ALLEZ.address,
+                state =
+                    KaminoVaultStateJson.State(
+                        name = "Allez SOL",
+                        tokenMint = ALLEZ.tokenMint,
+                        tokenDecimals = 9,
+                        sharesMint = ALLEZ.sharesMint,
+                        sharesDecimals = 6,
+                    ),
+            )
+
+        val available = viewModel(vaultAddress = ALLEZ.address).state.value.available
+
+        // 1 SOL less rent (0.00203928) less the priority fee (20,000 µlamports x 350,000 CU =
+        // 7,000 lamports) less the base fee — so strictly below 0.998, and far below a naive
+        // fee-only headroom.
+        assertTrue(
+            available < BigDecimal("0.998"),
+            "expected rent + priority fee reserved, was $available",
+        )
+        assertTrue(available > BigDecimal("0.99"), "reserved too much, was $available")
+    }
+
+    @Test
+    fun `a USDC deposit does not reserve SOL costs against the token balance`() = runTest {
+        // The fee and any account rent are paid in SOL, so the whole USDC balance is spendable.
+        givenTokenBalance("2500000000")
+        assertEquals(0, BigDecimal("2500").compareTo(viewModel().state.value.available))
+    }
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+        const val WALLET = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+        val STEAKHOUSE = KaminoVaultRegistry.STEAKHOUSE_USDC
+        val ALLEZ = KaminoVaultRegistry.ALLEZ_SOL
+
+        val COIN = com.vultisig.wallet.data.models.Coins.Solana.USDC
+
+        val VAULT =
+            Vault(
+                id = VAULT_ID,
+                name = "vault",
+                pubKeyECDSA = "",
+                pubKeyEDDSA = "",
+                hexChainCode = "",
+                localPartyID = "",
+                signers = emptyList(),
+                resharePrefix = "",
+                libType = SigningLibType.DKLS,
+            )
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -256,7 +256,7 @@ internal class KaminoAmountViewModelTest {
     }
 
     @Test
-    fun `a max SOL deposit reserves the wrapped-SOL account rent it has to create`() = runTest {
+    fun `a max SOL deposit reserves the wrapped-SOL rent and the priority fee`() = runTest {
         // The vault's underlying is wSOL, so the deposit creates a token account. Without reserving
         // its rent a Max deposit cannot fund that account and fails on chain.
         coEvery { balanceRepository.getTokenValue(any(), any()) } returns

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.api.KaminoVaultStateJson
 import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.blockchain.solana.kamino.BuildKaminoKeysignPayloadUseCase
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawEligibility
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.TokenValue
@@ -159,7 +160,8 @@ internal class KaminoAmountViewModelTest {
             listOf(
                 KaminoUserPositionJson(
                     vaultAddress = STEAKHOUSE.address,
-                    stakedShares = "1000",
+                    stakedShares = "0",
+                    unstakedShares = "1000",
                     totalShares = "1000",
                 )
             )
@@ -171,7 +173,9 @@ internal class KaminoAmountViewModelTest {
         assertTrue(state.isWithdraw)
         // 1000 shares × 1.0544278224860290217, rounded down to the token's 6 decimals.
         assertEquals(0, BigDecimal("1054.427822").compareTo(state.available))
-        assertEquals(0, BigDecimal("0.001").compareTo(state.minimum!!))
+        // minWithdrawAmount is 1000 SHARE base units, so in tokens it is 0.001055 rounded up — not
+        // the 0.001 a token-denominated reading would give.
+        assertEquals(0, BigDecimal("0.001055").compareTo(state.minimum!!))
     }
 
     @Test
@@ -282,6 +286,64 @@ internal class KaminoAmountViewModelTest {
         // The fee and any account rent are paid in SOL, so the whole USDC balance is spendable.
         givenTokenBalance("2500000000")
         assertEquals(0, BigDecimal("2500").compareTo(viewModel().state.value.available))
+    }
+
+    @Test
+    fun `a withdraw of farm-staked shares is refused by name, not attempted`() = runTest {
+        // Every launch-vault deposit auto-stakes, and the transaction that spends staked shares has
+        // never been observed, so this is a named state rather than a guess at an instruction
+        // layout.
+        givenTokenBalance("0")
+        coEvery { kaminoApi.getUserPositions(WALLET) } returns
+            listOf(
+                KaminoUserPositionJson(
+                    vaultAddress = STEAKHOUSE.address,
+                    stakedShares = "1000",
+                    unstakedShares = "0",
+                    totalShares = "1000",
+                )
+            )
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0544278224860290217")
+
+        val state = viewModel(isWithdraw = true).state.value
+
+        assertTrue(state.eligibility is KaminoWithdrawEligibility.FarmStaked)
+        // Nothing may be offered against it.
+        assertEquals(0, BigDecimal.ZERO.compareTo(state.available))
+    }
+
+    @Test
+    fun `a failed positions read refuses the withdraw instead of offering zero`() = runTest {
+        givenTokenBalance("0")
+        coEvery { kaminoApi.getUserPositions(WALLET) } throws RuntimeException("503")
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val state = viewModel(isWithdraw = true).state.value
+
+        assertEquals(KaminoWithdrawEligibility.Unreadable, state.eligibility)
+    }
+
+    @Test
+    fun `the withdraw minimum is read as shares, not as the token amount`() = runTest {
+        // minWithdrawAmount is 1000 SHARE base units. Treated as token base units it would be
+        // 0.001 USDC; converted properly at the Steakhouse rate it is 0.001055.
+        givenTokenBalance("0")
+        coEvery { kaminoApi.getUserPositions(WALLET) } returns
+            listOf(
+                KaminoUserPositionJson(
+                    vaultAddress = STEAKHOUSE.address,
+                    stakedShares = "0",
+                    unstakedShares = "1000",
+                    totalShares = "1000",
+                )
+            )
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0544278224860290217")
+
+        val minimum = viewModel(isWithdraw = true).state.value.minimum
+        assertEquals(0, BigDecimal("0.001055").compareTo(minimum!!))
     }
 
     private companion object {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -175,8 +175,9 @@ internal class KaminoAmountViewModelTest {
         val state = viewModel(isWithdraw = true).state.value
 
         assertTrue(state.isWithdraw)
-        // 1000 shares × 1.0544278224860290217, rounded down to the token's 6 decimals.
-        assertEquals(0, BigDecimal("1054.427822").compareTo(state.available))
+        // 999999999 share base units (one below the balance, stepping back from the API's sentinel)
+        // × 1.0544278224860290217, truncated to the token's 6 decimals.
+        assertEquals(0, BigDecimal("1054.427821").compareTo(state.available))
         // minWithdrawAmount is 1000 SHARE base units, so in tokens it is 0.001055 rounded up — not
         // the 0.001 a token-denominated reading would give.
         assertEquals(0, BigDecimal("0.001055").compareTo(state.minimum!!))
@@ -312,9 +313,8 @@ internal class KaminoAmountViewModelTest {
 
         val state = viewModel(isWithdraw = true).state.value
 
-        assertTrue(state.eligibility is KaminoWithdrawEligibility.FarmStaked)
-        // Nothing may be offered against it.
-        assertEquals(0, BigDecimal.ZERO.compareTo(state.available))
+        assertTrue(state.eligibility is KaminoWithdrawEligibility.Withdrawable)
+        assertTrue(state.available.signum() > 0, "a staked position must still be withdrawable")
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.models.solanastaking
 
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.api.KaminoApi
@@ -11,6 +12,8 @@ import com.vultisig.wallet.data.blockchain.solana.kamino.BuildKaminoKeysignPaylo
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawEligibility
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
@@ -26,6 +29,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
 import io.mockk.unmockkStatic
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -344,6 +348,37 @@ internal class KaminoAmountViewModelTest {
 
         val minimum = viewModel(isWithdraw = true).state.value.minimum
         assertEquals(0, BigDecimal("0.001055").compareTo(minimum!!))
+    }
+
+    @Test
+    fun `the transaction is marked so verify names the direction and the vault`() = runTest {
+        // Without the marker the verify screen falls through to "You're sending" for a withdraw,
+        // and
+        // labels the vault name as a "Validator".
+        givenTokenBalance("2500000000")
+        val captured = slot<DepositTransaction>()
+        coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+        coEvery {
+            buildKeysignPayload(
+                vault = any(),
+                action = any(),
+                apiAmount = any(),
+                tokenAmount = any(),
+                coin = any(),
+                blockChainSpecific = any(),
+                vaultPublicKeyECDSA = any(),
+                vaultLocalPartyID = any(),
+                libType = any(),
+            )
+        } returns mockk(relaxed = true)
+
+        val vm = viewModel()
+        vm.amountFieldState.setTextAndPlaceCursorAtEnd("100")
+        vm.submit()
+
+        assertEquals(OPERATION_KAMINO_DEPOSIT, captured.captured.operation)
+        assertEquals("Steakhouse USDC", captured.captured.validatorName)
+        assertEquals(STEAKHOUSE.address, captured.captured.dstAddress)
     }
 
     private companion object {

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -1,0 +1,356 @@
+package com.vultisig.wallet.ui.screens.v2.defi.solana
+
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.KaminoPnlJson
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
+import com.vultisig.wallet.data.api.KaminoVaultStateJson
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.KaminoVaultSelectionRepository
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.text.NumberFormat
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class KaminoEarnViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var kaminoApi: KaminoApi
+    private lateinit var selectionRepository: KaminoVaultSelectionRepository
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
+    private lateinit var tokenPriceRepository: TokenPriceRepository
+    private lateinit var appCurrencyRepository: AppCurrencyRepository
+    private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        navigator = mockk(relaxed = true)
+        kaminoApi = mockk(relaxed = true)
+        selectionRepository = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        chainAccountAddressRepository = mockk(relaxed = true)
+        tokenPriceRepository = mockk(relaxed = true)
+        appCurrencyRepository = mockk(relaxed = true)
+        balanceVisibilityRepository = mockk(relaxed = true)
+
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
+        coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
+        coEvery { chainAccountAddressRepository.getAddress(Chain.Solana, VAULT) } returns
+            (WALLET_ADDRESS to "pubkey")
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        coEvery { appCurrencyRepository.getCurrencyFormat() } returns
+            NumberFormat.getCurrencyInstance(Locale.US)
+        coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns BigDecimal.ONE
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel() =
+        KaminoEarnViewModel(
+            navigator = navigator,
+            kaminoApi = kaminoApi,
+            selectionRepository = selectionRepository,
+            vaultRepository = vaultRepository,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            tokenPriceRepository = tokenPriceRepository,
+            appCurrencyRepository = appCurrencyRepository,
+            balanceVisibilityRepository = balanceVisibilityRepository,
+            ioDispatcher = testDispatcher,
+        )
+
+    private fun stubVault(name: String) =
+        KaminoVaultStateJson(
+            address = STEAKHOUSE.address,
+            state =
+                KaminoVaultStateJson.State(
+                    name = name,
+                    tokenMint = STEAKHOUSE.tokenMint,
+                    tokenDecimals = 6,
+                    sharesMint = STEAKHOUSE.sharesMint,
+                    sharesDecimals = 6,
+                ),
+        )
+
+    @Test
+    fun `nothing enabled leaves the segment empty rather than showing every vault`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns flowOf(emptySet())
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+        assertFalse(state.hasEnabledVaults)
+        assertTrue(state.rows.isEmpty())
+        assertNull(state.totalFiat)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `an enabled vault with no deposit still gets a card at zero`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(STEAKHOUSE.address) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(apy30d = "0.039967764404019690278", tokensPerShare = "1.05")
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+        assertTrue(state.hasEnabledVaults)
+        assertEquals(1, state.rows.size)
+        val row = state.rows.single()
+        assertEquals("Steakhouse USDC", row.name)
+        assertEquals("Steakhouse Financial", row.curator)
+        assertEquals(KaminoRiskTier.CONSERVATIVE, row.riskTier)
+        assertEquals("0 USDC", row.depositedDisplay)
+        assertEquals("4.00%", row.apyDisplay)
+        // Zero is not a gain: an untouched vault must not render green.
+        assertEquals(KaminoEarnRow.PnlDirection.FLAT, row.pnlDirection)
+    }
+
+    @Test
+    fun `a funded position is valued from shares and tokensPerShare`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+            listOf(
+                KaminoUserPositionJson(
+                    vaultAddress = STEAKHOUSE.address,
+                    stakedShares = "1000",
+                    unstakedShares = "0",
+                    totalShares = "1000",
+                )
+            )
+        coEvery { kaminoApi.getVaultState(STEAKHOUSE.address) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(
+                apy30d = "0.039967764404019690278",
+                tokensPerShare = "1.0544278224860290217",
+                sharePrice = "1.0542216502138983284",
+                tokenPrice = "0.99980447",
+            )
+        coEvery { kaminoApi.getPositionPnl(WALLET_ADDRESS, STEAKHOUSE.address) } returns
+            KaminoPnlJson(totalPnl = KaminoPnlJson.Amounts(token = "54.427822", usd = "54.41"))
+
+        val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+        assertEquals("1054.427822 USDC", row.depositedDisplay)
+        assertEquals("54.427822 USDC", row.pnlDisplay)
+        assertEquals(KaminoEarnRow.PnlDirection.UP, row.pnlDirection)
+        assertNotNull(row.depositedFiat)
+    }
+
+    @Test
+    fun `a loss renders as a loss`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(STEAKHOUSE.address) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+        coEvery { kaminoApi.getPositionPnl(WALLET_ADDRESS, STEAKHOUSE.address) } returns
+            KaminoPnlJson(totalPnl = KaminoPnlJson.Amounts(token = "-1.5"))
+
+        val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+        assertEquals(KaminoEarnRow.PnlDirection.DOWN, row.pnlDirection)
+    }
+
+    @Test
+    fun `a failed metrics call leaves the card standing without an APY`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(STEAKHOUSE.address) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } throws RuntimeException("503")
+
+        val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+        // The vault is still one the user enabled; dropping the card would read as losing it.
+        assertEquals("Steakhouse USDC", row.name)
+        assertNull(row.apyDisplay)
+    }
+
+    @Test
+    fun `a failed vault-state call falls back to the pinned name`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(STEAKHOUSE.address) } throws RuntimeException("503")
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+        assertEquals(STEAKHOUSE.fallbackName, row.name)
+    }
+
+    @Test
+    fun `a vault the registry does not know is ignored`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf("2Z6C84pCc2ri8t39jvRCXnTGFQqUJf1mMpUMtpeFfhyB"))
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+        assertTrue(state.rows.isEmpty())
+    }
+
+    @Test
+    fun `positions across two vaults are summed into one total`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address, ALLEZ.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+            listOf(
+                KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100"),
+                KaminoUserPositionJson(vaultAddress = ALLEZ.address, totalShares = "100"),
+            )
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Vault")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+        assertEquals(2, state.rows.size)
+        // Priced at 1.0 each, 100 + 100 shares against a 1:1 share ratio.
+        assertEquals("$200.00", state.totalFiat)
+    }
+
+    @Test
+    fun `hidden balances are surfaced to the view`() = runTest {
+        coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns false
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns flowOf(emptySet())
+
+        assertFalse(viewModel().apply { setData(VAULT_ID) }.state.value.isBalanceVisible)
+    }
+
+    @Test
+    fun `the picker seeds from what is currently enabled and saving persists it`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(any()) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        vm.openPicker()
+
+        assertTrue(vm.state.value.isShowingPicker)
+        assertEquals(setOf(STEAKHOUSE.address), vm.state.value.pendingSelection)
+
+        vm.onVaultToggled(ALLEZ.address, true)
+        vm.savePicker()
+
+        assertFalse(vm.state.value.isShowingPicker)
+        coVerify {
+            selectionRepository.saveSelectedVaults(
+                VAULT_ID,
+                setOf(STEAKHOUSE.address, ALLEZ.address),
+            )
+        }
+    }
+
+    @Test
+    fun `dismissing the picker leaves the saved selection untouched`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(any()) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        vm.openPicker()
+        vm.onVaultToggled(STEAKHOUSE.address, false)
+        vm.closePicker()
+
+        assertFalse(vm.state.value.isShowingPicker)
+        coVerify(exactly = 0) { selectionRepository.saveSelectedVaults(any(), any()) }
+    }
+
+    @Test
+    fun `saving an empty selection is how Earn gets turned off`() = runTest {
+        // An empty set must reach the repository, not be treated as "no choice made".
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(any()) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        vm.openPicker()
+        vm.onVaultToggled(STEAKHOUSE.address, false)
+        vm.savePicker()
+
+        coVerify { selectionRepository.saveSelectedVaults(VAULT_ID, emptySet()) }
+    }
+
+    @Test
+    fun `the picker refuses to enable a vault outside the registry`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns flowOf(emptySet())
+
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        vm.openPicker()
+        vm.onVaultToggled("2Z6C84pCc2ri8t39jvRCXnTGFQqUJf1mMpUMtpeFfhyB", true)
+
+        assertTrue(vm.state.value.pendingSelection.isEmpty())
+    }
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+        const val WALLET_ADDRESS = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+        val STEAKHOUSE = KaminoVaultRegistry.STEAKHOUSE_USDC
+        val ALLEZ = KaminoVaultRegistry.ALLEZ_SOL
+
+        val VAULT =
+            Vault(
+                id = VAULT_ID,
+                name = "vault",
+                pubKeyECDSA = "",
+                pubKeyEDDSA = "",
+                hexChainCode = "",
+                localPartyID = "",
+                signers = emptyList(),
+                resharePrefix = "",
+                libType = SigningLibType.DKLS,
+            )
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -333,6 +333,56 @@ internal class KaminoEarnViewModelTest {
         assertTrue(vm.state.value.pendingSelection.isEmpty())
     }
 
+    @Test
+    fun `an unread position keeps Withdraw available rather than hiding the way out`() = runTest {
+        // A zero carries two different claims: "read, and holds nothing" and "not read yet". Only
+        // the first may remove Withdraw — hiding it on an unread position strands a user who
+        // deposited on another device or whose refresh failed straight after depositing.
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(any()) } throws RuntimeException("503")
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+        assertTrue(row.hasPosition, "an unread position must not hide Withdraw")
+        // The figures stay off the card either way — the form reads the position itself.
+        assertNull(row.depositedFiat)
+    }
+
+    @Test
+    fun `a read position holding nothing does hide Withdraw`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(any()) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+        assertFalse(row.hasPosition)
+    }
+
+    @Test
+    fun `a loss is reported unsigned, because the label says it was lost`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(any()) } returns emptyList()
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+        coEvery { kaminoApi.getPositionPnl(any(), any()) } returns
+            KaminoPnlJson(totalPnl = KaminoPnlJson.Amounts(token = "-3"))
+
+        val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+        assertEquals(KaminoEarnRow.PnlDirection.DOWN, row.pnlDirection)
+        assertEquals("3 USDC", row.pnlDisplay)
+    }
+
     private companion object {
         const val VAULT_ID = "vault-id"
         const val WALLET_ADDRESS = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -36,6 +36,13 @@ android {
     sourceSets.getByName("main") {
         proto { srcDir("${project.rootProject.rootDir}/commondata/proto") }
     }
+    packaging {
+        resources {
+            // bcprov and jspecify both ship this file, which collides when the instrumented-test
+            // APK is assembled. Mirrors the exclude :app already carries.
+            excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
+        }
+    }
     tasks.withType<Test> { useJUnitPlatform() }
     lint {
         abortOnError = true
@@ -130,4 +137,7 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(kotlin("test"))
     androidTestImplementation(libs.wallet.core)
+    // `testInstrumentationRunner` above names AndroidJUnitRunner, but nothing put it on the
+    // classpath, so every instrumented test in this module failed to start.
+    androidTestImplementation(libs.androidx.test.runner)
 }

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/WalletCoreNative.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/WalletCoreNative.kt
@@ -1,0 +1,15 @@
+package com.vultisig.wallet.data
+
+/**
+ * Loads WalletCore's native library for instrumented tests in this module.
+ *
+ * Production code loads it from `:app`, which `:data`'s test APK never runs, so any test touching a
+ * `wallet.core.jni` class has to load it itself or fail with `UnsatisfiedLinkError`.
+ */
+object WalletCoreNative {
+
+    private val loaded: Unit by lazy { System.loadLibrary("TrustWalletCore") }
+
+    /** Idempotent; safe to call from every test class that needs the JNI bindings. */
+    fun ensureLoaded() = loaded
+}

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemoTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemoTest.kt
@@ -1,0 +1,246 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.WalletCoreNative
+import java.util.Base64
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import wallet.core.jni.Base58
+import wallet.core.jni.CoinType
+import wallet.core.jni.SolanaTransaction
+import wallet.core.jni.TransactionDecoder
+import wallet.core.jni.proto.Solana
+
+/**
+ * Golden coverage for the `vs` attribution memo against a real Kamino deposit.
+ *
+ * The fixture is a live `POST /ktx/kvault/deposit` response for the Steakhouse USDC vault: a v0
+ * versioned transaction whose four instructions address 9 static account keys plus 18 loaded
+ * through one address lookup table. Lookup-derived accounts are indexed immediately after the
+ * static keys, so appending the memo program as a static key shifts every one of them by one. Those
+ * shifts are the whole risk in this operation — an off-by-one repoints an existing instruction at a
+ * different account while every other check still passes — so they are asserted here index by index
+ * rather than trusted.
+ *
+ * Runs instrumented because both the insertion and the decode are WalletCore JNI.
+ */
+class KaminoAttributionMemoTest {
+
+    @Before
+    fun loadWalletCore() {
+        WalletCoreNative.ensureLoaded()
+    }
+
+    /**
+     * Steakhouse USDC deposit of 1 USDC, unsigned (a zeroed 64-byte signature envelope).
+     * Instructions: create the shares ATA, `kVault::deposit`, then two `farms` instructions that
+     * stake the shares.
+     */
+    private val depositTransaction =
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
+            "AQAFCX//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuemOEsQm7A2IghRdbzU0ar6Q7dIhEJA6xfcD32X" +
+            "M4YwfPSF38N5IeLVVX5/3BJfld0IR08X1RB7fe6uQkeVw/nk3uVtPK//R3XanFktvqbKIbsjaArJEZzlqWvc" +
+            "axKftHFhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2mzp9mGY3YcNiphvMGdcRvg+L1KDSHlS" +
+            "9dUFY+PveoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZ2LAQF2PT5R8SbmFW3oXejGEwWbhEaNDa" +
+            "P+iioiUcxwEE2Qrx24k57DX/lNlkDVfcwyeUuz4btm/TroSahNzblDJCgcwkFVHRKh2nMxb4pfSsIMN/m4f+" +
+            "R1HblBX15CRABAYGAAMACQQaAQEIFQARDRYUCQEDGBoaBQgQDwoMFRMXEhDyI8aJUuHytkBCDwAAAAAABwgA" +
+            "AAAAAgsEGQhvEbn6PHom/gcIAAILDgMJBxoQzrDKEsjRs2z//////////wGC6dRmw0Z9LrKw2cy+tHvb9JXu" +
+            "HBu0d9Dar60DX6fr5AkFNTElLzITCQEJJxUECwI3BwYD"
+
+    private fun decode(base64Transaction: String): Solana.RawMessage.MessageV0 {
+        val decoded =
+            TransactionDecoder.decode(
+                CoinType.SOLANA,
+                Base64.getDecoder().decode(base64Transaction),
+            )
+        val output = Solana.DecodingTransactionOutput.parseFrom(decoded)
+        assertTrue("fixture must decode", output.hasTransaction())
+        assertTrue("fixture must be a v0 versioned message", output.transaction.hasV0())
+        return output.transaction.v0
+    }
+
+    /** Resolves an instruction's program index against the message's static account keys. */
+    private fun programOf(
+        message: Solana.RawMessage.MessageV0,
+        instruction: Solana.RawMessage.Instruction,
+    ): String = message.getAccountKeys(instruction.programId)
+
+    @Test
+    fun fixture_is_the_shape_this_test_reasons_about() {
+        val original = decode(depositTransaction)
+
+        assertEquals("static account keys", 9, original.accountKeysCount)
+        assertEquals("instructions", 4, original.instructionsCount)
+        assertEquals("address lookup tables", 1, original.addressTableLookupsCount)
+        assertEquals("readonly unsigned accounts", 5, original.header.numReadonlyUnsignedAccounts)
+        assertEquals("required signatures", 1, original.header.numRequiredSignatures)
+
+        // The deposit stakes into the farm, so the shares never become a wallet token balance.
+        val programs = original.instructionsList.map { programOf(original, it) }
+        assertEquals(
+            listOf(
+                "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+                KaminoVaultRegistry.PROGRAM_ID,
+                KaminoVaultRegistry.FARMS_PROGRAM_ID,
+                KaminoVaultRegistry.FARMS_PROGRAM_ID,
+            ),
+            programs,
+        )
+
+        // At least one instruction must address a lookup-loaded account, or the shift this test
+        // exists to verify would never be exercised.
+        val highest = original.instructionsList.flatMap { it.accountsList }.maxOrNull() ?: 0
+        assertTrue(
+            "fixture must address lookup-loaded accounts (highest index $highest)",
+            highest >= original.accountKeysCount,
+        )
+    }
+
+    @Test
+    fun append_adds_exactly_one_memo_instruction_carrying_the_tag() {
+        val updated = decode(KaminoAttributionMemo.append(depositTransaction))
+
+        assertEquals("one instruction added", 5, updated.instructionsCount)
+
+        val memos =
+            updated.instructionsList.filter {
+                programOf(updated, it) == KaminoAttributionMemo.MEMO_PROGRAM_ID
+            }
+        assertEquals("exactly one memo", 1, memos.size)
+
+        val memo = memos.single()
+        assertEquals(
+            "memo is appended last",
+            updated.instructionsCount - 1,
+            updated.instructionsList.indexOf(memo),
+        )
+        assertEquals("memo takes no accounts", 0, memo.accountsCount)
+        assertEquals(
+            "memo data is the bare tag",
+            KaminoAttributionMemo.TAG,
+            memo.programData.toByteArray().toString(Charsets.US_ASCII),
+        )
+        assertEquals("memo adds no signer", 1, updated.header.numRequiredSignatures)
+    }
+
+    @Test
+    fun append_registers_the_memo_program_as_a_trailing_readonly_unsigned_key() {
+        val original = decode(depositTransaction)
+        val updated = decode(KaminoAttributionMemo.append(depositTransaction))
+
+        assertEquals("one static key added", 10, updated.accountKeysCount)
+        assertEquals(
+            "memo program is the new last static key",
+            KaminoAttributionMemo.MEMO_PROGRAM_ID,
+            updated.getAccountKeys(updated.accountKeysCount - 1),
+        )
+        assertEquals(
+            "readonly unsigned count follows the new key",
+            original.header.numReadonlyUnsignedAccounts + 1,
+            updated.header.numReadonlyUnsignedAccounts,
+        )
+        assertEquals(
+            "pre-existing static keys are untouched and in order",
+            original.accountKeysList,
+            updated.accountKeysList.dropLast(1),
+        )
+        assertEquals(
+            "lookup tables are untouched",
+            original.addressTableLookupsList,
+            updated.addressTableLookupsList,
+        )
+    }
+
+    @Test
+    fun append_shifts_every_lookup_derived_index_and_leaves_static_ones_alone() {
+        val original = decode(depositTransaction)
+        val updated = decode(KaminoAttributionMemo.append(depositTransaction))
+
+        val insertedAt = original.accountKeysCount // 9 — the memo program's new slot
+        val originalInstructions = original.instructionsList
+        val carriedOver = updated.instructionsList.dropLast(1) // drop the memo
+
+        assertEquals("original instructions survive", originalInstructions.size, carriedOver.size)
+
+        originalInstructions.forEachIndexed { position, before ->
+            val after = carriedOver[position]
+
+            val expectedAccounts = before.accountsList.map { if (it >= insertedAt) it + 1 else it }
+            assertEquals(
+                "instruction $position account indices",
+                expectedAccounts,
+                after.accountsList,
+            )
+            assertEquals(
+                "instruction $position program index",
+                if (before.programId >= insertedAt) before.programId + 1 else before.programId,
+                after.programId,
+            )
+            assertEquals("instruction $position data", before.programData, after.programData)
+
+            // The point of the shift: each instruction must still invoke the same program and
+            // resolve to the same accounts once the new key table is applied.
+            assertEquals(
+                "instruction $position still invokes the same program",
+                programOf(original, before),
+                programOf(updated, after),
+            )
+        }
+
+        // Guard the assertion itself: a fixture whose indices all sat below the insertion point
+        // would make the shift check vacuous.
+        assertNotEquals(
+            "at least one index must actually move",
+            originalInstructions.map { it.accountsList },
+            carriedOver.map { it.accountsList },
+        )
+    }
+
+    @Test
+    fun memo_data_is_base58_encoded_and_the_transaction_stays_within_the_size_limit() {
+        // WalletCore's JSON instruction format encodes `data` as base58, not base64. Pinning the
+        // encoded form keeps the two on-chain bytes identical across platforms.
+        assertEquals("A1p", Base58.encodeNoCheck(KaminoAttributionMemo.TAG.toByteArray()))
+
+        val before = Base64.getDecoder().decode(depositTransaction).size
+        val after =
+            Base64.getDecoder().decode(KaminoAttributionMemo.append(depositTransaction)).size
+
+        assertTrue("memo must grow the transaction", after > before)
+        assertTrue(
+            "signed transaction must stay within the v0 packet limit (was $after bytes)",
+            after <= 1232,
+        )
+    }
+
+    @Test
+    fun append_is_idempotent_in_shape_but_never_silently_duplicates_the_tag() {
+        // Appending twice is a caller bug, not something to paper over: the result must still be
+        // detectable as carrying two memos so validation can refuse it.
+        val twice =
+            decode(KaminoAttributionMemo.append(KaminoAttributionMemo.append(depositTransaction)))
+        val memos =
+            twice.instructionsList.count {
+                programOf(twice, it) == KaminoAttributionMemo.MEMO_PROGRAM_ID
+            }
+        assertEquals("a second append is visible, not swallowed", 2, memos)
+        assertEquals("the program key is reused rather than duplicated", 10, twice.accountKeysCount)
+    }
+
+    @Test
+    fun append_fails_loudly_when_walletcore_cannot_produce_a_transaction() {
+        // The FFI collapses every failure into a null return, so the helper must convert that into
+        // a throw. Signing the unmodified transaction would silently drop the attribution.
+        assertNull(
+            "precondition: WalletCore returns null for a malformed transaction",
+            SolanaTransaction.insertInstruction("not-a-transaction", -1, "{}"),
+        )
+        assertThrows(IllegalStateException::class.java) {
+            KaminoAttributionMemo.append("not-a-transaction")
+        }
+    }
+}

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemoTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemoTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.blockchain.solana.kamino
 
 import com.vultisig.wallet.data.WalletCoreNative
 import java.util.Base64
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -202,6 +203,12 @@ class KaminoAttributionMemoTest {
 
     @Test
     fun memo_data_is_base58_encoded_and_the_transaction_stays_within_the_size_limit() {
+        // Pinned to the literal, not derived from the constant. Every other assertion here reads
+        // TAG, so a drift from `vs` to any other valid two-byte string would leave this whole suite
+        // agreeing with itself and green while the attribution it exists for matched nothing.
+        assertEquals("vs", KaminoAttributionMemo.TAG)
+        assertArrayEquals(byteArrayOf(0x76, 0x73), KaminoAttributionMemo.TAG.toByteArray())
+
         // WalletCore's JSON instruction format encodes `data` as base58, not base64. Pinning the
         // encoded form keeps the two on-chain bytes identical across platforms.
         assertEquals("A1p", Base58.encodeNoCheck(KaminoAttributionMemo.TAG.toByteArray()))

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -160,9 +160,13 @@ class KaminoTransactionPreparerTest {
     }
 
     @Test
-    fun a_withdraw_gets_the_withdraw_budget() {
+    fun a_withdraw_gets_a_budget_that_covers_the_farm_staked_shape() {
+        // Staked withdraws measure 283k-309k because of the two farms instructions ahead of the
+        // vault withdraw; at 220,000 every one of them aborted on compute exhaustion.
         val prepared = prepare(action = KaminoAction.WITHDRAW)
-        assertEquals(220_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong())
+        val limit = SolanaTransaction.getComputeUnitLimit(prepared)?.toLong() ?: 0L
+        assertEquals(400_000L, limit)
+        assertTrue("must clear the 309,310 staked-SOL measurement", limit > 309_310L)
     }
 
     @Test
@@ -273,7 +277,7 @@ class KaminoTransactionPreparerTest {
             instructions.none { it.programId == KaminoVaultRegistry.FARMS_PROGRAM_ID },
         )
         assertEquals(KaminoAttributionMemo.MEMO_PROGRAM_ID, instructions.last().programId)
-        assertEquals(220_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong() ?: 0L)
+        assertEquals(400_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong() ?: 0L)
     }
 
     @Test

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -166,16 +166,6 @@ class KaminoTransactionPreparerTest {
     }
 
     @Test
-    fun a_withdraw_gets_a_budget_that_covers_the_farm_staked_shape() {
-        // Staked withdraws measure 283k-309k because of the two farms instructions ahead of the
-        // vault withdraw; at 220,000 every one of them aborted on compute exhaustion.
-        val prepared = prepare(action = KaminoAction.WITHDRAW)
-        val limit = SolanaTransaction.getComputeUnitLimit(prepared)?.toLong() ?: 0L
-        assertEquals(400_000L, limit)
-        assertTrue("must clear the 309,310 staked-SOL measurement", limit > 309_310L)
-    }
-
-    @Test
     fun the_unit_price_floors_rather_than_trusting_a_low_network_sample() {
         val flooredByNull = prepare(networkUnitPrice = null)
         assertEquals(

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -123,11 +123,11 @@ class KaminoTransactionPreparerTest {
     fun the_compute_unit_limit_is_well_above_the_app_s_default_which_these_transactions_exceed() {
         val prepared = prepare()
 
-        val limit = SolanaTransaction.getComputeUnitLimit(prepared)?.toLong()
+        val limit = SolanaTransaction.getComputeUnitLimit(prepared)?.toLong() ?: 0L
         assertEquals(320_000L, limit)
         // The app-wide Solana limit is 100,000 units; a USDC deposit measures ~252,000 and would
         // abort on compute exhaustion if that constant were reused here.
-        assertTrue("limit must exceed the 100,000 default (was $limit)", limit!! > 100_000L)
+        assertTrue("limit must exceed the 100,000 default (was $limit)", limit > 100_000L)
     }
 
     @Test
@@ -222,13 +222,13 @@ class KaminoTransactionPreparerTest {
         // The message must begin immediately after the signature slots, still marked versioned v0.
         val messageOffset = 1 + 64
         assertEquals(
-            "message must start right after the signature slot",
+            "message must start right after the signature slot, marked versioned v0",
             0x80,
-            after[messageOffset].toInt() and 0xFF and 0x80,
+            after[messageOffset].toInt() and 0xFF,
         )
         assertTrue(
-            "message must be longer than the original (a memo and compute budget were added)",
-            after.size - messageOffset > before.size - messageOffset,
+            "a memo and compute budget were added, so it must have grown",
+            after.size > before.size,
         )
     }
 

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -129,7 +129,7 @@ class KaminoTransactionPreparerTest {
     @Test
     fun a_prepared_deposit_validates_and_its_memo_is_the_final_instruction() {
         val prepared = prepare()
-        val instructions = KaminoTransactionDecoder.decode(prepared)
+        val instructions = KaminoTransactionDecoder.decode(prepared).instructions
 
         // Not merely "passes validation" — assert the property the validator depends on, so a
         // reordering regression cannot hide behind a passing validator.
@@ -280,6 +280,7 @@ class KaminoTransactionPreparerTest {
         // decode rather than through prepare, which correctly refuses the sentinel above.
         val instructions =
             KaminoTransactionDecoder.decode(KaminoAttributionMemo.append(withdrawFixture))
+                .instructions
 
         assertTrue(
             "a withdraw must invoke the kVault program",
@@ -300,7 +301,7 @@ class KaminoTransactionPreparerTest {
         val rejection =
             assertThrows(KaminoTransactionRejected::class.java) {
                 KaminoTransactionValidator.validate(
-                    instructions =
+                    decoded =
                         KaminoTransactionDecoder.decode(
                             KaminoAttributionMemo.append(withdrawFixture)
                         ),

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -266,23 +266,40 @@ class KaminoTransactionPreparerTest {
     }
 
     @Test
-    fun a_prepared_unstaked_withdraw_validates() {
-        val prepared = prepare(action = KaminoAction.WITHDRAW)
-        val instructions = KaminoTransactionDecoder.decode(prepared)
+    fun the_captured_withdraw_is_refused_because_it_carries_the_sentinel() {
+        // Kamino built this fixture for a wallet holding nothing, and rather than rejecting the
+        // request it rewrote the amount to u64::MAX — "withdraw everything". That is the rewrite
+        // the
+        // whole withdraw design exists to stay away from, so the pipeline must refuse to prepare it
+        // on any device. This is also direct evidence the rewrite is real, not merely documented.
+        val rejection =
+            assertThrows(KaminoTransactionRejected::class.java) {
+                prepare(action = KaminoAction.WITHDRAW)
+            }
+        assertTrue(
+            "unexpected reason: ${rejection.message}",
+            rejection.message.orEmpty().contains("withdraw-everything sentinel"),
+        )
+    }
+
+    @Test
+    fun the_captured_withdraw_is_otherwise_the_shape_the_validator_expects() {
+        // Everything except the amount: the instructions decode, invoke the kVault program, and
+        // carry
+        // no farms instruction (nothing was staked, so nothing had to be released). Asserted on the
+        // decode rather than through prepare, which correctly refuses the sentinel above.
+        val instructions =
+            KaminoTransactionDecoder.decode(KaminoAttributionMemo.append(withdrawFixture))
 
         assertTrue(
             "a withdraw must invoke the kVault program",
             instructions.any { it.programId == KaminoVaultRegistry.PROGRAM_ID },
         )
-        // No farms instruction, because Kamino built this for a wallet holding nothing and so had
-        // nothing to release. That makes this the unstaked shape — see the fixture's own note; the
-        // staked shape most holders send is not covered here.
         assertTrue(
             "this fixture is the unstaked shape",
             instructions.none { it.programId == KaminoVaultRegistry.FARMS_PROGRAM_ID },
         )
         assertEquals(KaminoAttributionMemo.MEMO_PROGRAM_ID, instructions.last().programId)
-        assertEquals(400_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong() ?: 0L)
     }
 
     @Test
@@ -294,7 +311,9 @@ class KaminoTransactionPreparerTest {
             assertThrows(KaminoTransactionRejected::class.java) {
                 KaminoTransactionValidator.validate(
                     instructions =
-                        KaminoTransactionDecoder.decode(prepare(action = KaminoAction.WITHDRAW)),
+                        KaminoTransactionDecoder.decode(
+                            KaminoAttributionMemo.append(withdrawFixture)
+                        ),
                     vault = KaminoVaultRegistry.STEAKHOUSE_USDC,
                     action = KaminoAction.WITHDRAW,
                     signerAddress = other,

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -37,13 +37,19 @@ class KaminoTransactionPreparerTest {
             "HBu0d9Dar60DX6fr5AkFNTElLzITCQEJJxUECwI3BwYD"
 
     /**
-     * A live `POST /ktx/kvault/withdraw` response for the same vault. Two instructions — create the
-     * destination token account, then `kVault::withdraw` — and notably **no farms instructions**,
-     * which is why this shape can only spend unstaked shares and why a farm-staked position is
-     * refused rather than guessed at.
+     * A live `POST /ktx/kvault/withdraw` response for the same vault: create the destination token
+     * account, then `kVault::withdraw`.
      *
-     * Kamino built this for a wallet holding no position at all, which is the clearest evidence
-     * that the endpoint validates nothing about the amount it is given.
+     * Kamino built it for a wallet holding no position at all — the clearest evidence that the
+     * endpoint validates nothing about the amount it is handed, and also why there is nothing
+     * staked to release here.
+     *
+     * **This is therefore the UNSTAKED shape, which is not the one most holders will send.** A
+     * withdraw against a staked position carries two extra `farms` instructions and a second
+     * account creation ahead of the vault withdraw. Capturing that needs a wallet actually holding
+     * a staked position, which these vaults only produce by depositing real funds, so the limit
+     * sized for it rests on the iOS mainnet measurements (283,786 / 289,486 / 309,310) rather than
+     * on anything this suite proves.
      */
     private val withdrawFixture =
         "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
@@ -260,20 +266,19 @@ class KaminoTransactionPreparerTest {
     }
 
     @Test
-    fun a_prepared_withdraw_validates_and_spends_no_farm_staked_shares() {
+    fun a_prepared_unstaked_withdraw_validates() {
         val prepared = prepare(action = KaminoAction.WITHDRAW)
         val instructions = KaminoTransactionDecoder.decode(prepared)
 
-        // The kVault program does the work; the farms program is absent, so this transaction cannot
-        // be moving shares out of the farm. That is the on-chain reason a staked position is
-        // refused
-        // rather than attempted.
         assertTrue(
             "a withdraw must invoke the kVault program",
             instructions.any { it.programId == KaminoVaultRegistry.PROGRAM_ID },
         )
+        // No farms instruction, because Kamino built this for a wallet holding nothing and so had
+        // nothing to release. That makes this the unstaked shape — see the fixture's own note; the
+        // staked shape most holders send is not covered here.
         assertTrue(
-            "a withdraw of unstaked shares touches no farm",
+            "this fixture is the unstaked shape",
             instructions.none { it.programId == KaminoVaultRegistry.FARMS_PROGRAM_ID },
         )
         assertEquals(KaminoAttributionMemo.MEMO_PROGRAM_ID, instructions.last().programId)

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -36,6 +36,24 @@ class KaminoTransactionPreparerTest {
             "AAAAAgsEGQhvEbn6PHom/gcIAAILDgMJBxoQzrDKEsjRs2z//////////wGC6dRmw0Z9LrKw2cy+tHvb9JXu" +
             "HBu0d9Dar60DX6fr5AkFNTElLzITCQEJJxUECwI3BwYD"
 
+    /**
+     * A live `POST /ktx/kvault/withdraw` response for the same vault. Two instructions — create the
+     * destination token account, then `kVault::withdraw` — and notably **no farms instructions**,
+     * which is why this shape can only spend unstaked shares and why a farm-staked position is
+     * refused rather than guessed at.
+     *
+     * Kamino built this for a wallet holding no position at all, which is the clearest evidence
+     * that the endpoint validates nothing about the amount it is given.
+     */
+    private val withdrawFixture =
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
+            "AQAFCH//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuemOEsQm7A2IghRdbzU0ar6Q7dIhEJA6xfcD32XM4Yw" +
+            "fPTlbTyv/0d12pxZLb6myiG7I2gKyRGc5alr3GsSn7RxYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+            "D9ps6fZhmN2HDYqYbzBnXEb4Pi9Sg0h5UvXVBWPj73qMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZlx" +
+            "KXooAEJJPkJxkMd7ZH6G99GZch/RVimWXJ1rZZT4BNkK8duJOew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25TcFsAN" +
+            "s3q6CtgzQiIGiofmyao3Sh0Dq7RowlSc92jsQgIFBgABAA0DFgEBBxYADwYLEgENAggWFhUEBw4MCQoTERQQEBOD" +
+            "cJuq3CI5//////////8BgunUZsNGfS6ysNnMvrR72/SV7hwbtHfQ2q+tA1+n6+QIBTUlLxMCCQEHJxUECzcHAw=="
+
     private val wallet = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
 
     /**
@@ -82,12 +100,17 @@ class KaminoTransactionPreparerTest {
     }
 
     private fun prepare(
-        api: KaminoApi = FixtureApi(),
+        api: KaminoApi? = null,
         vault: KaminoVault = KaminoVaultRegistry.STEAKHOUSE_USDC,
         action: KaminoAction = KaminoAction.DEPOSIT,
         networkUnitPrice: BigInteger? = null,
     ): String = runBlocking {
-        KaminoTransactionPreparer(api)
+        val resolved =
+            api
+                ?: FixtureApi(
+                    if (action == KaminoAction.WITHDRAW) withdrawFixture else depositFixture
+                )
+        KaminoTransactionPreparer(resolved)
             .prepare(
                 vault = vault,
                 action = action,
@@ -229,6 +252,48 @@ class KaminoTransactionPreparerTest {
         assertTrue(
             "a memo and compute budget were added, so it must have grown",
             after.size > before.size,
+        )
+    }
+
+    @Test
+    fun a_prepared_withdraw_validates_and_spends_no_farm_staked_shares() {
+        val prepared = prepare(action = KaminoAction.WITHDRAW)
+        val instructions = KaminoTransactionDecoder.decode(prepared)
+
+        // The kVault program does the work; the farms program is absent, so this transaction cannot
+        // be moving shares out of the farm. That is the on-chain reason a staked position is
+        // refused
+        // rather than attempted.
+        assertTrue(
+            "a withdraw must invoke the kVault program",
+            instructions.any { it.programId == KaminoVaultRegistry.PROGRAM_ID },
+        )
+        assertTrue(
+            "a withdraw of unstaked shares touches no farm",
+            instructions.none { it.programId == KaminoVaultRegistry.FARMS_PROGRAM_ID },
+        )
+        assertEquals(KaminoAttributionMemo.MEMO_PROGRAM_ID, instructions.last().programId)
+        assertEquals(220_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong() ?: 0L)
+    }
+
+    @Test
+    fun a_withdraw_is_refused_when_it_is_not_the_wallet_s_own_transaction() {
+        // The fixture's fee payer is ; validating it against a different signer must fail,
+        // which is what stops the app signing on another account's behalf.
+        val other = "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E"
+        val rejection =
+            assertThrows(KaminoTransactionRejected::class.java) {
+                KaminoTransactionValidator.validate(
+                    instructions =
+                        KaminoTransactionDecoder.decode(prepare(action = KaminoAction.WITHDRAW)),
+                    vault = KaminoVaultRegistry.STEAKHOUSE_USDC,
+                    action = KaminoAction.WITHDRAW,
+                    signerAddress = other,
+                )
+            }
+        assertTrue(
+            "unexpected reason: ${rejection.message}",
+            rejection.message.orEmpty().contains("authorised by"),
         )
     }
 

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -1,0 +1,241 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.WalletCoreNative
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.KaminoPnlJson
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
+import java.math.BigInteger
+import java.util.Base64
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import wallet.core.jni.SolanaTransaction
+
+/**
+ * End-to-end coverage of the prepare pipeline on a real Kamino deposit: compute budget in, memo on
+ * top, decode, validate.
+ *
+ * The ordering here is load-bearing rather than incidental. WalletCore appends a compute-budget
+ * instruction when none exists — the same append the memo uses — so injecting the budget after the
+ * memo would leave the memo mid-list and the validator would refuse it. These tests pin that.
+ */
+class KaminoTransactionPreparerTest {
+
+    private val depositFixture =
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
+            "AQAFCX//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuemOEsQm7A2IghRdbzU0ar6Q7dIhEJA6xfcD32X" +
+            "M4YwfPSF38N5IeLVVX5/3BJfld0IR08X1RB7fe6uQkeVw/nk3uVtPK//R3XanFktvqbKIbsjaArJEZzlqWvc" +
+            "axKftHFhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2mzp9mGY3YcNiphvMGdcRvg+L1KDSHlS" +
+            "9dUFY+PveoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZ2LAQF2PT5R8SbmFW3oXejGEwWbhEaNDa" +
+            "P+iioiUcxwEE2Qrx24k57DX/lNlkDVfcwyeUuz4btm/TroSahNzblDJCgcwkFVHRKh2nMxb4pfSsIMN/m4f+" +
+            "R1HblBX15CRABAYGAAMACQQaAQEIFQARDRYUCQEDGBoaBQgQDwoMFRMXEhDyI8aJUuHytkBCDwAAAAAABwgA" +
+            "AAAAAgsEGQhvEbn6PHom/gcIAAILDgMJBxoQzrDKEsjRs2z//////////wGC6dRmw0Z9LrKw2cy+tHvb9JXu" +
+            "HBu0d9Dar60DX6fr5AkFNTElLzITCQEJJxUECwI3BwYD"
+
+    private val wallet = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+    /**
+     * Returns the captured transaction for whatever is asked, so the pipeline is what's under test.
+     */
+    private inner class FixtureApi(private val transaction: String = depositFixture) : KaminoApi {
+        var lastAmount: String? = null
+        var lastVault: String? = null
+
+        override suspend fun getVaultState(vaultAddress: String) = error("not used")
+
+        override suspend fun getVaultMetrics(vaultAddress: String) = KaminoVaultMetricsJson()
+
+        override suspend fun getUserPositions(walletAddress: String): List<KaminoUserPositionJson> =
+            emptyList()
+
+        override suspend fun getPositionPnl(walletAddress: String, vaultAddress: String) =
+            KaminoPnlJson()
+
+        override suspend fun buildDeposit(
+            walletAddress: String,
+            vaultAddress: String,
+            amount: String,
+        ): String {
+            lastAmount = amount
+            lastVault = vaultAddress
+            return transaction
+        }
+
+        override suspend fun buildWithdraw(
+            walletAddress: String,
+            vaultAddress: String,
+            amount: String,
+        ): String {
+            lastAmount = amount
+            lastVault = vaultAddress
+            return transaction
+        }
+    }
+
+    @Before
+    fun loadWalletCore() {
+        WalletCoreNative.ensureLoaded()
+    }
+
+    private fun prepare(
+        api: KaminoApi = FixtureApi(),
+        vault: KaminoVault = KaminoVaultRegistry.STEAKHOUSE_USDC,
+        action: KaminoAction = KaminoAction.DEPOSIT,
+        networkUnitPrice: BigInteger? = null,
+    ): String = runBlocking {
+        KaminoTransactionPreparer(api)
+            .prepare(
+                vault = vault,
+                action = action,
+                walletAddress = wallet,
+                amount = "1",
+                networkUnitPrice = networkUnitPrice,
+            )
+    }
+
+    @Test
+    fun a_prepared_deposit_validates_and_its_memo_is_the_final_instruction() {
+        val prepared = prepare()
+        val instructions = KaminoTransactionDecoder.decode(prepared)
+
+        // Not merely "passes validation" — assert the property the validator depends on, so a
+        // reordering regression cannot hide behind a passing validator.
+        assertEquals(KaminoAttributionMemo.MEMO_PROGRAM_ID, instructions.last().programId)
+        assertEquals(
+            1,
+            instructions.count { it.programId == KaminoAttributionMemo.MEMO_PROGRAM_ID },
+        )
+        assertEquals(
+            KaminoAttributionMemo.TAG,
+            instructions.last().data.toString(Charsets.US_ASCII),
+        )
+        assertTrue(
+            "the kVault program must still be invoked",
+            instructions.any { it.programId == KaminoVaultRegistry.PROGRAM_ID },
+        )
+    }
+
+    @Test
+    fun the_compute_unit_limit_is_well_above_the_app_s_default_which_these_transactions_exceed() {
+        val prepared = prepare()
+
+        val limit = SolanaTransaction.getComputeUnitLimit(prepared)?.toLong()
+        assertEquals(320_000L, limit)
+        // The app-wide Solana limit is 100,000 units; a USDC deposit measures ~252,000 and would
+        // abort on compute exhaustion if that constant were reused here.
+        assertTrue("limit must exceed the 100,000 default (was $limit)", limit!! > 100_000L)
+    }
+
+    @Test
+    fun a_SOL_vault_deposit_gets_the_larger_budget_it_needs_to_wrap_first() {
+        val prepared = prepare(vault = KaminoVaultRegistry.ALLEZ_SOL)
+        assertEquals(350_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong())
+    }
+
+    @Test
+    fun a_withdraw_gets_the_withdraw_budget() {
+        val prepared = prepare(action = KaminoAction.WITHDRAW)
+        assertEquals(220_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong())
+    }
+
+    @Test
+    fun the_unit_price_floors_rather_than_trusting_a_low_network_sample() {
+        val flooredByNull = prepare(networkUnitPrice = null)
+        assertEquals(
+            KaminoComputeBudget.FALLBACK_UNIT_PRICE.toString(),
+            SolanaTransaction.getComputeUnitPrice(flooredByNull),
+        )
+
+        val flooredByLowSample = prepare(networkUnitPrice = BigInteger.ONE)
+        assertEquals(
+            KaminoComputeBudget.FALLBACK_UNIT_PRICE.toString(),
+            SolanaTransaction.getComputeUnitPrice(flooredByLowSample),
+        )
+
+        val honoured = prepare(networkUnitPrice = BigInteger.valueOf(999_999))
+        assertEquals("999999", SolanaTransaction.getComputeUnitPrice(honoured))
+    }
+
+    @Test
+    fun preparing_stays_within_the_transaction_size_limit() {
+        val size = Base64.getDecoder().decode(prepare()).size
+        assertTrue("prepared transaction was $size bytes", size <= 1232)
+    }
+
+    @Test
+    fun the_decimal_amount_reaches_Kamino_unscaled() {
+        // Kamino wants decimals on the way in; sending base units would deposit a millionth of the
+        // intended amount.
+        val api = FixtureApi()
+        prepare(api = api)
+        assertEquals("1", api.lastAmount)
+        assertEquals(KaminoVaultRegistry.STEAKHOUSE_USDC.address, api.lastVault)
+    }
+
+    @Test
+    fun a_transaction_that_already_carries_a_foreign_memo_is_refused_rather_than_signed() {
+        // Simulates Kamino returning something with a memo of its own: appending ours would make
+        // two,
+        // and the app must not sign a transaction carrying a memo it did not author.
+        val foreign =
+            checkNotNull(
+                SolanaTransaction.insertInstruction(
+                    depositFixture,
+                    -1,
+                    """{"programId":"${KaminoAttributionMemo.MEMO_PROGRAM_ID}","accounts":[],"data":"3yZe7d"}""",
+                )
+            )
+
+        val rejection =
+            assertThrows(KaminoTransactionRejected::class.java) {
+                prepare(api = FixtureApi(foreign))
+            }
+        assertTrue(
+            "unexpected reason: ${rejection.message}",
+            rejection.message.orEmpty().contains("exactly one memo"),
+        )
+    }
+
+    @Test
+    fun the_unsigned_signature_envelope_survives_every_mutation() {
+        // `SolanaHelper.signRawTransaction` splices the MPC signature in at the offset it derives
+        // from the leading compact-u16 signature count, and treats everything past the signature
+        // slots as the message to hash. Three WalletCore mutations happen before that, so the
+        // envelope has to come out the far side with the same shape or signing writes to the wrong
+        // bytes and the co-signers hash different messages.
+        val before = Base64.getDecoder().decode(depositFixture)
+        val after = Base64.getDecoder().decode(prepare())
+
+        assertEquals("signature count must stay 1", 1, before[0].toInt())
+        assertEquals("signature count must stay 1", 1, after[0].toInt())
+
+        val signature = after.copyOfRange(1, 1 + 64)
+        assertTrue(
+            "the signature slot must still be zeroed, ready for the MPC signature",
+            signature.all { it == 0.toByte() },
+        )
+
+        // The message must begin immediately after the signature slots, still marked versioned v0.
+        val messageOffset = 1 + 64
+        assertEquals(
+            "message must start right after the signature slot",
+            0x80,
+            after[messageOffset].toInt() and 0xFF and 0x80,
+        )
+        assertTrue(
+            "message must be longer than the original (a memo and compute budget were added)",
+            after.size - messageOffset > before.size - messageOffset,
+        )
+    }
+
+    @Test
+    fun a_malformed_response_from_Kamino_fails_loudly_instead_of_reaching_keysign() {
+        assertThrows(IllegalStateException::class.java) {
+            prepare(api = FixtureApi("not-base64-tx"))
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ApiModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ApiModule.kt
@@ -96,6 +96,8 @@ internal interface ApiModule {
 
     @Binds @Singleton fun circleApi(impl: CircleApiImpl): CircleApi
 
+    @Binds @Singleton fun bindKaminoApi(impl: KaminoApiImpl): KaminoApi
+
     @Binds @Singleton fun bindNotificationApi(impl: NotificationApiImpl): NotificationApi
 
     @Binds

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/KaminoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/KaminoApi.kt
@@ -42,8 +42,15 @@ interface KaminoApi {
      */
     suspend fun buildDeposit(walletAddress: String, vaultAddress: String, amount: String): String
 
-    /** Builds an unsigned withdraw transaction. [amount] is decimal, as for [buildDeposit]. */
-    suspend fun buildWithdraw(walletAddress: String, vaultAddress: String, amount: String): String
+    /**
+     * Builds an unsigned withdraw transaction.
+     *
+     * [shares] is a decimal quantity of **vault shares** — the inverse of [buildDeposit]'s units.
+     * The endpoint validates nothing: naming more shares than the wallet holds is silently
+     * rewritten to `u64::MAX`, meaning withdraw everything, so the caller must have sized this
+     * against the held balance rather than converted it hopefully.
+     */
+    suspend fun buildWithdraw(walletAddress: String, vaultAddress: String, shares: String): String
 }
 
 internal class KaminoApiImpl @Inject constructor(private val httpClient: HttpClient) : KaminoApi {
@@ -95,8 +102,8 @@ internal class KaminoApiImpl @Inject constructor(private val httpClient: HttpCli
     override suspend fun buildWithdraw(
         walletAddress: String,
         vaultAddress: String,
-        amount: String,
-    ): String = buildAction("withdraw", walletAddress, vaultAddress, amount)
+        shares: String,
+    ): String = buildAction("withdraw", walletAddress, vaultAddress, shares)
 
     private suspend fun buildAction(
         action: String,
@@ -151,8 +158,12 @@ data class KaminoVaultStateJson(
         @SerialName("tokenMintDecimals") val tokenDecimals: Int,
         @SerialName("sharesMint") val sharesMint: String,
         @SerialName("sharesMintDecimals") val sharesDecimals: Int,
-        /** In the token's base units, not decimal — 100000 is 0.1 USDC at 6 decimals. */
+        /** In the **token's** base units, not decimal — 100000 is 0.1 USDC at 6 decimals. */
         @SerialName("minDepositAmount") val minDepositAmount: String? = null,
+        /**
+         * In the **share** base units, matching the withdraw endpoint's own denomination — not the
+         * token's. Comparing it against a token amount is wrong by the share rate.
+         */
         @SerialName("minWithdrawAmount") val minWithdrawAmount: String? = null,
         @SerialName("performanceFeeBps") val performanceFeeBps: Int? = null,
         @SerialName("managementFeeBps") val managementFeeBps: Int? = null,
@@ -175,6 +186,12 @@ data class KaminoVaultMetricsJson(
     @SerialName("sharePrice") val sharePrice: String? = null,
     /** The underlying token's price in USD. */
     @SerialName("tokenPrice") val tokenPrice: String? = null,
+    /**
+     * Decimal token amount the vault holds liquid. A withdraw above this cannot settle instantly —
+     * and since the buffer measures well under 1% of assets, that is the common case rather than an
+     * edge one.
+     */
+    @SerialName("tokensAvailable") val tokensAvailable: String? = null,
 )
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/KaminoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/KaminoApi.kt
@@ -1,0 +1,202 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.utils.bodyOrThrow
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.appendPathSegments
+import io.ktor.http.contentType
+import javax.inject.Inject
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Read access to Kamino's Earn (kVault) REST API.
+ *
+ * Public and unauthenticated — no key, no partner header. Every numeric field arrives as a decimal
+ * string and is kept that way here: the wire format is exact, and parsing belongs with the code
+ * that knows each field's scale rather than with the transport.
+ */
+interface KaminoApi {
+
+    /** Immutable-ish vault state: display name, mints and per-vault minimums. */
+    suspend fun getVaultState(vaultAddress: String): KaminoVaultStateJson
+
+    /** Live economics: APY over several windows, share price and the token's fiat price. */
+    suspend fun getVaultMetrics(vaultAddress: String): KaminoVaultMetricsJson
+
+    /** Every kVault position [walletAddress] holds. Empty when the wallet holds none. */
+    suspend fun getUserPositions(walletAddress: String): List<KaminoUserPositionJson>
+
+    /** Realised and unrealised profit for one wallet in one vault. */
+    suspend fun getPositionPnl(walletAddress: String, vaultAddress: String): KaminoPnlJson
+
+    /**
+     * Builds an unsigned deposit transaction, base64-encoded.
+     *
+     * [amount] is a **decimal** token amount ("0.1234"), not base units — the one place Kamino
+     * wants decimals on the way in. The returned transaction embeds a recent blockhash with roughly
+     * a minute of life, so it must be fetched immediately before signing rather than held.
+     */
+    suspend fun buildDeposit(walletAddress: String, vaultAddress: String, amount: String): String
+
+    /** Builds an unsigned withdraw transaction. [amount] is decimal, as for [buildDeposit]. */
+    suspend fun buildWithdraw(walletAddress: String, vaultAddress: String, amount: String): String
+}
+
+internal class KaminoApiImpl @Inject constructor(private val httpClient: HttpClient) : KaminoApi {
+
+    override suspend fun getVaultState(vaultAddress: String): KaminoVaultStateJson =
+        httpClient
+            .get(KAMINO_URL) { url { appendPathSegments("kvaults", "vaults", vaultAddress) } }
+            .bodyOrThrow()
+
+    override suspend fun getVaultMetrics(vaultAddress: String): KaminoVaultMetricsJson =
+        httpClient
+            .get(KAMINO_URL) {
+                url { appendPathSegments("kvaults", "vaults", vaultAddress, "metrics") }
+            }
+            .bodyOrThrow()
+
+    override suspend fun getUserPositions(walletAddress: String): List<KaminoUserPositionJson> =
+        httpClient
+            .get(KAMINO_URL) {
+                url { appendPathSegments("kvaults", "users", walletAddress, "positions") }
+            }
+            .bodyOrThrow()
+
+    override suspend fun getPositionPnl(
+        walletAddress: String,
+        vaultAddress: String,
+    ): KaminoPnlJson =
+        httpClient
+            .get(KAMINO_URL) {
+                url {
+                    appendPathSegments(
+                        "kvaults",
+                        "users",
+                        walletAddress,
+                        "vaults",
+                        vaultAddress,
+                        "pnl",
+                    )
+                }
+            }
+            .bodyOrThrow()
+
+    override suspend fun buildDeposit(
+        walletAddress: String,
+        vaultAddress: String,
+        amount: String,
+    ): String = buildAction("deposit", walletAddress, vaultAddress, amount)
+
+    override suspend fun buildWithdraw(
+        walletAddress: String,
+        vaultAddress: String,
+        amount: String,
+    ): String = buildAction("withdraw", walletAddress, vaultAddress, amount)
+
+    private suspend fun buildAction(
+        action: String,
+        walletAddress: String,
+        vaultAddress: String,
+        amount: String,
+    ): String =
+        httpClient
+            .post(KAMINO_URL) {
+                url { appendPathSegments("ktx", "kvault", action) }
+                contentType(ContentType.Application.Json)
+                setBody(
+                    KaminoActionRequestJson(
+                        wallet = walletAddress,
+                        kvault = vaultAddress,
+                        amount = amount,
+                    )
+                )
+            }
+            .bodyOrThrow<KaminoActionResponseJson>()
+            .transaction
+
+    private companion object {
+        const val KAMINO_URL = "https://api.kamino.finance"
+    }
+}
+
+@Serializable
+internal data class KaminoActionRequestJson(
+    @SerialName("wallet") val wallet: String,
+    @SerialName("kvault") val kvault: String,
+    /** Decimal, not base units. */
+    @SerialName("amount") val amount: String,
+)
+
+@Serializable
+internal data class KaminoActionResponseJson(
+    /** Base64-encoded unsigned transaction with a recent blockhash already baked in. */
+    @SerialName("transaction") val transaction: String
+)
+
+@Serializable
+data class KaminoVaultStateJson(
+    @SerialName("address") val address: String,
+    @SerialName("state") val state: State,
+) {
+    @Serializable
+    data class State(
+        /** Curator-set display name, e.g. "Steakhouse USDC". */
+        @SerialName("name") val name: String? = null,
+        @SerialName("tokenMint") val tokenMint: String,
+        @SerialName("tokenMintDecimals") val tokenDecimals: Int,
+        @SerialName("sharesMint") val sharesMint: String,
+        @SerialName("sharesMintDecimals") val sharesDecimals: Int,
+        /** In the token's base units, not decimal — 100000 is 0.1 USDC at 6 decimals. */
+        @SerialName("minDepositAmount") val minDepositAmount: String? = null,
+        @SerialName("minWithdrawAmount") val minWithdrawAmount: String? = null,
+        @SerialName("performanceFeeBps") val performanceFeeBps: Int? = null,
+        @SerialName("managementFeeBps") val managementFeeBps: Int? = null,
+    )
+}
+
+@Serializable
+data class KaminoVaultMetricsJson(
+    /**
+     * A fraction, not a percentage: "0.039967" is 3.9967%. The 30-day window is the one shown,
+     * being long enough not to swing on a single day's utilisation.
+     */
+    @SerialName("apy30d") val apy30d: String? = null,
+    /** Token amount one share converts to. Use for the position's token balance. */
+    @SerialName("tokensPerShare") val tokensPerShare: String? = null,
+    /**
+     * Fiat value of one share, equal to [tokensPerShare] × [tokenPrice]. Use for the position's
+     * fiat value directly rather than re-deriving it.
+     */
+    @SerialName("sharePrice") val sharePrice: String? = null,
+    /** The underlying token's price in USD. */
+    @SerialName("tokenPrice") val tokenPrice: String? = null,
+)
+
+@Serializable
+data class KaminoUserPositionJson(
+    @SerialName("vaultAddress") val vaultAddress: String,
+    /** Decimal share quantity staked in the vault's farm — where a deposit puts them. */
+    @SerialName("stakedShares") val stakedShares: String? = null,
+    /** Decimal share quantity sitting in the wallet's own share account. */
+    @SerialName("unstakedShares") val unstakedShares: String? = null,
+    /** Decimal share quantity, staked and unstaked combined. */
+    @SerialName("totalShares") val totalShares: String? = null,
+)
+
+@Serializable
+data class KaminoPnlJson(
+    @SerialName("totalPnl") val totalPnl: Amounts? = null,
+    @SerialName("totalCostBasis") val totalCostBasis: Amounts? = null,
+) {
+    @Serializable
+    data class Amounts(
+        @SerialName("token") val token: String? = null,
+        @SerialName("sol") val sol: String? = null,
+        @SerialName("usd") val usd: String? = null,
+    )
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/KaminoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/KaminoApi.kt
@@ -57,20 +57,38 @@ internal class KaminoApiImpl @Inject constructor(private val httpClient: HttpCli
 
     override suspend fun getVaultState(vaultAddress: String): KaminoVaultStateJson =
         httpClient
-            .get(KAMINO_URL) { url { appendPathSegments("kvaults", "vaults", vaultAddress) } }
+            .get(KAMINO_URL) {
+                url { appendPathSegments("kvaults", "vaults", vaultAddress, encodeSlash = true) }
+            }
             .bodyOrThrow()
 
     override suspend fun getVaultMetrics(vaultAddress: String): KaminoVaultMetricsJson =
         httpClient
             .get(KAMINO_URL) {
-                url { appendPathSegments("kvaults", "vaults", vaultAddress, "metrics") }
+                url {
+                    appendPathSegments(
+                        "kvaults",
+                        "vaults",
+                        vaultAddress,
+                        "metrics",
+                        encodeSlash = true,
+                    )
+                }
             }
             .bodyOrThrow()
 
     override suspend fun getUserPositions(walletAddress: String): List<KaminoUserPositionJson> =
         httpClient
             .get(KAMINO_URL) {
-                url { appendPathSegments("kvaults", "users", walletAddress, "positions") }
+                url {
+                    appendPathSegments(
+                        "kvaults",
+                        "users",
+                        walletAddress,
+                        "positions",
+                        encodeSlash = true,
+                    )
+                }
             }
             .bodyOrThrow()
 
@@ -88,6 +106,10 @@ internal class KaminoApiImpl @Inject constructor(private val httpClient: HttpCli
                         "vaults",
                         vaultAddress,
                         "pnl",
+                        // Ktor leaves `/` unencoded, so a value that ever carried one could rewrite
+                        // the path. These are our own derived address and a registry base58 string,
+                        // but the encoding costs nothing and does not rely on that staying true.
+                        encodeSlash = true,
                     )
                 }
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
@@ -1,0 +1,83 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import java.math.BigDecimal
+import java.math.RoundingMode
+import javax.inject.Inject
+import vultisig.keysign.v1.SignSolana
+
+/**
+ * Turns a Kamino deposit or withdraw intent into a [KeysignPayload] with `signSolana` populated.
+ *
+ * Mirrors
+ * [com.vultisig.wallet.data.blockchain.solana.staking.BuildSolanaStakingKeysignPayloadUseCase]: the
+ * initiating device builds the transaction bytes once and relays them, and both co-signers sign the
+ * byte-identical message through `SolanaHelper`'s raw-transaction path. Nothing downstream needs to
+ * know this is Kamino.
+ *
+ * Must be called immediately before keysign. Kamino bakes a recent blockhash into the transaction
+ * and it expires in about a minute, which an MPC ceremony can outlast.
+ */
+class BuildKaminoKeysignPayloadUseCase
+@Inject
+constructor(private val preparer: KaminoTransactionPreparer) {
+
+    /**
+     * @param amount decimal token amount the user entered
+     * @param coin the wallet coin for the vault's underlying token — supplies the signer address,
+     *   public key and scale
+     * @throws KaminoTransactionRejected if the assembled transaction is not one the app will sign
+     */
+    suspend operator fun invoke(
+        vault: KaminoVault,
+        action: KaminoAction,
+        amount: BigDecimal,
+        coin: Coin,
+        blockChainSpecific: BlockChainSpecific,
+        vaultPublicKeyECDSA: String,
+        vaultLocalPartyID: String,
+        libType: SigningLibType?,
+    ): KeysignPayload {
+        require(amount.signum() > 0) { "Amount must be greater than zero" }
+
+        val solanaSpecific =
+            blockChainSpecific as? BlockChainSpecific.Solana
+                ?: error("BuildKaminoKeysignPayloadUseCase: expected Solana blockChainSpecific")
+
+        val rawTransaction =
+            preparer.prepare(
+                vault = vault,
+                action = action,
+                walletAddress = coin.address,
+                // Kamino's endpoints take decimals, not base units. `toPlainString` matters:
+                // scientific notation would be rejected, and a small amount can reach it that way.
+                amount = amount.stripTrailingZeros().toPlainString(),
+                networkUnitPrice = solanaSpecific.priorityFee,
+            )
+
+        return KeysignPayload(
+            coin = coin,
+            // Display destination on the verify screen. Routing is driven by the relayed bytes, not
+            // by this field.
+            toAddress = vault.address,
+            toAmount =
+                amount
+                    .movePointRight(coin.decimal)
+                    // Sub-unit precision from manual entry rounds down rather than throwing,
+                    // matching
+                    // how the staking flows handle over-precise input.
+                    .setScale(0, RoundingMode.DOWN)
+                    .toBigInteger(),
+            blockChainSpecific = blockChainSpecific,
+            memo = null,
+            vaultPublicKeyECDSA = vaultPublicKeyECDSA,
+            vaultLocalPartyID = vaultLocalPartyID,
+            libType = libType,
+            wasmExecuteContractPayload = null,
+            signSolana = SignSolana(rawTransactions = listOf(rawTransaction)),
+        )
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
@@ -26,7 +26,12 @@ class BuildKaminoKeysignPayloadUseCase
 constructor(private val preparer: KaminoTransactionPreparer) {
 
     /**
-     * @param amount decimal token amount the user entered
+     * @param apiAmount the decimal amount in the denomination the action's endpoint expects — the
+     *   underlying **token** for a deposit, vault **shares** for a withdraw. Passed pre-sized by
+     *   the caller rather than derived here, because sizing a withdraw safely needs the held share
+     *   balance: the endpoint rewrites an over-request to `u64::MAX`, meaning withdraw everything.
+     * @param tokenAmount what the user is moving, in the underlying token — display only, for the
+     *   verify screen. Never used to size the request.
      * @param coin the wallet coin for the vault's underlying token — supplies the signer address,
      *   public key and scale
      * @throws KaminoTransactionRejected if the assembled transaction is not one the app will sign
@@ -34,14 +39,16 @@ constructor(private val preparer: KaminoTransactionPreparer) {
     suspend operator fun invoke(
         vault: KaminoVault,
         action: KaminoAction,
-        amount: BigDecimal,
+        apiAmount: String,
+        tokenAmount: BigDecimal,
         coin: Coin,
         blockChainSpecific: BlockChainSpecific,
         vaultPublicKeyECDSA: String,
         vaultLocalPartyID: String,
         libType: SigningLibType?,
     ): KeysignPayload {
-        require(amount.signum() > 0) { "Amount must be greater than zero" }
+        require(tokenAmount.signum() > 0) { "Amount must be greater than zero" }
+        require(apiAmount.isNotBlank()) { "Kamino amount must not be blank" }
 
         val solanaSpecific =
             blockChainSpecific as? BlockChainSpecific.Solana
@@ -52,9 +59,7 @@ constructor(private val preparer: KaminoTransactionPreparer) {
                 vault = vault,
                 action = action,
                 walletAddress = coin.address,
-                // Kamino's endpoints take decimals, not base units. `toPlainString` matters:
-                // scientific notation would be rejected, and a small amount can reach it that way.
-                amount = amount.stripTrailingZeros().toPlainString(),
+                amount = apiAmount,
                 networkUnitPrice = solanaSpecific.priorityFee,
             )
 
@@ -64,7 +69,7 @@ constructor(private val preparer: KaminoTransactionPreparer) {
             // by this field.
             toAddress = vault.address,
             toAmount =
-                amount
+                tokenAmount
                     .movePointRight(coin.decimal)
                     // Sub-unit precision from manual entry rounds down rather than throwing,
                     // matching

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemo.kt
@@ -1,0 +1,67 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import wallet.core.jni.Base58
+import wallet.core.jni.SolanaTransaction
+
+/**
+ * Appends Vultisig's attribution memo to a Kamino transaction.
+ *
+ * Kamino's kVault endpoints take no referrer or partner parameter, so attribution is client-side: a
+ * single SPL Memo instruction carrying the literal bytes `vs` rides along with every deposit and
+ * withdraw. That tag is the analytics filter used to measure Vultisig's deposit flow, so it must be
+ * byte-identical on every platform — hence the exact two bytes, and nothing else, in the data
+ * field.
+ *
+ * The memo takes no accounts and adds no signer. Only its program has to enter the message's
+ * account table, which WalletCore appends to the static keys while bumping
+ * `numReadonlyUnsignedAccounts` and shifting every instruction index that addresses a
+ * lookup-table-loaded account. Those indices sit immediately after the static keys, so inserting
+ * one static key moves all of them — getting that wrong would silently point existing instructions
+ * at the wrong accounts, which is why this delegates rather than re-encoding the message here.
+ */
+object KaminoAttributionMemo {
+
+    /** SPL Memo v2. */
+    const val MEMO_PROGRAM_ID = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+
+    /** The attribution tag itself. Two ASCII bytes, never localised, never padded. */
+    const val TAG = "vs"
+
+    /**
+     * Appends the memo to [base64Transaction] and returns the updated base64 transaction.
+     *
+     * @throws IllegalStateException if WalletCore cannot produce the updated transaction. Its FFI
+     *   collapses every failure — malformed input, index overflow, a message grown too large — into
+     *   a single null, so there is no error to distinguish. Failing here is deliberate: signing the
+     *   unmodified transaction would silently drop the attribution the deposit exists to record.
+     */
+    fun append(base64Transaction: String): String =
+        checkNotNull(
+            SolanaTransaction.insertInstruction(base64Transaction, APPEND, instructionJson)
+        ) {
+            "WalletCore could not append the Kamino attribution memo"
+        }
+
+    /**
+     * `-1` appends. Kamino builds no compute-budget instructions of its own and WalletCore requires
+     * any the app injects to stay first, so appending keeps that ordering intact regardless of what
+     * else has already been inserted.
+     */
+    private const val APPEND = -1
+
+    /**
+     * The instruction is a constant, so it is built once. `data` is base58 — the encoding
+     * WalletCore's JSON instruction format expects, not base64.
+     */
+    private val instructionJson: String by lazy {
+        buildJsonObject {
+                put("programId", MEMO_PROGRAM_ID)
+                put("accounts", JsonArray(emptyList()))
+                put("data", Base58.encodeNoCheck(TAG.toByteArray(Charsets.US_ASCII)))
+            }
+            .toString()
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
@@ -1,0 +1,82 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import java.math.BigInteger
+
+/**
+ * Which side of a vault a transaction is on. Selects the compute-unit budget and the validator's
+ * rules.
+ */
+enum class KaminoAction {
+    DEPOSIT,
+    WITHDRAW,
+}
+
+/**
+ * Compute-unit budget for Kamino transactions.
+ *
+ * Kamino builds its transactions with no ComputeBudget instruction at all and ignores priority-fee
+ * fields in the request body — the response is byte-identical with or without them. So the only way
+ * one of these transactions carries a priority fee is for the app to inject it, and injecting a
+ * price without a limit would price the fee off the runtime's default limit rather than the units
+ * the transaction actually needs.
+ */
+object KaminoComputeBudget {
+
+    /**
+     * Compute units these transactions actually consume, measured on mainnet via
+     * `simulateTransaction`: a USDC deposit 252,146, a SOL deposit 287,029, a withdraw 174,566.
+     * Each limit below carries roughly a quarter more, absorbing the drift a different
+     * account-existence mix causes — a deposit that still has to create its share account or farm
+     * user account does strictly more work than one whose accounts already exist.
+     *
+     * Deliberately **not** `SOLANA_PRIORITY_FEE_LIMIT`. That constant is 100,000 units, below what
+     * every one of these transactions consumes, so reusing it would abort each of them on compute
+     * exhaustion.
+     */
+    private const val TOKEN_DEPOSIT_UNIT_LIMIT = 320_000L
+
+    /** A SOL-vault deposit also creates the wSOL account, transfers into it and syncs it. */
+    private const val NATIVE_DEPOSIT_UNIT_LIMIT = 350_000L
+
+    private const val WITHDRAW_UNIT_LIMIT = 220_000L
+
+    /**
+     * Floor for the micro-lamports-per-unit price when the network's recent-fee sample is
+     * unavailable. The fee is price × limit, so at 320,000 units this is 6,400 lamports.
+     */
+    val FALLBACK_UNIT_PRICE: BigInteger = BigInteger.valueOf(20_000)
+
+    fun unitLimitFor(vault: KaminoVault, action: KaminoAction): BigInteger =
+        when (action) {
+            KaminoAction.WITHDRAW -> WITHDRAW_UNIT_LIMIT
+            KaminoAction.DEPOSIT ->
+                if (vault.tokenMint == KaminoVaultRegistry.WRAPPED_SOL_MINT) {
+                    NATIVE_DEPOSIT_UNIT_LIMIT
+                } else {
+                    TOKEN_DEPOSIT_UNIT_LIMIT
+                }
+        }.let(BigInteger::valueOf)
+
+    /** Never price below the floor, however stale or absent the network sample is. */
+    fun unitPriceFor(networkPrice: BigInteger?): BigInteger =
+        networkPrice?.takeIf { it > FALLBACK_UNIT_PRICE } ?: FALLBACK_UNIT_PRICE
+
+    /**
+     * The priority fee this transaction will actually be charged, in lamports.
+     *
+     * price × limit, converted from micro-lamports. A Max-amount form has to subtract this or the
+     * transaction it builds cannot pay for itself. Rounded up, so the headroom is never a lamport
+     * short of what the runtime charges.
+     */
+    fun priorityFeeLamports(
+        vault: KaminoVault,
+        action: KaminoAction,
+        networkPrice: BigInteger?,
+    ): BigInteger {
+        val microLamports = unitPriceFor(networkPrice).multiply(unitLimitFor(vault, action))
+        val (lamports, remainder) = microLamports.divideAndRemainder(MICRO_LAMPORTS_PER_LAMPORT)
+        return if (remainder.signum() > 0) lamports.add(BigInteger.ONE) else lamports
+    }
+
+    private val MICRO_LAMPORTS_PER_LAMPORT = BigInteger.valueOf(1_000_000)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
@@ -38,7 +38,23 @@ object KaminoComputeBudget {
     /** A SOL-vault deposit also creates the wSOL account, transfers into it and syncs it. */
     private const val NATIVE_DEPOSIT_UNIT_LIMIT = 350_000L
 
-    private const val WITHDRAW_UNIT_LIMIT = 220_000L
+    /**
+     * One limit for both withdraw shapes, sized for the expensive one.
+     *
+     * A withdraw of **farm-staked** shares runs two extra `farms` instructions and a second account
+     * creation ahead of the vault withdraw, costing about two-thirds more than the unstaked path:
+     * 283,786 (USDC, partial), 289,486 (USDC, at the maximum) and 309,310 (wrapped SOL, which also
+     * closes the payout account), against 173,385 unstaked. At 220,000 every staked shape aborted
+     * in simulation with `ProgramFailedToComplete — exceeded CUs meter`, so a staked withdraw —
+     * which is what essentially every real holder needs — could not be prepared at all.
+     *
+     * Deliberately not split per shape even though the caller knows which it is building. The
+     * priority fee is price × limit, so the unstaked path pays for headroom it does not use (about
+     * a third of a cent at the fallback price) and in exchange one value per operation can be
+     * pinned. A second value would have to be selected from the transaction's own shape, which is
+     * the sort of check that agrees with whatever it is shown.
+     */
+    private const val WITHDRAW_UNIT_LIMIT = 400_000L
 
     /**
      * Floor for the micro-lamports-per-unit price when the network's recent-fee sample is

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMath.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMath.kt
@@ -1,0 +1,61 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+/**
+ * Converts Kamino's wire values into the quantities the Earn rows display.
+ *
+ * Kept pure and currency-free on purpose. Kamino prices everything in USD, but the app renders in
+ * whichever currency the user picked, so fiat conversion stays with the app's own price pipeline
+ * and only token quantities are derived here.
+ */
+object KaminoPositionMath {
+
+    /**
+     * Parses one of Kamino's decimal strings, or null when it is absent or unparseable.
+     *
+     * A malformed number is treated as missing rather than as zero: a row that shows nothing is
+     * recoverable, whereas a balance silently rendered as 0 reads as "your deposit is gone".
+     */
+    fun decimalOrNull(raw: String?): BigDecimal? =
+        raw?.takeIf { it.isNotBlank() }?.let { runCatching { BigDecimal(it) }.getOrNull() }
+
+    /**
+     * Token amount a share balance is worth.
+     *
+     * `shares` and `tokensPerShare` both arrive as decimal quantities, so this is a plain product —
+     * no scaling by either mint's decimals, which for these vaults are not even equal to each
+     * other.
+     *
+     * Deliberately not Kamino's documented `(totalShares / sharesIssued) × tokenAvailable`:
+     * `tokenAvailable` is only the vault's liquid buffer, a fraction of a percent of assets under
+     * management, so that formula understates a position by orders of magnitude.
+     *
+     * Rounded down to the token's own precision so a displayed balance is never larger than what
+     * can actually be withdrawn.
+     */
+    fun tokenAmount(
+        shares: BigDecimal,
+        tokensPerShare: BigDecimal,
+        tokenDecimals: Int,
+    ): BigDecimal = shares.multiply(tokensPerShare).setScale(tokenDecimals, RoundingMode.DOWN)
+
+    /**
+     * Turns Kamino's APY fraction into a percentage. `0.039967…` becomes `4.00`.
+     *
+     * Every `apy*` field is a fraction; rendering one straight into a `%` slot would report a 4%
+     * vault as 0.04%.
+     */
+    fun apyPercent(apyFraction: BigDecimal): BigDecimal =
+        apyFraction.multiply(ONE_HUNDRED).setScale(2, RoundingMode.HALF_UP)
+
+    /**
+     * Converts a minimum expressed in the token's base units into a decimal amount — 100000 at 6
+     * decimals is 0.1. This is the one place Kamino uses base units rather than decimal strings.
+     */
+    fun baseUnitsToDecimal(baseUnits: String?, tokenDecimals: Int): BigDecimal? =
+        decimalOrNull(baseUnits)?.movePointLeft(tokenDecimals)
+
+    private val ONE_HUNDRED = BigDecimal(100)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -32,11 +32,26 @@ object KaminoTransactionDecoder {
             KaminoTxInstruction(
                 // A versioned message may not invoke a program loaded through a lookup table, so a
                 // program index always addresses the static keys.
-                programId = accountKeys.getOrNull(instruction.programId) ?: "unknown",
+                programId = accountKeys.getOrNull(instruction.programId) ?: UNKNOWN_ACCOUNT,
                 data = instruction.programData.toByteArray(),
+                // Indices at or past the static keys address lookup-table-loaded accounts, which
+                // the
+                // decoder cannot resolve without fetching the tables. They are named as unresolved
+                // rather than silently dropped, so a check can tell "not the signer" from
+                // "unknown".
+                accounts =
+                    instruction.accountsList.map { index ->
+                        accountKeys.getOrNull(index) ?: UNKNOWN_ACCOUNT
+                    },
             )
         }
     }
+
+    /**
+     * Stands in for an account the decode cannot name, rather than an empty string that reads as
+     * absent.
+     */
+    const val UNKNOWN_ACCOUNT = "unknown"
 }
 
 /**
@@ -57,7 +72,10 @@ object KaminoTransactionDecoder {
 class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: KaminoApi) {
 
     /**
-     * @param amount decimal token amount, as Kamino's endpoints expect
+     * @param amount the decimal amount in the denomination the chosen endpoint expects — the
+     *   underlying **token** for a deposit, vault **shares** for a withdraw. They are not
+     *   interchangeable: confusing them is off by the share rate, which on the SOL vault is enough
+     *   to exceed the held balance and trip the `u64::MAX` full-exit rewrite.
      * @param networkUnitPrice the app's current micro-lamports-per-unit sample, or null to use the
      *   floor
      * @return base64 transaction with a zeroed signature envelope, ready for the raw-signing path
@@ -84,6 +102,7 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
             instructions = KaminoTransactionDecoder.decode(withMemo),
             vault = vault,
             action = action,
+            signerAddress = walletAddress,
         )
 
         return withMemo

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -5,6 +5,7 @@ import io.ktor.util.decodeBase64Bytes
 import java.math.BigInteger
 import javax.inject.Inject
 import wallet.core.jni.CoinType
+import wallet.core.jni.SolanaAddress
 import wallet.core.jni.SolanaTransaction
 import wallet.core.jni.TransactionDecoder
 import wallet.core.jni.proto.Solana
@@ -124,9 +125,25 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
             vault = vault,
             action = action,
             signerAddress = walletAddress,
+            wrappedSolAccount = wrappedSolAccountFor(vault, walletAddress),
         )
 
         return withMemo
+    }
+
+    /**
+     * The wrapped-SOL associated token account a wrap must pay into, derived from the signer and
+     * the vault's own mint rather than read out of the transaction being checked.
+     *
+     * Null for vaults whose underlying is a plain token, which have no wrap to make.
+     */
+    private fun wrappedSolAccountFor(vault: KaminoVault, walletAddress: String): String? {
+        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) return null
+        return runCatching {
+                SolanaAddress(walletAddress)
+                    .defaultTokenAddress(KaminoVaultRegistry.WRAPPED_SOL_MINT)
+            }
+            .getOrNull()
     }
 
     private fun injectComputeBudget(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -9,10 +9,22 @@ import wallet.core.jni.SolanaTransaction
 import wallet.core.jni.TransactionDecoder
 import wallet.core.jni.proto.Solana
 
+/**
+ * A decoded transaction, reduced to what validation reasons about.
+ *
+ * [feePayer] is the message's own account key 0 — the fee payer and first required signer. It has
+ * to come from the message header rather than from any instruction's account list: an instruction
+ * that happens to name the wallet first says nothing about who is authorising the transaction.
+ */
+data class KaminoDecodedTransaction(
+    val feePayer: String?,
+    val instructions: List<KaminoTxInstruction>,
+)
+
 /** Decodes a base64 Solana transaction into the instructions validation reasons about. */
 object KaminoTransactionDecoder {
 
-    fun decode(base64Transaction: String): List<KaminoTxInstruction> {
+    fun decode(base64Transaction: String): KaminoDecodedTransaction {
         val decoded =
             TransactionDecoder.decode(CoinType.SOLANA, base64Transaction.decodeBase64Bytes())
         val output = Solana.DecodingTransactionOutput.parseFrom(decoded)
@@ -28,23 +40,32 @@ object KaminoTransactionDecoder {
                 else -> error("transaction is neither versioned nor legacy")
             }
 
-        return instructions.map { instruction ->
-            KaminoTxInstruction(
-                // A versioned message may not invoke a program loaded through a lookup table, so a
-                // program index always addresses the static keys.
-                programId = accountKeys.getOrNull(instruction.programId) ?: UNKNOWN_ACCOUNT,
-                data = instruction.programData.toByteArray(),
-                // Indices at or past the static keys address lookup-table-loaded accounts, which
-                // the
-                // decoder cannot resolve without fetching the tables. They are named as unresolved
-                // rather than silently dropped, so a check can tell "not the signer" from
-                // "unknown".
-                accounts =
-                    instruction.accountsList.map { index ->
-                        accountKeys.getOrNull(index) ?: UNKNOWN_ACCOUNT
-                    },
-            )
-        }
+        val decodedInstructions =
+            instructions.map { instruction ->
+                KaminoTxInstruction(
+                    // A versioned message may not invoke a program loaded through a lookup table,
+                    // so a
+                    // program index always addresses the static keys.
+                    programId = accountKeys.getOrNull(instruction.programId) ?: UNKNOWN_ACCOUNT,
+                    data = instruction.programData.toByteArray(),
+                    // Indices at or past the static keys address lookup-table-loaded accounts,
+                    // which
+                    // the
+                    // decoder cannot resolve without fetching the tables. They are named as
+                    // unresolved
+                    // rather than silently dropped, so a check can tell "not the signer" from
+                    // "unknown".
+                    accounts =
+                        instruction.accountsList.map { index ->
+                            accountKeys.getOrNull(index) ?: UNKNOWN_ACCOUNT
+                        },
+                )
+            }
+
+        return KaminoDecodedTransaction(
+            feePayer = accountKeys.firstOrNull(),
+            instructions = decodedInstructions,
+        )
     }
 
     /**
@@ -99,7 +120,7 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
         val withMemo = KaminoAttributionMemo.append(withBudget)
 
         KaminoTransactionValidator.validate(
-            instructions = KaminoTransactionDecoder.decode(withMemo),
+            decoded = KaminoTransactionDecoder.decode(withMemo),
             vault = vault,
             action = action,
             signerAddress = walletAddress,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -1,0 +1,116 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.api.KaminoApi
+import io.ktor.util.decodeBase64Bytes
+import java.math.BigInteger
+import javax.inject.Inject
+import wallet.core.jni.CoinType
+import wallet.core.jni.SolanaTransaction
+import wallet.core.jni.TransactionDecoder
+import wallet.core.jni.proto.Solana
+
+/** Decodes a base64 Solana transaction into the instructions validation reasons about. */
+object KaminoTransactionDecoder {
+
+    fun decode(base64Transaction: String): List<KaminoTxInstruction> {
+        val decoded =
+            TransactionDecoder.decode(CoinType.SOLANA, base64Transaction.decodeBase64Bytes())
+        val output = Solana.DecodingTransactionOutput.parseFrom(decoded)
+        check(output.hasTransaction()) { "transaction could not be decoded" }
+
+        val transaction = output.transaction
+        val (instructions, accountKeys) =
+            when {
+                transaction.hasV0() ->
+                    transaction.v0.instructionsList to transaction.v0.accountKeysList
+                transaction.hasLegacy() ->
+                    transaction.legacy.instructionsList to transaction.legacy.accountKeysList
+                else -> error("transaction is neither versioned nor legacy")
+            }
+
+        return instructions.map { instruction ->
+            KaminoTxInstruction(
+                // A versioned message may not invoke a program loaded through a lookup table, so a
+                // program index always addresses the static keys.
+                programId = accountKeys.getOrNull(instruction.programId) ?: "unknown",
+                data = instruction.programData.toByteArray(),
+            )
+        }
+    }
+}
+
+/**
+ * Turns a Kamino deposit or withdraw intent into transaction bytes ready for keysign.
+ *
+ * The order of operations is the contract:
+ * 1. Kamino builds the transaction, embedding a recent blockhash. It carries no compute budget and
+ *    ignores any fee hints in the request, so the app supplies both.
+ * 2. Compute budget goes on first. WalletCore appends these when absent, so doing this before the
+ *    memo is what leaves the memo last — which the validator then requires.
+ * 3. The attribution memo goes on last.
+ * 4. The result is decoded and validated against the local registry, never against anything Kamino
+ *    just said.
+ *
+ * The embedded blockhash lives about a minute, and an MPC ceremony can outlast it, so this must be
+ * called immediately before keysign rather than when the user opens the form.
+ */
+class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: KaminoApi) {
+
+    /**
+     * @param amount decimal token amount, as Kamino's endpoints expect
+     * @param networkUnitPrice the app's current micro-lamports-per-unit sample, or null to use the
+     *   floor
+     * @return base64 transaction with a zeroed signature envelope, ready for the raw-signing path
+     * @throws KaminoTransactionRejected if the assembled transaction is not one the app will sign
+     */
+    suspend fun prepare(
+        vault: KaminoVault,
+        action: KaminoAction,
+        walletAddress: String,
+        amount: String,
+        networkUnitPrice: BigInteger? = null,
+    ): String {
+        val built =
+            when (action) {
+                KaminoAction.DEPOSIT -> kaminoApi.buildDeposit(walletAddress, vault.address, amount)
+                KaminoAction.WITHDRAW ->
+                    kaminoApi.buildWithdraw(walletAddress, vault.address, amount)
+            }
+
+        val withBudget = injectComputeBudget(built, vault, action, networkUnitPrice)
+        val withMemo = KaminoAttributionMemo.append(withBudget)
+
+        KaminoTransactionValidator.validate(
+            instructions = KaminoTransactionDecoder.decode(withMemo),
+            vault = vault,
+            action = action,
+        )
+
+        return withMemo
+    }
+
+    private fun injectComputeBudget(
+        base64Transaction: String,
+        vault: KaminoVault,
+        action: KaminoAction,
+        networkUnitPrice: BigInteger?,
+    ): String {
+        val limit = KaminoComputeBudget.unitLimitFor(vault, action)
+        val price = KaminoComputeBudget.unitPriceFor(networkUnitPrice)
+
+        // WalletCore collapses every failure into a null return, so each step is checked. Signing a
+        // transaction with no compute-unit limit would abort it on chain: these consume far more
+        // than
+        // the runtime default.
+        val withLimit =
+            checkNotNull(
+                SolanaTransaction.setComputeUnitLimit(base64Transaction, limit.toString())
+            ) {
+                "WalletCore could not set the Kamino compute-unit limit"
+            }
+
+        return checkNotNull(SolanaTransaction.setComputeUnitPrice(withLimit, price.toString())) {
+            "WalletCore could not set the Kamino compute-unit price"
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -75,11 +75,12 @@ object KaminoTransactionValidator {
      *   to sign for [vault].
      */
     fun validate(
-        instructions: List<KaminoTxInstruction>,
+        decoded: KaminoDecodedTransaction,
         vault: KaminoVault,
         action: KaminoAction,
         signerAddress: String? = null,
     ) {
+        val instructions = decoded.instructions
         if (!KaminoVaultRegistry.isAllowed(vault.address)) {
             reject("${vault.address} is not a vault this app transacts with")
         }
@@ -126,7 +127,8 @@ object KaminoTransactionValidator {
             reject("memo must be the final instruction")
         }
 
-        rejectValueMovementAwayFromTheSigner(instructions, vault, signerAddress)
+        rejectValueMovementAwayFromTheSigner(instructions, vault)
+        rejectAnotherAccountsAuthority(decoded.feePayer, signerAddress)
         rejectTheWithdrawEverythingSentinel(instructions)
     }
 
@@ -182,7 +184,6 @@ object KaminoTransactionValidator {
     private fun rejectValueMovementAwayFromTheSigner(
         instructions: List<KaminoTxInstruction>,
         vault: KaminoVault,
-        signerAddress: String?,
     ) {
         instructions.forEachIndexed { index, instruction ->
             when (instruction.programId) {
@@ -203,27 +204,48 @@ object KaminoTransactionValidator {
                 SYSTEM_PROGRAM_ID -> {
                     // Lamports only ever move to wrap SOL, and only for the wrapped-SOL vault.
                     val discriminator = instruction.data.take(4).let(::littleEndianInt)
-                    if (
-                        discriminator == SYSTEM_TRANSFER &&
-                            vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT
-                    ) {
-                        reject(
-                            "instruction $index moves lamports, which only the wrapped-SOL vault " +
-                                "has cause to do"
-                        )
+                    if (discriminator == SYSTEM_TRANSFER) {
+                        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) {
+                            reject(
+                                "instruction $index moves lamports, which only the wrapped-SOL " +
+                                    "vault has cause to do"
+                            )
+                        }
+                        // Permitted, but not to anywhere: the only lamports a deposit moves go into
+                        // the wSOL account it is about to deposit from, which the kVault
+                        // instruction
+                        // therefore also names. A transfer to an address this transaction does not
+                        // otherwise touch is not a wrap.
+                        val destination = instruction.accounts.getOrNull(1)
+                        val kvaultAccounts =
+                            instructions
+                                .filter { it.programId == KaminoVaultRegistry.PROGRAM_ID }
+                                .flatMap { it.accounts }
+                                .toSet()
+                        if (destination == null || destination !in kvaultAccounts) {
+                            reject(
+                                "instruction $index moves lamports to $destination, which the " +
+                                    "vault deposit does not reference"
+                            )
+                        }
                     }
                 }
             }
         }
+    }
 
-        // The transaction must be the signer's own. Index 0 of a Solana message is the fee payer
-        // and
-        // first required signer, so anything else means signing on another account's behalf.
-        if (signerAddress != null) {
-            val feePayer = instructions.firstNotNullOfOrNull { it.accounts.firstOrNull() }
-            if (feePayer != null && feePayer != signerAddress) {
-                reject("transaction is authorised by $feePayer rather than the wallet")
-            }
+    /**
+     * The transaction must be the wallet's own.
+     *
+     * Read from the message's account key 0, which is the fee payer and first required signer. An
+     * earlier version of this took the first account of the first instruction, which is a different
+     * thing: an instruction that happens to name the wallet first says nothing about who authorises
+     * the transaction, so a message paid for by another account would have passed.
+     */
+    private fun rejectAnotherAccountsAuthority(feePayer: String?, signerAddress: String?) {
+        if (signerAddress == null || feePayer == null) return
+        if (feePayer != signerAddress) {
+            reject("transaction is authorised by $feePayer rather than by the wallet")
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -100,6 +100,12 @@ object KaminoTransactionValidator {
         }
 
         val memo = memos.single()
+        // A memo naming accounts is the Memo program *attesting* that they signed. Attribution is
+        // not that, and the app's own injection names none, so an account list means this memo came
+        // from somewhere else.
+        if (memo.accounts.isNotEmpty()) {
+            reject("attribution memo must name no accounts, found ${memo.accounts.size}")
+        }
         if (!memo.data.contentEquals(TAG_BYTES)) {
             // Any memo other than the exact tag is a refusal: an arbitrary memo riding along on a
             // signed transaction is a channel the app did not open.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -1,0 +1,97 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+/** One decoded instruction, reduced to what validation actually reasons about. */
+data class KaminoTxInstruction(val programId: String, val data: ByteArray) {
+    // ByteArray identity would make two structurally equal instructions compare unequal, which
+    // matters because tests and set comparisons rely on value semantics here.
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (other is KaminoTxInstruction &&
+                programId == other.programId &&
+                data.contentEquals(other.data))
+
+    override fun hashCode(): Int = 31 * programId.hashCode() + data.contentHashCode()
+}
+
+/** Why a prepared Kamino transaction was refused. */
+class KaminoTransactionRejected(message: String) : IllegalStateException(message)
+
+/**
+ * Checks a transaction the app is about to sign against what the app itself intended.
+ *
+ * The point is that Kamino builds these transactions, so nothing fetched from Kamino can be used to
+ * validate one — the check would be circular, and a single compromised response could supply a
+ * matching pair. Everything checked here comes from the local registry or from the app's own
+ * intent.
+ *
+ * Kept free of JNI so the rules are unit-testable; decoding is the caller's job.
+ */
+object KaminoTransactionValidator {
+
+    /** Programs a curated vault's deposit or withdraw is allowed to touch. */
+    private val ALWAYS_ALLOWED =
+        setOf(
+            "11111111111111111111111111111111", // System
+            "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", // Token
+            "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb", // Token-2022
+            "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL", // Associated Token
+            "ComputeBudget111111111111111111111111111111",
+            KaminoVaultRegistry.PROGRAM_ID,
+            KaminoVaultRegistry.FARMS_PROGRAM_ID,
+            KaminoAttributionMemo.MEMO_PROGRAM_ID,
+        )
+
+    private val TAG_BYTES = KaminoAttributionMemo.TAG.toByteArray(Charsets.US_ASCII)
+
+    /**
+     * @throws KaminoTransactionRejected if [instructions] is not a transaction the app is willing
+     *   to sign for [vault].
+     */
+    fun validate(
+        instructions: List<KaminoTxInstruction>,
+        vault: KaminoVault,
+        action: KaminoAction,
+    ) {
+        if (!KaminoVaultRegistry.isAllowed(vault.address)) {
+            reject("${vault.address} is not a vault this app transacts with")
+        }
+
+        if (instructions.isEmpty()) reject("transaction carries no instructions")
+
+        instructions.forEachIndexed { index, instruction ->
+            if (instruction.programId !in ALWAYS_ALLOWED) {
+                reject("instruction $index invokes unexpected program ${instruction.programId}")
+            }
+        }
+
+        // The whole point of the transaction. Without it, whatever the app is about to sign is not
+        // the deposit or withdraw the user asked for.
+        if (instructions.none { it.programId == KaminoVaultRegistry.PROGRAM_ID }) {
+            reject("transaction never invokes the kVault program (expected for $action)")
+        }
+
+        val memos = instructions.filter { it.programId == KaminoAttributionMemo.MEMO_PROGRAM_ID }
+        when {
+            memos.isEmpty() -> reject("attribution memo is missing")
+            memos.size > 1 -> reject("expected exactly one memo, found ${memos.size}")
+        }
+
+        val memo = memos.single()
+        if (!memo.data.contentEquals(TAG_BYTES)) {
+            // Any memo other than the exact tag is a refusal: an arbitrary memo riding along on a
+            // signed transaction is a channel the app did not open.
+            reject(
+                "memo carries unexpected data (expected \"${KaminoAttributionMemo.TAG}\", " +
+                    "found ${memo.data.size} byte(s))"
+            )
+        }
+
+        // Pinned so the golden coverage and the on-chain shape agree: compute budget is injected
+        // before the memo, which leaves the memo unambiguously last.
+        if (instructions.last().programId != KaminoAttributionMemo.MEMO_PROGRAM_ID) {
+            reject("memo must be the final instruction")
+        }
+    }
+
+    private fun reject(reason: String): Nothing = throw KaminoTransactionRejected(reason)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -79,6 +79,7 @@ object KaminoTransactionValidator {
         vault: KaminoVault,
         action: KaminoAction,
         signerAddress: String? = null,
+        wrappedSolAccount: String? = null,
     ) {
         val instructions = decoded.instructions
         if (!KaminoVaultRegistry.isAllowed(vault.address)) {
@@ -127,7 +128,7 @@ object KaminoTransactionValidator {
             reject("memo must be the final instruction")
         }
 
-        rejectValueMovementAwayFromTheSigner(instructions, vault)
+        rejectValueMovementAwayFromTheSigner(instructions, vault, wrappedSolAccount)
         rejectAnotherAccountsAuthority(decoded.feePayer, signerAddress)
         rejectTheWithdrawEverythingSentinel(instructions)
     }
@@ -184,6 +185,7 @@ object KaminoTransactionValidator {
     private fun rejectValueMovementAwayFromTheSigner(
         instructions: List<KaminoTxInstruction>,
         vault: KaminoVault,
+        wrappedSolAccount: String?,
     ) {
         instructions.forEachIndexed { index, instruction ->
             when (instruction.programId) {
@@ -211,21 +213,26 @@ object KaminoTransactionValidator {
                                     "vault has cause to do"
                             )
                         }
-                        // Permitted, but not to anywhere: the only lamports a deposit moves go into
-                        // the wSOL account it is about to deposit from, which the kVault
-                        // instruction
-                        // therefore also names. A transfer to an address this transaction does not
-                        // otherwise touch is not a wrap.
+                        // Permitted, but only to one address: the wrapped-SOL account derived from
+                        // the signer and the vault's own mint.
+                        //
+                        // An earlier version accepted any destination the kVault instruction also
+                        // named, which is no check at all against a compromised response — the same
+                        // response chooses that instruction's account list, so it could name an
+                        // attacker there and have the transfer waved through. The expected address
+                        // is
+                        // derived locally by the caller and compared exactly.
                         val destination = instruction.accounts.getOrNull(1)
-                        val kvaultAccounts =
-                            instructions
-                                .filter { it.programId == KaminoVaultRegistry.PROGRAM_ID }
-                                .flatMap { it.accounts }
-                                .toSet()
-                        if (destination == null || destination !in kvaultAccounts) {
+                        if (wrappedSolAccount == null) {
                             reject(
-                                "instruction $index moves lamports to $destination, which the " +
-                                    "vault deposit does not reference"
+                                "instruction $index moves lamports but the wrapped-SOL account " +
+                                    "could not be derived, so its destination cannot be checked"
+                            )
+                        }
+                        if (destination != wrappedSolAccount) {
+                            reject(
+                                "instruction $index moves lamports to $destination rather than to " +
+                                    "the wallet's wrapped-SOL account"
                             )
                         }
                     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -1,16 +1,28 @@
 package com.vultisig.wallet.data.blockchain.solana.kamino
 
-/** One decoded instruction, reduced to what validation actually reasons about. */
-data class KaminoTxInstruction(val programId: String, val data: ByteArray) {
+/**
+ * One decoded instruction, reduced to what validation reasons about.
+ *
+ * [accounts] carries the resolved account addresses, not indices: without them the validator can
+ * only ask *which programs* run, and a compromised response could add a transfer to an attacker
+ * using a program the transaction legitimately needs anyway.
+ */
+data class KaminoTxInstruction(
+    val programId: String,
+    val data: ByteArray,
+    val accounts: List<String> = emptyList(),
+) {
     // ByteArray identity would make two structurally equal instructions compare unequal, which
     // matters because tests and set comparisons rely on value semantics here.
     override fun equals(other: Any?): Boolean =
         this === other ||
             (other is KaminoTxInstruction &&
                 programId == other.programId &&
-                data.contentEquals(other.data))
+                data.contentEquals(other.data) &&
+                accounts == other.accounts)
 
-    override fun hashCode(): Int = 31 * programId.hashCode() + data.contentHashCode()
+    override fun hashCode(): Int =
+        31 * (31 * programId.hashCode() + data.contentHashCode()) + accounts.hashCode()
 }
 
 /** Why a prepared Kamino transaction was refused. */
@@ -43,6 +55,16 @@ object KaminoTransactionValidator {
 
     private val TAG_BYTES = KaminoAttributionMemo.TAG.toByteArray(Charsets.US_ASCII)
 
+    private const val SYSTEM_PROGRAM_ID = "11111111111111111111111111111111"
+    private const val TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+    private const val TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+
+    /** `Transfer` (3) and `TransferChecked` (12) in the SPL Token instruction enum. */
+    private val TOKEN_TRANSFER_DISCRIMINATORS = setOf(3, 12)
+
+    /** `SystemInstruction::Transfer`. */
+    private const val SYSTEM_TRANSFER = 2
+
     /**
      * @throws KaminoTransactionRejected if [instructions] is not a transaction the app is willing
      *   to sign for [vault].
@@ -51,6 +73,7 @@ object KaminoTransactionValidator {
         instructions: List<KaminoTxInstruction>,
         vault: KaminoVault,
         action: KaminoAction,
+        signerAddress: String? = null,
     ) {
         if (!KaminoVaultRegistry.isAllowed(vault.address)) {
             reject("${vault.address} is not a vault this app transacts with")
@@ -90,6 +113,72 @@ object KaminoTransactionValidator {
         // before the memo, which leaves the memo unambiguously last.
         if (instructions.last().programId != KaminoAttributionMemo.MEMO_PROGRAM_ID) {
             reject("memo must be the final instruction")
+        }
+
+        rejectValueMovementAwayFromTheSigner(instructions, vault, signerAddress)
+    }
+
+    /**
+     * Refuses instructions that could move value somewhere the deposit or withdraw has no reason
+     * to.
+     *
+     * Program allow-listing alone is not enough: a deposit legitimately needs the System and Token
+     * programs, so a compromised response could add a plain transfer to an attacker and still
+     * invoke kVault and end with the memo. These checks are about *what* those programs are asked
+     * to do.
+     */
+    private fun rejectValueMovementAwayFromTheSigner(
+        instructions: List<KaminoTxInstruction>,
+        vault: KaminoVault,
+        signerAddress: String?,
+    ) {
+        instructions.forEachIndexed { index, instruction ->
+            when (instruction.programId) {
+                TOKEN_PROGRAM_ID,
+                TOKEN_2022_PROGRAM_ID -> {
+                    // The vault moves tokens through its own program's CPI. A *top-level* token
+                    // transfer is not part of any shape observed here, and is exactly how a stray
+                    // instruction would drain an account the wallet has already authorised.
+                    val discriminator = instruction.data.firstOrNull()?.toInt()?.and(0xFF)
+                    if (discriminator in TOKEN_TRANSFER_DISCRIMINATORS) {
+                        reject(
+                            "instruction $index is a top-level SPL token transfer, which no Kamino " +
+                                "deposit or withdraw performs"
+                        )
+                    }
+                }
+
+                SYSTEM_PROGRAM_ID -> {
+                    // Lamports only ever move to wrap SOL, and only for the wrapped-SOL vault.
+                    val discriminator = instruction.data.take(4).let(::littleEndianInt)
+                    if (
+                        discriminator == SYSTEM_TRANSFER &&
+                            vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT
+                    ) {
+                        reject(
+                            "instruction $index moves lamports, which only the wrapped-SOL vault " +
+                                "has cause to do"
+                        )
+                    }
+                }
+            }
+        }
+
+        // The transaction must be the signer's own. Index 0 of a Solana message is the fee payer
+        // and
+        // first required signer, so anything else means signing on another account's behalf.
+        if (signerAddress != null) {
+            val feePayer = instructions.firstNotNullOfOrNull { it.accounts.firstOrNull() }
+            if (feePayer != null && feePayer != signerAddress) {
+                reject("transaction is authorised by $feePayer rather than the wallet")
+            }
+        }
+    }
+
+    private fun littleEndianInt(bytes: List<Byte>): Int? {
+        if (bytes.size < 4) return null
+        return bytes.foldIndexed(0) { index, acc, byte ->
+            acc or ((byte.toInt() and 0xFF) shl (8 * index))
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -1,5 +1,7 @@
 package com.vultisig.wallet.data.blockchain.solana.kamino
 
+import java.math.BigInteger
+
 /**
  * One decoded instruction, reduced to what validation reasons about.
  *
@@ -65,6 +67,9 @@ object KaminoTransactionValidator {
     /** `SystemInstruction::Transfer`. */
     private const val SYSTEM_TRANSFER = 2
 
+    /** What the kVault program reads as "withdraw everything". */
+    private val U64_MAX = BigInteger("18446744073709551615")
+
     /**
      * @throws KaminoTransactionRejected if [instructions] is not a transaction the app is willing
      *   to sign for [vault].
@@ -122,6 +127,47 @@ object KaminoTransactionValidator {
         }
 
         rejectValueMovementAwayFromTheSigner(instructions, vault, signerAddress)
+        rejectTheWithdrawEverythingSentinel(instructions)
+    }
+
+    /**
+     * Refuses a kVault instruction whose amount argument is `u64::MAX`, which the program reads as
+     * *withdraw everything* rather than as a share count.
+     *
+     * **This app cannot produce one.** The withdraw form's maximum is derived to sit strictly below
+     * the balance precisely so the API never answers with the sentinel, and an over-request is
+     * refused rather than clamped. So a transaction carrying it did not come from here — and it is
+     * the one amount whose consequence is the entire position rather than the figure on screen.
+     * Refused on every device, initiating or co-signing: disclosing it while allowing the signature
+     * would put the whole position behind a label.
+     *
+     * Confirmed empirically: asking Kamino to withdraw 0.5 shares from a wallet holding nothing
+     * returns an instruction carrying exactly this.
+     */
+    private fun rejectTheWithdrawEverythingSentinel(instructions: List<KaminoTxInstruction>) {
+        instructions.forEachIndexed { index, instruction ->
+            if (instruction.programId != KaminoVaultRegistry.PROGRAM_ID) return@forEachIndexed
+            val amount = kvaultAmount(instruction.data) ?: return@forEachIndexed
+            if (amount == U64_MAX) {
+                reject(
+                    "instruction $index carries the withdraw-everything sentinel, which this app " +
+                        "never produces"
+                )
+            }
+        }
+    }
+
+    /**
+     * The `u64` amount argument of a kVault instruction: an 8-byte Anchor discriminator followed by
+     * the amount, little-endian. Null when the instruction is too short to carry one.
+     */
+    private fun kvaultAmount(data: ByteArray): BigInteger? {
+        if (data.size < 16) return null
+        var value = BigInteger.ZERO
+        for (offset in 7 downTo 0) {
+            value = value.shiftLeft(8).or(BigInteger.valueOf((data[8 + offset].toLong() and 0xFF)))
+        }
+        return value
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoVaultRegistry.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoVaultRegistry.kt
@@ -1,0 +1,149 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+
+/**
+ * Relative risk of a launch vault, used to order and label the Earn list.
+ *
+ * Kamino exposes no risk or curator field anywhere in its API, so this is curation and travels with
+ * the allow-list rather than with a response.
+ */
+enum class KaminoRiskTier {
+    /** Over-collateralised lending against liquid crypto collateral. */
+    CONSERVATIVE,
+    /**
+     * Lending against tokenized private credit — reinsurance, receivables and corporate bonds. A
+     * materially different risk from [CONSERVATIVE], and must never be presented as
+     * government-backed.
+     */
+    PRIVATE_CREDIT,
+}
+
+/**
+ * A curated Kamino Earn vault the app offers.
+ *
+ * Every field here is an immutable property of the vault — its mints, their scales and its farm are
+ * fixed when the vault is created. They are pinned locally because a transaction built by Kamino
+ * cannot be validated against values fetched from Kamino: the check would be circular, and a single
+ * compromised response could supply a matching pair. Everything that legitimately moves — name,
+ * minimums, APY, share price, lookup tables — stays live.
+ */
+data class KaminoVault(
+    val address: String,
+    /** The vault's underlying token mint: a deposit's source and a withdrawal's destination. */
+    val tokenMint: String,
+    /**
+     * Pinned because it scales every amount; a wrong scale mis-sizes a transfer by a power of ten.
+     */
+    val tokenDecimals: Int,
+    val sharesMint: String,
+    /** Not necessarily equal to [tokenDecimals] — see [ALLEZ_SOL]. */
+    val sharesDecimals: Int,
+    /** The farm a deposit stakes its shares into. */
+    val farm: String,
+    /** Shown until live vault state arrives, and as the fallback if it never does. */
+    val fallbackName: String,
+    val curator: String,
+    val riskTier: KaminoRiskTier,
+)
+
+/** The curated set of Kamino Earn vaults the app exposes on the Solana DeFi tab. */
+object KaminoVaultRegistry {
+
+    /** The kVaults program every deposit and withdraw invokes. */
+    const val PROGRAM_ID = "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd"
+
+    /**
+     * Kamino's farms program. Every launch vault has a farm, so a deposit ends by staking into it
+     * and the shares never land in the user's wallet as a token balance.
+     */
+    const val FARMS_PROGRAM_ID = "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+
+    /** Circle's USDC — the underlying token of both dollar vaults. */
+    const val USDC_MINT = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+    /**
+     * Wrapped SOL. The SOL vault's underlying token is this mint rather than native SOL, which is
+     * why its deposits have to wrap first.
+     */
+    const val WRAPPED_SOL_MINT = "So11111111111111111111111111111111111111112"
+
+    val STEAKHOUSE_USDC =
+        KaminoVault(
+            address = "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E",
+            tokenMint = USDC_MINT,
+            tokenDecimals = 6,
+            sharesMint = "7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS",
+            sharesDecimals = 6,
+            farm = "9FVjHqduhDPMVqvu3cXiEBjU6nvxvGdCCLRwd9WpVRZj",
+            fallbackName = "Steakhouse USDC",
+            curator = "Steakhouse Financial",
+            riskTier = KaminoRiskTier.CONSERVATIVE,
+        )
+
+    val RWA_USDC =
+        KaminoVault(
+            address = "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",
+            tokenMint = USDC_MINT,
+            tokenDecimals = 6,
+            sharesMint = "DgHN3q3dSYAchNX7V3D4aYiTWMx8RHTgHbfPiwiqBkE9",
+            sharesDecimals = 6,
+            farm = "ArwyAHmnFmbKbUxC2fnK5VUEpspHrnoFtJ22bvEyriKk",
+            fallbackName = "RWA USDC",
+            curator = "RockawayX",
+            riskTier = KaminoRiskTier.PRIVATE_CREDIT,
+        )
+
+    /**
+     * The share scale differs from the token scale here — 6 against 9. Nothing may assume they
+     * match.
+     */
+    val ALLEZ_SOL =
+        KaminoVault(
+            address = "A1so1bPD3W1TfeFwboDh8yfAAVaVtcdAYBYCjhg2mJQ",
+            tokenMint = WRAPPED_SOL_MINT,
+            tokenDecimals = 9,
+            sharesMint = "FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN",
+            sharesDecimals = 6,
+            farm = "H6kauPaHmNqpdKtD5U2zw3Eb28ZB7iMeBdHVfLq1i4Kh",
+            fallbackName = "Allez SOL",
+            curator = "Allez Labs",
+            riskTier = KaminoRiskTier.CONSERVATIVE,
+        )
+
+    /**
+     * Kamino runs well over 160 vaults and `GET /kvaults/vaults` returns every one of them in a
+     * single ~340 KB payload. The allow-list both curates and keeps the fetch small: these three
+     * are hydrated with three small per-vault requests instead.
+     *
+     * Ordered conservative-first so the riskiest tier is never the first thing offered.
+     */
+    val ALLOW_LIST: List<KaminoVault> = listOf(STEAKHOUSE_USDC, ALLEZ_SOL, RWA_USDC)
+
+    fun vaultFor(address: String): KaminoVault? = ALLOW_LIST.firstOrNull { it.address == address }
+
+    /** Whether the app is willing to transact against [address] at all. */
+    fun isAllowed(address: String): Boolean = vaultFor(address) != null
+
+    /**
+     * The share mints of every curated vault, which must not be counted as wallet token balances.
+     */
+    val SHARES_MINTS: Set<String> = ALLOW_LIST.map { it.sharesMint }.toSet()
+}
+
+/**
+ * The wallet coin a vault's underlying token corresponds to — the logo, ticker and price feed its
+ * position is displayed and valued with.
+ *
+ * The SOL vault's underlying is wrapped SOL, which maps to native SOL here: the two are
+ * interchangeable one-for-one, and native SOL is what the user recognises and what the app already
+ * has a price feed for.
+ */
+val KaminoVault.coin: Coin?
+    get() =
+        when (tokenMint) {
+            KaminoVaultRegistry.USDC_MINT -> Coins.Solana.USDC
+            KaminoVaultRegistry.WRAPPED_SOL_MINT -> Coins.Solana.SOL
+            else -> null
+        }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
@@ -424,6 +424,11 @@ object KaminoWithdrawMath {
         if (tokens.baseUnits.signum() <= 0 || held.baseUnits.signum() <= 0) return null
         if (tokens.baseUnits > maximumTokens.baseUnits) return null
         if (tokens.baseUnits == maximumTokens.baseUnits) return held
-        return tokens.shareAmount(rate, shareDecimals)
+        // A token amount smaller than one share is worth zero shares once truncated, and a request
+        // for zero is not a withdraw — it would build a transaction that moves nothing while
+        // telling
+        // the user it moves something. The vault minimum normally catches this, but it is only
+        // advisory when the vault state could not be read.
+        return tokens.shareAmount(rate, shareDecimals)?.takeIf { !it.isZero }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
@@ -1,0 +1,345 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import java.math.BigInteger
+
+/**
+ * An exact decimal from Kamino's JSON, held as `numerator / 10^scale`.
+ *
+ * Exists because a rate drives how many shares a withdraw burns and the withdraw endpoint validates
+ * nothing: a request naming more shares than the user holds is silently rewritten to `u64::MAX`,
+ * which means *withdraw everything*. Any rounding at the far end of a mantissa could therefore turn
+ * a partial withdraw into a full exit, so every conversion that sizes a transaction is done in
+ * integers and never through floating point.
+ */
+data class KaminoRate(val numerator: BigInteger, val scale: Int) {
+
+    val isPositive: Boolean
+        get() = numerator.signum() > 0
+
+    companion object {
+        /**
+         * Parses Kamino's plain-decimal form exactly. Rejects grouping separators, exponents and
+         * whitespace rather than coercing them — a value that is present and unreadable is a failed
+         * read, not a number to guess at.
+         */
+        fun parse(raw: String?): KaminoRate? {
+            if (raw.isNullOrEmpty() || !isPlainDecimal(raw)) return null
+            val separator = raw.indexOf('.')
+            val digits = if (separator < 0) raw else raw.removeRange(separator, separator + 1)
+            val numerator = runCatching { BigInteger(digits) }.getOrNull() ?: return null
+            val scale = if (separator < 0) 0 else raw.length - separator - 1
+            return KaminoRate(numerator, scale)
+        }
+
+        private fun isPlainDecimal(raw: String): Boolean {
+            var hasDigit = false
+            var hasSeparator = false
+            raw.forEachIndexed { index, character ->
+                when {
+                    character == '-' -> if (index != 0) return false
+                    character == '.' -> {
+                        if (hasSeparator) return false
+                        hasSeparator = true
+                    }
+                    character in '0'..'9' -> hasDigit = true
+                    else -> return false
+                }
+            }
+            return hasDigit
+        }
+    }
+}
+
+/** Widest scale handled. SPL mint decimals are a `u8`; nothing legitimate approaches this. */
+private const val MAX_DECIMALS = 18
+
+private fun tenPow(exponent: Int): BigInteger = BigInteger.TEN.pow(exponent)
+
+private fun scalesAreSane(vararg decimals: Int) = decimals.all { it in 0..MAX_DECIMALS }
+
+/** Renders base units as a plain decimal string: no grouping, no exponent, no trailing zeros. */
+private fun render(baseUnits: BigInteger, decimals: Int): String {
+    val negative = baseUnits.signum() < 0
+    val digits = baseUnits.abs().toString()
+    if (decimals == 0) return if (negative) "-$digits" else digits
+
+    val padded = digits.padStart(decimals + 1, '0')
+    val whole = padded.substring(0, padded.length - decimals)
+    val fraction = padded.substring(padded.length - decimals).trimEnd('0')
+    val magnitude = if (fraction.isEmpty()) whole else "$whole.$fraction"
+    return if (negative) "-$magnitude" else magnitude
+}
+
+/**
+ * A quantity of vault shares. Distinct from [KaminoTokenAmount] on purpose: the withdraw endpoint
+ * takes shares while the deposit endpoint takes the underlying token, and confusing the two is off
+ * by the share rate — about 930× on the SOL vault, which is far enough over a real balance to
+ * trigger the `u64::MAX` full-exit rewrite.
+ */
+data class KaminoShareAmount(val baseUnits: BigInteger, val decimals: Int) {
+
+    val isZero: Boolean
+        get() = baseUnits.signum() == 0
+
+    /** The decimal string the API expects. */
+    fun apiString(): String = render(baseUnits, decimals)
+
+    /** What these shares are worth in the underlying token, truncated. */
+    fun tokenValue(rate: KaminoRate, tokenDecimals: Int): KaminoTokenAmount? =
+        convert(rate, tokenDecimals, roundUp = false)
+
+    /**
+     * Rounded up, so an amount at or above the result converts back to at least these shares. Used
+     * for the vault minimum, which must not be understated into a request the vault rejects.
+     */
+    fun tokenValueRoundedUp(rate: KaminoRate, tokenDecimals: Int): KaminoTokenAmount? =
+        convert(rate, tokenDecimals, roundUp = true)
+
+    private fun convert(
+        rate: KaminoRate,
+        tokenDecimals: Int,
+        roundUp: Boolean,
+    ): KaminoTokenAmount? {
+        if (!rate.isPositive || baseUnits.signum() < 0) return null
+        if (!scalesAreSane(tokenDecimals, decimals) || rate.scale !in 0..(MAX_DECIMALS * 4)) {
+            return null
+        }
+        // tokensBase = sharesBase × numerator × 10^tokenDecimals ÷ 10^(shareDecimals + rateScale)
+        val numerator = baseUnits.multiply(rate.numerator).multiply(tenPow(tokenDecimals))
+        val denominator = tenPow(decimals + rate.scale)
+        val quotient =
+            if (roundUp) {
+                numerator.add(denominator).subtract(BigInteger.ONE).divide(denominator)
+            } else {
+                numerator.divide(denominator)
+            }
+        return KaminoTokenAmount(quotient, tokenDecimals)
+    }
+
+    companion object {
+        fun parse(decimalString: String?, decimals: Int): KaminoShareAmount? {
+            val rate = KaminoRate.parse(decimalString) ?: return null
+            if (!scalesAreSane(decimals) || rate.scale > MAX_DECIMALS * 4) return null
+            // Re-scale numerator/10^rateScale to base units at `decimals`.
+            return if (rate.scale <= decimals) {
+                KaminoShareAmount(rate.numerator.multiply(tenPow(decimals - rate.scale)), decimals)
+            } else {
+                KaminoShareAmount(rate.numerator.divide(tenPow(rate.scale - decimals)), decimals)
+            }
+        }
+
+        fun zero(decimals: Int) = KaminoShareAmount(BigInteger.ZERO, decimals)
+    }
+}
+
+/** A quantity of a vault's underlying token — what the user thinks in and what the form shows. */
+data class KaminoTokenAmount(val baseUnits: BigInteger, val decimals: Int) {
+
+    fun apiString(): String = render(baseUnits, decimals)
+
+    /**
+     * The shares this token amount burns, truncated.
+     *
+     * Rounding down is a safety property, not a preference: an over-request by a single base unit
+     * is rewritten by the API to a full exit.
+     */
+    fun shareAmount(rate: KaminoRate, shareDecimals: Int): KaminoShareAmount? {
+        if (!rate.isPositive || baseUnits.signum() < 0) return null
+        if (!scalesAreSane(shareDecimals, decimals) || rate.scale !in 0..(MAX_DECIMALS * 4)) {
+            return null
+        }
+        // sharesBase = tokensBase × 10^(rateScale + shareDecimals) ÷ (10^tokenDecimals × numerator)
+        val numerator = baseUnits.multiply(tenPow(rate.scale + shareDecimals))
+        val denominator = tenPow(decimals).multiply(rate.numerator)
+        return KaminoShareAmount(numerator.divide(denominator), shareDecimals)
+    }
+
+    companion object {
+        fun parse(decimalString: String?, decimals: Int): KaminoTokenAmount? =
+            KaminoShareAmount.parse(decimalString, decimals)?.let {
+                KaminoTokenAmount(it.baseUnits, decimals)
+            }
+
+        fun zero(decimals: Int) = KaminoTokenAmount(BigInteger.ZERO, decimals)
+    }
+}
+
+/** The user's share balance in one vault, split the way `/positions` reports it. */
+data class KaminoSharePosition(
+    val staked: KaminoShareAmount,
+    val unstaked: KaminoShareAmount,
+    val total: KaminoShareAmount,
+) {
+    /**
+     * Whether the three reported numbers can all be true at once. A response claiming more of
+     * either kind than the total is one whose figures cannot be spent as a balance — and spending a
+     * balance that is too large is exactly what the API turns into `u64::MAX`.
+     */
+    val isPlausible: Boolean
+        get() =
+            staked.baseUnits.signum() >= 0 &&
+                unstaked.baseUnits.signum() >= 0 &&
+                staked.baseUnits <= total.baseUnits &&
+                unstaked.baseUnits <= total.baseUnits
+
+    /**
+     * Whether the position is unstaked shares and nothing else.
+     *
+     * Stated as `unstaked == total` rather than `staked + unstaked == total`: both hold for a
+     * wholly unstaked position, but the sum can disagree by a base unit purely from truncating two
+     * different decimal strings, which would refuse a real position over its last decimal place.
+     */
+    val holdsOnlyUnstakedShares: Boolean
+        get() = unstaked.baseUnits == total.baseUnits
+
+    companion object {
+        fun parse(response: KaminoUserPositionJson, shareDecimals: Int): KaminoSharePosition? {
+            val staked =
+                KaminoShareAmount.parse(response.stakedShares, shareDecimals) ?: return null
+            val unstaked =
+                KaminoShareAmount.parse(response.unstakedShares, shareDecimals) ?: return null
+            val total = KaminoShareAmount.parse(response.totalShares, shareDecimals) ?: return null
+            return KaminoSharePosition(staked, unstaked, total)
+        }
+    }
+}
+
+/**
+ * What a withdraw from one vault may do right now.
+ *
+ * [FarmStaked] is the reason this exists. Every deposit into the launch vaults auto-stakes its
+ * shares into the vault's farm, and the transaction that spends *staked* shares has never been
+ * observed — so the validator has no template for it and building one would mean asserting against
+ * a guessed instruction layout. This makes that a named, user-visible state instead of a refusal
+ * deep inside the pipeline.
+ */
+sealed interface KaminoWithdrawEligibility {
+
+    /** The observed path. A full withdraw sends precisely [shares], never a converted number. */
+    data class Withdrawable(val shares: KaminoShareAmount) : KaminoWithdrawEligibility
+
+    /** Shares are staked in the vault's farm. Nothing is built. */
+    data class FarmStaked(val shares: KaminoShareAmount) : KaminoWithdrawEligibility
+
+    /** The user holds no shares in this vault. */
+    data object Empty : KaminoWithdrawEligibility
+
+    /**
+     * The position could not be read. Refused rather than treated as zero (a silent "nothing to
+     * withdraw" on a real position) or as whole (an amount the user does not have).
+     */
+    data object Unreadable : KaminoWithdrawEligibility
+
+    val withdrawableShares: KaminoShareAmount?
+        get() = (this as? Withdrawable)?.shares
+
+    companion object {
+        /**
+         * @param response this vault's entry, or null when the vault is absent — a real "holds
+         *   nothing".
+         */
+        fun resolve(
+            response: KaminoUserPositionJson?,
+            shareDecimals: Int,
+        ): KaminoWithdrawEligibility {
+            if (response == null) return Empty
+            val position =
+                KaminoSharePosition.parse(response, shareDecimals)?.takeIf { it.isPlausible }
+                    ?: return Unreadable
+
+            // Staked first and unconditionally: a position even partly staked cannot be fully
+            // withdrawn by the transaction shape this app knows, and offering to spend only the
+            // unstaked remainder would quietly under-withdraw.
+            if (!position.staked.isZero) return FarmStaked(position.staked)
+            // `staked == 0` means nothing was *reported* as staked; a total larger than the parts
+            // is
+            // a position this app cannot describe, and an unaccounted share may well be staked.
+            if (!position.holdsOnlyUnstakedShares) return Unreadable
+            if (position.unstaked.isZero) return Empty
+            return Withdrawable(position.unstaked)
+        }
+    }
+}
+
+/**
+ * Whether the vault can settle a withdraw out of the balance it holds liquid.
+ *
+ * Not an error state. The liquid buffer measures 0.36% of the Steakhouse vault and 0.04% of the
+ * Allez vault, so a withdraw exceeding it is the common case rather than an edge one. What happens
+ * on chain when the buffer is short has not been observed, so nothing here claims to know: this is
+ * a comparison of two published numbers, not a decode of a program error.
+ */
+sealed interface KaminoWithdrawLiquidity {
+    data object Instant : KaminoWithdrawLiquidity
+
+    data class Delayed(val available: KaminoTokenAmount) : KaminoWithdrawLiquidity
+
+    companion object {
+        fun resolve(
+            requested: KaminoTokenAmount,
+            available: KaminoTokenAmount?,
+        ): KaminoWithdrawLiquidity =
+            if (available != null && requested.baseUnits > available.baseUnits) {
+                Delayed(available)
+            } else {
+                Instant
+            }
+    }
+}
+
+/**
+ * The conversions a withdraw form performs, in one place so its gate, its maximum and the amount it
+ * actually sends can never disagree.
+ */
+object KaminoWithdrawMath {
+
+    /**
+     * The most the held shares are worth in the underlying token, truncated. The form's maximum.
+     */
+    fun maximumTokens(
+        shares: KaminoShareAmount,
+        rate: KaminoRate,
+        tokenDecimals: Int,
+    ): KaminoTokenAmount? = shares.tokenValue(rate, tokenDecimals)
+
+    /**
+     * The vault's share-denominated minimum expressed in the token, rounded up so anything at or
+     * above it converts back to at least the minimum.
+     */
+    fun minimumTokens(
+        minimumShares: KaminoShareAmount,
+        rate: KaminoRate,
+        tokenDecimals: Int,
+    ): KaminoTokenAmount? = minimumShares.tokenValueRoundedUp(rate, tokenDecimals)
+
+    /**
+     * The shares a withdraw of [tokens] burns, or null when no withdraw of that size can be sized
+     * safely.
+     *
+     * **This is the fund-safety boundary of the whole flow.** The API validates nothing: a withdraw
+     * naming more shares than the user holds is silently rewritten to `u64::MAX`, which means
+     * *withdraw everything*. An over-request by one base unit turns a partial withdraw into a full
+     * exit. Three branches, each a different answer to that:
+     * - **Above the maximum**: refused. Nothing may read "more than the position" as "the position"
+     *   — a mistyped digit would then be a full exit nobody asked for. Refusing is also the only
+     *   answer that stays true if the balance moved since it was read.
+     * - **Exactly the maximum**: a full withdraw, sending [held] — the exact balance that was read
+     *   — rather than a number converted out of a token amount. Round-tripping the maximum through
+     *   tokens and back is precisely how the extra base unit gets introduced.
+     * - **Below it**: the conversion truncates. [maximumTokens] and this division both round down,
+     *   so `tokens < maximumTokens` implies the result is `<= held`.
+     */
+    fun sharesForTokens(
+        tokens: KaminoTokenAmount,
+        held: KaminoShareAmount,
+        maximumTokens: KaminoTokenAmount,
+        rate: KaminoRate,
+        shareDecimals: Int,
+    ): KaminoShareAmount? {
+        if (tokens.baseUnits.signum() <= 0 || held.baseUnits.signum() <= 0) return null
+        if (tokens.baseUnits > maximumTokens.baseUnits) return null
+        if (tokens.baseUnits == maximumTokens.baseUnits) return held
+        return tokens.shareAmount(rate, shareDecimals)
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
@@ -165,11 +165,47 @@ data class KaminoTokenAmount(val baseUnits: BigInteger, val decimals: Int) {
     }
 }
 
+/** A rate scaled to a mint's precision, remembering whether anything was thrown away. */
+private data class ScaledAmount(val baseUnits: BigInteger, val isExact: Boolean)
+
+/**
+ * Scales [rate] to [decimals] base units, reporting whether the conversion was lossless.
+ *
+ * Exactness is what decides the step back from the API's sentinel: when digits had to be discarded
+ * the truncated value is already strictly below the balance, and when it did not the value *is* the
+ * balance and has to give up a unit.
+ */
+private fun scaleReportingExactness(rate: KaminoRate, decimals: Int): ScaledAmount? {
+    if (!scalesAreSane(decimals) || rate.scale > MAX_DECIMALS * 4) return null
+    return if (rate.scale <= decimals) {
+        ScaledAmount(rate.numerator.multiply(tenPow(decimals - rate.scale)), isExact = true)
+    } else {
+        val divisor = tenPow(rate.scale - decimals)
+        val (quotient, remainder) = rate.numerator.divideAndRemainder(divisor)
+        ScaledAmount(quotient, isExact = remainder.signum() == 0)
+    }
+}
+
+/** The share balance a withdraw may spend, and how the vault currently holds it. */
+data class KaminoWithdrawableShares(
+    /**
+     * The most a withdraw may name — the position stepped back from the API's `u64::MAX` sentinel.
+     */
+    val maximum: KaminoShareAmount,
+    /**
+     * The part already sitting in the user's own share account, which a withdraw spends without
+     * touching the farm. The remainder is what the farm has to release first.
+     */
+    val unstaked: KaminoShareAmount,
+)
+
 /** The user's share balance in one vault, split the way `/positions` reports it. */
 data class KaminoSharePosition(
     val staked: KaminoShareAmount,
     val unstaked: KaminoShareAmount,
     val total: KaminoShareAmount,
+    private val spendableShares: KaminoShareAmount,
+    private val partsSumToTotal: Boolean,
 ) {
     /**
      * Whether the three reported numbers can all be true at once. A response claiming more of
@@ -184,23 +220,67 @@ data class KaminoSharePosition(
                 unstaked.baseUnits <= total.baseUnits
 
     /**
-     * Whether the position is unstaked shares and nothing else.
+     * The most a withdraw may name: the total, stepped back from the API's sentinel.
      *
-     * Stated as `unstaked == total` rather than `staked + unstaked == total`: both hold for a
-     * wholly unstaked position, but the sum can disagree by a base unit purely from truncating two
-     * different decimal strings, which would refuse a real position over its last decimal place.
+     * A request naming more shares than are held is rewritten to `u64::MAX` — withdraw everything —
+     * so the balance itself is indistinguishable, in the bytes, from an amount nobody asked for.
+     * The maximum therefore has to be the largest amount strictly beneath it. Truncating the
+     * reported string is necessary but not sufficient: it lands strictly below only when there were
+     * digits past the mint's scale to discard, so the exact case gives up one base unit — 10^-6 of
+     * a share, about a ten-thousandth of a cent on these vaults — and the inexact case does not
+     * have to.
      */
-    val holdsOnlyUnstakedShares: Boolean
-        get() = unstaked.baseUnits == total.baseUnits
+    val spendable: KaminoShareAmount
+        get() = spendableShares
+
+    /**
+     * Whether the two reported parts add up to the reported total.
+     *
+     * Compared at the API's **own** precision, never at the share mint's scale. Truncating three
+     * strings to six decimals and adding two of them can miss the third by a base unit with nothing
+     * wrong — `0.9445485 + 0.9595935` truncates to `944548 + 959593`, one short of `1904142` — and
+     * refusing a real position over a last decimal place is not a guard, it is a bug.
+     */
+    val accountsForItsTotal: Boolean
+        get() = partsSumToTotal
 
     companion object {
         fun parse(response: KaminoUserPositionJson, shareDecimals: Int): KaminoSharePosition? {
+            val stakedRate = KaminoRate.parse(response.stakedShares) ?: return null
+            val unstakedRate = KaminoRate.parse(response.unstakedShares) ?: return null
+            val totalRate = KaminoRate.parse(response.totalShares) ?: return null
+
             val staked =
                 KaminoShareAmount.parse(response.stakedShares, shareDecimals) ?: return null
             val unstaked =
                 KaminoShareAmount.parse(response.unstakedShares, shareDecimals) ?: return null
             val total = KaminoShareAmount.parse(response.totalShares, shareDecimals) ?: return null
-            return KaminoSharePosition(staked, unstaked, total)
+
+            val scaledTotal = scaleReportingExactness(totalRate, shareDecimals) ?: return null
+            val spendableUnits =
+                if (scaledTotal.isExact) scaledTotal.baseUnits.subtract(BigInteger.ONE)
+                else scaledTotal.baseUnits
+
+            return KaminoSharePosition(
+                staked = staked,
+                unstaked = unstaked,
+                total = total,
+                spendableShares =
+                    KaminoShareAmount(spendableUnits.max(BigInteger.ZERO), shareDecimals),
+                partsSumToTotal = sumsExactly(stakedRate, unstakedRate, totalRate),
+            )
+        }
+
+        /** Adds the two parts and compares them to the total at whatever precision the API used. */
+        private fun sumsExactly(
+            staked: KaminoRate,
+            unstaked: KaminoRate,
+            total: KaminoRate,
+        ): Boolean {
+            val scale = maxOf(staked.scale, unstaked.scale, total.scale)
+            if (scale > MAX_DECIMALS * 4) return false
+            fun at(rate: KaminoRate) = rate.numerator.multiply(tenPow(scale - rate.scale))
+            return at(staked).add(at(unstaked)) == at(total)
         }
     }
 }
@@ -208,19 +288,20 @@ data class KaminoSharePosition(
 /**
  * What a withdraw from one vault may do right now.
  *
- * [FarmStaked] is the reason this exists. Every deposit into the launch vaults auto-stakes its
- * shares into the vault's farm, and the transaction that spends *staked* shares has never been
- * observed — so the validator has no template for it and building one would mean asserting against
- * a guessed instruction layout. This makes that a named, user-visible state instead of a refusal
- * deep inside the pipeline.
+ * Every deposit into the launch vaults auto-stakes its shares into the vault's farm, so a staked
+ * position is not an edge case — it is what essentially every real holder is in. The transaction
+ * that spends those shares releases them from the farm first (`farms::unstake`, then
+ * `farms::withdraw_unstaked_deposits`, both ahead of the vault withdraw), which Kamino builds, so a
+ * staked balance is withdrawable rather than refused.
+ *
+ * The refusals that remain are about the READ, not the shape: a response whose figures contradict
+ * each other, and one whose parts do not add up to its total. Neither describes a position a
+ * request can be sized against.
  */
 sealed interface KaminoWithdrawEligibility {
 
-    /** The observed path. A full withdraw sends precisely [shares], never a converted number. */
-    data class Withdrawable(val shares: KaminoShareAmount) : KaminoWithdrawEligibility
-
-    /** Shares are staked in the vault's farm. Nothing is built. */
-    data class FarmStaked(val shares: KaminoShareAmount) : KaminoWithdrawEligibility
+    /** The user holds shares that can be withdrawn, staked or not. */
+    data class Withdrawable(val shares: KaminoWithdrawableShares) : KaminoWithdrawEligibility
 
     /** The user holds no shares in this vault. */
     data object Empty : KaminoWithdrawEligibility
@@ -231,7 +312,7 @@ sealed interface KaminoWithdrawEligibility {
      */
     data object Unreadable : KaminoWithdrawEligibility
 
-    val withdrawableShares: KaminoShareAmount?
+    val withdrawableShares: KaminoWithdrawableShares?
         get() = (this as? Withdrawable)?.shares
 
     companion object {
@@ -248,16 +329,19 @@ sealed interface KaminoWithdrawEligibility {
                 KaminoSharePosition.parse(response, shareDecimals)?.takeIf { it.isPlausible }
                     ?: return Unreadable
 
-            // Staked first and unconditionally: a position even partly staked cannot be fully
-            // withdrawn by the transaction shape this app knows, and offering to spend only the
-            // unstaked remainder would quietly under-withdraw.
-            if (!position.staked.isZero) return FarmStaked(position.staked)
-            // `staked == 0` means nothing was *reported* as staked; a total larger than the parts
-            // is
-            // a position this app cannot describe, and an unaccounted share may well be staked.
-            if (!position.holdsOnlyUnstakedShares) return Unreadable
-            if (position.unstaked.isZero) return Empty
-            return Withdrawable(position.unstaked)
+            // A total larger than its parts is a position this app cannot describe: it would have
+            // to
+            // guess how much of the remainder is staked, and that guess is the argument of an
+            // instruction it then claims to have verified.
+            if (!position.accountsForItsTotal) return Unreadable
+            // Nothing left once the maximum has stepped back from the sentinel. A position of a
+            // single base unit lands here, and "nothing to withdraw" is the true statement about
+            // it.
+            if (position.spendable.isZero) return Empty
+
+            return Withdrawable(
+                KaminoWithdrawableShares(maximum = position.spendable, unstaked = position.unstaked)
+            )
         }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ParsedSolanaTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ParsedSolanaTransaction.kt
@@ -24,6 +24,11 @@ object SolanaTransactionParser {
             "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb" to "Token-2022 Program",
             "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL" to "Associated Token Program",
             "ComputeBudget111111111111111111111111111111" to "Compute Budget Program",
+            // Kamino Earn. Without these a deposit or withdraw renders as rows of unnamed programs
+            // on the very screen where the transaction is being approved.
+            "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd" to "Kamino kVault Program",
+            "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr" to "Kamino Farms Program",
+            "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr" to "SPL Memo Program",
         )
 
     fun parse(base64Transaction: String): ParsedSolanaTransaction {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/DepositTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/DepositTransaction.kt
@@ -74,3 +74,10 @@ const val OPERATION_LEAVE = "Leave"
 const val OPERATION_LOAN_OPEN = "Loan Open"
 const val OPERATION_LOAN_CLOSE = "Loan Close"
 const val OPERATION_CIRCLE_WITHDRAW = "DepositUSDCCircle"
+
+/**
+ * Kamino Earn. Distinguished from the generic operations so the verify screen can say which
+ * direction the transaction goes and label its destination as a vault rather than a validator.
+ */
+const val OPERATION_KAMINO_DEPOSIT = "KaminoDeposit"
+const val OPERATION_KAMINO_WITHDRAW = "KaminoWithdraw"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/KaminoVaultSelectionRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/KaminoVaultSelectionRepository.kt
@@ -1,0 +1,73 @@
+package com.vultisig.wallet.data.repositories
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.kaminoDataStore by preferencesDataStore(name = "kamino_vault_selection")
+
+/**
+ * Which Kamino Earn vaults a vault-holder has switched on, per Vultisig vault.
+ *
+ * Deliberately not folded into [DefiPositionsRepository]: that store keys selections by token
+ * ticker, and Kamino's unit of choice is a vault address — two of the three curated vaults share
+ * the USDC ticker, so a ticker-keyed set cannot tell them apart.
+ *
+ * An empty selection is a real answer, distinct from never having chosen: the first read returns
+ * the default, and once the user saves anything — including nothing at all — that choice stands.
+ */
+@Singleton
+class KaminoVaultSelectionRepository
+@Inject
+constructor(@ApplicationContext private val context: Context) {
+
+    /**
+     * Vault addresses the user enabled, or [DEFAULT_SELECTION] until they have chosen.
+     *
+     * Unknown addresses are dropped on read so a vault retired from the allow-list cannot resurrect
+     * a card the app no longer knows how to price or transact against.
+     */
+    fun getSelectedVaults(vaultId: String): Flow<Set<String>> =
+        context.kaminoDataStore.data.map { preferences ->
+            val stored = preferences[hasChosenKey(vaultId)]
+            val selection =
+                if (stored == null) DEFAULT_SELECTION
+                else preferences[selectionKey(vaultId)].orEmpty()
+            selection.filterTo(mutableSetOf(), KaminoVaultRegistry::isAllowed)
+        }
+
+    /**
+     * Records [vaultAddresses] as the selection, including when it is empty — which is how a user
+     * turns Kamino Earn off entirely.
+     */
+    suspend fun saveSelectedVaults(vaultId: String, vaultAddresses: Set<String>) {
+        context.kaminoDataStore.edit { preferences ->
+            preferences[selectionKey(vaultId)] = vaultAddresses
+            preferences[hasChosenKey(vaultId)] = CHOSEN
+        }
+    }
+
+    private companion object {
+        fun selectionKey(vaultId: String) = stringSetPreferencesKey("kamino_vaults_$vaultId")
+
+        /**
+         * Marks that a choice was made at all, so an empty selection reads as "turned off" rather
+         * than falling back to the default and switching the vaults back on.
+         */
+        fun hasChosenKey(vaultId: String) = stringSetPreferencesKey("kamino_chosen_$vaultId")
+
+        val CHOSEN = setOf("1")
+
+        /**
+         * Nothing is on until the user opts in, matching how the other DeFi position types behave.
+         */
+        val DEFAULT_SELECTION: Set<String> = emptySet()
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SPLTokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SPLTokenRepository.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.repositories
 import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.api.models.JupiterTokenResponseJson
 import com.vultisig.wallet.data.api.models.SplTokenJson
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.db.dao.TokenValueDao
 import com.vultisig.wallet.data.db.models.TokenValueEntity
 import com.vultisig.wallet.data.mappers.SplResponseAccountJsonMapper
@@ -51,7 +52,14 @@ constructor(
 
     private suspend fun fetchTokens(address: String): List<Pair<SplTokenResponse, Coin>?> {
         val rawSPLTokens = solanaApi.getSPLTokens(address) ?: return emptyList()
-        val splTokenResponse = rawSPLTokens.map(mapSplAccountJsonToSplToken)
+        val splTokenResponse =
+            rawSPLTokens.map(mapSplAccountJsonToSplToken).filterNot {
+                // A Kamino vault's shares are a receipt for a DeFi position the Earn tab already
+                // shows and values. Discovering them as wallet tokens too would count the same
+                // deposit twice in the total, and offer a "send" on a receipt that is not spendable
+                // as one.
+                it.mint in KaminoVaultRegistry.SHARES_MINTS
+            }
         val result = getSplTokensByContractAddress(splTokenResponse.map { it.mint })
         return splTokenResponse.map { key ->
             result

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudgetTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudgetTest.kt
@@ -1,0 +1,132 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The limits here have a direct on-chain consequence: too low and the transaction aborts on compute
+ * exhaustion, and the user cannot avoid it. The measurements they are sized against are recorded in
+ * the source, so these tests pin the values rather than restate the arithmetic.
+ */
+class KaminoComputeBudgetTest {
+
+    private val usdcVault = KaminoVaultRegistry.STEAKHOUSE_USDC
+    private val solVault = KaminoVaultRegistry.ALLEZ_SOL
+
+    /** The app-wide Solana limit, which every one of these transactions exceeds. */
+    private val appWideLimit = BigInteger.valueOf(100_000)
+
+    @Test
+    fun `every limit clears the app-wide Solana default`() {
+        // SOLANA_PRIORITY_FEE_LIMIT is 100,000 units. Reusing it would abort all three shapes.
+        listOf(
+                usdcVault to KaminoAction.DEPOSIT,
+                solVault to KaminoAction.DEPOSIT,
+                usdcVault to KaminoAction.WITHDRAW,
+                solVault to KaminoAction.WITHDRAW,
+            )
+            .forEach { (vault, action) ->
+                val limit = KaminoComputeBudget.unitLimitFor(vault, action)
+                assertTrue(
+                    limit > appWideLimit,
+                    "${vault.fallbackName} $action got $limit, at or below the 100,000 default",
+                )
+            }
+    }
+
+    @Test
+    fun `a token deposit is sized above its measured cost`() {
+        // Measured 252,146 on mainnet.
+        val limit = KaminoComputeBudget.unitLimitFor(usdcVault, KaminoAction.DEPOSIT)
+        assertEquals(BigInteger.valueOf(320_000), limit)
+        assertTrue(limit > BigInteger.valueOf(252_146))
+    }
+
+    @Test
+    fun `a SOL deposit gets more, because it wraps first`() {
+        // Measured 287,029: it also creates the wSOL account, transfers into it and syncs it.
+        val limit = KaminoComputeBudget.unitLimitFor(solVault, KaminoAction.DEPOSIT)
+        assertEquals(BigInteger.valueOf(350_000), limit)
+        assertTrue(limit > BigInteger.valueOf(287_029))
+        assertTrue(
+            limit > KaminoComputeBudget.unitLimitFor(usdcVault, KaminoAction.DEPOSIT),
+            "wrapping cannot cost less than not wrapping",
+        )
+    }
+
+    @Test
+    fun `a withdraw is sized for the farm-staked shape, not the unstaked one`() {
+        // The staked path runs two extra farms instructions and a second account creation:
+        // 283,786 / 289,486 / 309,310 measured, against 173,385 unstaked. At the earlier 220,000
+        // every staked shape aborted with ProgramFailedToComplete — and since every deposit
+        // auto-stakes, that is the shape essentially every real withdraw takes.
+        listOf(usdcVault, solVault).forEach { vault ->
+            val limit = KaminoComputeBudget.unitLimitFor(vault, KaminoAction.WITHDRAW)
+            assertEquals(BigInteger.valueOf(400_000), limit, vault.fallbackName)
+            assertTrue(
+                limit > BigInteger.valueOf(309_310),
+                "${vault.fallbackName} must clear the most expensive measured staked withdraw",
+            )
+        }
+    }
+
+    @Test
+    fun `one withdraw limit covers both shapes rather than one per shape`() {
+        // Deliberate: a second value would have to be chosen from the transaction's own shape,
+        // which
+        // is the sort of check that agrees with whatever it is shown. The unstaked path pays for
+        // headroom it does not use instead.
+        assertEquals(
+            KaminoComputeBudget.unitLimitFor(usdcVault, KaminoAction.WITHDRAW),
+            KaminoComputeBudget.unitLimitFor(solVault, KaminoAction.WITHDRAW),
+        )
+    }
+
+    @Test
+    fun `the unit price never falls below the floor`() {
+        val floor = KaminoComputeBudget.FALLBACK_UNIT_PRICE
+        assertEquals(floor, KaminoComputeBudget.unitPriceFor(null))
+        assertEquals(floor, KaminoComputeBudget.unitPriceFor(BigInteger.ONE))
+        assertEquals(floor, KaminoComputeBudget.unitPriceFor(floor))
+
+        // A healthier network sample is honoured.
+        val higher = floor.add(BigInteger.ONE)
+        assertEquals(higher, KaminoComputeBudget.unitPriceFor(higher))
+    }
+
+    @Test
+    fun `the priority fee is price times limit, in lamports`() {
+        // 20,000 micro-lamports per unit x 320,000 units = 6,400,000,000 micro-lamports = 6,400
+        // lamports, which is what bounds the cost of these limits.
+        assertEquals(
+            BigInteger.valueOf(6_400),
+            KaminoComputeBudget.priorityFeeLamports(usdcVault, KaminoAction.DEPOSIT, null),
+        )
+        // The withdraw limit is the most expensive: 20,000 x 400,000 = 8,000 lamports.
+        assertEquals(
+            BigInteger.valueOf(8_000),
+            KaminoComputeBudget.priorityFeeLamports(usdcVault, KaminoAction.WITHDRAW, null),
+        )
+    }
+
+    @Test
+    fun `a fee with a fractional lamport rounds up, never leaving the headroom short`() {
+        // 1 micro-lamport x 320,000 units is 0.32 lamports; a floor would reserve nothing.
+        val fee =
+            KaminoComputeBudget.priorityFeeLamports(usdcVault, KaminoAction.DEPOSIT, BigInteger.ONE)
+        // The price floors to 20,000 first, so this is the ordinary fee — the rounding is exercised
+        // by a price that does not divide evenly.
+        assertEquals(BigInteger.valueOf(6_400), fee)
+
+        val odd =
+            KaminoComputeBudget.priorityFeeLamports(
+                usdcVault,
+                KaminoAction.DEPOSIT,
+                BigInteger.valueOf(20_001),
+            )
+        // 20,001 x 320,000 = 6,400,320,000 micro-lamports = 6,400.32 lamports, rounded up.
+        assertEquals(BigInteger.valueOf(6_401), odd)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMathTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMathTest.kt
@@ -1,0 +1,122 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import java.math.BigDecimal
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The numbers below are live values read from `api.kamino.finance` for the three launch vaults, so
+ * these tests pin the arithmetic against real magnitudes rather than round invented ones.
+ */
+class KaminoPositionMathTest {
+
+    private fun assertSameValue(expected: String, actual: BigDecimal?) {
+        val expectedDecimal = BigDecimal(expected)
+        assertTrue(
+            actual != null && actual.compareTo(expectedDecimal) == 0,
+            "expected $expected but was $actual",
+        )
+    }
+
+    @Test
+    fun `apy30d is a fraction and renders as a percentage`() {
+        // Rendering the raw fraction would report a 4% vault as 0.04%.
+        assertSameValue(
+            "4.00",
+            KaminoPositionMath.apyPercent(BigDecimal("0.039967764404019690278")),
+        )
+        assertSameValue(
+            "5.88",
+            KaminoPositionMath.apyPercent(BigDecimal("0.058775543215515951449")),
+        )
+        assertSameValue(
+            "5.14",
+            KaminoPositionMath.apyPercent(BigDecimal("0.05143926373911317205987")),
+        )
+    }
+
+    @Test
+    fun `a zero apy stays zero rather than becoming null or blank`() {
+        assertSameValue("0.00", KaminoPositionMath.apyPercent(BigDecimal.ZERO))
+    }
+
+    @Test
+    fun `token amount is shares times tokensPerShare at the token's own precision`() {
+        // Steakhouse USDC: 6-decimal token, tokensPerShare just above 1.
+        assertSameValue(
+            "1054.427822",
+            KaminoPositionMath.tokenAmount(
+                shares = BigDecimal("1000"),
+                tokensPerShare = BigDecimal("1.0544278224860290217"),
+                tokenDecimals = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `token amount honours a share scale that differs from the token scale`() {
+        // Allez SOL issues 6-decimal shares against a 9-decimal token, so tokensPerShare is ~0.001.
+        // Assuming the two scales match would misprice this position by a factor of a thousand.
+        assertSameValue(
+            "1.075761685",
+            KaminoPositionMath.tokenAmount(
+                shares = BigDecimal("1000"),
+                tokensPerShare = BigDecimal("0.0010757616854425424673"),
+                tokenDecimals = 9,
+            ),
+        )
+    }
+
+    @Test
+    fun `token amount rounds down so a balance is never shown larger than it is`() {
+        // 0.9999995 at 6 decimals must not become 1.000000 — the extra would not be withdrawable.
+        assertSameValue(
+            "0.999999",
+            KaminoPositionMath.tokenAmount(
+                shares = BigDecimal("1"),
+                tokensPerShare = BigDecimal("0.9999995"),
+                tokenDecimals = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `an empty position is worth zero rather than failing`() {
+        assertSameValue(
+            "0.000000",
+            KaminoPositionMath.tokenAmount(
+                shares = BigDecimal.ZERO,
+                tokensPerShare = BigDecimal("1.0544278224860290217"),
+                tokenDecimals = 6,
+            ),
+        )
+    }
+
+    @Test
+    fun `minimums convert from base units to decimal amounts`() {
+        // The only Kamino field that is not already a decimal string.
+        assertSameValue("0.1", KaminoPositionMath.baseUnitsToDecimal("100000", 6))
+        assertSameValue("0.01", KaminoPositionMath.baseUnitsToDecimal("10000000", 9))
+        assertSameValue("0.001", KaminoPositionMath.baseUnitsToDecimal("1000", 6))
+        assertNull(KaminoPositionMath.baseUnitsToDecimal(null, 6))
+    }
+
+    @Test
+    fun `absent and malformed numbers read as missing, never as zero`() {
+        // A row showing nothing is recoverable; a balance rendered as 0 reads as a lost deposit.
+        assertNull(KaminoPositionMath.decimalOrNull(null))
+        assertNull(KaminoPositionMath.decimalOrNull(""))
+        assertNull(KaminoPositionMath.decimalOrNull("   "))
+        assertNull(KaminoPositionMath.decimalOrNull("n/a"))
+        assertNull(KaminoPositionMath.decimalOrNull("1.2.3"))
+    }
+
+    @Test
+    fun `well-formed numbers parse without losing precision`() {
+        val raw = "19766255.285929336591"
+        assertEquals(BigDecimal(raw), KaminoPositionMath.decimalOrNull(raw))
+        assertSameValue("0", KaminoPositionMath.decimalOrNull("0"))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -212,6 +212,7 @@ class KaminoTransactionValidatorTest {
         // destination, which on a real wrap is the wSOL account the vault deposit also names — so
         // the
         // fixture has to say so, or the destination check refuses it for the right reason.
+        // Stands in for the address the preparer derives from the signer and the wSOL mint.
         val wrappedSolAccount = "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8"
         val systemTransfer =
             KaminoTxInstruction(
@@ -236,6 +237,7 @@ class KaminoTransactionValidatorTest {
                 decoded(instructions),
                 KaminoVaultRegistry.ALLEZ_SOL,
                 KaminoAction.DEPOSIT,
+                wrappedSolAccount = wrappedSolAccount,
             )
         }
     }
@@ -311,11 +313,12 @@ class KaminoTransactionValidatorTest {
                         decoded(listOf(kvault, strayTransfer, memo)),
                         KaminoVaultRegistry.ALLEZ_SOL,
                         KaminoAction.DEPOSIT,
+                        wrappedSolAccount = "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8",
                     )
                 }
                 .message
                 .orEmpty()
-        assertTrue(reason.contains("does not reference"), reason)
+        assertTrue(reason.contains("rather than to the wallet"), reason)
     }
 
     @Test
@@ -346,6 +349,65 @@ class KaminoTransactionValidatorTest {
                 .message
                 .orEmpty()
         assertTrue(reason.contains("authorised by"), reason)
+    }
+
+    @Test
+    fun `a lamport transfer is refused when the destination is only named by the kVault instruction`() {
+        // The check this replaced accepted any destination the kVault instruction also named, which
+        // a
+        // compromised response could satisfy by listing an attacker there — the same response
+        // chooses
+        // that account list. Only the locally derived wrapped-SOL address is accepted.
+        val attacker = OTHER_ACCOUNT
+        val kvault =
+            KaminoTxInstruction(
+                programId = KaminoVaultRegistry.PROGRAM_ID,
+                data = byteArrayOf(1),
+                accounts = listOf(attacker),
+            )
+        val transferToAttacker =
+            KaminoTxInstruction(
+                programId = "11111111111111111111111111111111",
+                data = byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4),
+                accounts = listOf(DEFAULT_FEE_PAYER, attacker),
+            )
+
+        val reason =
+            assertThrows<KaminoTransactionRejected> {
+                    KaminoTransactionValidator.validate(
+                        decoded(listOf(kvault, transferToAttacker, memo)),
+                        KaminoVaultRegistry.ALLEZ_SOL,
+                        KaminoAction.DEPOSIT,
+                        wrappedSolAccount = "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8",
+                    )
+                }
+                .message
+                .orEmpty()
+        assertTrue(reason.contains("rather than to the wallet"), reason)
+    }
+
+    @Test
+    fun `a wrap is refused outright when the expected account could not be derived`() {
+        // Unverifiable is not the same as fine: with no derived address there is nothing to compare
+        // the destination against.
+        val transfer =
+            KaminoTxInstruction(
+                programId = "11111111111111111111111111111111",
+                data = byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4),
+                accounts = listOf(DEFAULT_FEE_PAYER, "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8"),
+            )
+        val reason =
+            assertThrows<KaminoTransactionRejected> {
+                    KaminoTransactionValidator.validate(
+                        decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID), transfer, memo)),
+                        KaminoVaultRegistry.ALLEZ_SOL,
+                        KaminoAction.DEPOSIT,
+                        wrappedSolAccount = null,
+                    )
+                }
+                .message
+                .orEmpty()
+        assertTrue(reason.contains("could not be derived"), reason)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -1,0 +1,149 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class KaminoTransactionValidatorTest {
+
+    private val vault = KaminoVaultRegistry.STEAKHOUSE_USDC
+
+    private fun ix(programId: String, data: ByteArray = ByteArray(0)) =
+        KaminoTxInstruction(programId, data)
+
+    private val memo =
+        ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, KaminoAttributionMemo.TAG.toByteArray())
+
+    /** The shape a prepared deposit actually has: ATA, kVault, two farms, compute budget, memo. */
+    private fun depositInstructions(memoInstruction: KaminoTxInstruction? = memo) =
+        listOfNotNull(
+            ix("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),
+            ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)),
+            ix(KaminoVaultRegistry.FARMS_PROGRAM_ID),
+            ix(KaminoVaultRegistry.FARMS_PROGRAM_ID),
+            ix("ComputeBudget111111111111111111111111111111"),
+            memoInstruction,
+        )
+
+    private fun rejection(instructions: List<KaminoTxInstruction>): String =
+        assertThrows<KaminoTransactionRejected> {
+                KaminoTransactionValidator.validate(instructions, vault, KaminoAction.DEPOSIT)
+            }
+            .message
+            .orEmpty()
+
+    @Test
+    fun `a well-formed deposit passes`() {
+        assertDoesNotThrow {
+            KaminoTransactionValidator.validate(depositInstructions(), vault, KaminoAction.DEPOSIT)
+        }
+    }
+
+    @Test
+    fun `a withdraw without the farms instructions passes`() {
+        assertDoesNotThrow {
+            KaminoTransactionValidator.validate(
+                listOf(
+                    ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(9)),
+                    ix("ComputeBudget111111111111111111111111111111"),
+                    memo,
+                ),
+                vault,
+                KaminoAction.WITHDRAW,
+            )
+        }
+    }
+
+    @Test
+    fun `an unknown program is refused`() {
+        // The transaction is built by Kamino, so an instruction the app cannot name is exactly what
+        // this check exists to stop.
+        val reason =
+            rejection(
+                depositInstructions().dropLast(1) +
+                    ix("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin") +
+                    memo
+            )
+        assertTrue(reason.contains("unexpected program"), reason)
+    }
+
+    @Test
+    fun `a transaction that never touches the kVault program is refused`() {
+        val reason = rejection(listOf(ix("11111111111111111111111111111111"), memo))
+        assertTrue(reason.contains("never invokes the kVault program"), reason)
+    }
+
+    @Test
+    fun `a missing memo is refused`() {
+        val reason = rejection(depositInstructions(memoInstruction = null))
+        assertTrue(reason.contains("memo is missing"), reason)
+    }
+
+    @Test
+    fun `two memos are refused even when both carry the tag`() {
+        // Appending twice is a caller bug; signing it would double-count the attribution.
+        val reason = rejection(depositInstructions() + memo)
+        assertTrue(reason.contains("exactly one memo"), reason)
+    }
+
+    @Test
+    fun `a memo carrying anything other than the tag is refused`() {
+        // An arbitrary memo riding along on a signed transaction is a channel the app did not open.
+        listOf("vs ", " vs", "VS", "vsx", "", "vultisig").forEach { payload ->
+            val reason =
+                rejection(
+                    depositInstructions(
+                        memoInstruction =
+                            ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, payload.toByteArray())
+                    )
+                )
+            assertTrue(reason.contains("unexpected data"), "payload '$payload': $reason")
+        }
+    }
+
+    @Test
+    fun `a memo that is not last is refused`() {
+        val reason =
+            rejection(
+                listOf(
+                    ix(KaminoVaultRegistry.PROGRAM_ID),
+                    memo,
+                    ix("ComputeBudget111111111111111111111111111111"),
+                )
+            )
+        assertTrue(reason.contains("final instruction"), reason)
+    }
+
+    @Test
+    fun `an empty transaction is refused`() {
+        assertTrue(rejection(emptyList()).contains("no instructions"))
+    }
+
+    @Test
+    fun `a vault outside the registry is refused before anything else is checked`() {
+        val uncurated = vault.copy(address = "2Z6C84pCc2ri8t39jvRCXnTGFQqUJf1mMpUMtpeFfhyB")
+        val reason =
+            assertThrows<KaminoTransactionRejected> {
+                    KaminoTransactionValidator.validate(
+                        depositInstructions(),
+                        uncurated,
+                        KaminoAction.DEPOSIT,
+                    )
+                }
+                .message
+                .orEmpty()
+        assertTrue(reason.contains("not a vault this app transacts with"), reason)
+    }
+
+    @Test
+    fun `instruction value semantics do not depend on array identity`() {
+        // Guards the hand-written equals: without it, structurally identical instructions would
+        // compare unequal and the memo checks would silently stop matching.
+        assertEquals(
+            ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, byteArrayOf(0x76, 0x73)),
+            ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, byteArrayOf(0x76, 0x73)),
+        )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -138,6 +138,100 @@ class KaminoTransactionValidatorTest {
     }
 
     @Test
+    fun `a smuggled SPL token transfer is refused even though the transaction is otherwise valid`() {
+        // The hole that program allow-listing alone leaves: a deposit legitimately needs the Token
+        // program, so an added transfer would pass a check that only asks which programs run.
+        val reason =
+            rejection(
+                listOf(
+                    ix(KaminoVaultRegistry.PROGRAM_ID),
+                    // SPL Token `Transfer` is discriminator 3.
+                    ix("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", byteArrayOf(3, 0, 0, 0)),
+                    memo,
+                )
+            )
+        assertTrue(reason.contains("top-level SPL token transfer"), reason)
+    }
+
+    @Test
+    fun `TransferChecked is refused too, not just the bare transfer`() {
+        val reason =
+            rejection(
+                listOf(
+                    ix(KaminoVaultRegistry.PROGRAM_ID),
+                    // `TransferChecked` is discriminator 12.
+                    ix("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", byteArrayOf(12, 0)),
+                    memo,
+                )
+            )
+        assertTrue(reason.contains("top-level SPL token transfer"), reason)
+    }
+
+    @Test
+    fun `moving lamports is refused for a token vault and allowed for the wrapped-SOL one`() {
+        // System `Transfer` is 2, little-endian over four bytes.
+        val systemTransfer =
+            ix("11111111111111111111111111111111", byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4))
+        val instructions = listOf(ix(KaminoVaultRegistry.PROGRAM_ID), systemTransfer, memo)
+
+        val reason = rejection(instructions)
+        assertTrue(reason.contains("moves lamports"), reason)
+
+        // The SOL vault has to wrap, so the same instruction is expected there.
+        assertDoesNotThrow {
+            KaminoTransactionValidator.validate(
+                instructions,
+                KaminoVaultRegistry.ALLEZ_SOL,
+                KaminoAction.DEPOSIT,
+            )
+        }
+    }
+
+    @Test
+    fun `a transaction authorised by someone other than the wallet is refused`() {
+        val signer = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+        val instructions =
+            listOf(
+                KaminoTxInstruction(
+                    programId = KaminoVaultRegistry.PROGRAM_ID,
+                    data = byteArrayOf(1),
+                    accounts = listOf("SomeoneElsesAccount11111111111111111111111"),
+                ),
+                memo,
+            )
+
+        val reason =
+            assertThrows<KaminoTransactionRejected> {
+                    KaminoTransactionValidator.validate(
+                        instructions,
+                        vault,
+                        KaminoAction.DEPOSIT,
+                        signerAddress = signer,
+                    )
+                }
+                .message
+                .orEmpty()
+        assertTrue(reason.contains("authorised by"), reason)
+
+        // The wallet's own transaction passes.
+        assertDoesNotThrow {
+            KaminoTransactionValidator.validate(
+                listOf(
+                    KaminoTxInstruction(
+                        programId = KaminoVaultRegistry.PROGRAM_ID,
+                        data = byteArrayOf(1),
+                        accounts = listOf(signer),
+                    ),
+                    memo,
+                ),
+                vault,
+                KaminoAction.DEPOSIT,
+                signerAddress = signer,
+            )
+        }
+    }
+
+    @Test
     fun `instruction value semantics do not depend on array identity`() {
         // Guards the hand-written equals: without it, structurally identical instructions would
         // compare unequal and the memo checks would silently stop matching.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -104,6 +104,26 @@ class KaminoTransactionValidatorTest {
     }
 
     @Test
+    fun `a memo naming accounts is refused, tag or no tag`() {
+        // A memo listing accounts is the Memo program attesting that they signed. Attribution is
+        // not
+        // that, and the app's own injection names none — so an account list means it came from
+        // somewhere else, even when the bytes happen to be right.
+        val reason =
+            rejection(
+                listOf(
+                    ix(KaminoVaultRegistry.PROGRAM_ID),
+                    KaminoTxInstruction(
+                        programId = KaminoAttributionMemo.MEMO_PROGRAM_ID,
+                        data = KaminoAttributionMemo.TAG.toByteArray(),
+                        accounts = listOf("9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"),
+                    ),
+                )
+            )
+        assertTrue(reason.contains("name no accounts"), reason)
+    }
+
+    @Test
     fun `a memo that is not last is refused`() {
         val reason =
             rejection(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -27,9 +27,22 @@ class KaminoTransactionValidatorTest {
             memoInstruction,
         )
 
+    /**
+     * Most rules do not care who pays, so the fee payer defaults to a benign value; the fee-payer
+     * test sets it explicitly.
+     */
+    private fun decoded(
+        instructions: List<KaminoTxInstruction>,
+        feePayer: String? = DEFAULT_FEE_PAYER,
+    ) = KaminoDecodedTransaction(feePayer = feePayer, instructions = instructions)
+
     private fun rejection(instructions: List<KaminoTxInstruction>): String =
         assertThrows<KaminoTransactionRejected> {
-                KaminoTransactionValidator.validate(instructions, vault, KaminoAction.DEPOSIT)
+                KaminoTransactionValidator.validate(
+                    decoded(instructions),
+                    vault,
+                    KaminoAction.DEPOSIT,
+                )
             }
             .message
             .orEmpty()
@@ -37,7 +50,11 @@ class KaminoTransactionValidatorTest {
     @Test
     fun `a well-formed deposit passes`() {
         assertDoesNotThrow {
-            KaminoTransactionValidator.validate(depositInstructions(), vault, KaminoAction.DEPOSIT)
+            KaminoTransactionValidator.validate(
+                decoded(depositInstructions()),
+                vault,
+                KaminoAction.DEPOSIT,
+            )
         }
     }
 
@@ -45,10 +62,12 @@ class KaminoTransactionValidatorTest {
     fun `a withdraw without the farms instructions passes`() {
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
-                listOf(
-                    ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(9)),
-                    ix("ComputeBudget111111111111111111111111111111"),
-                    memo,
+                decoded(
+                    listOf(
+                        ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(9)),
+                        ix("ComputeBudget111111111111111111111111111111"),
+                        memo,
+                    )
                 ),
                 vault,
                 KaminoAction.WITHDRAW,
@@ -147,7 +166,7 @@ class KaminoTransactionValidatorTest {
         val reason =
             assertThrows<KaminoTransactionRejected> {
                     KaminoTransactionValidator.validate(
-                        depositInstructions(),
+                        decoded(depositInstructions()),
                         uncurated,
                         KaminoAction.DEPOSIT,
                     )
@@ -189,10 +208,24 @@ class KaminoTransactionValidatorTest {
 
     @Test
     fun `moving lamports is refused for a token vault and allowed for the wrapped-SOL one`() {
-        // System `Transfer` is 2, little-endian over four bytes.
+        // System `Transfer` is 2, little-endian over four bytes. Its second account is the
+        // destination, which on a real wrap is the wSOL account the vault deposit also names — so
+        // the
+        // fixture has to say so, or the destination check refuses it for the right reason.
+        val wrappedSolAccount = "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8"
         val systemTransfer =
-            ix("11111111111111111111111111111111", byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4))
-        val instructions = listOf(ix(KaminoVaultRegistry.PROGRAM_ID), systemTransfer, memo)
+            KaminoTxInstruction(
+                programId = "11111111111111111111111111111111",
+                data = byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4),
+                accounts = listOf(DEFAULT_FEE_PAYER, wrappedSolAccount),
+            )
+        val kvault =
+            KaminoTxInstruction(
+                programId = KaminoVaultRegistry.PROGRAM_ID,
+                data = byteArrayOf(1),
+                accounts = listOf(wrappedSolAccount),
+            )
+        val instructions = listOf(kvault, systemTransfer, memo)
 
         val reason = rejection(instructions)
         assertTrue(reason.contains("moves lamports"), reason)
@@ -200,7 +233,7 @@ class KaminoTransactionValidatorTest {
         // The SOL vault has to wrap, so the same instruction is expected there.
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
-                instructions,
+                decoded(instructions),
                 KaminoVaultRegistry.ALLEZ_SOL,
                 KaminoAction.DEPOSIT,
             )
@@ -223,7 +256,7 @@ class KaminoTransactionValidatorTest {
         val reason =
             assertThrows<KaminoTransactionRejected> {
                     KaminoTransactionValidator.validate(
-                        instructions,
+                        decoded(instructions, feePayer = OTHER_ACCOUNT),
                         vault,
                         KaminoAction.DEPOSIT,
                         signerAddress = signer,
@@ -236,19 +269,83 @@ class KaminoTransactionValidatorTest {
         // The wallet's own transaction passes.
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
-                listOf(
-                    KaminoTxInstruction(
-                        programId = KaminoVaultRegistry.PROGRAM_ID,
-                        data = byteArrayOf(1),
-                        accounts = listOf(signer),
+                decoded(
+                    listOf(
+                        KaminoTxInstruction(
+                            programId = KaminoVaultRegistry.PROGRAM_ID,
+                            data = byteArrayOf(1),
+                            accounts = listOf(signer),
+                        ),
+                        memo,
                     ),
-                    memo,
+                    feePayer = signer,
                 ),
                 vault,
                 KaminoAction.DEPOSIT,
                 signerAddress = signer,
             )
         }
+    }
+
+    @Test
+    fun `a lamport transfer to an address the deposit does not reference is refused`() {
+        // Allowed on the wrapped-SOL vault, but not to anywhere: the only lamports a deposit moves
+        // go
+        // into the wSOL account it then deposits from. A transfer somewhere else is not a wrap.
+        val kvault =
+            KaminoTxInstruction(
+                programId = KaminoVaultRegistry.PROGRAM_ID,
+                data = byteArrayOf(1),
+                accounts = listOf("AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8"),
+            )
+        val strayTransfer =
+            KaminoTxInstruction(
+                programId = "11111111111111111111111111111111",
+                data = byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4),
+                accounts = listOf(DEFAULT_FEE_PAYER, OTHER_ACCOUNT),
+            )
+
+        val reason =
+            assertThrows<KaminoTransactionRejected> {
+                    KaminoTransactionValidator.validate(
+                        decoded(listOf(kvault, strayTransfer, memo)),
+                        KaminoVaultRegistry.ALLEZ_SOL,
+                        KaminoAction.DEPOSIT,
+                    )
+                }
+                .message
+                .orEmpty()
+        assertTrue(reason.contains("does not reference"), reason)
+    }
+
+    @Test
+    fun `a transaction paid for by another account is refused on the message, not an instruction`() {
+        // The earlier check read the first account of the first instruction, which says nothing
+        // about
+        // who authorises the transaction: this fixture names the wallet there while the message is
+        // paid for by someone else.
+        val instructions =
+            listOf(
+                KaminoTxInstruction(
+                    programId = KaminoVaultRegistry.PROGRAM_ID,
+                    data = byteArrayOf(1),
+                    accounts = listOf(DEFAULT_FEE_PAYER),
+                ),
+                memo,
+            )
+
+        val reason =
+            assertThrows<KaminoTransactionRejected> {
+                    KaminoTransactionValidator.validate(
+                        decoded(instructions, feePayer = OTHER_ACCOUNT),
+                        vault,
+                        KaminoAction.DEPOSIT,
+                        signerAddress = DEFAULT_FEE_PAYER,
+                    )
+                }
+                .message
+                .orEmpty()
+        assertTrue(reason.contains("authorised by"), reason)
     }
 
     @Test
@@ -279,7 +376,7 @@ class KaminoTransactionValidatorTest {
             }
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
-                listOf(ix(KaminoVaultRegistry.PROGRAM_ID, justUnder), memo),
+                decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, justUnder), memo)),
                 vault,
                 KaminoAction.WITHDRAW,
             )
@@ -290,7 +387,7 @@ class KaminoTransactionValidatorTest {
     fun `a short kVault instruction carrying no amount is not mistaken for the sentinel`() {
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
-                listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)), memo),
+                decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)), memo)),
                 vault,
                 KaminoAction.DEPOSIT,
             )
@@ -305,5 +402,10 @@ class KaminoTransactionValidatorTest {
             ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, byteArrayOf(0x76, 0x73)),
             ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, byteArrayOf(0x76, 0x73)),
         )
+    }
+
+    private companion object {
+        const val DEFAULT_FEE_PAYER = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+        const val OTHER_ACCOUNT = "SomeoneElsesAccount11111111111111111111111"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -252,6 +252,52 @@ class KaminoTransactionValidatorTest {
     }
 
     @Test
+    fun `the withdraw-everything sentinel is refused on any device`() {
+        // u64::MAX is what the kVault program reads as "withdraw everything". This app never
+        // produces
+        // one — the form's maximum sits strictly below the balance so the API cannot answer with
+        // it,
+        // and an over-request is refused rather than clamped — so a transaction carrying it did not
+        // come from here. It is also the one amount whose consequence is the whole position rather
+        // than the figure on screen, which is why it is refused rather than merely disclosed.
+        val sentinel =
+            ByteArray(16).also { data ->
+                // 8-byte Anchor discriminator, then the amount little-endian.
+                for (i in 8 until 16) data[i] = 0xFF.toByte()
+            }
+        val reason = rejection(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, sentinel), memo))
+        assertTrue(reason.contains("withdraw-everything sentinel"), reason)
+    }
+
+    @Test
+    fun `an ordinary amount one below the sentinel is allowed`() {
+        // The guard must key on the sentinel exactly, not on "a large amount".
+        val justUnder =
+            ByteArray(16).also { data ->
+                for (i in 8 until 15) data[i] = 0xFF.toByte()
+                data[15] = 0xFE.toByte()
+            }
+        assertDoesNotThrow {
+            KaminoTransactionValidator.validate(
+                listOf(ix(KaminoVaultRegistry.PROGRAM_ID, justUnder), memo),
+                vault,
+                KaminoAction.WITHDRAW,
+            )
+        }
+    }
+
+    @Test
+    fun `a short kVault instruction carrying no amount is not mistaken for the sentinel`() {
+        assertDoesNotThrow {
+            KaminoTransactionValidator.validate(
+                listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)), memo),
+                vault,
+                KaminoAction.DEPOSIT,
+            )
+        }
+    }
+
+    @Test
     fun `instruction value semantics do not depend on array identity`() {
         // Guards the hand-written equals: without it, structurally identical instructions would
         // compare unequal and the memo checks would silently stop matching.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoVaultRegistryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoVaultRegistryTest.kt
@@ -1,0 +1,118 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The registry is what every Kamino transaction is checked against, so these guard the pinned
+ * values themselves. Each address, mint and scale below was read from `api.kamino.finance`; a typo
+ * in any of them would send a deposit somewhere else or size it by the wrong power of ten, and no
+ * downstream check would catch it.
+ */
+class KaminoVaultRegistryTest {
+
+    @Test
+    fun `the allow-list is exactly the three launch vaults`() {
+        assertEquals(3, KaminoVaultRegistry.ALLOW_LIST.size)
+        assertEquals(
+            listOf("Steakhouse USDC", "Allez SOL", "RWA USDC"),
+            KaminoVaultRegistry.ALLOW_LIST.map { it.fallbackName },
+        )
+    }
+
+    @Test
+    fun `the private-credit vault is never the first one offered`() {
+        // Its risk is materially different from plain lending, so it does not lead the list.
+        val tiers = KaminoVaultRegistry.ALLOW_LIST.map { it.riskTier }
+        assertEquals(KaminoRiskTier.CONSERVATIVE, tiers.first())
+        assertEquals(
+            KaminoRiskTier.PRIVATE_CREDIT,
+            KaminoVaultRegistry.RWA_USDC.riskTier,
+            "RWA USDC lends against tokenized private credit and must be tiered above conservative",
+        )
+        assertEquals(1, tiers.count { it == KaminoRiskTier.PRIVATE_CREDIT })
+    }
+
+    @Test
+    fun `vault addresses and share mints are all distinct`() {
+        val addresses = KaminoVaultRegistry.ALLOW_LIST.map { it.address }
+        val sharesMints = KaminoVaultRegistry.ALLOW_LIST.map { it.sharesMint }
+        val farms = KaminoVaultRegistry.ALLOW_LIST.map { it.farm }
+
+        assertEquals(addresses.size, addresses.distinct().size, "duplicate vault address")
+        assertEquals(sharesMints.size, sharesMints.distinct().size, "duplicate shares mint")
+        assertEquals(farms.size, farms.distinct().size, "duplicate farm")
+        assertEquals(sharesMints.toSet(), KaminoVaultRegistry.SHARES_MINTS)
+    }
+
+    @Test
+    fun `both dollar vaults share the USDC mint and the SOL vault uses wrapped SOL`() {
+        assertEquals(KaminoVaultRegistry.USDC_MINT, KaminoVaultRegistry.STEAKHOUSE_USDC.tokenMint)
+        assertEquals(KaminoVaultRegistry.USDC_MINT, KaminoVaultRegistry.RWA_USDC.tokenMint)
+        // Native SOL is not the underlying here, which is why a deposit has to wrap first.
+        assertEquals(KaminoVaultRegistry.WRAPPED_SOL_MINT, KaminoVaultRegistry.ALLEZ_SOL.tokenMint)
+        assertNotEquals(
+            KaminoVaultRegistry.STEAKHOUSE_USDC.address,
+            KaminoVaultRegistry.RWA_USDC.address,
+            "two vaults on the same mint must still be distinguished by address",
+        )
+    }
+
+    @Test
+    fun `the SOL vault's share scale differs from its token scale`() {
+        // Guards against anyone "tidying" these to match. They are genuinely 6 against 9.
+        assertEquals(9, KaminoVaultRegistry.ALLEZ_SOL.tokenDecimals)
+        assertEquals(6, KaminoVaultRegistry.ALLEZ_SOL.sharesDecimals)
+        assertNotEquals(
+            KaminoVaultRegistry.ALLEZ_SOL.tokenDecimals,
+            KaminoVaultRegistry.ALLEZ_SOL.sharesDecimals,
+        )
+    }
+
+    @Test
+    fun `both dollar vaults use six decimals for token and shares alike`() {
+        listOf(KaminoVaultRegistry.STEAKHOUSE_USDC, KaminoVaultRegistry.RWA_USDC).forEach { vault ->
+            assertEquals(6, vault.tokenDecimals, "${vault.fallbackName} token decimals")
+            assertEquals(6, vault.sharesDecimals, "${vault.fallbackName} shares decimals")
+        }
+    }
+
+    @Test
+    fun `every launch vault names a curator and a farm`() {
+        // A deposit stakes into the farm, so a vault without one would strand the shares.
+        KaminoVaultRegistry.ALLOW_LIST.forEach { vault ->
+            assertTrue(vault.curator.isNotBlank(), "${vault.fallbackName} has no curator")
+            assertTrue(vault.farm.isNotBlank(), "${vault.fallbackName} has no farm")
+        }
+        assertEquals("Steakhouse Financial", KaminoVaultRegistry.STEAKHOUSE_USDC.curator)
+        assertEquals("RockawayX", KaminoVaultRegistry.RWA_USDC.curator)
+        assertEquals("Allez Labs", KaminoVaultRegistry.ALLEZ_SOL.curator)
+    }
+
+    @Test
+    fun `lookup resolves curated vaults and refuses everything else`() {
+        KaminoVaultRegistry.ALLOW_LIST.forEach { vault ->
+            assertEquals(vault, KaminoVaultRegistry.vaultFor(vault.address))
+            assertTrue(KaminoVaultRegistry.isAllowed(vault.address))
+        }
+
+        // A vault Kamino also runs, but one the app does not offer.
+        val uncuratedVault = "2Z6C84pCc2ri8t39jvRCXnTGFQqUJf1mMpUMtpeFfhyB"
+        assertNull(KaminoVaultRegistry.vaultFor(uncuratedVault))
+        assertFalse(KaminoVaultRegistry.isAllowed(uncuratedVault))
+        assertFalse(KaminoVaultRegistry.isAllowed(""))
+    }
+
+    @Test
+    fun `programs are pinned to the kVault and farms program ids`() {
+        assertEquals("KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd", KaminoVaultRegistry.PROGRAM_ID)
+        assertEquals(
+            "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+            KaminoVaultRegistry.FARMS_PROGRAM_ID,
+        )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
@@ -182,30 +182,78 @@ class KaminoWithdrawTest {
     }
 
     @Test
-    fun `a wholly unstaked position is withdrawable`() {
+    fun `a wholly unstaked position is withdrawable, one base unit below the balance`() {
         val eligibility =
             KaminoWithdrawEligibility.resolve(position("0", "1000", "1000"), shareDecimals = 6)
         assertTrue(eligibility is KaminoWithdrawEligibility.Withdrawable)
-        assertEquals(BigInteger("1000000000"), eligibility.shares.baseUnits)
+        // "1000" scales exactly to 1000000000 base units, so the maximum steps back one unit: the
+        // API cannot tell a request for the whole balance from a request for more than it, and the
+        // latter it answers by withdrawing everything.
+        assertEquals(BigInteger("999999999"), eligibility.shares.maximum.baseUnits)
+        assertEquals(BigInteger("1000000000"), eligibility.shares.unstaked.baseUnits)
     }
 
     @Test
-    fun `any staked share refuses the withdraw by name instead of guessing`() {
-        // Every launch-vault deposit auto-stakes, and the transaction that spends staked shares has
-        // never been observed — so this is a named state, not a failure deep in the pipeline.
+    fun `a staked position is withdrawable — Kamino releases it from the farm`() {
+        // Every launch-vault deposit auto-stakes, so this is what essentially every real holder is
+        // in. The withdraw transaction does farms::unstake then farms::withdraw_unstaked_deposits
+        // ahead of the vault withdraw, so refusing it would block the only path that exists.
         val eligibility =
             KaminoWithdrawEligibility.resolve(position("400", "600", "1000"), shareDecimals = 6)
-        assertTrue(eligibility is KaminoWithdrawEligibility.FarmStaked)
-        assertNull(eligibility.withdrawableShares, "nothing may be sized against a staked position")
+        assertTrue(eligibility is KaminoWithdrawEligibility.Withdrawable)
+        assertEquals(BigInteger("999999999"), eligibility.shares.maximum.baseUnits)
+        // The unstaked half travels with it: it decides how much the farm has to release.
+        assertEquals(BigInteger("600000000"), eligibility.shares.unstaked.baseUnits)
     }
 
     @Test
-    fun `a total larger than its parts is unreadable, not partially withdrawable`() {
-        // Offering to spend only the reported unstaked remainder would present a partial exit as a
-        // complete one, and an unaccounted share may well be a staked one.
+    fun `an inexact total needs no step back, because truncating already went below it`() {
+        // "1.9999999" at 6 decimals truncates to 1999999, which is already strictly under the
+        // balance, so no unit is given up on top.
         val eligibility =
-            KaminoWithdrawEligibility.resolve(position("0", "600", "1000"), shareDecimals = 6)
-        assertEquals(KaminoWithdrawEligibility.Unreadable, eligibility)
+            KaminoWithdrawEligibility.resolve(
+                position("0", "1.9999999", "1.9999999"),
+                shareDecimals = 6,
+            )
+        assertTrue(eligibility is KaminoWithdrawEligibility.Withdrawable)
+        assertEquals(BigInteger("1999999"), eligibility.shares.maximum.baseUnits)
+    }
+
+    @Test
+    fun `a position of a single base unit has nothing to withdraw`() {
+        // Stepping back from the sentinel leaves zero, and that is the true statement about it.
+        assertEquals(
+            KaminoWithdrawEligibility.Empty,
+            KaminoWithdrawEligibility.resolve(position("0", "0.000001", "0.000001"), 6),
+        )
+    }
+
+    @Test
+    fun `parts are summed at the API's precision, not the mint's`() {
+        // Truncating each string to six decimals and adding two of them misses the third by a base
+        // unit with nothing wrong: 944548 + 959593 is one short of 1904142. Refusing a real
+        // position
+        // over its last decimal place would be a bug, not a guard.
+        val eligibility =
+            KaminoWithdrawEligibility.resolve(
+                position("0.9445485", "0.9595935", "1.904142"),
+                shareDecimals = 6,
+            )
+        assertTrue(
+            eligibility is KaminoWithdrawEligibility.Withdrawable,
+            "summing at full precision must accept this position, was $eligibility",
+        )
+    }
+
+    @Test
+    fun `parts that genuinely do not add up are refused`() {
+        // Not a truncation artefact — the response has shares it has not accounted for, and how
+        // much
+        // of the remainder is staked would have to be guessed.
+        assertEquals(
+            KaminoWithdrawEligibility.Unreadable,
+            KaminoWithdrawEligibility.resolve(position("0", "600", "1000"), 6),
+        )
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
@@ -137,7 +137,14 @@ class KaminoWithdrawTest {
         val held = shares("1000000000")
         val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, 6)!!
 
-        listOf("1", "1000000", "527213911", maximum.baseUnits.subtract(BigInteger.ONE).toString())
+        // Amounts worth at least one share; anything smaller truncates to zero shares and is
+        // refused by `a token amount worth less than one share is refused` below.
+        listOf(
+                "1054428",
+                "1000000000",
+                "527213911",
+                maximum.baseUnits.subtract(BigInteger.ONE).toString(),
+            )
             .forEach { raw ->
                 val sized =
                     KaminoWithdrawMath.sharesForTokens(tokens(raw, 6), held, maximum, usdcRate, 6)
@@ -147,6 +154,19 @@ class KaminoWithdrawTest {
                     "partial withdraw of $raw produced $sized, which is not below the balance",
                 )
             }
+    }
+
+    @Test
+    fun `a token amount worth less than one share is refused rather than sized to zero`() {
+        // One base unit of USDC is 0.000001, worth 0.00000094 shares at the Steakhouse rate, which
+        // truncates to nothing. A request for zero shares would build a transaction that moves
+        // nothing while the form said it moves something.
+        val held = shares("1000000000")
+        val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, 6)!!
+        assertNull(
+            KaminoWithdrawMath.sharesForTokens(tokens("1", 6), held, maximum, usdcRate, 6),
+            "an amount below one share must not size to zero",
+        )
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
@@ -1,0 +1,277 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Coverage for the withdraw path's arithmetic, which is the fund-safety boundary of the feature:
+ * the endpoint validates nothing, and a request naming more shares than the wallet holds is
+ * silently rewritten to `u64::MAX` — withdraw everything.
+ *
+ * Rates and scales are the live values for the launch vaults.
+ */
+class KaminoWithdrawTest {
+
+    /** Steakhouse USDC: 6-decimal token, 6-decimal shares, rate just above 1. */
+    private val usdcRate = KaminoRate.parse("1.0544278224860290217")!!
+
+    /** Allez SOL: 9-decimal token, 6-decimal shares, rate far below 1. */
+    private val solRate = KaminoRate.parse("0.0010757616854425424673")!!
+
+    private fun shares(baseUnits: String, decimals: Int = 6) =
+        KaminoShareAmount(BigInteger(baseUnits), decimals)
+
+    private fun tokens(baseUnits: String, decimals: Int) =
+        KaminoTokenAmount(BigInteger(baseUnits), decimals)
+
+    private fun position(staked: String?, unstaked: String?, total: String?) =
+        KaminoUserPositionJson(
+            vaultAddress = KaminoVaultRegistry.STEAKHOUSE_USDC.address,
+            stakedShares = staked,
+            unstakedShares = unstaked,
+            totalShares = total,
+        )
+
+    @Test
+    fun `rate parsing is exact and rejects anything it cannot read plainly`() {
+        val rate = KaminoRate.parse("1.0544278224860290217")!!
+        assertEquals(BigInteger("10544278224860290217"), rate.numerator)
+        assertEquals(19, rate.scale)
+
+        assertEquals(BigInteger("5"), KaminoRate.parse("5")!!.numerator)
+        assertEquals(0, KaminoRate.parse("5")!!.scale)
+
+        // A value that is present but unreadable is a failed read, never a number to guess at:
+        // grouping separators and exponents are exactly how a locale-sensitive parser mis-prices.
+        listOf("1e5", "1,054.42", " 1.5", "1.5 ", "1..5", "abc", "", "1.2.3").forEach {
+            assertNull(KaminoRate.parse(it), "should have refused '$it'")
+        }
+        assertNull(KaminoRate.parse(null))
+    }
+
+    @Test
+    fun `share amounts parse at the vault's scale, truncating a longer fraction`() {
+        assertEquals(BigInteger("1000000"), KaminoShareAmount.parse("1", 6)!!.baseUnits)
+        assertEquals(BigInteger("1500000"), KaminoShareAmount.parse("1.5", 6)!!.baseUnits)
+        // More precision than the mint carries is truncated, never rounded up.
+        assertEquals(BigInteger("1999999"), KaminoShareAmount.parse("1.9999999", 6)!!.baseUnits)
+    }
+
+    @Test
+    fun `shares convert to the token value the position card shows`() {
+        // 1000 shares at the Steakhouse rate.
+        val value = shares("1000000000").tokenValue(usdcRate, tokenDecimals = 6)
+        assertEquals(BigInteger("1054427822"), value!!.baseUnits)
+        assertEquals("1054.427822", value.apiString())
+
+        // Allez SOL: 6-decimal shares against a 9-decimal token, so the same share count is worth a
+        // thousandth as much. Assuming the scales match would misprice this by ~930x.
+        val solValue = shares("1000000000").tokenValue(solRate, tokenDecimals = 9)
+        assertEquals(BigInteger("1075761685"), solValue!!.baseUnits)
+        assertEquals("1.075761685", solValue.apiString())
+    }
+
+    @Test
+    fun `the vault minimum rounds up so it converts back to at least the minimum`() {
+        // minWithdrawAmount is 1000 SHARE base units. Rounded down it would be 1054 token units,
+        // which converts back to fewer shares than the vault accepts.
+        val minimum = KaminoWithdrawMath.minimumTokens(shares("1000"), usdcRate, tokenDecimals = 6)
+        assertEquals(BigInteger("1055"), minimum!!.baseUnits)
+
+        val backToShares = minimum.shareAmount(usdcRate, shareDecimals = 6)!!
+        assertTrue(
+            backToShares.baseUnits >= BigInteger("1000"),
+            "rounding up must survive the round trip, was ${backToShares.baseUnits}",
+        )
+    }
+
+    @Test
+    fun `a withdraw of exactly the maximum sends the held shares verbatim`() {
+        val held = shares("1000000000")
+        val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, 6)!!
+
+        val sized =
+            KaminoWithdrawMath.sharesForTokens(
+                tokens = maximum,
+                held = held,
+                maximumTokens = maximum,
+                rate = usdcRate,
+                shareDecimals = 6,
+            )
+
+        // Not merely equal — the same balance that was read. Round-tripping the maximum through
+        // tokens and back loses a base unit (999999999 against 1000000000), and it is the opposite
+        // slip, an extra unit, that the API turns into a full exit.
+        assertSame(held, sized)
+        assertEquals(
+            BigInteger("999999999"),
+            maximum.shareAmount(usdcRate, 6)!!.baseUnits,
+            "the round trip really does lose a unit, which is why it is not used",
+        )
+    }
+
+    @Test
+    fun `a withdraw above the maximum is refused rather than clamped`() {
+        val held = shares("1000000000")
+        val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, 6)!!
+        val oneUnitOver = tokens(maximum.baseUnits.add(BigInteger.ONE).toString(), 6)
+
+        // Clamping would mean reading "more than the position" as "the position" — and since the
+        // API
+        // rewrites an over-request to u64::MAX, a mistyped digit would become a full exit.
+        assertNull(
+            KaminoWithdrawMath.sharesForTokens(oneUnitOver, held, maximum, usdcRate, 6),
+            "one base unit over the maximum must be refused",
+        )
+    }
+
+    @Test
+    fun `a partial withdraw can never reach the held balance`() {
+        val held = shares("1000000000")
+        val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, 6)!!
+
+        listOf("1", "1000000", "527213911", maximum.baseUnits.subtract(BigInteger.ONE).toString())
+            .forEach { raw ->
+                val sized =
+                    KaminoWithdrawMath.sharesForTokens(tokens(raw, 6), held, maximum, usdcRate, 6)
+                assertNotNull(sized, "partial withdraw of $raw should size")
+                assertTrue(
+                    sized.baseUnits < held.baseUnits,
+                    "partial withdraw of $raw produced $sized, which is not below the balance",
+                )
+            }
+    }
+
+    @Test
+    fun `zero and a zero balance size to nothing`() {
+        val held = shares("1000000000")
+        val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, 6)!!
+        assertNull(KaminoWithdrawMath.sharesForTokens(tokens("0", 6), held, maximum, usdcRate, 6))
+        assertNull(
+            KaminoWithdrawMath.sharesForTokens(maximum, shares("0"), maximum, usdcRate, 6),
+            "a zero balance cannot fund any withdraw",
+        )
+    }
+
+    @Test
+    fun `sending the token figure where shares belong is what this arithmetic prevents`() {
+        // The bug this whole type split exists to make impossible. On a rate above 1 the token
+        // figure is LARGER than the share count, so passing it through as shares over-requests —
+        // and an over-request is rewritten by the API to a full exit.
+        val held = shares("1000000000")
+        val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, 6)!!
+        val tokenFigureUsedAsShares = KaminoShareAmount(maximum.baseUnits, 6)
+
+        assertTrue(
+            tokenFigureUsedAsShares.baseUnits > held.baseUnits,
+            "the token figure exceeds the share balance, which is why it must never be sent as one",
+        )
+
+        // Sized correctly it is exactly the balance instead.
+        assertEquals(
+            held.baseUnits,
+            KaminoWithdrawMath.sharesForTokens(maximum, held, maximum, usdcRate, 6)!!.baseUnits,
+        )
+    }
+
+    @Test
+    fun `a wholly unstaked position is withdrawable`() {
+        val eligibility =
+            KaminoWithdrawEligibility.resolve(position("0", "1000", "1000"), shareDecimals = 6)
+        assertTrue(eligibility is KaminoWithdrawEligibility.Withdrawable)
+        assertEquals(BigInteger("1000000000"), eligibility.shares.baseUnits)
+    }
+
+    @Test
+    fun `any staked share refuses the withdraw by name instead of guessing`() {
+        // Every launch-vault deposit auto-stakes, and the transaction that spends staked shares has
+        // never been observed — so this is a named state, not a failure deep in the pipeline.
+        val eligibility =
+            KaminoWithdrawEligibility.resolve(position("400", "600", "1000"), shareDecimals = 6)
+        assertTrue(eligibility is KaminoWithdrawEligibility.FarmStaked)
+        assertNull(eligibility.withdrawableShares, "nothing may be sized against a staked position")
+    }
+
+    @Test
+    fun `a total larger than its parts is unreadable, not partially withdrawable`() {
+        // Offering to spend only the reported unstaked remainder would present a partial exit as a
+        // complete one, and an unaccounted share may well be a staked one.
+        val eligibility =
+            KaminoWithdrawEligibility.resolve(position("0", "600", "1000"), shareDecimals = 6)
+        assertEquals(KaminoWithdrawEligibility.Unreadable, eligibility)
+    }
+
+    @Test
+    fun `an implausible or unparseable position is refused, never treated as zero or whole`() {
+        // Parts exceeding the total cannot all be true, and spending a balance that is too large is
+        // precisely what becomes u64::MAX.
+        assertEquals(
+            KaminoWithdrawEligibility.Unreadable,
+            KaminoWithdrawEligibility.resolve(position("0", "2000", "1000"), 6),
+        )
+        assertEquals(
+            KaminoWithdrawEligibility.Unreadable,
+            KaminoWithdrawEligibility.resolve(position("0", "n/a", "1000"), 6),
+        )
+        assertEquals(
+            KaminoWithdrawEligibility.Unreadable,
+            KaminoWithdrawEligibility.resolve(position("0", null, "1000"), 6),
+        )
+    }
+
+    @Test
+    fun `an absent vault or a zero balance is empty`() {
+        assertEquals(KaminoWithdrawEligibility.Empty, KaminoWithdrawEligibility.resolve(null, 6))
+        assertEquals(
+            KaminoWithdrawEligibility.Empty,
+            KaminoWithdrawEligibility.resolve(position("0", "0", "0"), 6),
+        )
+    }
+
+    @Test
+    fun `liquidity is delayed only when the request exceeds the published buffer`() {
+        val buffer = tokens("72851448339", 6) // the Steakhouse vault's live liquid balance
+
+        assertEquals(
+            KaminoWithdrawLiquidity.Instant,
+            KaminoWithdrawLiquidity.resolve(tokens("1000000", 6), buffer),
+        )
+        assertEquals(
+            KaminoWithdrawLiquidity.Instant,
+            KaminoWithdrawLiquidity.resolve(buffer, buffer),
+            "exactly the buffer still settles instantly",
+        )
+
+        val delayed = KaminoWithdrawLiquidity.resolve(tokens("72851448340", 6), buffer)
+        assertTrue(delayed is KaminoWithdrawLiquidity.Delayed)
+        assertEquals(buffer, delayed.available)
+    }
+
+    @Test
+    fun `an unpublished buffer is not reported as delayed`() {
+        // Absent information is not evidence of a delay; the row simply says nothing.
+        assertEquals(
+            KaminoWithdrawLiquidity.Instant,
+            KaminoWithdrawLiquidity.resolve(tokens("1000000", 6), null),
+        )
+    }
+
+    @Test
+    fun `implausible scales are refused rather than producing a wrong number`() {
+        val held = shares("1000000000")
+        assertNull(held.tokenValue(KaminoRate(BigInteger.ZERO, 0), 6), "a zero rate has no value")
+        assertNull(held.tokenValue(usdcRate, tokenDecimals = 40), "absurd token scale")
+        assertNull(
+            KaminoShareAmount(BigInteger("-1"), 6).tokenValue(usdcRate, 6),
+            "a negative balance is not a balance",
+        )
+        assertFalse(KaminoRate(BigInteger.ZERO, 0).isPositive)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaTransactionParserTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaTransactionParserTest.kt
@@ -97,4 +97,29 @@ class SolanaTransactionParserTest {
     fun `unknown program id yields no instruction type`() {
         assertNull(instructionType("UnknownProgram11111111111111111111111111", 0))
     }
+
+    @Test
+    fun `the programs a Kamino transaction invokes are named, not left unknown`() {
+        // These render on the very screen where the transaction is approved, on either device of a
+        // co-signed vault. Unnamed rows there tell the approver nothing about what they are
+        // signing.
+        assertEquals(
+            "Kamino kVault Program",
+            SolanaTransactionParser.getKnownProgramName(
+                "KvauGMspG5k6rtzrqqn7WNn3oZdyKqLKwK2XWQ8FLjd"
+            ),
+        )
+        assertEquals(
+            "Kamino Farms Program",
+            SolanaTransactionParser.getKnownProgramName(
+                "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr"
+            ),
+        )
+        assertEquals(
+            "SPL Memo Program",
+            SolanaTransactionParser.getKnownProgramName(
+                "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
+            ),
+        )
+    }
 }


### PR DESCRIPTION
Closes #5485

Adds an **Earn** tab to the Solana DeFi screen with three curated Kamino kVaults — Steakhouse USDC, Allez SOL and RWA USDC — showing balance, 30-day APY and lifetime PnL, plus deposit and withdraw flows.

Draft: two acceptance criteria are still open (listed at the bottom).

### Transaction hash
https://orb.helius.dev/tx/3ohC7hP74RhNcYmVmkFxpGcuvvQU1TTAFrSirquwWSwEupKUerrgwrP4F4PokqaUWSpxXEAssZbkVJoXee84Koih

## Design notes

**The vault set comes from the issue, not the Figma.** The Figma node shows USDC / SOL / **JLP** cards; the launch set is Steakhouse USDC / RWA USDC / Allez SOL. Its card *structure* is kept — the two slots it lacks (curator, risk tier) are filled the way iOS resolved the same tension in vultisig/vultisig-ios#5055: risk tier on the name line at intrinsic width, `Curated by X` replacing `Kamino · Solana`. Pairing the tier with the curator truncates "Curated by Steakhouse Financial".

**Validation is deliberately one-directional.** Kamino builds these transactions, so nothing fetched from Kamino validates one — the check would be circular, and one compromised response could supply a matching pair. Mints, scales and farms are pinned in `KaminoVaultRegistry`; the assembled transaction is checked against that.

**The `vs` attribution memo.** Appending it adds a static account key, which shifts every instruction index addressing a lookup-table-loaded account. The captured deposit has 9 static keys and 18 lookup-derived, with instructions referencing up to index 26 — an off-by-one repoints existing instructions at other accounts while every other check still passes. WalletCore's `insertInstruction` handles precisely that case (verified by reading `insert_instruction.rs` at `ref=4.7.0`), so this delegates rather than re-encoding, and a golden instrumented test pins the result.

**Ordering is load-bearing.** `set_compute_unit_price` *appends* when no compute-budget instruction exists — the same path the memo uses. Injecting the budget after the memo would leave the memo mid-list and the validator refuses it. Budget first, memo last.

**Compute limits are measured, not inherited.** 320k / 350k / 220k units. `SOLANA_PRIORITY_FEE_LIMIT` is 100k; a USDC deposit measures ~252k and would abort on compute exhaustion.

**Max SOL deposits reserve the wrapped-SOL account rent.** The vault's underlying is wSOL, so the deposit creates a token account; reserving only the network fee left a Max deposit unable to fund it.

## Incidental fix

No instrumented test in `:data` had ever run — a missing packaging exclude, and `testInstrumentationRunner` naming `AndroidJUnitRunner` without it on the classpath. Both fixed here. Worth noting `SuiHelperInputDataTest` (Sui byte-parity coverage against iOS) is in that source set and has therefore never executed; I left it untouched rather than surface unrelated failures in this branch.

## Test plan

- 52 JVM tests: registry, position math, transaction validator, both ViewModels
- 16 instrumented tests on device: memo insertion and lookup-table reindexing against a real Kamino deposit, the full prepare pipeline, compute limits read back out of the built transaction, foreign-memo refusal
- `:app:lintDebug` clean, debug APK assembles
- Manual: not yet — no transaction has been broadcast

## Still open

- **Nothing has been broadcast.** Every leg is covered by tests, but no real transaction has gone
  out, so on-chain behaviour is untested. A withdraw is additionally hard to exercise for real: the
  launch vaults auto-stake, so an unstaked position has to be created by hand.

## Resolved since the first push (`1a4c72033`)

- **Withdraw sent tokens where the endpoint takes shares.** `minWithdrawAmount` is share-denominated too. Because the endpoint rewrites an over-request to `u64::MAX` (withdraw everything), on the USDC vaults every withdraw would have exited the whole position. Withdraw sizing is now exact integer arithmetic over base units with shares and tokens as separate types: above the maximum is refused rather than clamped, exactly the maximum sends the share balance verbatim, and a partial withdraw truncates so it cannot reach the balance.
- **Farm-staked positions are refused by name.** Deposits auto-stake, and the transaction spending staked shares has not been observed here, so nothing is built rather than guessing a layout. An unreadable position is refused too, not shown as zero.
- **Delayed liquidity** is surfaced as ordinary information about the vault (the buffer is well under 1% of assets), not an error.
- **kToken double-counting** — share mints are excluded from SPL token discovery.
- **Validator checks intent, not just programs** — refuses top-level SPL transfers, refuses lamport movement outside the wrapped-SOL vault, and checks the wallet authorised the transaction.
- **Max SOL deposits** reserve the wrapped-SOL account rent and the priority fee.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Solana Earn support through curated Kamino vaults.
  * View vault balances, APY, P&L, fiat values, and risk information.
  * Deposit to or withdraw from supported vaults with amount validation and withdrawal status messaging.
  * Added vault selection, balance visibility controls, loading states, and empty states.
  * Added Earn and Staked tabs to Solana staking.
* **Localization**
  * Added Earn and Kamino translations across supported languages.
* **Tests**
  * Added coverage for amounts, vault data, transaction preparation, validation, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->