### PR TITLE
fix(defi): render token amounts and APY in the user's locale

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,7 +49,14 @@ android {
         }
         jniLibs { keepDebugSymbols += "**/*.so" }
     }
-    tasks.withType<Test> { useJUnitPlatform() }
+    tasks.withType<Test> {
+        useJUnitPlatform()
+        // Amount and APY rendering follows the user's locale, so assertions on formatted strings
+        // are only stable once the JVM the tests run on has one. Tests that care about another
+        // locale set it themselves.
+        systemProperty("user.language", "en")
+        systemProperty("user.country", "US")
+    }
     lint {
         abortOnError = true
         absolutePaths = false

--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingVerifyViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingVerifyViewModel.kt
@@ -22,6 +22,8 @@ import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCase
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
+import com.vultisig.wallet.ui.utils.formatPercent
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import javax.inject.Inject
@@ -125,9 +127,12 @@ constructor(
                 BigDecimal(tx.srcTokenValue.value)
                     .movePointLeft(coin.decimal)
                     .stripTrailingZeros()
-                    .toPlainString()
+                    .formatTokenAmount()
             val feeCrypto =
-                "${BigDecimal(tx.estimatedFees.value).movePointLeft(coin.decimal).stripTrailingZeros().toPlainString()} ${coin.ticker}"
+                BigDecimal(tx.estimatedFees.value)
+                    .movePointLeft(coin.decimal)
+                    .stripTrailingZeros()
+                    .formatTokenAmount(coin.ticker)
 
             // Render with truncated valopers first, then enrich with monikers + commission.
             _state.update {
@@ -216,8 +221,8 @@ constructor(
     private fun resolve(valoper: String, byAddress: Map<String, CosmosValidator>): String {
         val v = byAddress[valoper] ?: return truncated(valoper)
         val display = v.moniker.ifEmpty { truncated(valoper) }
-        val pct = v.commission.movePointRight(2).stripTrailingZeros().toPlainString()
-        return "$display ($pct% commission)"
+        val pct = v.commission.movePointRight(2).stripTrailingZeros().formatPercent()
+        return "$display ($pct commission)"
     }
 
     private fun truncated(value: String): String =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -41,6 +41,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.model.BondNodeState.Companion.from
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.screens.v2.defi.model.PositionUiModelDialog
 import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -500,7 +501,9 @@ constructor(
                             stakeAssetHeader = UiText.StringResource(R.string.cacao_pool),
                             stakeAmount = stakeAmount,
                             stakedAmountDisplay =
-                                "${stakeAmount.setScale(4, RoundingMode.DOWN).toPlainString()} CACAO",
+                                stakeAmount
+                                    .setScale(4, RoundingMode.DOWN)
+                                    .formatTokenAmount("CACAO"),
                             stakedFiatDisplay = stakedFiat,
                             apy = details.apr?.formatPercentage(),
                             isLoading = false,
@@ -865,7 +868,15 @@ constructor(
                             assetTicker = assetCoinTicker,
                             apr = apr?.formatPercentage(),
                             position =
-                                "${cacaoAmount.setScale(4, RoundingMode.DOWN).stripTrailingZeros().toPlainString()} CACAO + ${assetAmount.setScale(4, RoundingMode.DOWN).stripTrailingZeros().toPlainString()} $assetCoinTicker",
+                                cacaoAmount
+                                    .setScale(4, RoundingMode.DOWN)
+                                    .stripTrailingZeros()
+                                    .formatTokenAmount("CACAO") +
+                                    " + " +
+                                    assetAmount
+                                        .setScale(4, RoundingMode.DOWN)
+                                        .stripTrailingZeros()
+                                        .formatTokenAmount(assetCoinTicker),
                             positionKey = pool.positionKey,
                             canRemove = liquidityUnits > BigDecimal.ZERO,
                             chainLogo = assetChain?.monoToneLogo,
@@ -1025,5 +1036,5 @@ private fun mayaPoolChainPrefixToChain(prefix: String): Chain? =
 private fun formatCacaoReward(reward: Double): String {
     val rewardBase = BigDecimal.valueOf(reward).setScale(0, RoundingMode.DOWN).toBigInteger()
     val cacaoAmount = rewardBase.toValue(10).setScale(4, RoundingMode.DOWN)
-    return "${cacaoAmount.toPlainString()} ${Coins.MayaChain.CACAO.ticker}"
+    return cacaoAmount.formatTokenAmount(Coins.MayaChain.CACAO.ticker)
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -54,6 +54,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.model.PositionUiModelDialog
 import com.vultisig.wallet.ui.screens.v2.defi.thorchainSupportStakingDeFi
 import com.vultisig.wallet.ui.screens.v2.defi.toUiModel
 import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -746,14 +747,14 @@ constructor(
     private suspend fun rujiPositionUiModel(details: StakingDetails): StakePositionUiModel {
         val isAutoCompound = details.coin.id == Coins.ThorChain.sRUJI.id
         val stakedAmount = Chain.ThorChain.coinType.toValue(details.stakeAmount)
-        val formattedAmount = "${stakedAmount.toPlainString()} $RUJI_SYMBOL"
+        val formattedAmount = stakedAmount.formatTokenAmount(RUJI_SYMBOL)
         val stakedFiat = calculateStakingFiatPrice(stakedAmount, Coins.ThorChain.RUJI)
 
         val rewards =
             details.rewards?.let { rewardAmount ->
                 val rewardAmountFormatted = Chain.ThorChain.coinType.toValue(rewardAmount)
                 val rewardValue = rewardAmountFormatted.setScale(6, RoundingMode.DOWN)
-                "${rewardValue.toPlainString()} ${details.rewardsCoin?.ticker ?: RUJI_REWARDS_SYMBOL}"
+                rewardValue.formatTokenAmount(details.rewardsCoin?.ticker ?: RUJI_REWARDS_SYMBOL)
             }
 
         return StakePositionUiModel(
@@ -793,7 +794,7 @@ constructor(
                 }
                 .collect { position ->
                     val stakedAmount = Chain.ThorChain.coinType.toValue(position.stakeAmount)
-                    val formattedAmount = "${stakedAmount.toPlainString()} TCY"
+                    val formattedAmount = stakedAmount.formatTokenAmount("TCY")
                     val stakedFiat = calculateStakingFiatPrice(stakedAmount, position.coin)
 
                     // Create and return the UI model
@@ -903,7 +904,7 @@ constructor(
                                     stakeAssetHeader =
                                         UiText.FormattedText(headerResId, listOf(coin.ticker)),
                                     stakedAmountDisplay =
-                                        "${stakeAmount.toPlainString()} ${coin.ticker}",
+                                        stakeAmount.formatTokenAmount(coin.ticker),
                                     // No .orEmpty(): a missed lookup means "we have no price",
                                     // which the card states as unavailable. Coercing it to "" would
                                     // drop the fiat line instead.
@@ -1178,8 +1179,9 @@ constructor(
             assetTicker = assetTicker,
             apr = annualPercentageRate?.formatPercentage(),
             position =
-                "${runeAmount.stripTrailingZeros().toPlainString()} ${Coins.ThorChain.RUNE.ticker} + " +
-                    "${assetAmount.stripTrailingZeros().toPlainString()} $assetTicker",
+                runeAmount.stripTrailingZeros().formatTokenAmount(Coins.ThorChain.RUNE.ticker) +
+                    " + " +
+                    assetAmount.stripTrailingZeros().formatTokenAmount(assetTicker),
             positionKey = pool,
             chainLogo = assetChain?.monoToneLogo,
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/TonDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/TonDeFiPositionsViewModel.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.formatPercentage
 import com.vultisig.wallet.ui.screens.v2.defi.model.PositionUiModelDialog
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -207,7 +208,11 @@ constructor(
                     if (position != null) {
                         cachedPoolAddress = primary!!.pool
                         cachedStakedDisplay =
-                            "${staked.toBigDecimal().movePointLeft(tonCoin.decimal).stripTrailingZeros().toPlainString()} ${tonCoin.ticker}"
+                            staked
+                                .toBigDecimal()
+                                .movePointLeft(tonCoin.decimal)
+                                .stripTrailingZeros()
+                                .formatTokenAmount(tonCoin.ticker)
                         position
                     } else {
                         cachedPoolAddress = null
@@ -271,7 +276,7 @@ constructor(
             totalAmountPrice = stakedFiat,
             ticker = coin.ticker,
             poolName = poolInfo?.name?.takeIf { it.isNotBlank() } ?: shortPool(poolAddress),
-            stakedDisplay = "${stakedTon.stripTrailingZeros().toPlainString()} ${coin.ticker}",
+            stakedDisplay = stakedTon.stripTrailingZeros().formatTokenAmount(coin.ticker),
             stakedFiatDisplay = stakedFiat,
             // tonapi `apy` is a percentage (13.27 = 13.27%); `formatPercentage` multiplies by 100,
             // so scale to a fraction first.
@@ -282,7 +287,10 @@ constructor(
                 pendingWithdraw
                     .takeIf { it > BigInteger.ZERO }
                     ?.let {
-                        "${it.toBigDecimal().movePointLeft(coin.decimal).stripTrailingZeros().toPlainString()} ${coin.ticker}"
+                        it.toBigDecimal()
+                            .movePointLeft(coin.decimal)
+                            .stripTrailingZeros()
+                            .formatTokenAmount(coin.ticker)
                     },
             unlockEpochMs = poolInfo?.cycleEnd?.takeIf { isLocked }?.let { it * 1000L },
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/TonStakeViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/TonStakeViewModel.kt
@@ -170,6 +170,9 @@ constructor(
         _state.update { it.copy(percentageSelected = percent) }
         val available = _state.value.stakeableBalance
         if (available <= BigDecimal.ZERO) return
+        // Deliberately not locale-formatted: `submit()` reads this field back with
+        // `toBigDecimalOrNull()`, which only parses `.` as the decimal separator and rejects
+        // grouping separators outright.
         val amount =
             available
                 .multiply(BigDecimal(percent))

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/TronDeFiPositionsViewModel.kt
@@ -29,6 +29,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.screens.v2.defi.model.PositionUiModelDialog
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -225,7 +226,7 @@ constructor(
         return TronStakingUiModel(
             totalAmountPrice = currencyFormat.format(defiTotal.multiply(trxPrice)),
             frozenTotalPrice = currencyFormat.format(frozenTotal.multiply(trxPrice)),
-            frozenTotalTrx = frozenTotal.stripTrailingZeros().toPlainString(),
+            frozenTotalTrx = frozenTotal.stripTrailingZeros().formatTokenAmount(),
             availableBandwidth = stats.availableBandwidth,
             totalBandwidth = stats.totalBandwidth,
             availableEnergy = stats.availableEnergy,
@@ -244,7 +245,7 @@ constructor(
                 val amountSun = entry.unfreezeAmount ?: return@mapNotNull null
                 val expireTimeMs = entry.unfreezeExpireTime ?: return@mapNotNull null
                 TronPendingWithdrawalUiModel(
-                    amountTrx = amountSun.sunToTrx().toPlainString(),
+                    amountTrx = amountSun.sunToTrx().formatTokenAmount(),
                     expiryEpochMs = expireTimeMs,
                     resourceType = entry.type.toTronResourceType(),
                 )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategy.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.utils.UiText
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.UUID
@@ -213,7 +214,7 @@ private fun resolveDepositAmount(
         throw InvalidTransactionDataException(
             UiText.FormattedText(
                 R.string.ton_stake_error_min_amount,
-                listOf(minDepositTon.toPlainString(), token.ticker),
+                listOf(minDepositTon.formatTokenAmount(), token.ticker),
             )
         )
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/TronStakingService.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/TronStakingService.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import java.math.BigDecimal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -130,7 +131,7 @@ internal class TronStakingService(
         uiState.update {
             it.copy(
                 tronBalanceAvailableOverride =
-                    balances.forResource(type).stripTrailingZeros().toPlainString()
+                    balances.forResource(type).stripTrailingZeros().formatTokenAmount()
             )
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/LoadSolanaValidatorOptionsUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/LoadSolanaValidatorOptionsUseCase.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.models.solanastaking
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingService
 import com.vultisig.wallet.data.blockchain.solana.staking.ValidatorMetadataProvider
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.ui.utils.formatPercent
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
@@ -41,7 +42,7 @@ constructor(
                     md?.apyEstimate?.let {
                         it.multiply(BigDecimal(100))
                             .setScale(2, RoundingMode.HALF_UP)
-                            .toPlainString() + "%"
+                            .formatPercent()
                     },
             )
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
@@ -31,6 +31,8 @@ import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
+import com.vultisig.wallet.ui.utils.formatPercent
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -342,7 +344,7 @@ constructor(
                         isBalanceVisible = isBalanceVisible,
                         totalStakedFiatDisplay = totalFiat,
                         totalStakedSolDisplay =
-                            "${totalStakedSolAmount.stripTrailingZeros().toPlainString()} $SOL_TICKER",
+                            totalStakedSolAmount.stripTrailingZeros().formatTokenAmount(SOL_TICKER),
                         positions = rows,
                         error = null,
                     )
@@ -376,16 +378,15 @@ constructor(
             validatorAddressDisplay = shortAddress(account.stakePubkey),
             validatorLogoUrl = metadata?.logoUrl,
             votePubkey = account.voter,
-            stakedDisplay = "${stakedSol.toPlainString()} ${SOL_TICKER}",
+            stakedDisplay = stakedSol.formatTokenAmount(SOL_TICKER),
             stakedFiatDisplay = stakedFiat,
-            rentReserveDisplay = "${rentReserveSol.toPlainString()} $SOL_TICKER",
+            rentReserveDisplay = rentReserveSol.formatTokenAmount(SOL_TICKER),
             state = account.state,
             stateLabel = stateLabel(account.state),
             // metadata.apyEstimate is a fraction (0.0572); render as a percentage.
             apyDisplay =
                 metadata?.apyEstimate?.let {
-                    it.multiply(BigDecimal(100)).setScale(2, RoundingMode.HALF_UP).toPlainString() +
-                        "%"
+                    it.multiply(BigDecimal(100)).setScale(2, RoundingMode.HALF_UP).formatPercent()
                 },
             canManage =
                 account.state == SolanaStakeState.Active ||

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosDelegateScreen.kt
@@ -52,7 +52,10 @@ import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosDelegateUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosDelegateViewModel
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.formatPercent
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import java.math.BigDecimal
+import java.math.RoundingMode
 
 /**
  * Stake form for LUNA / LUNC — mirrors iOS `CosmosDelegateTransactionScreen`: centered amount
@@ -226,7 +229,7 @@ internal fun BalanceAvailableRow(ticker: String, available: BigDecimal) {
             color = Theme.v2.colors.text.primary,
         )
         Text(
-            text = "${available.stripTrailingZeros().toPlainString()} $ticker",
+            text = available.stripTrailingZeros().formatTokenAmount(ticker),
             style = Theme.brockmann.body.s.medium,
             color = Theme.v2.colors.text.secondary,
             textAlign = TextAlign.End,
@@ -557,7 +560,7 @@ private fun ValidatorPickerRow(
             UiSpacer(size = 8.dp)
         }
         Text(
-            text = "${formatCommissionPercent(validator.commission)}%",
+            text = formatCommissionPercent(validator.commission),
             style = Theme.brockmann.body.s.medium,
             color = Theme.v2.colors.text.primary,
             maxLines = 1,
@@ -573,9 +576,9 @@ private fun ValidatorPickerRow(
 private fun formatCommissionPercent(commission: BigDecimal): String =
     commission
         .movePointRight(2)
-        .setScale(2, java.math.RoundingMode.HALF_UP)
+        .setScale(2, RoundingMode.HALF_UP)
         .stripTrailingZeros()
-        .toPlainString()
+        .formatPercent()
 
 /**
  * Voting power arrives as bond-denom base units (uint string). Render it in whole-token units with

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -66,6 +66,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.NoPositionsContainer
 import com.vultisig.wallet.ui.screens.v2.defi.PositionsSelectionDialog
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
+import com.vultisig.wallet.ui.utils.formatPercent
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
@@ -568,7 +569,9 @@ private fun PositionRow(
                 )
                 Text(
                     text =
-                        "${apy.multiply(java.math.BigDecimal(100)).setScale(2, java.math.RoundingMode.HALF_UP).toPlainString()}%",
+                        apy.multiply(BigDecimal(100))
+                            .setScale(2, RoundingMode.HALF_UP)
+                            .formatPercent(),
                     style = Theme.brockmann.body.s.medium,
                     color = Theme.v2.colors.alerts.success,
                 )
@@ -719,7 +722,7 @@ private fun UnbondingCard(unbonding: CosmosUnbondingDelegation) {
                 text =
                     stringResource(
                         R.string.cosmos_staking_unbonding_entry_format,
-                        entry.balance.toPlainString(),
+                        formatStakeAmount(entry.balance),
                         completion,
                     ),
                 style = Theme.brockmann.body.s.medium,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiFormatters.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiFormatters.kt
@@ -31,7 +31,7 @@ internal fun Date?.formatDate(): String {
 
 internal fun BigInteger.formatAmount(coinType: CoinType, symbol: String? = null): String {
     if (this == BigInteger.ZERO) {
-        return "0.0 ${symbol ?: coinType.symbol}"
+        return ZERO_AMOUNT.formatTokenAmount(symbol ?: coinType.symbol)
     }
     val chainAmount = coinType.toValue(this)
     val rounded = chainAmount.setScale(8, RoundingMode.DOWN)
@@ -40,7 +40,7 @@ internal fun BigInteger.formatAmount(coinType: CoinType, symbol: String? = null)
 
 internal fun BigInteger.formatAmount(decimals: Int, symbol: String): String {
     if (this == BigInteger.ZERO) {
-        return "0.0 $symbol"
+        return ZERO_AMOUNT.formatTokenAmount(symbol)
     }
     val chainAmount = this.toBigDecimal().divide(java.math.BigDecimal.TEN.pow(decimals))
     val rounded = chainAmount.setScale(8, RoundingMode.DOWN)
@@ -69,3 +69,6 @@ internal fun Double.formatToString(): String {
 
 private const val PERCENTAGE_DECIMALS = 2
 private val ONE_HUNDRED = BigDecimal(100)
+
+/** Scale 1 so an empty position keeps reading "0.0", separator aside, as it always has. */
+private val ZERO_AMOUNT = BigDecimal.ZERO.setScale(1)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiFormatters.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiFormatters.kt
@@ -4,6 +4,8 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.coinType
 import com.vultisig.wallet.data.utils.symbol
 import com.vultisig.wallet.data.utils.toValue
+import com.vultisig.wallet.ui.utils.formatPercent
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.RoundingMode
@@ -33,7 +35,7 @@ internal fun BigInteger.formatAmount(coinType: CoinType, symbol: String? = null)
     }
     val chainAmount = coinType.toValue(this)
     val rounded = chainAmount.setScale(8, RoundingMode.DOWN)
-    return "${rounded.toPlainString()} ${symbol ?: coinType.symbol}"
+    return rounded.formatTokenAmount(symbol ?: coinType.symbol)
 }
 
 internal fun BigInteger.formatAmount(decimals: Int, symbol: String): String {
@@ -42,20 +44,28 @@ internal fun BigInteger.formatAmount(decimals: Int, symbol: String): String {
     }
     val chainAmount = this.toBigDecimal().divide(java.math.BigDecimal.TEN.pow(decimals))
     val rounded = chainAmount.setScale(8, RoundingMode.DOWN)
-    return "${rounded.toPlainString()} $symbol"
+    return rounded.formatTokenAmount(symbol)
 }
 
-internal fun Double.formatPercentage(): String {
-    return "%.2f%%".format(Locale.US, this * 100)
-}
+internal fun Double.formatPercentage(): String =
+    // BigDecimal cannot hold NaN or an infinity, which an APY read straight off the wire can be.
+    if (!isFinite()) "$this%"
+    else
+        BigDecimal.valueOf(this)
+            .multiply(ONE_HUNDRED)
+            .setScale(PERCENTAGE_DECIMALS, RoundingMode.HALF_UP)
+            .formatPercent()
 
 internal fun Double.formatRuneReward(): String {
     val rewardBase = BigDecimal.valueOf(this).setScale(0, RoundingMode.DOWN).toBigInteger()
     val runeAmount = Chain.ThorChain.coinType.toValue(rewardBase).setScale(4, RoundingMode.DOWN)
-    return "${runeAmount.toPlainString()} ${Chain.ThorChain.coinType.symbol}"
+    return runeAmount.formatTokenAmount(Chain.ThorChain.coinType.symbol)
 }
 
 internal fun Double.formatToString(): String {
     val value = BigDecimal.valueOf(this).setScale(6, RoundingMode.DOWN)
-    return "${value.toPlainString()} ${Chain.ThorChain.coinType.symbol}"
+    return value.formatTokenAmount(Chain.ThorChain.coinType.symbol)
 }
+
+private const val PERCENTAGE_DECIMALS = 2
+private val ONE_HUNDRED = BigDecimal(100)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoAmountScreen.kt
@@ -29,6 +29,7 @@ import com.vultisig.wallet.ui.models.solanastaking.KaminoAmountViewModel
 import com.vultisig.wallet.ui.screens.cosmosstaking.StakingAmountCard
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import java.math.BigDecimal
 
 /**
@@ -94,7 +95,7 @@ internal fun KaminoAmountContent(
             state.minimum != null && amount < state.minimum ->
                 stringResource(
                     R.string.kamino_amount_below_minimum,
-                    state.minimum.stripTrailingZeros().toPlainString(),
+                    state.minimum.stripTrailingZeros().formatTokenAmount(),
                     state.ticker,
                 )
             else -> null
@@ -147,7 +148,7 @@ internal fun KaminoAmountContent(
                             BigDecimal(delayed.available.baseUnits)
                                 .movePointLeft(delayed.available.decimals)
                                 .stripTrailingZeros()
-                                .toPlainString(),
+                                .formatTokenAmount(),
                             state.ticker,
                         ),
                     style = Theme.brockmann.supplementary.caption,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -22,6 +22,8 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.screens.v2.defi.FIAT_VALUE_UNAVAILABLE
+import com.vultisig.wallet.ui.utils.formatPercent
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -342,18 +344,16 @@ constructor(
             tokenLogo = coin?.logo.orEmpty(),
             tokenTicker = coin?.ticker.orEmpty(),
             depositedDisplay =
-                tokenAmount?.let {
-                    "${it.stripTrailingZeros().toPlainString()} ${coin?.ticker.orEmpty()}".trim()
-                } ?: FIAT_VALUE_UNAVAILABLE,
+                tokenAmount?.let { it.stripTrailingZeros().formatTokenAmount(coin?.ticker).trim() }
+                    ?: FIAT_VALUE_UNAVAILABLE,
             depositedFiat = tokenAmount?.let { amount -> coin?.let { fiatOrNull(amount, it) } },
-            apyDisplay = apy?.let { "${it.toPlainString()}%" },
+            apyDisplay = apy?.formatPercent(),
             pnlDisplay =
                 pnlToken?.let {
                     // Unsigned: the row's label already says whether this was earned or lost, so a
                     // minus sign in front of "Lost" would state it twice.
                     val amount = it.abs().setScale(vault.tokenDecimals, RoundingMode.DOWN)
-                    "${amount.stripTrailingZeros().toPlainString()} ${coin?.ticker.orEmpty()}"
-                        .trim()
+                    amount.stripTrailingZeros().formatTokenAmount(coin?.ticker).trim()
                 },
             pnlDirection =
                 when {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonStakeScreen.kt
@@ -45,6 +45,7 @@ import com.vultisig.wallet.ui.models.defi.TonStakeViewModel
 import com.vultisig.wallet.ui.screens.cosmosstaking.StakingAmountCard
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
+import com.vultisig.wallet.ui.utils.formatTokenAmount
 import java.math.BigDecimal
 import java.text.DecimalFormat
 
@@ -86,7 +87,7 @@ internal fun TonStakeScreen(viewModel: TonStakeViewModel = hiltViewModel()) {
                         text =
                             stringResource(
                                 R.string.ton_stake_error_min_amount,
-                                state.requiredMinStake.stripTrailingZeros().toPlainString(),
+                                state.requiredMinStake.stripTrailingZeros().formatTokenAmount(),
                                 ticker,
                             ),
                         style = Theme.brockmann.supplementary.caption,
@@ -389,6 +390,6 @@ private fun PoolMonogram(letter: String, size: Int) {
 }
 
 private fun formatMinStake(minStake: BigDecimal): String =
-    minStake.stripTrailingZeros().toPlainString()
+    minStake.stripTrailingZeros().formatTokenAmount()
 
 private fun formatApy(apy: Double): String = DecimalFormat("0.##").format(apy)

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/TokenAmountFormat.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/TokenAmountFormat.kt
@@ -1,0 +1,52 @@
+package com.vultisig.wallet.ui.utils
+
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
+import java.util.Locale
+
+/**
+ * Locale-aware rendering for user-facing token amounts and percentages.
+ *
+ * `BigDecimal.toPlainString()` always writes `.` as the decimal separator and never groups, so a
+ * user reading the app in Russian, German, Dutch or Portuguese was shown `1054.427822 USDC` where
+ * their locale writes `1 054,427822 USDC`. Fiat already goes through
+ * `AppCurrencyRepository.getCurrencyFormat()`; these helpers are the token-side equivalent, so a
+ * screen mixing the two no longer renders one number in the user's convention and the next in
+ * en-US.
+ *
+ * The plain string form stays correct for text the app parses back — amount fields, request
+ * payloads, memos — because those are read by code, not by a person.
+ */
+internal fun BigDecimal.formatTokenAmount(
+    ticker: String? = null,
+    decimals: Int = scale().coerceAtLeast(0),
+    locale: Locale = Locale.getDefault(),
+): String {
+    val amount = formatDecimal(this, decimals, locale)
+    return if (ticker.isNullOrBlank()) amount else "$amount $ticker"
+}
+
+/**
+ * Renders a percentage that is already expressed in percent units — `4.00` becomes `4.00%` (or
+ * `4,00%`). APY fractions must be multiplied by 100 before they get here.
+ */
+internal fun BigDecimal.formatPercent(
+    decimals: Int = scale().coerceAtLeast(0),
+    locale: Locale = Locale.getDefault(),
+): String = formatDecimal(this, decimals, locale) + "%"
+
+/**
+ * The receiver's own scale is the display precision by default, so callers keep exactly the digits
+ * they rounded or stripped to and only the separators change.
+ */
+private fun formatDecimal(value: BigDecimal, decimals: Int, locale: Locale): String =
+    DecimalFormat("#,##0", DecimalFormatSymbols.getInstance(locale))
+        .apply {
+            minimumFractionDigits = decimals
+            maximumFractionDigits = decimals
+            // Never round a displayed balance up — it would claim more than the position holds.
+            roundingMode = RoundingMode.DOWN
+        }
+        .format(value)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/StakeStrategyTest.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.ui.utils.UiText
 import io.mockk.coEvery
 import io.mockk.mockk
 import java.math.BigInteger
+import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -126,15 +127,23 @@ internal class StakeStrategyTest {
 
     @Test
     fun `deposit below pool minimum is rejected`() = runTest {
-        givenPool(implementation = "whales", minStake = 50_000_000_000)
-        givenAccounts()
-        givenSpecific()
-        nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
-        // 50 TON < min_stake (50) + 1 TON commission.
-        tokenAmount.setTextAndPlaceCursorAtEnd("50")
+        val previousLocale = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.GERMANY)
+            givenPool(implementation = "whales", minStake = 50_500_000_000)
+            givenAccounts()
+            givenSpecific()
+            nodeAddress.setTextAndPlaceCursorAtEnd("0:pool")
+            // 51 TON < min_stake (50.5) + 1 TON commission.
+            tokenAmount.setTextAndPlaceCursorAtEnd("51")
 
-        val ex = assertFailsWith<InvalidTransactionDataException> { stake().build() }
-        assertEquals(R.string.ton_stake_error_min_amount, (ex.text as UiText.FormattedText).resId)
+            val ex = assertFailsWith<InvalidTransactionDataException> { stake().build() }
+            val text = ex.text as UiText.FormattedText
+            assertEquals(R.string.ton_stake_error_min_amount, text.resId)
+            assertEquals(listOf("51,5", "TON"), text.formatArgs)
+        } finally {
+            Locale.setDefault(previousLocale)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiFormattersTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiFormattersTest.kt
@@ -1,0 +1,55 @@
+package com.vultisig.wallet.ui.screens.v2.defi
+
+import io.kotest.matchers.shouldBe
+import java.math.BigInteger
+import java.util.Locale
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+internal class DeFiFormattersTest {
+
+    private val defaultLocale = Locale.getDefault()
+
+    @AfterEach
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun `an amount is grouped and separated the way the locale writes numbers`() {
+        Locale.setDefault(Locale.US)
+        BigInteger("123456789012").formatAmount(decimals = 8, symbol = "RUNE") shouldBe
+            "1,234.56789012 RUNE"
+
+        Locale.setDefault(Locale.GERMANY)
+        BigInteger("123456789012").formatAmount(decimals = 8, symbol = "RUNE") shouldBe
+            "1.234,56789012 RUNE"
+    }
+
+    @Test
+    fun `an empty position reads zero in the locale's own separator`() {
+        // The zero branch returns early, so it needs the formatter too — otherwise a German user
+        // reads "0.0 RUNE" on an empty position and "1.234,5 RUNE" on a funded one.
+        Locale.setDefault(Locale.US)
+        BigInteger.ZERO.formatAmount(decimals = 8, symbol = "RUNE") shouldBe "0.0 RUNE"
+
+        Locale.setDefault(Locale.GERMANY)
+        BigInteger.ZERO.formatAmount(decimals = 8, symbol = "RUNE") shouldBe "0,0 RUNE"
+    }
+
+    @Test
+    fun `a percentage follows the locale and is no longer pinned to en-US`() {
+        Locale.setDefault(Locale.US)
+        0.1327.formatPercentage() shouldBe "13.27%"
+
+        Locale.setDefault(Locale.GERMANY)
+        0.1327.formatPercentage() shouldBe "13,27%"
+    }
+
+    @Test
+    fun `a non-finite APY renders rather than throwing`() {
+        // BigDecimal cannot hold either, and an APY read off the wire can be both.
+        Double.NaN.formatPercentage() shouldBe "NaN%"
+        Double.POSITIVE_INFINITY.formatPercentage() shouldBe "Infinity%"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -56,9 +56,14 @@ internal class KaminoEarnViewModelTest {
     private lateinit var appCurrencyRepository: AppCurrencyRepository
     private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
 
+    private val defaultLocale = Locale.getDefault()
+
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
+        // Amount rendering follows the user's locale, so the expected strings below only hold once
+        // the locale the test runs under is pinned.
+        Locale.setDefault(Locale.US)
         navigator = mockk(relaxed = true)
         kaminoApi = mockk(relaxed = true)
         selectionRepository = mockk(relaxed = true)
@@ -81,6 +86,7 @@ internal class KaminoEarnViewModelTest {
     @AfterEach
     fun tearDown() {
         Dispatchers.resetMain()
+        Locale.setDefault(defaultLocale)
     }
 
     private fun viewModel() =
@@ -170,10 +176,40 @@ internal class KaminoEarnViewModelTest {
 
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
-        assertEquals("1054.427822 USDC", row.depositedDisplay)
+        assertEquals("1,054.427822 USDC", row.depositedDisplay)
         assertEquals("54.427822 USDC", row.pnlDisplay)
         assertEquals(KaminoEarnRow.PnlDirection.UP, row.pnlDirection)
         assertNotNull(row.depositedFiat)
+    }
+
+    @Test
+    fun `a locale that writes decimals with a comma gets its own separators`() = runTest {
+        Locale.setDefault(Locale.forLanguageTag("ru-RU"))
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+            listOf(
+                KaminoUserPositionJson(
+                    vaultAddress = STEAKHOUSE.address,
+                    stakedShares = "1000",
+                    unstakedShares = "0",
+                    totalShares = "1000",
+                )
+            )
+        coEvery { kaminoApi.getVaultState(STEAKHOUSE.address) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(
+                apy30d = "0.039967764404019690278",
+                tokensPerShare = "1.0544278224860290217",
+            )
+        coEvery { kaminoApi.getPositionPnl(WALLET_ADDRESS, STEAKHOUSE.address) } returns
+            KaminoPnlJson(totalPnl = KaminoPnlJson.Amounts(token = "54.427822"))
+
+        val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+        assertEquals("1\u00A0054,427822 USDC", row.depositedDisplay)
+        assertEquals("54,427822 USDC", row.pnlDisplay)
+        assertEquals("4,00%", row.apyDisplay)
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/utils/TokenAmountFormatTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/utils/TokenAmountFormatTest.kt
@@ -1,0 +1,93 @@
+package com.vultisig.wallet.ui.utils
+
+import java.math.BigDecimal
+import java.util.Locale
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+internal class TokenAmountFormatTest {
+
+    private val defaultLocale = Locale.getDefault()
+
+    @AfterEach
+    fun tearDown() {
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun `a dot locale keeps the English rendering`() {
+        assertEquals(
+            "1,054.427822 USDC",
+            BigDecimal("1054.427822").formatTokenAmount("USDC", locale = Locale.US),
+        )
+    }
+
+    @Test
+    fun `a comma locale writes the decimal separator its own way`() {
+        assertEquals(
+            "1.054,427822 USDC",
+            BigDecimal("1054.427822").formatTokenAmount("USDC", locale = Locale.GERMANY),
+        )
+        // Russian groups with a non-breaking space, which is exactly why the separator cannot be
+        // hardcoded.
+        assertEquals(
+            "1 054,427822 USDC",
+            BigDecimal("1054.427822")
+                .formatTokenAmount("USDC", locale = Locale.forLanguageTag("ru-RU")),
+        )
+    }
+
+    @Test
+    fun `the receiver's scale is the display precision`() {
+        // A caller that rounded to four places keeps four, trailing zeros included.
+        assertEquals(
+            "12.3400 CACAO",
+            BigDecimal("12.3400").formatTokenAmount("CACAO", locale = Locale.US),
+        )
+        // A caller that stripped them keeps none.
+        assertEquals(
+            "12.34 CACAO",
+            BigDecimal("12.3400")
+                .stripTrailingZeros()
+                .formatTokenAmount("CACAO", locale = Locale.US),
+        )
+        // stripTrailingZeros leaves whole numbers at a negative scale; that is not fewer digits.
+        assertEquals(
+            "800 TRX",
+            BigDecimal("800.000000")
+                .stripTrailingZeros()
+                .formatTokenAmount("TRX", locale = Locale.US),
+        )
+    }
+
+    @Test
+    fun `an explicit precision truncates rather than rounds up`() {
+        // Rounding up would claim more than the position holds.
+        assertEquals(
+            "1.9999 SOL",
+            BigDecimal("1.99999").formatTokenAmount("SOL", decimals = 4, locale = Locale.US),
+        )
+    }
+
+    @Test
+    fun `an omitted or blank ticker leaves the number bare`() {
+        assertEquals("1,000.5", BigDecimal("1000.5").formatTokenAmount(locale = Locale.US))
+        assertEquals("1,000.5", BigDecimal("1000.5").formatTokenAmount("", locale = Locale.US))
+    }
+
+    @Test
+    fun `percentages follow the same locale separators`() {
+        assertEquals("4.00%", BigDecimal("4.00").formatPercent(locale = Locale.US))
+        assertEquals("4,00%", BigDecimal("4.00").formatPercent(locale = Locale.GERMANY))
+        assertEquals("13.27%", BigDecimal("13.27").formatPercent(decimals = 2, locale = Locale.US))
+    }
+
+    @Test
+    fun `the default locale is the user's locale`() {
+        Locale.setDefault(Locale.GERMANY)
+
+        assertEquals("1.054,43 USDC", BigDecimal("1054.43").formatTokenAmount("USDC"))
+        assertEquals("4,00%", BigDecimal("4.00").formatPercent())
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/utils/TokenAmountFormatTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/utils/TokenAmountFormatTest.kt
@@ -1,8 +1,8 @@
 package com.vultisig.wallet.ui.utils
 
+import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
 import java.util.Locale
-import kotlin.test.assertEquals
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 
@@ -17,77 +17,61 @@ internal class TokenAmountFormatTest {
 
     @Test
     fun `a dot locale keeps the English rendering`() {
-        assertEquals(
-            "1,054.427822 USDC",
-            BigDecimal("1054.427822").formatTokenAmount("USDC", locale = Locale.US),
-        )
+        BigDecimal("1054.427822").formatTokenAmount("USDC", locale = Locale.US) shouldBe
+            "1,054.427822 USDC"
     }
 
     @Test
     fun `a comma locale writes the decimal separator its own way`() {
-        assertEquals(
-            "1.054,427822 USDC",
-            BigDecimal("1054.427822").formatTokenAmount("USDC", locale = Locale.GERMANY),
-        )
+        BigDecimal("1054.427822").formatTokenAmount("USDC", locale = Locale.GERMANY) shouldBe
+            "1.054,427822 USDC"
         // Russian groups with a non-breaking space, which is exactly why the separator cannot be
         // hardcoded.
-        assertEquals(
-            "1 054,427822 USDC",
-            BigDecimal("1054.427822")
-                .formatTokenAmount("USDC", locale = Locale.forLanguageTag("ru-RU")),
-        )
+        BigDecimal("1054.427822")
+            .formatTokenAmount("USDC", locale = Locale.forLanguageTag("ru-RU")) shouldBe
+            "1 054,427822 USDC"
     }
 
     @Test
     fun `the receiver's scale is the display precision`() {
         // A caller that rounded to four places keeps four, trailing zeros included.
-        assertEquals(
-            "12.3400 CACAO",
-            BigDecimal("12.3400").formatTokenAmount("CACAO", locale = Locale.US),
-        )
+        BigDecimal("12.3400").formatTokenAmount("CACAO", locale = Locale.US) shouldBe
+            "12.3400 CACAO"
         // A caller that stripped them keeps none.
-        assertEquals(
-            "12.34 CACAO",
-            BigDecimal("12.3400")
-                .stripTrailingZeros()
-                .formatTokenAmount("CACAO", locale = Locale.US),
-        )
+        BigDecimal("12.3400")
+            .stripTrailingZeros()
+            .formatTokenAmount("CACAO", locale = Locale.US) shouldBe "12.34 CACAO"
         // stripTrailingZeros leaves whole numbers at a negative scale; that is not fewer digits.
-        assertEquals(
-            "800 TRX",
-            BigDecimal("800.000000")
-                .stripTrailingZeros()
-                .formatTokenAmount("TRX", locale = Locale.US),
-        )
+        BigDecimal("800.000000")
+            .stripTrailingZeros()
+            .formatTokenAmount("TRX", locale = Locale.US) shouldBe "800 TRX"
     }
 
     @Test
     fun `an explicit precision truncates rather than rounds up`() {
         // Rounding up would claim more than the position holds.
-        assertEquals(
-            "1.9999 SOL",
-            BigDecimal("1.99999").formatTokenAmount("SOL", decimals = 4, locale = Locale.US),
-        )
+        BigDecimal("1.99999").formatTokenAmount("SOL", decimals = 4, locale = Locale.US) shouldBe
+            "1.9999 SOL"
     }
 
     @Test
     fun `an omitted or blank ticker leaves the number bare`() {
-        assertEquals("1,000.5", BigDecimal("1000.5").formatTokenAmount(locale = Locale.US))
-        assertEquals("1,000.5", BigDecimal("1000.5").formatTokenAmount("", locale = Locale.US))
+        BigDecimal("1000.5").formatTokenAmount(locale = Locale.US) shouldBe "1,000.5"
+        BigDecimal("1000.5").formatTokenAmount("", locale = Locale.US) shouldBe "1,000.5"
     }
 
     @Test
     fun `percentages follow the same locale separators`() {
-        assertEquals("4.00%", BigDecimal("4.00").formatPercent(locale = Locale.US))
-        assertEquals("4,00%", BigDecimal("4.00").formatPercent(locale = Locale.GERMANY))
-        assertEquals("13.27%", BigDecimal("13.27").formatPercent(decimals = 2, locale = Locale.US))
+        BigDecimal("4.00").formatPercent(locale = Locale.US) shouldBe "4.00%"
+        BigDecimal("4.00").formatPercent(locale = Locale.GERMANY) shouldBe "4,00%"
+        BigDecimal("13.27").formatPercent(decimals = 2, locale = Locale.US) shouldBe "13.27%"
     }
 
     @Test
     fun `the default locale is the user's locale`() {
         Locale.setDefault(Locale.GERMANY)
 
-        assertEquals("1.054,43 USDC", BigDecimal("1054.43").formatTokenAmount("USDC"))
-        assertEquals("4,00%", BigDecimal("4.00").formatPercent())
+        BigDecimal("1054.43").formatTokenAmount("USDC") shouldBe "1.054,43 USDC"
+        BigDecimal("4.00").formatPercent() shouldBe "4,00%"
     }
 }


### PR DESCRIPTION
Closes #5593.

## Summary

A localized build showed every DeFi and staking amount in en-US. `BigDecimal.toPlainString()` always writes `.` as the decimal separator and never groups, so a user reading the app in Russian, German, Dutch or Portuguese saw `1054.427822 USDC` sitting next to a fiat total that `AppCurrencyRepository.getCurrencyFormat()` had already rendered in their own convention.

This adds one shared display path for token quantities and percentages and routes the DeFi and staking screens through it.

- `BigDecimal.formatTokenAmount(ticker, decimals, locale)` and `BigDecimal.formatPercent(decimals, locale)` in `ui/utils/TokenAmountFormat.kt`.
- The receiver's own scale is the display precision by default, so every migrated call site keeps exactly the digits it rounded or stripped to — only the separators change.
- Rounding stays `DOWN`, so a displayed balance is never larger than what the position holds.
- Fiat is untouched and still goes through `getCurrencyFormat()`.

## Migrated

Token amounts and APY:

- `KaminoEarnViewModel` (deposited, PnL, APY), `TonDeFiPositionsViewModel`, `TronDeFiPositionsViewModel`
- `DeFiFormatters` — `formatAmount`, `formatRuneReward`, `formatToString`, and `formatPercentage`, which was pinned to `Locale.US` and is the APY path for Thorchain / Mayachain / TON
- `ThorchainDefiPositionsViewModel`, `MayachainDefiPositionsViewModel`, `SolanaStakingPositionsViewModel`, `LoadSolanaValidatorOptionsUseCase`, `CosmosStakingVerifyViewModel`, `TronStakingService`
- Screens: `CosmosStakingPositionsScreen`, `CosmosDelegateScreen`, `KaminoAmountScreen`, `TonStakeScreen`

## Deliberate exceptions

Amount-field prefills and API/base-unit payloads keep `toPlainString()`: those strings are read back by code, not by a person, and `toBigDecimalOrNull()` rejects both `,` as a decimal separator and grouping separators outright. That covers `TonStakeViewModel` (comment added at the call site), `SolanaDelegateViewModel`, `KaminoAmountViewModel`, the Cosmos delegate / undelegate / redelegate forms, and the Cosmos positions → form route arguments.

Send, swap and keysign amount rendering is out of scope here; `TokenValueToDecimalUiStringMapper` on that side is already locale-aware.

## Test plan

- `TokenAmountFormatTest` — en-US (`.`), de-DE and ru-RU (`,`, plus the non-breaking-space grouping separator), precision preservation, truncate-rather-than-round-up, bare and blank tickers, percentages, and default-locale behavior.
- `KaminoEarnViewModelTest` — pins `Locale.US` and now expects `1,054.427822 USDC`; adds a ru-RU case asserting `1 054,427822 USDC`, `54,427822 USDC` and `4,00%`.
- Unit tests now run under a pinned `user.language` / `user.country`, since assertions on formatted amounts are only stable once the JVM has a locale. Verified the property reaches the forked JVM by temporarily setting `fr` / `FR` and watching a formatted-APY assertion fail.
- `:app:compileDebugKotlin`, `:app:testDebugUnitTest` and `:app:lintDebug` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added locale-aware formatting for token amounts, percentages, tickers, decimal precision, and grouping.
  - Updated staking and DeFi screens to display balances, rewards, fees, APY, commissions, and withdrawal values consistently.
  - Added support for locale-specific decimal and grouping separators.

- **Bug Fixes**
  - Improved rounding and truncation for displayed token values and percentages.
  - Preserved machine-readable decimal formatting where required.

- **Tests**
  - Added coverage for locale-specific formatting, precision, tickers, percentages, and default-locale handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->