### PR TITLE
Fix Kamino SOL max deposit reserve

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -39,6 +39,7 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.utils.runCatchingCancellable
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -195,7 +196,8 @@ constructor(
             }
 
             val available = spendableBalance(vault, coin)
-            val vaultState = runCatching { kaminoApi.getVaultState(vault.address) }.getOrNull()
+            val vaultState =
+                runCatchingCancellable { kaminoApi.getVaultState(vault.address) }.getOrNull()
 
             _state.update {
                 it.copy(
@@ -239,27 +241,22 @@ constructor(
             .movePointLeft(coin.decimal)
     }
 
+    /**
+     * Reads the network's median priority price directly rather than through
+     * [BlockChainSpecificRepository.getSpecific], which also fetches a recent blockhash and ATA
+     * lookups unrelated to pricing. Any one of those failing would fail the whole call, nulling out
+     * the price too and dropping the floor from the app-wide 1,000,000 to
+     * [KaminoComputeBudget.FALLBACK_UNIT_PRICE]'s 20,000 — under-reserving the exact way #5599
+     * failed, just at a smaller scale. [SolanaApi.getMedianPriorityFee] already falls back to
+     * 1,000,000 internally and never throws but for cancellation, so nothing here needs its own
+     * fallback.
+     */
     private suspend fun kaminoDepositPriorityFee(vault: KaminoVault, coin: Coin): BigInteger {
-        val solanaSpecific =
-            runCatching {
-                    blockChainSpecificRepository
-                        .getSpecific(
-                            chain = Chain.Solana,
-                            address = coin.address,
-                            token = coin,
-                            gasFee = TokenValue(SolanaHelper.DefaultFeeInLamports, coin),
-                            isSwap = false,
-                            isMaxAmountEnabled = false,
-                            isDeposit = true,
-                        )
-                        .blockChainSpecific as? BlockChainSpecific.Solana
-                }
-                .getOrNull()
-
+        val networkPrice = solanaApi.getMedianPriorityFee(listOf(coin.address))
         return KaminoComputeBudget.priorityFeeLamports(
             vault = vault,
             action = KaminoAction.DEPOSIT,
-            networkPrice = solanaSpecific?.priorityFee,
+            networkPrice = networkPrice,
         )
     }
 
@@ -281,19 +278,33 @@ constructor(
     }
 
     private suspend fun tokenAccountRentReserve(): BigInteger =
-        runCatching { solanaApi.getMinimumBalanceForRentExemption() }
+        runCatchingCancellable { solanaApi.getMinimumBalanceForRentExemption() }
             .getOrNull()
             ?.takeIf { it.signum() > 0 } ?: SPL_TOKEN_ACCOUNT_RENT_LAMPORTS
 
     private suspend fun tokenAccountExists(walletAddress: String, mint: String): Boolean =
-        runCatching {
+        runCatchingCancellable {
                 solanaApi.getTokenAssociatedAccountByOwner(walletAddress, mint).first != null
             }
             .getOrDefault(false)
 
+    /**
+     * Whether the wallet already has a farm UserState account for this vault, so a redeposit does
+     * not need to pay its rent again.
+     *
+     * Goes through [KaminoWithdrawEligibility.resolve] rather than checking for a bare entry in the
+     * response: the same endpoint keeps a zero-share row for a wallet that has fully exited, and
+     * the withdraw flow already treats that row as no position. Checking entry presence alone would
+     * disagree with that and waive the rent on an account that may no longer exist.
+     */
     private suspend fun hasKaminoVaultPosition(walletAddress: String, vault: KaminoVault): Boolean =
-        runCatching {
-                kaminoApi.getUserPositions(walletAddress).any { it.vaultAddress == vault.address }
+        runCatchingCancellable {
+                val entry =
+                    kaminoApi.getUserPositions(walletAddress).firstOrNull {
+                        it.vaultAddress == vault.address
+                    }
+                KaminoWithdrawEligibility.resolve(entry, vault.sharesDecimals) is
+                    KaminoWithdrawEligibility.Withdrawable
             }
             .getOrDefault(false)
 
@@ -305,7 +316,8 @@ constructor(
      * is denominated in is derived from those, never the other way round.
      */
     private suspend fun loadWithdrawState(vault: KaminoVault, coin: Coin) {
-        val positions = runCatching { kaminoApi.getUserPositions(coin.address) }.getOrNull()
+        val positions =
+            runCatchingCancellable { kaminoApi.getUserPositions(coin.address) }.getOrNull()
         val eligibility =
             if (positions == null) {
                 // A failed read is neither "nothing to withdraw" nor "everything": refuse it.
@@ -317,7 +329,8 @@ constructor(
                 )
             }
 
-        val metrics = runCatching { kaminoApi.getVaultMetrics(vault.address) }.getOrNull()
+        val metrics =
+            runCatchingCancellable { kaminoApi.getVaultMetrics(vault.address) }.getOrNull()
         val rate = KaminoRate.parse(metrics?.tokensPerShare)
         val held = eligibility.withdrawableShares?.maximum
 
@@ -328,7 +341,8 @@ constructor(
                 null
             }
 
-        val vaultState = runCatching { kaminoApi.getVaultState(vault.address) }.getOrNull()
+        val vaultState =
+            runCatchingCancellable { kaminoApi.getVaultState(vault.address) }.getOrNull()
         // Share base units, not token — comparing it against a token amount would be wrong by the
         // whole share rate (about 930x on the SOL vault).
         val minimumShares =
@@ -479,6 +493,16 @@ constructor(
             // is `SolanaHelper.defaultFeeInLamports`, the same 1,000,000, plus price × limit — so
             // the two devices quote one figure for one transaction instead of two.
             val recordedBudget = keysignPayload.blockChainSpecific as BlockChainSpecific.Solana
+            // A first native-SOL deposit also spends the rent [spendableBalance] reserved against
+            // the same balance, on the wSOL ATA, share ATA and farm UserState it creates. Folded in
+            // here too, or the amount plus this fee would undercount the wallet's starting balance
+            // by exactly that rent on the verify screen.
+            val rentReserve =
+                if (!route.isWithdraw && coin.isNativeToken) {
+                    kaminoNativeDepositRentReserve(vault, coin)
+                } else {
+                    BigInteger.ZERO
+                }
             val gasFee =
                 TokenValue(
                     value =
@@ -487,7 +511,8 @@ constructor(
                                 vault = vault,
                                 action = action,
                                 networkPrice = recordedBudget.priorityFee,
-                            ),
+                            ) +
+                            rentReserve,
                     token = solCoin,
                 )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -219,12 +219,10 @@ constructor(
      * Wallet balance less everything the deposit itself has to pay for, so a Max amount produces a
      * transaction that can actually land.
      *
-     * For the SOL vault that is three things, not one: the base fee, the priority fee this
-     * transaction will be charged (price × the compute limit, far from negligible at these limits),
-     * and the rent-exempt reserve for the **wrapped-SOL account the deposit has to create** — the
-     * vault's underlying is wSOL, not native SOL. Reserving only the base fee, as this first did,
-     * leaves a Max deposit unable to fund that account and it fails on chain. The native staking
-     * flow reserves rent the same way.
+     * For a first SOL-vault deposit that is several things, not one: the base fee, the charged
+     * Kamino priority fee (price × compute limit), and rent for every account the deposit creates:
+     * wSOL ATA, share ATA and farm user-state. Reserving only the transfer-shaped fee leaves a Max
+     * deposit unable to fund those accounts and it fails at preflight.
      *
      * A token deposit pays all of that in SOL, so the token balance is spendable in full.
      */
@@ -232,29 +230,71 @@ constructor(
         val balance = balanceRepository.getTokenValue(coin.address, coin).first().value
         if (!coin.isNativeToken) return BigDecimal(balance).movePointLeft(coin.decimal)
 
-        val priorityFee =
-            KaminoComputeBudget.priorityFeeLamports(
-                vault = vault,
-                action = KaminoAction.DEPOSIT,
-                networkPrice = null,
-            )
-        val wrappedSolRent =
-            if (vault.tokenMint == KaminoVaultRegistry.WRAPPED_SOL_MINT) {
-                // Falling back to zero would quietly hand the whole balance to a Max deposit that
-                // then cannot fund the account it creates. The 165-byte token-account rent is a
-                // network constant in practice, so the known value is a far better answer than
-                // none.
-                runCatching { solanaApi.getMinimumBalanceForRentExemption() }
-                    .getOrNull()
-                    ?.takeIf { it.signum() > 0 } ?: SPL_TOKEN_ACCOUNT_RENT_LAMPORTS
-            } else {
-                BigInteger.ZERO
-            }
+        val priorityFee = kaminoDepositPriorityFee(vault, coin)
+        val rentReserve = kaminoNativeDepositRentReserve(vault, coin)
 
-        val headroom = SolanaHelper.DefaultFeeInLamports + priorityFee + wrappedSolRent
+        val headroom = SolanaHelper.DefaultFeeInLamports + priorityFee + rentReserve
         return BigDecimal((balance - headroom).coerceAtLeast(BigInteger.ZERO))
             .movePointLeft(coin.decimal)
     }
+
+    private suspend fun kaminoDepositPriorityFee(vault: KaminoVault, coin: Coin): BigInteger {
+        val solanaSpecific =
+            runCatching {
+                    blockChainSpecificRepository
+                        .getSpecific(
+                            chain = Chain.Solana,
+                            address = coin.address,
+                            token = coin,
+                            gasFee = TokenValue(SolanaHelper.DefaultFeeInLamports, coin),
+                            isSwap = false,
+                            isMaxAmountEnabled = false,
+                            isDeposit = true,
+                        )
+                        .blockChainSpecific as? BlockChainSpecific.Solana
+                }
+                .getOrNull()
+
+        return KaminoComputeBudget.priorityFeeLamports(
+            vault = vault,
+            action = KaminoAction.DEPOSIT,
+            networkPrice = solanaSpecific?.priorityFee,
+        )
+    }
+
+    private suspend fun kaminoNativeDepositRentReserve(vault: KaminoVault, coin: Coin): BigInteger {
+        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) return BigInteger.ZERO
+
+        val tokenAccountRent = tokenAccountRentReserve()
+        val wrappedSolRent =
+            tokenAccountRent.takeUnless { tokenAccountExists(coin.address, vault.tokenMint) }
+                ?: BigInteger.ZERO
+        val shareAccountRent =
+            tokenAccountRent.takeUnless { tokenAccountExists(coin.address, vault.sharesMint) }
+                ?: BigInteger.ZERO
+        val farmUserStateRent =
+            FARM_USER_STATE_RENT_LAMPORTS.takeUnless { hasKaminoVaultPosition(coin.address, vault) }
+                ?: BigInteger.ZERO
+
+        return wrappedSolRent + shareAccountRent + farmUserStateRent
+    }
+
+    private suspend fun tokenAccountRentReserve(): BigInteger =
+        runCatching { solanaApi.getMinimumBalanceForRentExemption() }
+            .getOrNull()
+            ?.takeIf { it.signum() > 0 } ?: SPL_TOKEN_ACCOUNT_RENT_LAMPORTS
+
+    private suspend fun tokenAccountExists(walletAddress: String, mint: String): Boolean =
+        runCatching {
+                solanaApi.getTokenAssociatedAccountByOwner(walletAddress, mint).first != null
+            }
+            .getOrDefault(false)
+
+    private suspend fun hasKaminoVaultPosition(walletAddress: String, vault: KaminoVault): Boolean =
+        runCatching {
+                kaminoApi.getUserPositions(walletAddress).any { it.vaultAddress == vault.address }
+            }
+            .getOrDefault(false)
 
     /**
      * Resolves what the withdraw form may offer, in shares first and tokens only as a projection.
@@ -568,6 +608,13 @@ constructor(
          * — reserving nothing would be worse than reserving a value that has not moved in practice.
          */
         val SPL_TOKEN_ACCOUNT_RENT_LAMPORTS: BigInteger = BigInteger.valueOf(2_039_280)
+
+        /**
+         * Rent-exempt minimum Kamino charges when a first deposit creates the farms `UserState`.
+         * The account size is Kamino-owned, so keep the observed mainnet lamport value here rather
+         * than pretending the app can derive it from SPL token-account rent.
+         */
+        val FARM_USER_STATE_RENT_LAMPORTS: BigInteger = BigInteger.valueOf(6_299_080)
 
         val ONE_HUNDRED = BigDecimal(100)
         const val DEFAULT_SCALE = 6

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -90,6 +90,7 @@ internal class KaminoAmountViewModelTest {
         // 165-byte SPL token account rent-exempt reserve, the real mainnet figure.
         coEvery { solanaApi.getMinimumBalanceForRentExemption() } returns BigInteger("2039280")
         coEvery { solanaApi.getTokenAssociatedAccountByOwner(any(), any()) } returns (null to false)
+        coEvery { solanaApi.getMedianPriorityFee(any()) } returns KAMINO_UNIT_PRICE
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { chainAccountAddressRepository.getAddress(Chain.Solana, VAULT) } returns
             (WALLET to "pubkey")
@@ -304,6 +305,51 @@ internal class KaminoAmountViewModelTest {
         // 350,000), two token-account rents (2,039,280 each) and farm UserState rent (6,299,080).
         assertEquals(0, BigDecimal("0.98827236").compareTo(available))
     }
+
+    @Test
+    fun `a first native SOL deposit charges the same rent it reserved, not just the network fee`() =
+        runTest {
+            // Otherwise the verify screen shows an amount plus a fee that together fall short of
+            // the wallet's starting balance by exactly the account rent this deposit actually
+            // spends.
+            coEvery { balanceRepository.getTokenValue(any(), any()) } returns
+                flowOf(TokenValue(value = BigInteger("1000000000"), token = COIN))
+            coEvery { kaminoApi.getVaultState(any()) } returns
+                KaminoVaultStateJson(
+                    address = ALLEZ.address,
+                    state =
+                        KaminoVaultStateJson.State(
+                            name = "Allez SOL",
+                            tokenMint = ALLEZ.tokenMint,
+                            tokenDecimals = 9,
+                            sharesMint = ALLEZ.sharesMint,
+                            sharesDecimals = 6,
+                        ),
+                )
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+            coEvery {
+                buildKeysignPayload(
+                    vault = any(),
+                    action = any(),
+                    apiAmount = any(),
+                    tokenAmount = any(),
+                    coin = any(),
+                    blockChainSpecific = any(),
+                    vaultPublicKeyECDSA = any(),
+                    vaultLocalPartyID = any(),
+                    libType = any(),
+                )
+            } returns keysignPayloadWithKaminoBudget()
+
+            val vm = viewModel(vaultAddress = ALLEZ.address)
+            vm.amountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+            vm.submit()
+
+            // Base fee (1,000,000) + priority fee (350,000) + wSOL and share ATA rent (2,039,280
+            // each) + farm UserState rent (6,299,080) = 11,727,640.
+            assertEquals(BigInteger("11727640"), captured.captured.estimatedFees.value)
+        }
 
     @Test
     fun `a USDC deposit does not reserve SOL costs against the token balance`() = runTest {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -87,9 +87,28 @@ internal class KaminoAmountViewModelTest {
 
         // 165-byte SPL token account rent-exempt reserve, the real mainnet figure.
         coEvery { solanaApi.getMinimumBalanceForRentExemption() } returns BigInteger("2039280")
+        coEvery { solanaApi.getTokenAssociatedAccountByOwner(any(), any()) } returns (null to false)
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { chainAccountAddressRepository.getAddress(Chain.Solana, VAULT) } returns
             (WALLET to "pubkey")
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = Chain.Solana,
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = false,
+                isMaxAmountEnabled = false,
+                isDeposit = true,
+            )
+        } returns
+            com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo(
+                BlockChainSpecific.Solana(
+                    recentBlockHash = "blockhash",
+                    priorityFee = KAMINO_UNIT_PRICE,
+                    priorityLimit = BigInteger("100000"),
+                )
+            )
         coEvery { kaminoApi.getVaultState(any()) } returns
             KaminoVaultStateJson(
                 address = STEAKHOUSE.address,
@@ -243,10 +262,7 @@ internal class KaminoAmountViewModelTest {
         val available = viewModel(vaultAddress = ALLEZ.address).state.value.available
 
         assertTrue(available < BigDecimal.ONE, "expected less than a whole SOL, was $available")
-        assertTrue(
-            available > BigDecimal("0.99"),
-            "expected most of the balance to remain, was $available",
-        )
+        assertTrue(available > BigDecimal("0.98"), "reserved too much, was $available")
     }
 
     @Test
@@ -261,9 +277,10 @@ internal class KaminoAmountViewModelTest {
     }
 
     @Test
-    fun `a max SOL deposit reserves the wrapped-SOL rent and the priority fee`() = runTest {
-        // The vault's underlying is wSOL, so the deposit creates a token account. Without reserving
-        // its rent a Max deposit cannot fund that account and fails on chain.
+    fun `a max SOL deposit reserves first deposit rent and the charged priority fee`() = runTest {
+        // First deposits into the SOL vault create the wSOL ATA, share ATA and farm UserState. The
+        // priority fee must use the same unit price the transaction builder records, not the
+        // KaminoComputeBudget fallback.
         coEvery { balanceRepository.getTokenValue(any(), any()) } returns
             flowOf(TokenValue(value = BigInteger("1000000000"), token = COIN))
         coEvery { kaminoApi.getVaultState(any()) } returns
@@ -281,14 +298,9 @@ internal class KaminoAmountViewModelTest {
 
         val available = viewModel(vaultAddress = ALLEZ.address).state.value.available
 
-        // 1 SOL less rent (0.00203928) less the priority fee (20,000 µlamports x 350,000 CU =
-        // 7,000 lamports) less the base fee — so strictly below 0.998, and far below a naive
-        // fee-only headroom.
-        assertTrue(
-            available < BigDecimal("0.998"),
-            "expected rent + priority fee reserved, was $available",
-        )
-        assertTrue(available > BigDecimal("0.99"), "reserved too much, was $available")
+        // 1 SOL less base fee (1,000,000), priority fee (1,000,000 µlamports x 350,000 CU =
+        // 350,000), two token-account rents (2,039,280 each) and farm UserState rent (6,299,080).
+        assertEquals(0, BigDecimal("0.98827236").compareTo(available))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- calculate Kamino SOL max deposit priority headroom from the same Solana priority price used by the payload build path
- reserve first-deposit rent for missing wSOL ATA, share ATA, and Kamino farm UserState accounts
- pin the first-deposit SOL max amount regression in Kamino amount tests

Fixes #5599

on chain tx link: https://orbmarkets.io/tx/3JcwWazxR9hg32mCc3rgweetVK6nzEaiKw3bRFah7GSoFbeNtEw7NCqB2yFmBdfjziVs2GZrzTk4eEpztYyiJUpa
## Testing
- ./gradlew :app:testDebugUnitTest --tests com.vultisig.wallet.ui.models.solanastaking.KaminoAmountViewModelTest
- ./gradlew :app:ktfmtCheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SOL deposit balance calculations by reserving required network fees and account-creation rent.
  * Added fallback handling when fee, rent, account, or position data cannot be retrieved.
  * Increased accuracy for first-time Kamino deposits, including newly created account costs.

* **Tests**
  * Updated deposit scenarios and balance expectations to reflect revised fee and rent calculations.
  * Added coverage for priority fees and first-deposit account creation costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->