### PR TITLE
Remove broad FileProvider cache root

### DIFF
--- a/app/src/main/res/xml/shared_images.xml
+++ b/app/src/main/res/xml/shared_images.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths>
-    <!--  TODO only here for tests; maybe we should remove this  -->
-    <cache-path name="cache" path="." />
-
     <cache-path name="shared_images" path="images/"/>
     <external-path name="qr_codes" path="./Download/Vultisig/QRCodes/"/>
 </paths>


### PR DESCRIPTION
## Summary
- remove the test-only FileProvider cache root for the entire cache directory
- keep the scoped shared images cache path and QR code export path

Fixes #5576

## Testing
- ./gradlew :app:processDebugResources