### PR TITLE
fix(swap): default limit swap on instead of opt-in

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LimitSwapConfig.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LimitSwapConfig.kt
@@ -7,11 +7,11 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * DataStore-backed feature flag for the THORChain Limit Swap ("Place Limit Order") flow. Default is
- * `false` — the feature is opt-in via Settings → Advanced → Limit Orders. Combined (AND) with the
+ * `true` — the feature is opt-out via Settings → Advanced → Limit Orders. Combined (AND) with the
  * remote `limit-swap` kill switch in `SwapFormViewModel`.
  */
 interface LimitSwapConfig {
-    /** Live flow of the user's Advanced Settings → Limit Swap toggle. Defaults to `false`. */
+    /** Live flow of the user's Advanced Settings → Limit Swap toggle. Defaults to `true`. */
     val isFeatureEnabled: Flow<Boolean>
 
     /** Persists the user's new toggle value. */
@@ -23,7 +23,7 @@ internal class LimitSwapConfigImpl @Inject constructor(private val dataStore: Ap
     LimitSwapConfig {
 
     override val isFeatureEnabled: Flow<Boolean>
-        get() = dataStore.readData(LIMIT_SWAP_ENABLED_KEY, false)
+        get() = dataStore.readData(LIMIT_SWAP_ENABLED_KEY, true)
 
     override suspend fun setFeatureEnabled(enabled: Boolean) {
         dataStore.set(LIMIT_SWAP_ENABLED_KEY, enabled)


### PR DESCRIPTION
## Summary
- Limit Swap currently requires users to manually enable it in Settings → Advanced. Flip the local `LimitSwapConfig` DataStore default from `false` to `true` so it's on out of the box.
- Users can still turn it off from the same Advanced Settings toggle. Still gated by the remote `limit-swap` feature flag kill switch in `SwapFormViewModel`.

## Test plan
- [x] `./gradlew :data:compileDebugKotlin` passes
- [ ] Verify fresh install shows Limit Swap enabled in Advanced Settings without any manual toggle
- [ ] Verify toggling off in Advanced Settings still persists and disables the feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Limit Swap is now enabled by default, allowing users to access the feature without manually opting in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->