### PR TITLE
fix(defi): send a Kamino withdraw to the signer, not to the vault

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -24,6 +24,7 @@ import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawEligibili
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawLiquidity
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawMath
 import com.vultisig.wallet.data.blockchain.solana.kamino.coin
+import com.vultisig.wallet.data.blockchain.solana.kamino.kaminoDestinationAddress
 import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
@@ -458,7 +459,9 @@ constructor(
                     srcAddress = coin.address,
                     srcTokenValue = TokenValue(value = keysignPayload.toAmount, token = coin),
                     memo = "",
-                    dstAddress = vault.address,
+                    // The verify screen reads this stored copy, not the payload above, so the
+                    // withdraw branch has to be applied here too or nothing the user sees changes.
+                    dstAddress = kaminoDestinationAddress(vault, action, coin.address),
                     estimatedFees = gasFee,
                     estimateFeesFiat = "",
                     // The payload's, not `specific`'s. `KeysignShareViewModel` rebuilds the relayed

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawEligibili
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_WITHDRAW
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
@@ -39,6 +40,7 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -382,6 +384,75 @@ internal class KaminoAmountViewModelTest {
 
         assertEquals(OPERATION_KAMINO_DEPOSIT, captured.captured.operation)
         assertEquals("Steakhouse USDC", captured.captured.validatorName)
+        assertEquals(STEAKHOUSE.address, captured.captured.dstAddress)
+    }
+
+    @Test
+    fun `a withdraw is destined for the signer's own account, not the vault`() = runTest {
+        // The vault is where a withdrawal comes *from*. Naming it as the destination told the
+        // approving user the opposite of what the transaction does — and on an Android co-signer
+        // it lands on the generic Send screen with no withdraw framing at all, so the vault address
+        // reads as an ordinary payee.
+        givenTokenBalance("0")
+        coEvery { kaminoApi.getUserPositions(WALLET) } returns
+            listOf(
+                KaminoUserPositionJson(
+                    vaultAddress = STEAKHOUSE.address,
+                    stakedShares = "0",
+                    unstakedShares = "1000000000",
+                    totalShares = "1000000000",
+                )
+            )
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0544278224860290217")
+        val captured = slot<DepositTransaction>()
+        coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+        coEvery {
+            buildKeysignPayload(
+                vault = any(),
+                action = any(),
+                apiAmount = any(),
+                tokenAmount = any(),
+                coin = any(),
+                blockChainSpecific = any(),
+                vaultPublicKeyECDSA = any(),
+                vaultLocalPartyID = any(),
+                libType = any(),
+            )
+        } returns keysignPayloadWithKaminoBudget()
+
+        val vm = viewModel(isWithdraw = true)
+        vm.amountFieldState.setTextAndPlaceCursorAtEnd("1")
+        vm.submit()
+
+        assertEquals(OPERATION_KAMINO_WITHDRAW, captured.captured.operation)
+        assertEquals(WALLET, captured.captured.dstAddress)
+        assertNotEquals(STEAKHOUSE.address, captured.captured.dstAddress)
+    }
+
+    @Test
+    fun `a deposit is still destined for the vault`() = runTest {
+        givenTokenBalance("2500000000")
+        val captured = slot<DepositTransaction>()
+        coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+        coEvery {
+            buildKeysignPayload(
+                vault = any(),
+                action = any(),
+                apiAmount = any(),
+                tokenAmount = any(),
+                coin = any(),
+                blockChainSpecific = any(),
+                vaultPublicKeyECDSA = any(),
+                vaultLocalPartyID = any(),
+                libType = any(),
+            )
+        } returns keysignPayloadWithKaminoBudget()
+
+        val vm = viewModel()
+        vm.amountFieldState.setTextAndPlaceCursorAtEnd("100")
+        vm.submit()
+
         assertEquals(STEAKHOUSE.address, captured.captured.dstAddress)
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/BuildKaminoKeysignPayloadUseCase.kt
@@ -10,6 +10,26 @@ import javax.inject.Inject
 import vultisig.keysign.v1.SignSolana
 
 /**
+ * Where a Kamino [action] moves money to, for the verify screen's destination row.
+ *
+ * A deposit pays the vault. A withdraw pays [signerAddress] — the vault is the source, and naming
+ * it as the destination tells the approving user the opposite of what the transaction does.
+ *
+ * Shared by the payload and by the [com.vultisig.wallet.data.models.DepositTransaction] the verify
+ * screen actually reads, because those are two places that must not drift: the screen shows the
+ * stored copy, so a branch applied to only one of them fixes nothing the user can see.
+ */
+fun kaminoDestinationAddress(
+    vault: KaminoVault,
+    action: KaminoAction,
+    signerAddress: String,
+): String =
+    when (action) {
+        KaminoAction.DEPOSIT -> vault.address
+        KaminoAction.WITHDRAW -> signerAddress
+    }
+
+/**
  * Turns a Kamino deposit or withdraw intent into a [KeysignPayload] with `signSolana` populated.
  *
  * Mirrors
@@ -92,8 +112,10 @@ constructor(private val preparer: KaminoTransactionPreparer) {
         return KeysignPayload(
             coin = coin,
             // Display destination on the verify screen. Routing is driven by the relayed bytes, not
-            // by this field.
-            toAddress = vault.address,
+            // by this field — but it is what the approving user is told the money is going to, and
+            // the two directions do not share an answer: a deposit pays the vault, a withdraw pays
+            // the signer's own account and the vault is the *source*. iOS branches the same way.
+            toAddress = kaminoDestinationAddress(vault, action, coin.address),
             toAmount =
                 tokenAmount
                     .movePointRight(coin.decimal)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDestinationAddressTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDestinationAddressTest.kt
@@ -1,0 +1,86 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Which address the verify screen names as the destination.
+ *
+ * Routing lives in the relayed transaction bytes, so nothing here moves money — but this is what
+ * the approving user is told the money is going to, and a withdraw pays their own account. The
+ * vault is the *source* of a withdrawal; naming it as the destination states the reverse.
+ *
+ * The preparer is mocked so these run without WalletCore or a captured response: the point under
+ * test is the branch, not the bytes.
+ */
+class KaminoDestinationAddressTest {
+
+    private val vault = KaminoVaultRegistry.STEAKHOUSE_USDC
+    private val signer = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+    private val coin =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "USDC",
+            logo = "usdc",
+            address = signer,
+            decimal = vault.tokenDecimals,
+            hexPublicKey = "",
+            priceProviderID = "usd-coin",
+            contractAddress = KaminoVaultRegistry.USDC_MINT,
+            isNativeToken = false,
+        )
+
+    @Test
+    fun `a deposit is destined for the vault`() {
+        assertEquals(vault.address, kaminoDestinationAddress(vault, KaminoAction.DEPOSIT, signer))
+    }
+
+    @Test
+    fun `a withdraw is destined for the signer, because the vault is where it comes from`() {
+        assertEquals(signer, kaminoDestinationAddress(vault, KaminoAction.WITHDRAW, signer))
+        assertNotEquals(
+            vault.address,
+            kaminoDestinationAddress(vault, KaminoAction.WITHDRAW, signer),
+        )
+    }
+
+    @Test
+    fun `the payload carries the branched destination, not the vault for both directions`() =
+        runTest {
+            val preparer = mockk<KaminoTransactionPreparer>()
+            coEvery { preparer.prepare(any(), any(), any(), any(), any()) } returns "raw-tx"
+            val build = BuildKaminoKeysignPayloadUseCase(preparer)
+
+            suspend fun payloadFor(action: KaminoAction) =
+                build(
+                    vault = vault,
+                    action = action,
+                    apiAmount = "1",
+                    tokenAmount = BigDecimal.ONE,
+                    coin = coin,
+                    blockChainSpecific =
+                        BlockChainSpecific.Solana(
+                            recentBlockHash = "",
+                            priorityFee = BigInteger.valueOf(1_000_000),
+                            priorityLimit = BigInteger.valueOf(100_000),
+                        ),
+                    vaultPublicKeyECDSA = "",
+                    vaultLocalPartyID = "",
+                    libType = SigningLibType.DKLS,
+                )
+
+            assertEquals(vault.address, payloadFor(KaminoAction.DEPOSIT).toAddress)
+            assertEquals(signer, payloadFor(KaminoAction.WITHDRAW).toAddress)
+        }
+}


### PR DESCRIPTION
Fixes #5605

## Summary

A Kamino Earn withdraw is paid out of the vault into the user's own Solana account, but both the keysign payload and the stored `DepositTransaction` named the vault as the destination — the same value a deposit uses. The verify screen therefore told the approving user the money was going to the place it was coming from.

Nothing was at risk and nothing was misrouted: routing lives in the relayed transaction bytes, and this field is display only. What it affected is what the user was asked to approve.

## Changes

The branch lives in one function, used by both sites:

```kotlin
fun kaminoDestinationAddress(vault: KaminoVault, action: KaminoAction, signerAddress: String) =
    when (action) {
        KaminoAction.DEPOSIT -> vault.address
        KaminoAction.WITHDRAW -> signerAddress
    }
```

- `BuildKaminoKeysignPayloadUseCase` uses it for `toAddress`.
- `KaminoAmountViewModel` uses it for the `DepositTransaction`'s `dstAddress`.

Deliberately not two copies of the same `when`. Those two sites drifting is what produced the bug, and the stored transaction is the one the verify screen reads — branching only the payload would have changed nothing the user sees.

iOS branches the same way, for the same stated reason (`KaminoKeysignPayloadFactory.swift:81`: *"A withdraw pays the user's own account, so that is the destination — not the vault, which is where the funds come from."*).

## Test plan

Five new tests, each verified to be a real regression guard by reverting the fix and confirming it fails:

| Test | Fails when |
|---|---|
| `a withdraw is destined for the signer's own account, not the vault` | the ViewModel site is reverted |
| `a deposit is still destined for the vault` | — (pins the unchanged direction) |
| `the payload carries the branched destination, not the vault for both directions` | the use-case site is reverted |
| `a deposit is destined for the vault` | — |
| `a withdraw is destined for the signer, because the vault is where it comes from` | — |

The new `KaminoDestinationAddressTest` mocks the preparer, so it covers the payload branch without WalletCore or a captured response. That matters here: the captured withdraw fixture carries the `u64::MAX` full-exit sentinel and is refused by the validator by design, so no instrumented test can build a withdraw payload end to end.

`:app:testDebugUnitTest`, `:data:testDebugUnitTest`, `:data:lintDebug` and ktfmt pass.

**Not run:** `:data:connectedDebugAndroidTest` — no emulator available at the time of writing. Nothing in that suite asserts on `toAddress`, so the risk is low, but it has not been run against this change.

## Out of scope

The issue also notes that a Kamino payload carries no memo, so `JoinKeysignViewModel.isDepositPayload` returns false and an Android co-signer renders the generic Send verify screen with no withdraw framing. The destination it shows is now correct, but the framing is still wrong. That is a larger change than the remediation this issue asks for and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Kamino transaction destinations based on the action:
    * Deposits are directed to the vault.
    * Withdrawals are directed to the wallet.

* **Tests**
  * Added coverage confirming destination addresses in transactions and signing payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->