### PR TITLE
fix(defi): use the cross-platform 8k2mz Kamino attribution tag

### DIFF
--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemoTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemoTest.kt
@@ -17,7 +17,7 @@ import wallet.core.jni.TransactionDecoder
 import wallet.core.jni.proto.Solana
 
 /**
- * Golden coverage for the `vs` attribution memo against a real Kamino deposit.
+ * Golden coverage for the `8k2mz` attribution memo against a real Kamino deposit.
  *
  * The fixture is a live `POST /ktx/kvault/deposit` response for the Steakhouse USDC vault: a v0
  * versioned transaction whose four instructions address 9 static account keys plus 18 loaded
@@ -204,14 +204,18 @@ class KaminoAttributionMemoTest {
     @Test
     fun memo_data_is_base58_encoded_and_the_transaction_stays_within_the_size_limit() {
         // Pinned to the literal, not derived from the constant. Every other assertion here reads
-        // TAG, so a drift from `vs` to any other valid two-byte string would leave this whole suite
-        // agreeing with itself and green while the attribution it exists for matched nothing.
-        assertEquals("vs", KaminoAttributionMemo.TAG)
-        assertArrayEquals(byteArrayOf(0x76, 0x73), KaminoAttributionMemo.TAG.toByteArray())
+        // TAG, so a drift from `8k2mz` to any other valid string would leave this whole suite
+        // agreeing with itself and green while the attribution it exists for matched nothing. The
+        // tag is case-sensitive — it is filtered as bytes, so `8K2MZ` counts as nothing.
+        assertEquals("8k2mz", KaminoAttributionMemo.TAG)
+        assertArrayEquals(
+            byteArrayOf(0x38, 0x6b, 0x32, 0x6d, 0x7a),
+            KaminoAttributionMemo.TAG.toByteArray(),
+        )
 
         // WalletCore's JSON instruction format encodes `data` as base58, not base64. Pinning the
-        // encoded form keeps the two on-chain bytes identical across platforms.
-        assertEquals("A1p", Base58.encodeNoCheck(KaminoAttributionMemo.TAG.toByteArray()))
+        // encoded form keeps the five on-chain bytes identical across platforms.
+        assertEquals("7NBh6Z7", Base58.encodeNoCheck(KaminoAttributionMemo.TAG.toByteArray()))
 
         val before = Base64.getDecoder().decode(depositTransaction).size
         val after =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoAttributionMemo.kt
@@ -10,9 +10,10 @@ import wallet.core.jni.SolanaTransaction
  * Appends Vultisig's attribution memo to a Kamino transaction.
  *
  * Kamino's kVault endpoints take no referrer or partner parameter, so attribution is client-side: a
- * single SPL Memo instruction carrying the literal bytes `vs` rides along with every deposit and
- * withdraw. That tag is the analytics filter used to measure Vultisig's deposit flow, so it must be
- * byte-identical on every platform — hence the exact two bytes, and nothing else, in the data
+ * single SPL Memo instruction carrying the literal bytes `8k2mz` rides along with every deposit and
+ * withdraw. That tag is the filter every downstream measurement of Vultisig-originated deposits
+ * keys on — Kamino's own attribution and the public Dune queries alike — so it must be
+ * byte-identical here, on iOS and on Windows: the exact five bytes, and nothing else, in the data
  * field.
  *
  * The memo takes no accounts and adds no signer. Only its program has to enter the message's
@@ -27,8 +28,12 @@ object KaminoAttributionMemo {
     /** SPL Memo v2. */
     const val MEMO_PROGRAM_ID = "MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr"
 
-    /** The attribution tag itself. Two ASCII bytes, never localised, never padded. */
-    const val TAG = "vs"
+    /**
+     * The attribution tag itself. Five ASCII bytes, case-sensitive, never localised, never padded:
+     * it is compared and filtered as bytes, so `8K2MZ` is a different memo that nothing downstream
+     * would count.
+     */
+    const val TAG = "8k2mz"
 
     /**
      * Appends the memo to [base64Transaction] and returns the updated base64 transaction.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -110,7 +110,9 @@ class KaminoTransactionValidatorTest {
     @Test
     fun `a memo carrying anything other than the tag is refused`() {
         // An arbitrary memo riding along on a signed transaction is a channel the app did not open.
-        listOf("vs ", " vs", "VS", "vsx", "", "vultisig").forEach { payload ->
+        // The tag is matched whole and case-sensitively: a memo that merely starts with it, or that
+        // differs only in case, is a different memo that the attribution filter would not count.
+        listOf("8k2m", "8k2mz1", "8k2mz ", " 8k2mz", "8K2MZ", "", "vultisig").forEach { payload ->
             val reason =
                 rejection(
                     depositInstructions(
@@ -461,8 +463,8 @@ class KaminoTransactionValidatorTest {
         // Guards the hand-written equals: without it, structurally identical instructions would
         // compare unequal and the memo checks would silently stop matching.
         assertEquals(
-            ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, byteArrayOf(0x76, 0x73)),
-            ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, byteArrayOf(0x76, 0x73)),
+            ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, byteArrayOf(0x38, 0x6b, 0x32, 0x6d, 0x7a)),
+            ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, byteArrayOf(0x38, 0x6b, 0x32, 0x6d, 0x7a)),
         )
     }
 


### PR DESCRIPTION
## Summary

The attribution memo on Kamino deposits and withdraws carried `vs`. iOS writes `8k2mz` ([vultisig-ios#5166](https://github.com/vultisig/vultisig-ios/pull/5166)), so nothing this app originated was being attributed.

Kamino's kvault API takes no referrer or partner parameter, which is why attribution is an SPL Memo in the first place, and why the bytes are the whole point: the tag is the filter every downstream measurement of Vultisig-originated deposits keys on — Kamino's own attribution and the public Dune queries alike — and it has to be byte-identical on iOS, Android and Windows.

- `KaminoAttributionMemo.TAG` → `8k2mz`. The injector's base58 `data`, the validator's exact-match and its rejection message all read that one constant, so they move together.
- The golden test and the near-miss rejection list stay pinned to the literal rather than reading `TAG`. That is deliberate: if they derived it, a drift to any other valid string would leave the whole suite agreeing with itself and green while the attribution matched nothing.
- The near-miss list now follows iOS's — `8k2m`, `8k2mz1`, a trailing space, a leading space, `8K2MZ`. The tag is matched whole and as bytes, so each of those is a different memo that no downstream filter counts.

No behaviour changes beyond the bytes: the memo is still one instruction, naming no accounts, appended last after the compute-budget pair, and still the only memo the app will sign.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest --tests "*Kamino*"` — passes, including the rewritten near-miss rejection cases
- [x] `./gradlew :data:assembleDebugAndroidTest` — compiles
- [ ] `KaminoAttributionMemoTest` (instrumented) — **not run locally, no device available.** It is the test that exercises the real WalletCore insertion against a live deposit fixture and pins the base58 encoding `7NBh6Z7`. That value was computed offline, not observed on device, so it needs the instrumented run before merge.
- [ ] One live deposit on device, confirming the on-chain memo reads `8k2mz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Kamino transaction attribution to use the `8k2mz` memo tag.
  * Improved validation coverage for formatted, case-variant, empty, and unrelated memo values.
  * Updated transaction attribution checks to reflect the new five-byte memo format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->