### PR TITLE
chore: bump version to 1.0.117

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.vultisig.wallet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = 36
-        versionCode = 116
-        versionName = "1.0.116"
+        versionCode = 117
+        versionName = "1.0.117"
 
         testInstrumentationRunner = "com.vultisig.wallet.util.HiltTestRunner"
 


### PR DESCRIPTION
Bump versionCode to 117 / versionName to 1.0.117 for release v1.0.117.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android app to version 1.0.117.
  * Increased the release version code to 117.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->