### PR TITLE
Fix EVM nonce RPC error handling

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -352,8 +352,10 @@ class EvmApiImp(
                 },
             )
         if (rpcResp.error != null) {
-            Timber.d("get nonce ,address: $address error: ${rpcResp.error.message}")
-            return BigInteger.ZERO
+            throw NetworkException(
+                httpStatusCode = 0,
+                message = "get nonce rpc error, address=$address: ${rpcResp.error.message}",
+            )
         }
 
         return BigInteger(rpcResp.result?.removePrefix("0x") ?: "0", 16)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiNonceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiNonceTest.kt
@@ -1,0 +1,57 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Behavioural tests for [EvmApiImp.getNonce] around issue #5571: an RPC failure must propagate
+ * instead of collapsing into a fake nonce 0. The method intentionally keeps the `latest` block tag
+ * so resend/replace flows can reuse the mined nonce.
+ */
+class EvmApiNonceTest {
+
+    private fun api(client: io.ktor.client.HttpClient) =
+        EvmApiImp(client, "https://api.vultisig.com/ethereum/", Chain.Ethereum)
+
+    @Test
+    fun `getNonce propagates an RPC failure instead of swallowing it into zero`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":null,"error":{"code":-32005,"message":"rate limited"}}""",
+            )
+
+        assertFailsWith<NetworkException> {
+            api(client).getNonce("0x1111111111111111111111111111111111111111")
+        }
+    }
+
+    @Test
+    fun `getNonce returns parsed nonce and keeps latest block tag`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val client =
+            MockHttpClient.capturingRequest(
+                HttpStatusCode.OK,
+                body = """{"id":1,"result":"0x5","error":null}""",
+                capture = capture,
+            )
+
+        val nonce = api(client).getNonce("0x1111111111111111111111111111111111111111")
+
+        assertEquals(BigInteger.valueOf(5L), nonce)
+        assertTrue(
+            capture.lastBody.contains(
+                """"params":["0x1111111111111111111111111111111111111111","latest"]"""
+            ),
+            "expected getNonce to keep the latest block tag, got ${capture.lastBody}",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes defect A from #5571 by making `EvmApi.getNonce` propagate JSON-RPC errors instead of silently returning `BigInteger.ZERO`.

## Details

`eth_getTransactionCount` only enters the RPC error branch on an actual RPC failure such as rate limiting or node errors. Returning zero there can cause the app to sign with an invalid nonce and only fail after the keysign ceremony. This now throws `NetworkException`, matching the hardened `getGasPrice` behavior.

This intentionally does not change the block tag from `latest` to `pending`; the issue comment confirms `latest` is intended so resend/replace-by-fee flows can reuse the mined nonce.

## Validation

- `./gradlew :data:testDebugUnitTest --tests com.vultisig.wallet.data.api.EvmApiNonceTest`
- `./gradlew :data:ktfmtCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrieving transaction nonces: RPC errors now report a network error instead of returning an invalid zero value.
  * Successfully returned nonces continue to be parsed correctly using the latest block information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->