### PR TITLE
fix(defi): make the Kamino compute budget agree with iOS

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -27,6 +27,7 @@ import com.vultisig.wallet.data.blockchain.solana.kamino.coin
 import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
 import com.vultisig.wallet.data.models.OPERATION_KAMINO_WITHDRAW
@@ -395,9 +396,14 @@ constructor(
             // The fee is paid in SOL, never in the vault's underlying token. Denominating it in
             // `coin` rendered a lamport count against USDC's six decimals, so the verify screen
             // read "1 USDC" for a fee of 0.001 SOL. Every sibling Solana flow uses the native coin.
+            //
+            // Falls back to the coin definition rather than refusing when the vault has no native
+            // SOL enabled — the fee is paid out of the same wallet either way, this value is only
+            // ever displayed, and a deposit the user can otherwise afford must not be blocked by
+            // which tokens they happen to have switched on.
             val solCoin =
                 storedVault.coins.firstOrNull { it.chain == Chain.Solana && it.isNativeToken }
-                    ?: error("SOL is not enabled in vault ${route.vaultId}")
+                    ?: Coins.Solana.SOL.copy(address = coin.address)
 
             val specific =
                 blockChainSpecificRepository.getSpecific(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
 import com.vultisig.wallet.data.models.OPERATION_KAMINO_WITHDRAW
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.BalanceRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -391,13 +392,19 @@ constructor(
             val storedVault =
                 vaultRepository.get(route.vaultId) ?: error("Vault ${route.vaultId} not found")
 
-            val gasFee = TokenValue(value = SolanaHelper.DefaultFeeInLamports, token = coin)
+            // The fee is paid in SOL, never in the vault's underlying token. Denominating it in
+            // `coin` rendered a lamport count against USDC's six decimals, so the verify screen
+            // read "1 USDC" for a fee of 0.001 SOL. Every sibling Solana flow uses the native coin.
+            val solCoin =
+                storedVault.coins.firstOrNull { it.chain == Chain.Solana && it.isNativeToken }
+                    ?: error("SOL is not enabled in vault ${route.vaultId}")
+
             val specific =
                 blockChainSpecificRepository.getSpecific(
                     chain = Chain.Solana,
                     address = coin.address,
                     token = coin,
-                    gasFee = gasFee,
+                    gasFee = TokenValue(SolanaHelper.DefaultFeeInLamports, solCoin),
                     isSwap = false,
                     isMaxAmountEnabled = false,
                     isDeposit = true,
@@ -417,6 +424,26 @@ constructor(
                     libType = storedVault.libType,
                 )
 
+            // What this transaction will be charged, read back from the compute budget the payload
+            // records rather than from a flat constant, so the number on this screen is the number
+            // inside the bytes.
+            //
+            // Deliberately the same arithmetic iOS applies to the relayed payload — its base term
+            // is `SolanaHelper.defaultFeeInLamports`, the same 1,000,000, plus price × limit — so
+            // the two devices quote one figure for one transaction instead of two.
+            val recordedBudget = keysignPayload.blockChainSpecific as BlockChainSpecific.Solana
+            val gasFee =
+                TokenValue(
+                    value =
+                        SolanaHelper.DefaultFeeInLamports +
+                            KaminoComputeBudget.priorityFeeLamports(
+                                vault = vault,
+                                action = action,
+                                networkPrice = recordedBudget.priorityFee,
+                            ),
+                    token = solCoin,
+                )
+
             val depositTx =
                 DepositTransaction(
                     id = UUID.randomUUID().toString(),
@@ -428,7 +455,11 @@ constructor(
                     dstAddress = vault.address,
                     estimatedFees = gasFee,
                     estimateFeesFiat = "",
-                    blockChainSpecific = specific.blockChainSpecific,
+                    // The payload's, not `specific`'s. `KeysignShareViewModel` rebuilds the relayed
+                    // KeysignPayload out of this transaction, so whatever is stored here is what a
+                    // co-signer receives — storing the generic values would put them straight back
+                    // and an iPhone would still see a fee that is not the one in the bytes.
+                    blockChainSpecific = keysignPayload.blockChainSpecific,
                     operation =
                         if (route.isWithdraw) OPERATION_KAMINO_WITHDRAW
                         else OPERATION_KAMINO_DEPOSIT,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -18,6 +18,8 @@ import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.repositories.BalanceRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -50,6 +52,7 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SignSolana
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class KaminoAmountViewModelTest {
@@ -371,7 +374,7 @@ internal class KaminoAmountViewModelTest {
                 vaultLocalPartyID = any(),
                 libType = any(),
             )
-        } returns mockk(relaxed = true)
+        } returns keysignPayloadWithKaminoBudget()
 
         val vm = viewModel()
         vm.amountFieldState.setTextAndPlaceCursorAtEnd("100")
@@ -380,6 +383,75 @@ internal class KaminoAmountViewModelTest {
         assertEquals(OPERATION_KAMINO_DEPOSIT, captured.captured.operation)
         assertEquals("Steakhouse USDC", captured.captured.validatorName)
         assertEquals(STEAKHOUSE.address, captured.captured.dstAddress)
+    }
+
+    @Test
+    fun `the stored transaction carries the payload's compute budget, not the generic one`() =
+        runTest {
+            // `KeysignShareViewModel` rebuilds the relayed KeysignPayload out of this transaction,
+            // so whatever is stored here is what a co-signer receives. Storing the generic Solana
+            // values put a 100,000-unit limit back into a transaction whose bytes reserve 320,000,
+            // and an iPhone refused to join: "the network fee inside this transaction is not the
+            // one shown above".
+            givenTokenBalance("2500000000")
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+            coEvery {
+                buildKeysignPayload(
+                    vault = any(),
+                    action = any(),
+                    apiAmount = any(),
+                    tokenAmount = any(),
+                    coin = any(),
+                    blockChainSpecific = any(),
+                    vaultPublicKeyECDSA = any(),
+                    vaultLocalPartyID = any(),
+                    libType = any(),
+                )
+            } returns keysignPayloadWithKaminoBudget()
+
+            val vm = viewModel()
+            vm.amountFieldState.setTextAndPlaceCursorAtEnd("100")
+            vm.submit()
+
+            val stored = captured.captured.blockChainSpecific as BlockChainSpecific.Solana
+            assertEquals(KAMINO_UNIT_LIMIT, stored.priorityLimit)
+            assertEquals(KAMINO_UNIT_PRICE, stored.priorityFee)
+        }
+
+    @Test
+    fun `the network fee is quoted in SOL, not in the vault's underlying token`() = runTest {
+        // A lamport count tagged with USDC's six decimals rendered as "1 USDC" on the verify
+        // screen. The fee is paid in SOL whatever the vault holds.
+        givenTokenBalance("2500000000")
+        val captured = slot<DepositTransaction>()
+        coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+        coEvery {
+            buildKeysignPayload(
+                vault = any(),
+                action = any(),
+                apiAmount = any(),
+                tokenAmount = any(),
+                coin = any(),
+                blockChainSpecific = any(),
+                vaultPublicKeyECDSA = any(),
+                vaultLocalPartyID = any(),
+                libType = any(),
+            )
+        } returns keysignPayloadWithKaminoBudget()
+
+        val vm = viewModel()
+        vm.amountFieldState.setTextAndPlaceCursorAtEnd("100")
+        vm.submit()
+
+        val fee = captured.captured.estimatedFees
+        assertEquals("SOL", fee.unit)
+        // The decimals are half the bug: 1,000,000 lamports against USDC's 6 rendered as "1", and
+        // against SOL's 9 renders as 0.001.
+        assertEquals(9, fee.decimals)
+        // The same arithmetic iOS applies to a relayed payload: 1,000,000 base plus price x limit.
+        assertEquals(BigInteger("1320000"), fee.value)
+        assertEquals(0, BigDecimal("0.00132").compareTo(fee.decimal))
     }
 
     @Test
@@ -403,7 +475,35 @@ internal class KaminoAmountViewModelTest {
         )
     }
 
+    /**
+     * What [BuildKaminoKeysignPayloadUseCase] returns in production: a payload whose chain-specific
+     * records the compute budget injected into the bytes, rather than the generic Solana values it
+     * was built from. A relaxed mock cannot stand in — the ViewModel reads this back.
+     */
+    private fun keysignPayloadWithKaminoBudget() =
+        KeysignPayload(
+            coin = COIN,
+            toAddress = STEAKHOUSE.address,
+            toAmount = BigInteger("100000000"),
+            blockChainSpecific =
+                BlockChainSpecific.Solana(
+                    recentBlockHash = "",
+                    priorityFee = KAMINO_UNIT_PRICE,
+                    priorityLimit = KAMINO_UNIT_LIMIT,
+                ),
+            memo = null,
+            vaultPublicKeyECDSA = "",
+            vaultLocalPartyID = "",
+            libType = SigningLibType.DKLS,
+            wasmExecuteContractPayload = null,
+            signSolana = SignSolana(rawTransactions = listOf("tx")),
+        )
+
     private companion object {
+        /** The clamped price and the token-deposit limit a Steakhouse USDC deposit carries. */
+        val KAMINO_UNIT_PRICE: BigInteger = BigInteger("1000000")
+        val KAMINO_UNIT_LIMIT: BigInteger = BigInteger("320000")
+
         const val VAULT_ID = "vault-id"
         const val WALLET = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
 

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -140,4 +140,5 @@ dependencies {
     // `testInstrumentationRunner` above names AndroidJUnitRunner, but nothing put it on the
     // classpath, so every instrumented test in this module failed to start.
     androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
 }

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCaseTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCaseTest.kt
@@ -10,6 +10,7 @@ import java.math.BigInteger
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
 import wallet.core.jni.SolanaTransaction
@@ -72,6 +73,11 @@ class BuildKaminoKeysignPayloadUseCaseTest {
                         recentBlockHash = "",
                         priorityFee = networkSample,
                         priorityLimit = genericLimit,
+                        // The shape a token deposit produces: the sender's token account is known,
+                        // the destination's is not. iOS reads exactly this as "an ATA must be
+                        // created" and adds rent for it.
+                        fromAddressPubKey = "6dqjbdM6yEkT1x4LcvMRxr5vfnKvUyBUsHqBcxYRJmVW",
+                        toAddressPubKey = null,
                     ),
                 vaultPublicKeyECDSA = "",
                 vaultLocalPartyID = "",
@@ -115,12 +121,23 @@ class BuildKaminoKeysignPayloadUseCaseTest {
     }
 
     @Test
+    fun the_token_account_hints_are_cleared_so_no_phantom_ATA_rent_is_added() {
+        val specific = build().blockChainSpecific as BlockChainSpecific.Solana
+
+        // iOS does not relay an ATA rent figure, it infers one: a named from-account with no
+        // to-account means "create an ATA", worth 2,039,280 lamports. Kamino's bytes create
+        // whatever they need internally, so relaying these overstated the fee by 0.00204 SOL.
+        assertNull(specific.fromAddressPubKey)
+        assertNull(specific.toAddressPubKey)
+    }
+
+    @Test
     fun the_recorded_fee_is_what_the_user_will_actually_be_charged() {
         val specific = build().blockChainSpecific as BlockChainSpecific.Solana
 
-        // price x limit / 1e6. Against the generic pair the verify screen showed 3,134,280
-        // lamports of priority fee for a transaction that reserves 320,000 — off by an order of
-        // magnitude, in the direction that overstates the cost.
+        // price x limit / 1e6. Against the generic pair this term was 100,000 lamports for a
+        // transaction that reserves 320,000 — and the co-signer quoted 0.00313928 SOL overall:
+        // 1,000,000 base + 2,039,280 of ATA rent it inferred + those 100,000.
         val lamports =
             specific.priorityFee
                 .multiply(specific.priorityLimit)

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCaseTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCaseTest.kt
@@ -5,9 +5,10 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
 import java.math.BigDecimal
 import java.math.BigInteger
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNull
@@ -55,13 +56,13 @@ class BuildKaminoKeysignPayloadUseCaseTest {
         WalletCoreNative.ensureLoaded()
     }
 
-    private fun build(action: KaminoAction = KaminoAction.DEPOSIT) = runBlocking {
+    private suspend fun build(action: KaminoAction = KaminoAction.DEPOSIT): KeysignPayload {
         val api =
             KaminoFixtureApi(
                 if (action == KaminoAction.WITHDRAW) KaminoFixtures.WITHDRAW
                 else KaminoFixtures.DEPOSIT
             )
-        BuildKaminoKeysignPayloadUseCase(KaminoTransactionPreparer(api))
+        return BuildKaminoKeysignPayloadUseCase(KaminoTransactionPreparer(api))
             .invoke(
                 vault = vault,
                 action = action,
@@ -86,9 +87,9 @@ class BuildKaminoKeysignPayloadUseCaseTest {
     }
 
     @Test
-    fun the_recorded_compute_budget_is_the_one_inside_the_transaction() {
+    fun the_recorded_compute_budget_is_the_one_inside_the_transaction() = runTest {
         val payload = build()
-        val raw = payload.signSolana!!.rawTransactions.single()
+        val raw = checkNotNull(payload.signSolana).rawTransactions.single()
         val specific = payload.blockChainSpecific as BlockChainSpecific.Solana
 
         // Exactly the comparison iOS makes before it will join.
@@ -105,7 +106,7 @@ class BuildKaminoKeysignPayloadUseCaseTest {
     }
 
     @Test
-    fun the_generic_solana_values_are_replaced_rather_than_relayed() {
+    fun the_generic_solana_values_are_replaced_rather_than_relayed() = runTest {
         val specific = build().blockChainSpecific as BlockChainSpecific.Solana
 
         // Both differ from what came in, which is the whole bug: relaying either unchanged is what
@@ -121,7 +122,7 @@ class BuildKaminoKeysignPayloadUseCaseTest {
     }
 
     @Test
-    fun the_token_account_hints_are_cleared_so_no_phantom_ATA_rent_is_added() {
+    fun the_token_account_hints_are_cleared_so_no_phantom_ATA_rent_is_added() = runTest {
         val specific = build().blockChainSpecific as BlockChainSpecific.Solana
 
         // iOS does not relay an ATA rent figure, it infers one: a named from-account with no
@@ -132,7 +133,7 @@ class BuildKaminoKeysignPayloadUseCaseTest {
     }
 
     @Test
-    fun the_recorded_fee_is_what_the_user_will_actually_be_charged() {
+    fun the_recorded_fee_is_what_the_user_will_actually_be_charged() = runTest {
         val specific = build().blockChainSpecific as BlockChainSpecific.Solana
 
         // price x limit / 1e6. Against the generic pair this term was 100,000 lamports for a

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCaseTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCaseTest.kt
@@ -1,0 +1,134 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.WalletCoreNative
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import wallet.core.jni.SolanaTransaction
+
+/**
+ * The payload has to record the compute budget the bytes actually carry.
+ *
+ * iOS refuses to co-sign otherwise. `KaminoVerifyPresentation.priorityFeeAgrees` compares the
+ * relayed `BlockChainSpecific.Solana(priorityFee, priorityLimit)` against the ComputeBudget pair it
+ * decodes out of the transaction and requires **equality**, showing "the network fee inside this
+ * transaction is not the one shown above. Do not sign it." on any difference.
+ *
+ * The generic Solana values these payloads are built from describe a plain transfer — a
+ * 100,000-unit limit and the raw network sample — so relaying them unchanged both blocked every
+ * iPhone co-signer and priced the verify screen off a limit no Kamino transaction uses.
+ */
+class BuildKaminoKeysignPayloadUseCaseTest {
+
+    private val vault = KaminoVaultRegistry.STEAKHOUSE_USDC
+
+    /** A sample above the ceiling, which is what `getMedianPriorityFee` routinely returns. */
+    private val networkSample = BigInteger.valueOf(31_342_800)
+
+    /** The app-wide Solana compute limit, which is not the limit a Kamino transaction reserves. */
+    private val genericLimit = BigInteger.valueOf(100_000)
+
+    private val coin =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "USDC",
+            logo = "usdc",
+            address = KaminoFixtures.WALLET,
+            decimal = vault.tokenDecimals,
+            hexPublicKey = "",
+            priceProviderID = "usd-coin",
+            contractAddress = KaminoVaultRegistry.USDC_MINT,
+            isNativeToken = false,
+        )
+
+    @Before
+    fun loadWalletCore() {
+        WalletCoreNative.ensureLoaded()
+    }
+
+    private fun build(action: KaminoAction = KaminoAction.DEPOSIT) = runBlocking {
+        val api =
+            KaminoFixtureApi(
+                if (action == KaminoAction.WITHDRAW) KaminoFixtures.WITHDRAW
+                else KaminoFixtures.DEPOSIT
+            )
+        BuildKaminoKeysignPayloadUseCase(KaminoTransactionPreparer(api))
+            .invoke(
+                vault = vault,
+                action = action,
+                apiAmount = "1",
+                tokenAmount = BigDecimal.ONE,
+                coin = coin,
+                blockChainSpecific =
+                    BlockChainSpecific.Solana(
+                        recentBlockHash = "",
+                        priorityFee = networkSample,
+                        priorityLimit = genericLimit,
+                    ),
+                vaultPublicKeyECDSA = "",
+                vaultLocalPartyID = "",
+                libType = SigningLibType.DKLS,
+            )
+    }
+
+    @Test
+    fun the_recorded_compute_budget_is_the_one_inside_the_transaction() {
+        val payload = build()
+        val raw = payload.signSolana!!.rawTransactions.single()
+        val specific = payload.blockChainSpecific as BlockChainSpecific.Solana
+
+        // Exactly the comparison iOS makes before it will join.
+        assertEquals(
+            "recorded limit must equal the SetComputeUnitLimit in the bytes",
+            SolanaTransaction.getComputeUnitLimit(raw),
+            specific.priorityLimit.toString(),
+        )
+        assertEquals(
+            "recorded price must equal the SetComputeUnitPrice in the bytes",
+            SolanaTransaction.getComputeUnitPrice(raw),
+            specific.priorityFee.toString(),
+        )
+    }
+
+    @Test
+    fun the_generic_solana_values_are_replaced_rather_than_relayed() {
+        val specific = build().blockChainSpecific as BlockChainSpecific.Solana
+
+        // Both differ from what came in, which is the whole bug: relaying either unchanged is what
+        // an iPhone reads as a fee that is not the one shown.
+        assertEquals(
+            KaminoComputeBudget.unitLimitFor(vault, KaminoAction.DEPOSIT),
+            specific.priorityLimit,
+        )
+        assertNotEquals(genericLimit, specific.priorityLimit)
+
+        assertEquals(KaminoComputeBudget.MAX_UNIT_PRICE, specific.priorityFee)
+        assertNotEquals(networkSample, specific.priorityFee)
+    }
+
+    @Test
+    fun the_recorded_fee_is_what_the_user_will_actually_be_charged() {
+        val specific = build().blockChainSpecific as BlockChainSpecific.Solana
+
+        // price x limit / 1e6. Against the generic pair the verify screen showed 3,134,280
+        // lamports of priority fee for a transaction that reserves 320,000 — off by an order of
+        // magnitude, in the direction that overstates the cost.
+        val lamports =
+            specific.priorityFee
+                .multiply(specific.priorityLimit)
+                .divide(BigInteger.valueOf(1_000_000))
+        assertEquals(BigInteger.valueOf(320_000), lamports)
+        assertEquals(
+            KaminoComputeBudget.priorityFeeLamports(vault, KaminoAction.DEPOSIT, networkSample),
+            lamports,
+        )
+    }
+}

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoFixtures.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoFixtures.kt
@@ -1,0 +1,92 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.KaminoPnlJson
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
+
+/**
+ * Live Kamino responses, captured once and shared by the tests that exercise the prepare pipeline.
+ *
+ * Kept here rather than inside one test class so the payload coverage and the preparer coverage
+ * assert against the same bytes — the point of both is that what the payload records and what the
+ * transaction carries are the same compute budget.
+ */
+internal object KaminoFixtures {
+
+    /** A live `POST /ktx/kvault/deposit` response for the Steakhouse USDC vault. */
+    const val DEPOSIT =
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
+            "AQAFCX//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuemOEsQm7A2IghRdbzU0ar6Q7dIhEJA6xfcD32X" +
+            "M4YwfPSF38N5IeLVVX5/3BJfld0IR08X1RB7fe6uQkeVw/nk3uVtPK//R3XanFktvqbKIbsjaArJEZzlqWvc" +
+            "axKftHFhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2mzp9mGY3YcNiphvMGdcRvg+L1KDSHlS" +
+            "9dUFY+PveoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZ2LAQF2PT5R8SbmFW3oXejGEwWbhEaNDa" +
+            "P+iioiUcxwEE2Qrx24k57DX/lNlkDVfcwyeUuz4btm/TroSahNzblDJCgcwkFVHRKh2nMxb4pfSsIMN/m4f+" +
+            "R1HblBX15CRABAYGAAMACQQaAQEIFQARDRYUCQEDGBoaBQgQDwoMFRMXEhDyI8aJUuHytkBCDwAAAAAABwgA" +
+            "AAAAAgsEGQhvEbn6PHom/gcIAAILDgMJBxoQzrDKEsjRs2z//////////wGC6dRmw0Z9LrKw2cy+tHvb9JXu" +
+            "HBu0d9Dar60DX6fr5AkFNTElLzITCQEJJxUECwI3BwYD"
+
+    /**
+     * A live `POST /ktx/kvault/withdraw` response for the same vault: create the destination token
+     * account, then `kVault::withdraw`.
+     *
+     * Kamino built it for a wallet holding no position at all — the clearest evidence that the
+     * endpoint validates nothing about the amount it is handed, and also why there is nothing
+     * staked to release here.
+     *
+     * **This is therefore the UNSTAKED shape, which is not the one most holders will send.** A
+     * withdraw against a staked position carries two extra `farms` instructions and a second
+     * account creation ahead of the vault withdraw. Capturing that needs a wallet actually holding
+     * a staked position, which these vaults only produce by depositing real funds, so the limit
+     * sized for it rests on the iOS mainnet measurements (283,786 / 289,486 / 309,310) rather than
+     * on anything this suite proves.
+     */
+    const val WITHDRAW =
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
+            "AQAFCH//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuemOEsQm7A2IghRdbzU0ar6Q7dIhEJA6xfcD32XM4Yw" +
+            "fPTlbTyv/0d12pxZLb6myiG7I2gKyRGc5alr3GsSn7RxYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
+            "D9ps6fZhmN2HDYqYbzBnXEb4Pi9Sg0h5UvXVBWPj73qMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZlx" +
+            "KXooAEJJPkJxkMd7ZH6G99GZch/RVimWXJ1rZZT4BNkK8duJOew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25TcFsAN" +
+            "s3q6CtgzQiIGiofmyao3Sh0Dq7RowlSc92jsQgIFBgABAA0DFgEBBxYADwYLEgENAggWFhUEBw4MCQoTERQQEBOD" +
+            "cJuq3CI5//////////8BgunUZsNGfS6ysNnMvrR72/SV7hwbtHfQ2q+tA1+n6+QIBTUlLxMCCQEHJxUECzcHAw=="
+
+    /** The wallet the fixtures above were built for — their fee payer and only required signer. */
+    const val WALLET = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+}
+
+/** Returns the captured transaction for whatever is asked, so the pipeline is what's under test. */
+internal class KaminoFixtureApi(private val transaction: String = KaminoFixtures.DEPOSIT) :
+    KaminoApi {
+    var lastAmount: String? = null
+    var lastVault: String? = null
+
+    override suspend fun getVaultState(vaultAddress: String) = error("not used")
+
+    override suspend fun getVaultMetrics(vaultAddress: String) = KaminoVaultMetricsJson()
+
+    override suspend fun getUserPositions(walletAddress: String): List<KaminoUserPositionJson> =
+        emptyList()
+
+    override suspend fun getPositionPnl(walletAddress: String, vaultAddress: String) =
+        KaminoPnlJson()
+
+    override suspend fun buildDeposit(
+        walletAddress: String,
+        vaultAddress: String,
+        amount: String,
+    ): String {
+        lastAmount = amount
+        lastVault = vaultAddress
+        return transaction
+    }
+
+    override suspend fun buildWithdraw(
+        walletAddress: String,
+        vaultAddress: String,
+        amount: String,
+    ): String {
+        lastAmount = amount
+        lastVault = vaultAddress
+        return transaction
+    }
+}

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -230,6 +230,43 @@ class KaminoTransactionPreparerTest {
     }
 
     @Test
+    fun the_unit_price_is_capped_at_the_ceiling_an_iPhone_co_signer_will_accept() {
+        // iOS clamps the sample into the same range and its decoder refuses a transaction priced
+        // outside it, so an uncapped price is one no iPhone will join. The sample reaching here
+        // comes from `getMedianPriorityFee`, which already floors at 1,000,000 and caps at
+        // 100,000,000 — every congested-network reading is above the ceiling, not an edge case.
+        val capped = prepare(networkUnitPrice = BigInteger.valueOf(100_000_000))
+        assertEquals(
+            KaminoComputeBudget.MAX_UNIT_PRICE.toString(),
+            SolanaTransaction.getComputeUnitPrice(capped),
+        )
+    }
+
+    @Test
+    fun a_response_that_already_carries_a_compute_budget_is_refused_rather_than_double_priced() {
+        // The price is now inserted rather than set, and an insert cannot overwrite. If Kamino ever
+        // starts returning its own `SetComputeUnitPrice`, ours would be a second one and the chain
+        // would reject the transaction — after a full signing ceremony had been spent on it.
+        val alreadyPriced =
+            checkNotNull(
+                SolanaTransaction.insertInstruction(
+                    depositFixture,
+                    -1,
+                    KaminoComputeBudget.setUnitPriceInstructionJson(BigInteger.valueOf(7_000)),
+                )
+            )
+
+        val rejection =
+            assertThrows(IllegalStateException::class.java) {
+                prepare(api = FixtureApi(alreadyPriced))
+            }
+        assertTrue(
+            "unexpected reason: ${rejection.message}",
+            rejection.message.orEmpty().contains("ComputeBudget instructions at"),
+        )
+    }
+
+    @Test
     fun preparing_stays_within_the_transaction_size_limit() {
         val size = Base64.getDecoder().decode(prepare()).size
         assertTrue("prepared transaction was $size bytes", size <= 1232)

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -2,9 +2,6 @@ package com.vultisig.wallet.data.blockchain.solana.kamino
 
 import com.vultisig.wallet.data.WalletCoreNative
 import com.vultisig.wallet.data.api.KaminoApi
-import com.vultisig.wallet.data.api.KaminoPnlJson
-import com.vultisig.wallet.data.api.KaminoUserPositionJson
-import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
 import java.math.BigInteger
 import java.util.Base64
 import kotlinx.coroutines.runBlocking
@@ -28,81 +25,6 @@ import wallet.core.jni.SolanaTransaction
  */
 class KaminoTransactionPreparerTest {
 
-    private val depositFixture =
-        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
-            "AQAFCX//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuemOEsQm7A2IghRdbzU0ar6Q7dIhEJA6xfcD32X" +
-            "M4YwfPSF38N5IeLVVX5/3BJfld0IR08X1RB7fe6uQkeVw/nk3uVtPK//R3XanFktvqbKIbsjaArJEZzlqWvc" +
-            "axKftHFhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP2mzp9mGY3YcNiphvMGdcRvg+L1KDSHlS" +
-            "9dUFY+PveoyXJY9OJInxuz0QKRSODYMLWhOZ2v8QhASOe9jb6fhZ2LAQF2PT5R8SbmFW3oXejGEwWbhEaNDa" +
-            "P+iioiUcxwEE2Qrx24k57DX/lNlkDVfcwyeUuz4btm/TroSahNzblDJCgcwkFVHRKh2nMxb4pfSsIMN/m4f+" +
-            "R1HblBX15CRABAYGAAMACQQaAQEIFQARDRYUCQEDGBoaBQgQDwoMFRMXEhDyI8aJUuHytkBCDwAAAAAABwgA" +
-            "AAAAAgsEGQhvEbn6PHom/gcIAAILDgMJBxoQzrDKEsjRs2z//////////wGC6dRmw0Z9LrKw2cy+tHvb9JXu" +
-            "HBu0d9Dar60DX6fr5AkFNTElLzITCQEJJxUECwI3BwYD"
-
-    /**
-     * A live `POST /ktx/kvault/withdraw` response for the same vault: create the destination token
-     * account, then `kVault::withdraw`.
-     *
-     * Kamino built it for a wallet holding no position at all — the clearest evidence that the
-     * endpoint validates nothing about the amount it is handed, and also why there is nothing
-     * staked to release here.
-     *
-     * **This is therefore the UNSTAKED shape, which is not the one most holders will send.** A
-     * withdraw against a staked position carries two extra `farms` instructions and a second
-     * account creation ahead of the vault withdraw. Capturing that needs a wallet actually holding
-     * a staked position, which these vaults only produce by depositing real funds, so the limit
-     * sized for it rests on the iOS mainnet measurements (283,786 / 289,486 / 309,310) rather than
-     * on anything this suite proves.
-     */
-    private val withdrawFixture =
-        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
-            "AQAFCH//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuemOEsQm7A2IghRdbzU0ar6Q7dIhEJA6xfcD32XM4Yw" +
-            "fPTlbTyv/0d12pxZLb6myiG7I2gKyRGc5alr3GsSn7RxYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" +
-            "D9ps6fZhmN2HDYqYbzBnXEb4Pi9Sg0h5UvXVBWPj73qMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZlx" +
-            "KXooAEJJPkJxkMd7ZH6G99GZch/RVimWXJ1rZZT4BNkK8duJOew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25TcFsAN" +
-            "s3q6CtgzQiIGiofmyao3Sh0Dq7RowlSc92jsQgIFBgABAA0DFgEBBxYADwYLEgENAggWFhUEBw4MCQoTERQQEBOD" +
-            "cJuq3CI5//////////8BgunUZsNGfS6ysNnMvrR72/SV7hwbtHfQ2q+tA1+n6+QIBTUlLxMCCQEHJxUECzcHAw=="
-
-    private val wallet = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
-
-    /**
-     * Returns the captured transaction for whatever is asked, so the pipeline is what's under test.
-     */
-    private inner class FixtureApi(private val transaction: String = depositFixture) : KaminoApi {
-        var lastAmount: String? = null
-        var lastVault: String? = null
-
-        override suspend fun getVaultState(vaultAddress: String) = error("not used")
-
-        override suspend fun getVaultMetrics(vaultAddress: String) = KaminoVaultMetricsJson()
-
-        override suspend fun getUserPositions(walletAddress: String): List<KaminoUserPositionJson> =
-            emptyList()
-
-        override suspend fun getPositionPnl(walletAddress: String, vaultAddress: String) =
-            KaminoPnlJson()
-
-        override suspend fun buildDeposit(
-            walletAddress: String,
-            vaultAddress: String,
-            amount: String,
-        ): String {
-            lastAmount = amount
-            lastVault = vaultAddress
-            return transaction
-        }
-
-        override suspend fun buildWithdraw(
-            walletAddress: String,
-            vaultAddress: String,
-            amount: String,
-        ): String {
-            lastAmount = amount
-            lastVault = vaultAddress
-            return transaction
-        }
-    }
-
     @Before
     fun loadWalletCore() {
         WalletCoreNative.ensureLoaded()
@@ -116,14 +38,15 @@ class KaminoTransactionPreparerTest {
     ): String = runBlocking {
         val resolved =
             api
-                ?: FixtureApi(
-                    if (action == KaminoAction.WITHDRAW) withdrawFixture else depositFixture
+                ?: KaminoFixtureApi(
+                    if (action == KaminoAction.WITHDRAW) KaminoFixtures.WITHDRAW
+                    else KaminoFixtures.DEPOSIT
                 )
         KaminoTransactionPreparer(resolved)
             .prepare(
                 vault = vault,
                 action = action,
-                walletAddress = wallet,
+                walletAddress = KaminoFixtures.WALLET,
                 amount = "1",
                 networkUnitPrice = networkUnitPrice,
             )
@@ -250,7 +173,7 @@ class KaminoTransactionPreparerTest {
         val alreadyPriced =
             checkNotNull(
                 SolanaTransaction.insertInstruction(
-                    depositFixture,
+                    KaminoFixtures.DEPOSIT,
                     -1,
                     KaminoComputeBudget.setUnitPriceInstructionJson(BigInteger.valueOf(7_000)),
                 )
@@ -258,7 +181,7 @@ class KaminoTransactionPreparerTest {
 
         val rejection =
             assertThrows(IllegalStateException::class.java) {
-                prepare(api = FixtureApi(alreadyPriced))
+                prepare(api = KaminoFixtureApi(alreadyPriced))
             }
         assertTrue(
             "unexpected reason: ${rejection.message}",
@@ -276,7 +199,7 @@ class KaminoTransactionPreparerTest {
     fun the_decimal_amount_reaches_Kamino_unscaled() {
         // Kamino wants decimals on the way in; sending base units would deposit a millionth of the
         // intended amount.
-        val api = FixtureApi()
+        val api = KaminoFixtureApi()
         prepare(api = api)
         assertEquals("1", api.lastAmount)
         assertEquals(KaminoVaultRegistry.STEAKHOUSE_USDC.address, api.lastVault)
@@ -290,7 +213,7 @@ class KaminoTransactionPreparerTest {
         val foreign =
             checkNotNull(
                 SolanaTransaction.insertInstruction(
-                    depositFixture,
+                    KaminoFixtures.DEPOSIT,
                     -1,
                     """{"programId":"${KaminoAttributionMemo.MEMO_PROGRAM_ID}","accounts":[],"data":"3yZe7d"}""",
                 )
@@ -298,7 +221,7 @@ class KaminoTransactionPreparerTest {
 
         val rejection =
             assertThrows(KaminoTransactionRejected::class.java) {
-                prepare(api = FixtureApi(foreign))
+                prepare(api = KaminoFixtureApi(foreign))
             }
         assertTrue(
             "unexpected reason: ${rejection.message}",
@@ -313,7 +236,7 @@ class KaminoTransactionPreparerTest {
         // slots as the message to hash. Three WalletCore mutations happen before that, so the
         // envelope has to come out the far side with the same shape or signing writes to the wrong
         // bytes and the co-signers hash different messages.
-        val before = Base64.getDecoder().decode(depositFixture)
+        val before = Base64.getDecoder().decode(KaminoFixtures.DEPOSIT)
         val after = Base64.getDecoder().decode(prepare())
 
         assertEquals("signature count must stay 1", 1, before[0].toInt())
@@ -362,7 +285,7 @@ class KaminoTransactionPreparerTest {
         // no farms instruction (nothing was staked, so nothing had to be released). Asserted on the
         // decode rather than through prepare, which correctly refuses the sentinel above.
         val instructions =
-            KaminoTransactionDecoder.decode(KaminoAttributionMemo.append(withdrawFixture))
+            KaminoTransactionDecoder.decode(KaminoAttributionMemo.append(KaminoFixtures.WITHDRAW))
                 .instructions
 
         assertTrue(
@@ -386,7 +309,7 @@ class KaminoTransactionPreparerTest {
                 KaminoTransactionValidator.validate(
                     decoded =
                         KaminoTransactionDecoder.decode(
-                            KaminoAttributionMemo.append(withdrawFixture)
+                            KaminoAttributionMemo.append(KaminoFixtures.WITHDRAW)
                         ),
                     vault = KaminoVaultRegistry.STEAKHOUSE_USDC,
                     action = KaminoAction.WITHDRAW,
@@ -402,7 +325,7 @@ class KaminoTransactionPreparerTest {
     @Test
     fun a_malformed_response_from_Kamino_fails_loudly_instead_of_reaching_keysign() {
         assertThrows(IllegalStateException::class.java) {
-            prepare(api = FixtureApi("not-base64-tx"))
+            prepare(api = KaminoFixtureApi("not-base64-tx"))
         }
     }
 }

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
 import java.math.BigInteger
 import java.util.Base64
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
@@ -19,9 +20,11 @@ import wallet.core.jni.SolanaTransaction
  * End-to-end coverage of the prepare pipeline on a real Kamino deposit: compute budget in, memo on
  * top, decode, validate.
  *
- * The ordering here is load-bearing rather than incidental. WalletCore appends a compute-budget
- * instruction when none exists — the same append the memo uses — so injecting the budget after the
- * memo would leave the memo mid-list and the validator would refuse it. These tests pin that.
+ * The ordering here is load-bearing rather than incidental, in two directions. The memo is
+ * appended, so injecting the budget after it would leave the memo mid-list and the validator would
+ * refuse it. And the budget pair has to lead the transaction as limit-then-price, because an iPhone
+ * co-signer emits the same two at 0 and 1 and matches everything after them by position. These
+ * tests pin both.
  */
 class KaminoTransactionPreparerTest {
 
@@ -145,6 +148,49 @@ class KaminoTransactionPreparerTest {
         assertTrue(
             "the kVault program must still be invoked",
             instructions.any { it.programId == KaminoVaultRegistry.PROGRAM_ID },
+        )
+    }
+
+    @Test
+    fun the_compute_budget_leads_the_transaction_as_limit_then_price() {
+        // The layout an iPhone co-signer matches against positionally: limit at 0, price at 1,
+        // everything Kamino built after them, memo last. WalletCore's own `setComputeUnitPrice`
+        // appends instead, which put the price after the ATA creation and the vault deposit and
+        // made
+        // every Android-initiated Kamino transaction unjoinable from iOS.
+        val instructions = KaminoTransactionDecoder.decode(prepare()).instructions
+
+        assertEquals(KaminoComputeBudget.PROGRAM_ID, instructions[0].programId)
+        assertEquals(
+            KaminoComputeBudget.SET_UNIT_LIMIT_DISCRIMINATOR,
+            instructions[0].data.first().toInt() and 0xFF,
+        )
+
+        assertEquals(KaminoComputeBudget.PROGRAM_ID, instructions[1].programId)
+        assertEquals(
+            KaminoComputeBudget.SET_UNIT_PRICE_DISCRIMINATOR,
+            instructions[1].data.first().toInt() and 0xFF,
+        )
+        // The exact bytes the app encoded, so a re-encoding regression cannot pass by carrying some
+        // other price at the right position.
+        assertArrayEquals(
+            KaminoComputeBudget.setUnitPriceData(KaminoComputeBudget.FALLBACK_UNIT_PRICE),
+            instructions[1].data,
+        )
+
+        // Nothing else invokes ComputeBudget: a stray third would mean the append is still
+        // happening
+        // somewhere.
+        assertEquals(2, instructions.count { it.programId == KaminoComputeBudget.PROGRAM_ID })
+        assertEquals(KaminoAttributionMemo.MEMO_PROGRAM_ID, instructions.last().programId)
+        // The instructions Kamino built sit between the budget and the memo, in the order it
+        // returned them — which is what makes matching them by position meaningful at all.
+        assertTrue(
+            "Kamino's own instructions must sit between the budget and the memo",
+            instructions.subList(2, instructions.size - 1).none {
+                it.programId == KaminoComputeBudget.PROGRAM_ID ||
+                    it.programId == KaminoAttributionMemo.MEMO_PROGRAM_ID
+            },
         )
     }
 

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -130,6 +130,12 @@ class KaminoTransactionPreparerTest {
 
     @Test
     fun a_SOL_vault_deposit_gets_the_larger_budget_it_needs_to_wrap_first() {
+        // Note the fixture: this is the captured **USDC** deposit prepared against the SOL vault,
+        // because no ALLEZ_SOL response has been captured — doing so needs a wallet depositing real
+        // SOL. So what this pins is that the vault selects the larger limit and that the limit
+        // reaches the wire; the wrap-and-sync instruction shape a real SOL deposit carries is not
+        // exercised here. Inventing bytes for it would assert against a transaction Kamino never
+        // sent. The 350,000 value itself rests on the iOS mainnet measurement of 287,029.
         val prepared = prepare(vault = KaminoVaultRegistry.ALLEZ_SOL)
         assertEquals(350_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong())
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
@@ -63,6 +63,24 @@ constructor(private val preparer: KaminoTransactionPreparer) {
                 networkUnitPrice = solanaSpecific.priorityFee,
             )
 
+        // The compute budget the app just injected, recorded where the payload carries it.
+        //
+        // The generic Solana values these arrive as describe a plain transfer — a 100,000-unit
+        // limit and the raw network sample — and neither is what went into these bytes. iOS
+        // compares the two for equality before it will co-sign (`KaminoVerifyPresentation
+        // .priorityFeeAgrees`) and refuses on any difference, with "the network fee inside this
+        // transaction is not the one shown above". The same mismatch also makes the fee on the
+        // verify screen wrong: it would be priced off 100,000 units rather than the 320,000–400,000
+        // these actually reserve.
+        //
+        // `unitPriceFor` is idempotent, so passing the sample to both this and `prepare` above
+        // yields the same price by construction rather than by coincidence.
+        val kaminoSpecific =
+            solanaSpecific.copy(
+                priorityFee = KaminoComputeBudget.unitPriceFor(solanaSpecific.priorityFee),
+                priorityLimit = KaminoComputeBudget.unitLimitFor(vault, action),
+            )
+
         return KeysignPayload(
             coin = coin,
             // Display destination on the verify screen. Routing is driven by the relayed bytes, not
@@ -76,7 +94,7 @@ constructor(private val preparer: KaminoTransactionPreparer) {
                     // how the staking flows handle over-precise input.
                     .setScale(0, RoundingMode.DOWN)
                     .toBigInteger(),
-            blockChainSpecific = blockChainSpecific,
+            blockChainSpecific = kaminoSpecific,
             memo = null,
             vaultPublicKeyECDSA = vaultPublicKeyECDSA,
             vaultLocalPartyID = vaultLocalPartyID,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
@@ -79,6 +79,14 @@ constructor(private val preparer: KaminoTransactionPreparer) {
             solanaSpecific.copy(
                 priorityFee = KaminoComputeBudget.unitPriceFor(solanaSpecific.priorityFee),
                 priorityLimit = KaminoComputeBudget.unitLimitFor(vault, action),
+                // Cleared, not carried. iOS does not relay an ATA rent figure — it *infers* one,
+                // adding 2,039,280 lamports whenever the from-address token account is named and
+                // the to-address one is not, which is exactly the shape a token deposit produces
+                // here. Kamino's own transaction creates whatever accounts it needs inside the
+                // bytes, so that surcharge describes a transfer this is not. iOS's own Kamino
+                // factory sets both to nil for the same reason.
+                fromAddressPubKey = null,
+                toAddressPubKey = null,
             )
 
         return KeysignPayload(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
@@ -1,6 +1,10 @@
 package com.vultisig.wallet.data.blockchain.solana.kamino
 
 import java.math.BigInteger
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import wallet.core.jni.Base58
 
 /**
  * Which side of a vault a transaction is on. Selects the compute-unit budget and the validator's
@@ -21,6 +25,15 @@ enum class KaminoAction {
  * the transaction actually needs.
  */
 object KaminoComputeBudget {
+
+    /** The ComputeBudget program both injected instructions invoke. */
+    const val PROGRAM_ID = "ComputeBudget111111111111111111111111111111"
+
+    /** `ComputeBudgetInstruction::SetComputeUnitLimit`, borsh discriminator 2, then a `u32`. */
+    const val SET_UNIT_LIMIT_DISCRIMINATOR = 2
+
+    /** `ComputeBudgetInstruction::SetComputeUnitPrice`, borsh discriminator 3, then a `u64`. */
+    const val SET_UNIT_PRICE_DISCRIMINATOR = 3
 
     /**
      * Compute units these transactions actually consume, measured on mainnet via
@@ -95,4 +108,44 @@ object KaminoComputeBudget {
     }
 
     private val MICRO_LAMPORTS_PER_LAMPORT = BigInteger.valueOf(1_000_000)
+
+    /**
+     * The `SetComputeUnitPrice` instruction as WalletCore's JSON instruction format, ready to
+     * insert at a chosen position.
+     *
+     * Built here rather than left to `SolanaTransaction.setComputeUnitPrice`, which appends: the
+     * two budget instructions have to sit together at the front, and the helper would leave the
+     * price behind every instruction Kamino built. See [KaminoTransactionPreparer] for why the
+     * position is part of the cross-platform contract.
+     *
+     * The instruction takes no accounts, and `data` is base58 — the encoding WalletCore's JSON
+     * format expects, not base64.
+     */
+    fun setUnitPriceInstructionJson(price: BigInteger): String =
+        buildJsonObject {
+                put("programId", PROGRAM_ID)
+                put("accounts", JsonArray(emptyList()))
+                put("data", Base58.encodeNoCheck(setUnitPriceData(price)))
+            }
+            .toString()
+
+    /**
+     * Borsh-encoded `SetComputeUnitPrice`: the discriminator byte followed by the micro-lamport
+     * price as a little-endian `u64`.
+     */
+    fun setUnitPriceData(price: BigInteger): ByteArray {
+        require(price.signum() >= 0 && price.bitLength() <= 64) {
+            "compute-unit price $price does not fit a u64"
+        }
+        val data = ByteArray(9)
+        data[0] = SET_UNIT_PRICE_DISCRIMINATOR.toByte()
+        var remaining = price
+        for (offset in 1..8) {
+            data[offset] = remaining.and(BYTE_MASK).toInt().toByte()
+            remaining = remaining.shiftRight(8)
+        }
+        return data
+    }
+
+    private val BYTE_MASK = BigInteger.valueOf(0xFF)
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
@@ -75,6 +75,22 @@ object KaminoComputeBudget {
      */
     val FALLBACK_UNIT_PRICE: BigInteger = BigInteger.valueOf(20_000)
 
+    /**
+     * Ceiling on the sampled price, in micro-lamports per compute unit.
+     *
+     * The sample is a number a remote node hands us, multiplied by a six-figure limit to produce
+     * lamports the user pays, so unbounded it is an unbounded fee. At this ceiling and the largest
+     * limit the priority fee tops out at 400,000 lamports (0.0004 SOL).
+     *
+     * It is also a cross-platform contract, not just a spend cap: iOS clamps into the same `[floor,
+     * ceiling]` range and its decoder *refuses* a transaction priced outside it
+     * (`KaminoTransactionDecoder.swift`), so anything above this is a transaction an iPhone
+     * co-signer will not join. That is not a hypothetical here — the sample this receives comes
+     * from `SolanaApi.getMedianPriorityFee`, which floors at the app-wide 1,000,000 and caps at
+     * 100,000,000, so every congested-network sample would land above the ceiling unclamped.
+     */
+    val MAX_UNIT_PRICE: BigInteger = BigInteger.valueOf(1_000_000)
+
     fun unitLimitFor(vault: KaminoVault, action: KaminoAction): BigInteger =
         when (action) {
             KaminoAction.WITHDRAW -> WITHDRAW_UNIT_LIMIT
@@ -86,9 +102,15 @@ object KaminoComputeBudget {
                 }
         }.let(BigInteger::valueOf)
 
-    /** Never price below the floor, however stale or absent the network sample is. */
+    /**
+     * Brings a sampled network price inside `[FALLBACK_UNIT_PRICE, MAX_UNIT_PRICE]`, the same range
+     * iOS clamps into and the only range its decoder accepts.
+     *
+     * The floor is a floor rather than a default: a sample below it would under-tip a transaction
+     * that has to land before its blockhash expires.
+     */
     fun unitPriceFor(networkPrice: BigInteger?): BigInteger =
-        networkPrice?.takeIf { it > FALLBACK_UNIT_PRICE } ?: FALLBACK_UNIT_PRICE
+        (networkPrice ?: FALLBACK_UNIT_PRICE).coerceIn(FALLBACK_UNIT_PRICE, MAX_UNIT_PRICE)
 
     /**
      * The priority fee this transaction will actually be charged, in lamports.
@@ -134,18 +156,11 @@ object KaminoComputeBudget {
      * price as a little-endian `u64`.
      */
     fun setUnitPriceData(price: BigInteger): ByteArray {
-        require(price.signum() >= 0 && price.bitLength() <= 64) {
+        // The sign is checked separately: `bitLength` ignores it, so -1 would clear the bound.
+        require(price.signum() >= 0 && price.bitLength() <= Long.SIZE_BITS) {
             "compute-unit price $price does not fit a u64"
         }
-        val data = ByteArray(9)
-        data[0] = SET_UNIT_PRICE_DISCRIMINATOR.toByte()
-        var remaining = price
-        for (offset in 1..8) {
-            data[offset] = remaining.and(BYTE_MASK).toInt().toByte()
-            remaining = remaining.shiftRight(8)
-        }
-        return data
+        return byteArrayOf(SET_UNIT_PRICE_DISCRIMINATOR.toByte()) +
+            ByteArray(Long.SIZE_BYTES) { byte -> price.shiftRight(8 * byte).toInt().toByte() }
     }
-
-    private val BYTE_MASK = BigInteger.valueOf(0xFF)
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -169,17 +169,26 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
                 "WalletCore could not set the Kamino compute-unit limit"
             }
 
-        // WalletCore chooses where the limit goes — index 0, unless the first instruction is
-        // `AdvanceNonceAccount`, which Kamino never builds — so the position is observed rather
-        // than
-        // assumed. Anything but 0 is not the layout iOS emits, and is refused here rather than sent
-        // to a co-signer that would silently decline it.
-        val limitIndex =
-            KaminoTransactionDecoder.decode(withLimit).instructions.indexOfFirst {
-                it.programId == KaminoComputeBudget.PROGRAM_ID
+        // Two assumptions are read back here rather than trusted, because the insert below adds a
+        // price unconditionally where `setComputeUnitPrice` used to overwrite one in place.
+        //
+        // Where the limit landed: WalletCore chooses that — index 0, unless the first instruction
+        // is `AdvanceNonceAccount`, which Kamino never builds. Anything but 0 is not the layout iOS
+        // emits, and is refused here rather than sent to a co-signer that would silently decline
+        // it.
+        //
+        // That it is the only one: Kamino's responses carry no compute budget today. Should one
+        // ever arrive carrying its own *price*, `setComputeUnitLimit` would leave it untouched and
+        // the insert below would make two `SetComputeUnitPrice` instructions — which the chain
+        // rejects, after a full signing ceremony has already been spent on it.
+        val instructions = KaminoTransactionDecoder.decode(withLimit).instructions
+        val budgetIndices =
+            instructions.indices.filter {
+                instructions[it].programId == KaminoComputeBudget.PROGRAM_ID
             }
-        check(limitIndex == UNIT_LIMIT_INDEX) {
-            "WalletCore put the Kamino compute-unit limit at index $limitIndex, not $UNIT_LIMIT_INDEX"
+        check(budgetIndices == listOf(UNIT_LIMIT_INDEX)) {
+            "expected the app's compute-unit limit alone at index $UNIT_LIMIT_INDEX, " +
+                "found ComputeBudget instructions at $budgetIndices"
         }
 
         // Deliberately not `SolanaTransaction.setComputeUnitPrice`. The two helpers place their

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -82,9 +82,12 @@ object KaminoTransactionDecoder {
  * The order of operations is the contract:
  * 1. Kamino builds the transaction, embedding a recent blockhash. It carries no compute budget and
  *    ignores any fee hints in the request, so the app supplies both.
- * 2. Compute budget goes on first. WalletCore appends these when absent, so doing this before the
- *    memo is what leaves the memo last — which the validator then requires.
- * 3. The attribution memo goes on last.
+ * 2. Compute budget goes on first, as the two leading instructions: the unit limit at index 0 and
+ *    the unit price at index 1. That is the layout iOS emits and matches the remaining instructions
+ *    against positionally, so it is a cross-platform contract rather than a preference — get it
+ *    wrong and an iPhone co-signer reads the transaction as unsigned-for and will not join.
+ * 3. The attribution memo goes on last, after the budget, which is what leaves it unambiguously
+ *    final — the position the validator then requires.
  * 4. The result is decoded and validated against the local registry, never against anything Kamino
  *    just said.
  *
@@ -166,8 +169,41 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
                 "WalletCore could not set the Kamino compute-unit limit"
             }
 
-        return checkNotNull(SolanaTransaction.setComputeUnitPrice(withLimit, price.toString())) {
+        // WalletCore chooses where the limit goes — index 0, unless the first instruction is
+        // `AdvanceNonceAccount`, which Kamino never builds — so the position is observed rather
+        // than
+        // assumed. Anything but 0 is not the layout iOS emits, and is refused here rather than sent
+        // to a co-signer that would silently decline it.
+        val limitIndex =
+            KaminoTransactionDecoder.decode(withLimit).instructions.indexOfFirst {
+                it.programId == KaminoComputeBudget.PROGRAM_ID
+            }
+        check(limitIndex == UNIT_LIMIT_INDEX) {
+            "WalletCore put the Kamino compute-unit limit at index $limitIndex, not $UNIT_LIMIT_INDEX"
+        }
+
+        // Deliberately not `SolanaTransaction.setComputeUnitPrice`. The two helpers place their
+        // instruction differently: the limit is *inserted at the front*, the price is *appended*.
+        // Kamino's responses carry no compute budget, so that pair leaves the price behind every
+        // instruction Kamino built, and an iOS co-signer — which emits the two at 0 and 1 and reads
+        // the rest positionally — finds the wrong instruction where the price belongs, marks the
+        // transaction unreadable and refuses to join. Swapping the call order does not help; the
+        // limit still lands at index 0.
+        return checkNotNull(
+            SolanaTransaction.insertInstruction(
+                withLimit,
+                UNIT_PRICE_INDEX,
+                KaminoComputeBudget.setUnitPriceInstructionJson(price),
+            )
+        ) {
             "WalletCore could not set the Kamino compute-unit price"
         }
+    }
+
+    private companion object {
+        private const val UNIT_LIMIT_INDEX = 0
+
+        /** Right after the limit, which is where iOS puts it. */
+        private const val UNIT_PRICE_INDEX = UNIT_LIMIT_INDEX + 1
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -49,7 +49,7 @@ object KaminoTransactionValidator {
             "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", // Token
             "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb", // Token-2022
             "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL", // Associated Token
-            "ComputeBudget111111111111111111111111111111",
+            KaminoComputeBudget.PROGRAM_ID,
             KaminoVaultRegistry.PROGRAM_ID,
             KaminoVaultRegistry.FARMS_PROGRAM_ID,
             KaminoAttributionMemo.MEMO_PROGRAM_ID,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudgetTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudgetTest.kt
@@ -4,6 +4,7 @@ import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * The limits here have a direct on-chain consequence: too low and the transaction aborts on compute
@@ -128,5 +129,37 @@ class KaminoComputeBudgetTest {
             )
         // 20,001 x 320,000 = 6,400,320,000 micro-lamports = 6,400.32 lamports, rounded up.
         assertEquals(BigInteger.valueOf(6_401), odd)
+    }
+
+    @Test
+    fun `SetComputeUnitPrice is borsh - discriminator 3 then a little-endian u64`() {
+        // Hand-encoded because the app now builds this instruction itself rather than letting
+        // WalletCore append one. Getting the width or the endianness wrong would price the fee at
+        // some other number entirely, and nothing downstream would say so.
+        assertEquals(
+            listOf(3, 0x20, 0x4E, 0, 0, 0, 0, 0, 0),
+            KaminoComputeBudget.setUnitPriceData(BigInteger.valueOf(20_000)).map {
+                it.toInt() and 0xFF
+            },
+        )
+
+        assertEquals(
+            listOf(3, 0, 0, 0, 0, 0, 0, 0, 0),
+            KaminoComputeBudget.setUnitPriceData(BigInteger.ZERO).map { it.toInt() and 0xFF },
+        )
+
+        // The full u64 range is representable; one past it is not a price the instruction can
+        // carry.
+        val maxU64 = BigInteger.TWO.pow(64).subtract(BigInteger.ONE)
+        assertEquals(
+            List(9) { if (it == 0) 3 else 0xFF },
+            KaminoComputeBudget.setUnitPriceData(maxU64).map { it.toInt() and 0xFF },
+        )
+        assertThrows<IllegalArgumentException> {
+            KaminoComputeBudget.setUnitPriceData(maxU64.add(BigInteger.ONE))
+        }
+        assertThrows<IllegalArgumentException> {
+            KaminoComputeBudget.setUnitPriceData(BigInteger.valueOf(-1))
+        }
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudgetTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudgetTest.kt
@@ -98,6 +98,34 @@ class KaminoComputeBudgetTest {
     }
 
     @Test
+    fun `the unit price is capped, because iOS refuses anything above the ceiling`() {
+        // Not merely a spend cap. iOS clamps into the same range and its decoder rejects a
+        // transaction priced outside it, so an uncapped price is a transaction an iPhone co-signer
+        // will not join. And the sample this receives comes from `getMedianPriorityFee`, which
+        // already floors at the app-wide 1,000,000 and caps at 100,000,000 — so without this every
+        // congested-network sample would sail past the ceiling.
+        val ceiling = KaminoComputeBudget.MAX_UNIT_PRICE
+        assertEquals(BigInteger.valueOf(1_000_000), ceiling)
+        assertEquals(ceiling, KaminoComputeBudget.unitPriceFor(ceiling))
+        assertEquals(ceiling, KaminoComputeBudget.unitPriceFor(ceiling.add(BigInteger.ONE)))
+        assertEquals(ceiling, KaminoComputeBudget.unitPriceFor(BigInteger.valueOf(100_000_000)))
+
+        // Just below stays exactly where it is: the clamp must not round anything in range.
+        val below = ceiling.subtract(BigInteger.ONE)
+        assertEquals(below, KaminoComputeBudget.unitPriceFor(below))
+
+        // The ceiling bounds the worst fee too: 1,000,000 x 400,000 / 1e6 = 400,000 lamports.
+        assertEquals(
+            BigInteger.valueOf(400_000),
+            KaminoComputeBudget.priorityFeeLamports(
+                usdcVault,
+                KaminoAction.WITHDRAW,
+                BigInteger.valueOf(100_000_000),
+            ),
+        )
+    }
+
+    @Test
     fun `the priority fee is price times limit, in lamports`() {
         // 20,000 micro-lamports per unit x 320,000 units = 6,400,000,000 micro-lamports = 6,400
         // lamports, which is what bounds the cost of these limits.


### PR DESCRIPTION
Fixes #5598

### Transaction hash
https://orb.helius.dev/tx/nvE6t5pzCzSnsGjRhwfHUGc7bbpRqcaHyJn3MjBCKDHuLBrT1krTcAgcHz33g69dC71kDeW8BY2ASc8JELL7kFB

## Summary

An Android-initiated Kamino deposit or withdraw could not be co-signed from an iPhone. The reported cause was instruction ordering, but fixing that exposed three more disagreements with iOS in the same area — each of which independently blocks the join, and each with the same practical symptom, so they cannot be told apart from the co-signer's screen.

All four are fixed here. No funds are at risk and neither platform has shipped a store build with Kamino Earn.

## 1. The compute-unit price was appended instead of following the limit

`KaminoTransactionPreparer` injected the ComputeBudget pair with two WalletCore helpers that place their instruction differently: `setComputeUnitLimit` inserts at the front, `setComputeUnitPrice` appends. Kamino's responses carry no ComputeBudget instruction, so every prepared deposit and withdraw came out as:

```
[limit, ATA create, kvault deposit, farms init, farms stake, price, memo]
```

iOS emits the pair at 0 and 1 and matches the instructions that follow *by position*, so it found the ATA create where the price should be, marked the transaction unreadable and refused to join. Swapping the call order does not help — the limit still lands at index 0.

The price is now built locally (borsh: discriminator 3 followed by a little-endian `u64`) and inserted at index 1 with `SolanaTransaction.insertInstruction`, the path the attribution memo already uses. The ComputeBudget program key is already in the static keys after the limit, so WalletCore reuses it and no account indices shift.

## 2. The unit price had no ceiling

`unitPriceFor` only floored. iOS clamps the sample into `[20_000, 1_000_000]` and its decoder **refuses** a transaction priced outside that range (`KaminoTransactionDecoder.swift:383-384`), so an unclamped price is a transaction no iPhone will join.

That is not a hypothetical: the sample reaching this code comes from `SolanaApi.getMedianPriorityFee`, which returns `maxOf(median, 1_000_000)` capped at `100_000_000`. Every reading it produces is at or above the ceiling iOS enforces. `unitPriceFor` now clamps into the same range `KaminoComputeBudget.clampedUnitPrice` uses on iOS.

## 3. A response carrying its own compute budget would have been double-priced

Replacing `setComputeUnitPrice` with `insertInstruction` drops the in-place overwrite. Kamino's responses carry no ComputeBudget instruction today, but should one ever arrive with its own *price*, `setComputeUnitLimit` would leave it untouched and the insert would produce two `SetComputeUnitPrice` instructions — which the chain rejects, after a full signing ceremony has been spent on it.

The read-back that already ran after the limit now collects **every** ComputeBudget index and requires exactly `[0]`. One decode covers both the position contract and the absence of anything else, and it also catches a response supplying its own limit.

## 4. The payload recorded a different fee from the one in the bytes

The relayed `KeysignPayload` carried the generic Solana fee fields — the raw network sample and the app-wide `SOLANA_PRIORITY_FEE_LIMIT` of 100,000 units — while the bytes carried the Kamino budget just injected. `KaminoVerifyPresentation.priorityFeeAgrees` compares the two for **equality** before iOS will co-sign, so the join screen showed:

> The network fee inside this transaction is not the one shown above. Do not sign it.

and disabled the Join button. The limit alone was enough to fail it: 100,000 recorded against 320,000 in the bytes.

The same mismatch made the fee on the verify screen wrong on both platforms — priced off 100,000 units, it quoted 3,134,280 lamports of priority fee for a transaction whose real priority fee is 320,000, overstating the cost by an order of magnitude.

`BuildKaminoKeysignPayloadUseCase` now records both fields from the same functions the transaction is built with. `unitPriceFor` is idempotent, so the payload and the bytes agree by construction rather than by coincidence. Safe for signing: the raw path never reads these fields — they only feed `applyPriorityFee` on the transfer and staking signing inputs, and the Kamino bytes are already built.

## Also

- The ComputeBudget program id in the validator's allow-list points at `KaminoComputeBudget.PROGRAM_ID` instead of repeating the literal.
- `setUnitPriceData` drops a redundant mask and accumulator; `toInt().toByte()` already narrows to the low eight bits.
- The androidTest fixtures move to a shared `KaminoFixtures`, so the payload coverage and the preparer coverage assert against the same captured responses instead of drifting copies.

## Test plan

`:data:connectedDebugAndroidTest` — 36/36 pass on an Android 13 emulator. `:data:testDebugUnitTest` and `:data:lintDebug` pass.

Every fix was verified to be a real regression guard by reverting it and confirming the intended test fails:

| Reverted | Test | Failure |
|---|---|---|
| `insertInstruction` → `setComputeUnitPrice` | `the_compute_budget_leads_the_transaction_as_limit_then_price` | `expected:<ComputeBudget111...> but was:<ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL>` — the ATA create sitting where the price belongs |
| clamp → floor-only | `the_unit_price_is_capped_at_the_ceiling_an_iPhone_co_signer_will_accept` | `expected:<1000000> but was:<100000000>` |
| index list → `indexOfFirst` | `a_response_that_already_carries_a_compute_budget_is_refused_rather_than_double_priced` | no exception thrown |
| recorded budget → relayed generic values | `the_recorded_fee_is_what_the_user_will_actually_be_charged` | `expected:<320000> but was:<3134280>` — the exact priority fee behind the 0.00313928 SOL an iPhone refused |

Unit tests additionally pin the borsh encoding across the full `u64` range with its out-of-range rejections, and the price clamp at both bounds.

Known gap: the withdraw fixture is the **unstaked** shape, captured from a wallet holding no position. The staked shape — two extra `farms` instructions — has no fixture, so the withdraw compute limit rests on the iOS mainnet measurements rather than on anything this suite proves.

## Follow-up, not in this PR

The Kamino path takes its price sample from `getMedianPriorityFee`, whose own 1,000,000 floor sits exactly at the ceiling above. The clamp is therefore always binding and the 20,000 fallback is unreachable in practice, costing roughly 400,000 lamports of priority fee per transaction rather than 8,000. iOS avoids this by sampling `getRecentPrioritizationFees` raw and clamping that, instead of reusing the app-wide Solana value. Giving the Kamino path its own sample is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Corrected Solana transaction ordering so compute limits and pricing appear before Kamino instructions, with memos placed last.
- Rejected duplicate or unexpected compute-budget instructions.
- Added safe fallback and maximum limits for compute-unit pricing.
- Improved compute-budget encoding and validation.
- Ensured signing payloads record accurate Kamino compute limits and fees.
- Corrected fee calculations to use native Solana fees and preserve blockchain-specific transaction data.
- Prevented phantom token-account rent charges.

## Tests
- Expanded coverage for ordering, memo placement, encoding, boundary values, price capping, malformed responses, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
