### PR TITLE
fix(defi): total both Solana DeFi positions in the chain header

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -3214,6 +3214,7 @@ private fun SolanaStakingPositionsLoadedPreview() {
             com.vultisig.wallet.ui.models.solanastaking.SolanaStakingPositionsUiState(
                 isLoading = false,
                 totalStakedFiatDisplay = "$78.04",
+                chainTotalFiatDisplay = "$78.04",
                 totalStakedSolDisplay = "1 SOL",
                 positions =
                     listOf(
@@ -3303,6 +3304,7 @@ private fun SolanaStakingPositionsEmptyPreview() {
             com.vultisig.wallet.ui.models.solanastaking.SolanaStakingPositionsUiState(
                 isLoading = false,
                 totalStakedFiatDisplay = "$0.00",
+                chainTotalFiatDisplay = "$0.00",
                 totalStakedSolDisplay = "0 SOL",
                 positions = emptyList(),
                 isBalanceVisible = true,
@@ -4045,6 +4047,8 @@ private fun SolanaDeFiPreview(tab: DeFiTab, hasEnabledVaults: Boolean = true) {
                 isLoading = false,
                 isBalanceVisible = true,
                 totalStakedFiatDisplay = "$1,240.50",
+                // Staking plus the Earn tab, the way the banner reports it on device.
+                chainTotalFiatDisplay = if (hasEnabledVaults) "$2,294.72" else "$1,240.50",
                 totalStakedSolDisplay = "12.5 SOL",
                 positions =
                     listOf(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
@@ -29,6 +29,7 @@ import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnTotal
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import com.vultisig.wallet.ui.utils.formatPercent
@@ -44,6 +45,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import timber.log.Timber
@@ -108,10 +110,12 @@ internal data class SolanaStakingPositionsUiState(
     val chainTotalFiatDisplay: String? = null,
     /**
      * The two halves [chainTotalFiatDisplay] is made of, kept raw because they are loaded by
-     * separate view-models and either may arrive first.
+     * separate view-models and either may arrive first. The Kamino half is stored exactly as it was
+     * handed over, currency tag included, so the screen can tell "Earn's figure has not reached
+     * this view-model yet" from "Earn has no figure".
      */
     val stakedFiatValue: BigDecimal? = null,
-    val kaminoFiatValue: BigDecimal? = null,
+    val kaminoTotal: KaminoEarnTotal? = null,
     val positions: List<SolanaStakePositionRow> = emptyList(),
     val error: UiText? = null,
 )
@@ -144,13 +148,52 @@ constructor(
 
     private var vaultId: VaultId = ""
     private var loadJob: Job? = null
+    private var currencyJob: Job? = null
     private var solCoin: Coin? = null
     private var accountsByPubkey: Map<String, SolanaStakeAccount> = emptyMap()
     private var isBuildingStakingTx: Boolean = false
 
+    /**
+     * The currency the figures on screen were priced in, together with its format. Held as one
+     * reference so a reader never sees a format from one currency next to the ticker of another,
+     * and null until the first load has priced anything.
+     */
+    @Volatile private var pricing: Pricing? = null
+
+    private data class Pricing(val currency: AppCurrency, val format: NumberFormat)
+
     fun setData(vaultId: VaultId) {
         this.vaultId = vaultId
-        loadData()
+        observeCurrency()
+    }
+
+    /**
+     * Loads on entry and again on every display-currency change: every figure here is priced, so a
+     * switch invalidates them rather than merely relabelling them. The collector's first emission
+     * performs the initial load.
+     */
+    private fun observeCurrency() {
+        currencyJob?.cancel()
+        currencyJob =
+            viewModelScope.safeLaunch(
+                onError = { Timber.e(it, "Failed to watch the app currency") }
+            ) {
+                appCurrencyRepository.currency.distinctUntilChanged().collect { currency ->
+                    if (pricing?.currency?.equals(currency) == false) {
+                        // Drop the old-currency figures instead of leaving them under a new
+                        // symbol while the reload runs.
+                        pricing = null
+                        _state.update {
+                            it.copy(
+                                isLoading = true,
+                                totalStakedFiatDisplay = null,
+                                chainTotalFiatDisplay = null,
+                            )
+                        }
+                    }
+                    loadData(currency)
+                }
+            }
     }
 
     fun refresh() {
@@ -166,18 +209,12 @@ constructor(
      *
      * Null is "not resolved", which is not zero: reporting the staking half alone would present a
      * number that is short by a real position as the chain's whole DeFi balance.
+     *
+     * Applied synchronously on purpose. Formatting asynchronously here let two handovers finish out
+     * of order, so an earlier total could land last and sit on the banner as the current one.
      */
-    fun onKaminoTotalChanged(total: BigDecimal?) {
-        viewModelScope.safeLaunch(onError = { Timber.w(it, "Failed to total the Solana header") }) {
-            val currencyFormat = appCurrencyRepository.getCurrencyFormat()
-            _state.update {
-                it.withChainTotal(
-                    staked = it.stakedFiatValue,
-                    kamino = total,
-                    format = currencyFormat,
-                )
-            }
-        }
+    fun onKaminoTotalChanged(total: KaminoEarnTotal?) {
+        _state.update { it.withChainTotal(staked = it.stakedFiatValue, kamino = total) }
     }
 
     fun onStake() {
@@ -321,7 +358,7 @@ constructor(
         }
     }
 
-    private fun loadData() {
+    private fun loadData(selectedCurrency: AppCurrency? = null) {
         loadJob?.cancel()
         loadJob =
             viewModelScope.safeLaunch(
@@ -349,8 +386,9 @@ constructor(
                 }
 
                 val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
-                val currency = appCurrencyRepository.currency.first()
+                val currency = selectedCurrency ?: appCurrencyRepository.currency.first()
                 val currencyFormat = appCurrencyRepository.getCurrencyFormat()
+                pricing = Pricing(currency = currency, format = currencyFormat)
                 val price = cachedPrice(solCoin.id, currency)
 
                 this@SolanaStakingPositionsViewModel.solCoin = solCoin
@@ -384,11 +422,7 @@ constructor(
                             positions = rows,
                             error = null,
                         )
-                        .withChainTotal(
-                            staked = stakedFiatValue,
-                            kamino = it.kaminoFiatValue,
-                            format = currencyFormat,
-                        )
+                        .withChainTotal(staked = stakedFiatValue, kamino = it.kaminoTotal)
                 }
             }
     }
@@ -460,18 +494,25 @@ constructor(
      * printing the other half, which would read as the chain total while being short by whatever
      * the unread side holds. A user with no Kamino vault enabled has a resolved zero there, so the
      * common staking-only case still shows a figure.
+     *
+     * A Kamino half priced in some other currency counts as unresolved too. The two view-models
+     * read the selected currency independently, so a mid-session switch reaches one before the
+     * other; the banner waits that window out rather than adding euros to dollars.
      */
     private fun SolanaStakingPositionsUiState.withChainTotal(
         staked: BigDecimal?,
-        kamino: BigDecimal?,
-        format: NumberFormat,
-    ): SolanaStakingPositionsUiState =
-        copy(
+        kamino: KaminoEarnTotal?,
+    ): SolanaStakingPositionsUiState {
+        val pricing = pricing
+        val kaminoValue = kamino?.takeIf { it.currency == pricing?.currency }?.value
+        return copy(
             stakedFiatValue = staked,
-            kaminoFiatValue = kamino,
+            kaminoTotal = kamino,
             chainTotalFiatDisplay =
-                if (staked == null || kamino == null) null else format.format(staked.add(kamino)),
+                if (staked == null || kaminoValue == null || pricing == null) null
+                else pricing.format.format(staked.add(kaminoValue)),
         )
+    }
 
     private suspend fun cachedPrice(tokenId: String, currency: AppCurrency): BigDecimal =
         tokenPriceRepository.getCachedPrice(tokenId = tokenId, appCurrency = currency)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
@@ -100,6 +100,18 @@ internal data class SolanaStakingPositionsUiState(
     // string would slip past that and draw a blank line where the price belongs.
     val totalStakedFiatDisplay: String? = null,
     val totalStakedSolDisplay: String = "",
+    /**
+     * The chain's whole DeFi holding — native staking plus Kamino Earn — for the header banner,
+     * which is labelled with the chain rather than with the selected tab. Null renders as the
+     * unavailable marker, same as [totalStakedFiatDisplay].
+     */
+    val chainTotalFiatDisplay: String? = null,
+    /**
+     * The two halves [chainTotalFiatDisplay] is made of, kept raw because they are loaded by
+     * separate view-models and either may arrive first.
+     */
+    val stakedFiatValue: BigDecimal? = null,
+    val kaminoFiatValue: BigDecimal? = null,
     val positions: List<SolanaStakePositionRow> = emptyList(),
     val error: UiText? = null,
 )
@@ -145,6 +157,27 @@ constructor(
         if (vaultId.isEmpty()) return
         _state.update { it.copy(isReloading = true) }
         loadData()
+    }
+
+    /**
+     * The Kamino Earn total for this vault, handed over by the screen. Earn is loaded by its own
+     * view-model, so the header banner — which is labelled with the chain, not with the selected
+     * tab — can only be their sum once both sides have reported.
+     *
+     * Null is "not resolved", which is not zero: reporting the staking half alone would present a
+     * number that is short by a real position as the chain's whole DeFi balance.
+     */
+    fun onKaminoTotalChanged(total: BigDecimal?) {
+        viewModelScope.safeLaunch(onError = { Timber.w(it, "Failed to total the Solana header") }) {
+            val currencyFormat = appCurrencyRepository.getCurrencyFormat()
+            _state.update {
+                it.withChainTotal(
+                    staked = it.stakedFiatValue,
+                    kamino = total,
+                    format = currencyFormat,
+                )
+            }
+        }
     }
 
     fun onStake() {
@@ -335,19 +368,27 @@ constructor(
                             acc + account.delegatedStake.toBigDecimal()
                         }
                         .movePointLeft(solCoin.decimal)
-                val totalFiat = currencyFormat.format(totalStakedSolAmount.multiply(price))
+                val stakedFiatValue = totalStakedSolAmount.multiply(price)
+                val totalFiat = currencyFormat.format(stakedFiatValue)
 
                 _state.update {
                     it.copy(
-                        isLoading = false,
-                        isReloading = false,
-                        isBalanceVisible = isBalanceVisible,
-                        totalStakedFiatDisplay = totalFiat,
-                        totalStakedSolDisplay =
-                            totalStakedSolAmount.stripTrailingZeros().formatTokenAmount(SOL_TICKER),
-                        positions = rows,
-                        error = null,
-                    )
+                            isLoading = false,
+                            isReloading = false,
+                            isBalanceVisible = isBalanceVisible,
+                            totalStakedFiatDisplay = totalFiat,
+                            totalStakedSolDisplay =
+                                totalStakedSolAmount
+                                    .stripTrailingZeros()
+                                    .formatTokenAmount(SOL_TICKER),
+                            positions = rows,
+                            error = null,
+                        )
+                        .withChainTotal(
+                            staked = stakedFiatValue,
+                            kamino = it.kaminoFiatValue,
+                            format = currencyFormat,
+                        )
                 }
             }
     }
@@ -411,6 +452,26 @@ constructor(
 
     private fun shortAddress(address: String): String =
         if (address.length > 12) "${address.take(6)}…${address.takeLast(4)}" else address
+
+    /**
+     * Folds the two halves of the chain's DeFi holding into the banner value.
+     *
+     * Unknown wins over known: while either half is unresolved the banner says so rather than
+     * printing the other half, which would read as the chain total while being short by whatever
+     * the unread side holds. A user with no Kamino vault enabled has a resolved zero there, so the
+     * common staking-only case still shows a figure.
+     */
+    private fun SolanaStakingPositionsUiState.withChainTotal(
+        staked: BigDecimal?,
+        kamino: BigDecimal?,
+        format: NumberFormat,
+    ): SolanaStakingPositionsUiState =
+        copy(
+            stakedFiatValue = staked,
+            kaminoFiatValue = kamino,
+            chainTotalFiatDisplay =
+                if (staked == null || kamino == null) null else format.format(staked.add(kamino)),
+        )
 
     private suspend fun cachedPrice(tokenId: String, currency: AppCurrency): BigDecimal =
         tokenPriceRepository.getCachedPrice(tokenId = tokenId, appCurrency = currency)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
@@ -29,7 +29,7 @@ import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
-import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnTotal
+import com.vultisig.wallet.ui.screens.v2.defi.DefiFiatTotal
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import com.vultisig.wallet.ui.utils.formatPercent
@@ -58,7 +58,9 @@ import timber.log.Timber
  * @property validatorName display name (metadata) or truncated vote pubkey when unenriched
  * @property validatorLogoUrl absolute logo URL, or null to fall back to a monogram avatar
  * @property stakedDisplay delegated stake formatted as SOL, e.g. `"12.5 SOL"`
- * @property stakedFiatDisplay pre-formatted fiat value of the delegated stake
+ * @property stakedFiatDisplay pre-formatted fiat value of the delegated stake, null while it is not
+ *   known in the selected currency — a display-currency change drops it until the reload re-prices
+ *   it, rather than leaving a figure that is now a number in one currency wearing another's symbol
  * @property stateLabel localized lifecycle label (Active / Activating / Deactivating / Inactive)
  * @property apyDisplay pre-formatted APY (e.g. `"5.72%"`), or null when unknown
  * @property canManage the account is Active/Activating/Deactivating, so the Move/Stake actions row
@@ -76,7 +78,7 @@ internal data class SolanaStakePositionRow(
     val validatorLogoUrl: String?,
     val votePubkey: String?,
     val stakedDisplay: String,
-    val stakedFiatDisplay: String,
+    val stakedFiatDisplay: String?,
     val rentReserveDisplay: String,
     val state: SolanaStakeState,
     val stateLabel: UiText,
@@ -110,12 +112,12 @@ internal data class SolanaStakingPositionsUiState(
     val chainTotalFiatDisplay: String? = null,
     /**
      * The two halves [chainTotalFiatDisplay] is made of, kept raw because they are loaded by
-     * separate view-models and either may arrive first. The Kamino half is stored exactly as it was
-     * handed over, currency tag included, so the screen can tell "Earn's figure has not reached
-     * this view-model yet" from "Earn has no figure".
+     * separate view-models and either may arrive first. Each keeps the currency it was priced in —
+     * the Kamino half exactly as it was handed over, so the screen can also tell "Earn's figure has
+     * not reached this view-model yet" from "Earn has no figure".
      */
-    val stakedFiatValue: BigDecimal? = null,
-    val kaminoTotal: KaminoEarnTotal? = null,
+    val stakedFiat: DefiFiatTotal? = null,
+    val kaminoTotal: DefiFiatTotal? = null,
     val positions: List<SolanaStakePositionRow> = emptyList(),
     val error: UiText? = null,
 )
@@ -181,13 +183,17 @@ constructor(
                 appCurrencyRepository.currency.distinctUntilChanged().collect { currency ->
                     if (pricing?.currency?.equals(currency) == false) {
                         // Drop the old-currency figures instead of leaving them under a new
-                        // symbol while the reload runs.
+                        // symbol while the reload runs. The per-account fiat goes with them: those
+                        // strings are priced too, and a reload that then fails never rebuilds
+                        // them, so leaving them would strand each card on the old currency.
                         pricing = null
                         _state.update {
                             it.copy(
                                 isLoading = true,
                                 totalStakedFiatDisplay = null,
                                 chainTotalFiatDisplay = null,
+                                positions =
+                                    it.positions.map { row -> row.copy(stakedFiatDisplay = null) },
                             )
                         }
                     }
@@ -213,8 +219,8 @@ constructor(
      * Applied synchronously on purpose. Formatting asynchronously here let two handovers finish out
      * of order, so an earlier total could land last and sit on the banner as the current one.
      */
-    fun onKaminoTotalChanged(total: KaminoEarnTotal?) {
-        _state.update { it.withChainTotal(staked = it.stakedFiatValue, kamino = total) }
+    fun onKaminoTotalChanged(total: DefiFiatTotal?) {
+        _state.update { it.withChainTotal(staked = it.stakedFiat, kamino = total) }
     }
 
     fun onStake() {
@@ -388,7 +394,6 @@ constructor(
                 val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
                 val currency = selectedCurrency ?: appCurrencyRepository.currency.first()
                 val currencyFormat = appCurrencyRepository.getCurrencyFormat()
-                pricing = Pricing(currency = currency, format = currencyFormat)
                 val price = cachedPrice(solCoin.id, currency)
 
                 this@SolanaStakingPositionsViewModel.solCoin = solCoin
@@ -409,6 +414,10 @@ constructor(
                 val stakedFiatValue = totalStakedSolAmount.multiply(price)
                 val totalFiat = currencyFormat.format(stakedFiatValue)
 
+                // Published with the figures it priced, not ahead of them: everything the banner
+                // adds up is checked against this currency, so a load still in flight must not
+                // already claim its own.
+                pricing = Pricing(currency = currency, format = currencyFormat)
                 _state.update {
                     it.copy(
                             isLoading = false,
@@ -422,7 +431,10 @@ constructor(
                             positions = rows,
                             error = null,
                         )
-                        .withChainTotal(staked = stakedFiatValue, kamino = it.kaminoTotal)
+                        .withChainTotal(
+                            staked = DefiFiatTotal(stakedFiatValue, currency),
+                            kamino = it.kaminoTotal,
+                        )
                 }
             }
     }
@@ -495,22 +507,26 @@ constructor(
      * the unread side holds. A user with no Kamino vault enabled has a resolved zero there, so the
      * common staking-only case still shows a figure.
      *
-     * A Kamino half priced in some other currency counts as unresolved too. The two view-models
-     * read the selected currency independently, so a mid-session switch reaches one before the
-     * other; the banner waits that window out rather than adding euros to dollars.
+     * A half priced in some other currency counts as unresolved too, and both are held to that —
+     * the staking one is no safer than Kamino's. The two view-models read the selected currency
+     * independently, so a mid-session switch reaches one before the other, and Kamino's zero-vault
+     * answer needs no network call at all: it can arrive re-priced while this side is still holding
+     * the figure it read before the switch. The banner waits that window out rather than summing
+     * across currencies or restamping an old total with a new symbol.
      */
     private fun SolanaStakingPositionsUiState.withChainTotal(
-        staked: BigDecimal?,
-        kamino: KaminoEarnTotal?,
+        staked: DefiFiatTotal?,
+        kamino: DefiFiatTotal?,
     ): SolanaStakingPositionsUiState {
         val pricing = pricing
+        val stakedValue = staked?.takeIf { it.currency == pricing?.currency }?.value
         val kaminoValue = kamino?.takeIf { it.currency == pricing?.currency }?.value
         return copy(
-            stakedFiatValue = staked,
+            stakedFiat = staked,
             kaminoTotal = kamino,
             chainTotalFiatDisplay =
-                if (staked == null || kaminoValue == null || pricing == null) null
-                else pricing.format.format(staked.add(kaminoValue)),
+                if (stakedValue == null || kaminoValue == null || pricing == null) null
+                else pricing.format.format(stakedValue.add(kaminoValue)),
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModel.kt
@@ -393,7 +393,10 @@ constructor(
 
                 val isBalanceVisible = balanceVisibilityRepository.getVisibility(vaultId)
                 val currency = selectedCurrency ?: appCurrencyRepository.currency.first()
-                val currencyFormat = appCurrencyRepository.getCurrencyFormat()
+                // Built for the currency this load prices in rather than read live, so [pricing]
+                // pairs a format and a currency that cannot disagree if the selection changes
+                // part-way through.
+                val currencyFormat = appCurrencyRepository.getCurrencyFormat(currency)
                 val price = cachedPrice(solCoin.id, currency)
 
                 this@SolanaStakingPositionsViewModel.solCoin = solCoin

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DefiFiatTotal.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DefiFiatTotal.kt
@@ -1,0 +1,14 @@
+package com.vultisig.wallet.ui.screens.v2.defi
+
+import androidx.compose.runtime.Immutable
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import java.math.BigDecimal
+
+/**
+ * A fiat figure together with the currency it was priced in.
+ *
+ * A chain header adds up halves that separate view-models price, each reading the selected currency
+ * on its own clock. Carrying the currency lets that sum refuse to happen while a mid-session switch
+ * has only landed on one side, instead of adding euros to dollars.
+ */
+@Immutable data class DefiFiatTotal(val value: BigDecimal, val currency: AppCurrency)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
@@ -16,6 +16,12 @@ data class KaminoEarnUiModel(
     val rows: List<KaminoEarnRow> = emptyList(),
     /** Summed across vaults in the user's currency; null while unresolved. */
     val totalFiat: String? = null,
+    /**
+     * The same sum before formatting, so the chain header can add it to native staking without
+     * re-parsing [totalFiat]. Zero when no vault is enabled — that is the user holding nothing
+     * here, a known value — and null only while the total is genuinely unresolved.
+     */
+    val totalFiatValue: BigDecimal? = null,
     val isBalanceVisible: Boolean = true,
     /** Whether the last load stopped on an error, so the tab can say so rather than look empty. */
     val loadFailed: Boolean = false,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
@@ -2,17 +2,8 @@ package com.vultisig.wallet.ui.screens.v2.defi.solana
 
 import androidx.compose.runtime.Immutable
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
-import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.ui.screens.v2.defi.DefiFiatTotal
 import java.math.BigDecimal
-
-/**
- * A fiat figure together with the currency it was priced in.
- *
- * The chain header adds this to a half priced by a different view-model, and the two read the
- * selected currency independently. Carrying the currency lets that sum refuse to happen while a
- * mid-session switch has only landed on one side, instead of adding euros to dollars.
- */
-@Immutable data class KaminoEarnTotal(val value: BigDecimal, val currency: AppCurrency)
 
 /** State of the Kamino Earn segment of the Solana DeFi tab. */
 @Immutable
@@ -32,7 +23,7 @@ data class KaminoEarnUiModel(
      * here, a known value — and null whenever any enabled vault is unread or unpriced, because a
      * sum that silently omits one of them is not this wallet's Kamino total.
      */
-    val totalValue: KaminoEarnTotal? = null,
+    val totalValue: DefiFiatTotal? = null,
     val isBalanceVisible: Boolean = true,
     /** Whether the last load stopped on an error, so the tab can say so rather than look empty. */
     val loadFailed: Boolean = false,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
@@ -2,7 +2,17 @@ package com.vultisig.wallet.ui.screens.v2.defi.solana
 
 import androidx.compose.runtime.Immutable
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
+import com.vultisig.wallet.data.models.settings.AppCurrency
 import java.math.BigDecimal
+
+/**
+ * A fiat figure together with the currency it was priced in.
+ *
+ * The chain header adds this to a half priced by a different view-model, and the two read the
+ * selected currency independently. Carrying the currency lets that sum refuse to happen while a
+ * mid-session switch has only landed on one side, instead of adding euros to dollars.
+ */
+@Immutable data class KaminoEarnTotal(val value: BigDecimal, val currency: AppCurrency)
 
 /** State of the Kamino Earn segment of the Solana DeFi tab. */
 @Immutable
@@ -19,9 +29,10 @@ data class KaminoEarnUiModel(
     /**
      * The same sum before formatting, so the chain header can add it to native staking without
      * re-parsing [totalFiat]. Zero when no vault is enabled — that is the user holding nothing
-     * here, a known value — and null only while the total is genuinely unresolved.
+     * here, a known value — and null whenever any enabled vault is unread or unpriced, because a
+     * sum that silently omits one of them is not this wallet's Kamino total.
      */
-    val totalFiatValue: BigDecimal? = null,
+    val totalValue: KaminoEarnTotal? = null,
     val isBalanceVisible: Boolean = true,
     /** Whether the last load stopped on an error, so the tab can say so rather than look empty. */
     val loadFailed: Boolean = false,
@@ -56,13 +67,15 @@ data class KaminoEarnRow(
     val pnlDirection: PnlDirection,
     /**
      * The row's fiat value, kept alongside its formatted form so the screen total can be summed
-     * without re-parsing display strings. Zero when the position or its price is unresolved.
+     * without re-parsing display strings. Null when the position or its price could not be read — a
+     * zero there would drop the vault out of every total that adds these up, which reads as a
+     * deposit having shrunk rather than as a figure that is briefly unknown.
      */
-    val fiatValue: BigDecimal = BigDecimal.ZERO,
+    val fiatValue: BigDecimal? = null,
     /**
      * Whether the wallet actually holds shares here. Kept separate from [fiatValue] because a
-     * failed price lookup leaves that at zero, and a position must not disappear because it could
-     * not be priced.
+     * failed price lookup leaves that unresolved, and a position must not disappear because it
+     * could not be priced.
      */
     val hasPosition: Boolean = false,
 ) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.blockchain.solana.kamino.coin
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -35,6 +36,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
@@ -72,11 +74,18 @@ constructor(
     private var loadJob: Job? = null
     private var selectionJob: Job? = null
 
+    /**
+     * The enabled set [KaminoEarnUiModel.totalValue] was summed over. A stored total answers one
+     * question — this selection, in this currency — so once either changes it stops being an answer
+     * and is dropped rather than carried forward.
+     */
+    private var totalCoverage: Set<String> = emptySet()
+
     fun setData(vaultId: String) {
         this.vaultId = vaultId
         forgetStoredShareTokens()
         loadBalanceVisibility()
-        observeSelection()
+        observeSelectionAndCurrency()
     }
 
     /**
@@ -179,21 +188,27 @@ constructor(
 
     /**
      * Reloads whenever the opt-in changes, so toggling a vault under Manage positions takes effect
-     * without leaving the screen.
+     * without leaving the screen, and whenever the display currency changes, because every figure
+     * here is priced — leaving them be after a switch would relabel them without re-pricing.
      */
-    private fun observeSelection() {
+    private fun observeSelectionAndCurrency() {
         selectionJob?.cancel()
         selectionJob =
             viewModelScope.safeLaunch {
-                selectionRepository.getSelectedVaults(vaultId).distinctUntilChanged().collect {
-                    selected ->
-                    _state.update { it.copy(hasEnabledVaults = selected.isNotEmpty()) }
-                    load(selected)
-                }
+                combine(
+                        selectionRepository.getSelectedVaults(vaultId),
+                        appCurrencyRepository.currency,
+                        ::Pair,
+                    )
+                    .distinctUntilChanged()
+                    .collect { (selected, currency) ->
+                        _state.update { it.copy(hasEnabledVaults = selected.isNotEmpty()) }
+                        load(selected, currency)
+                    }
             }
     }
 
-    private fun load(selected: Set<String>? = null) {
+    private fun load(selected: Set<String>? = null, selectedCurrency: AppCurrency? = null) {
         loadJob?.cancel()
         loadJob =
             viewModelScope.safeLaunch(
@@ -206,6 +221,15 @@ constructor(
             ) {
                 val enabled = selected ?: selectionRepository.getSelectedVaults(vaultId).first()
                 val vaults = KaminoVaultRegistry.ALLOW_LIST.filter { it.address in enabled }
+                val currency = selectedCurrency ?: appCurrencyRepository.currency.first()
+
+                // Drop a stored total that no longer describes this selection or this currency
+                // before anything else, so neither this load's fallback nor a failure part-way
+                // through can leave it on screen as though it still answered.
+                if (totalCoverage != enabled || _state.value.totalValue?.currency != currency) {
+                    totalCoverage = emptySet()
+                    _state.update { it.copy(totalFiat = null, totalValue = null) }
+                }
 
                 if (vaults.isEmpty()) {
                     _state.update {
@@ -216,7 +240,7 @@ constructor(
                             totalFiat = null,
                             // Zero, not null: no vault enabled is a read that succeeded and found
                             // nothing, so the chain header can still add it up.
-                            totalFiatValue = BigDecimal.ZERO,
+                            totalValue = KaminoEarnTotal(BigDecimal.ZERO, currency),
                         )
                     }
                     return@safeLaunch
@@ -242,6 +266,7 @@ constructor(
                                             walletAddress = walletAddress,
                                             position = positions?.get(vault.address),
                                             positionsAreKnown = positions != null,
+                                            currency = currency,
                                         )
                                     }
                                     .getOrElse { throwable ->
@@ -258,8 +283,19 @@ constructor(
                 }
 
                 val resolved = rows.filterNotNull()
-                val resolvedTotal = resolved.takeIf { it.isNotEmpty() }?.let(::totalFiatValue)
+                // Only a sum covering every enabled vault is this wallet's Kamino total. A vault
+                // whose row failed to build, or whose price never landed, would otherwise be folded
+                // in as a zero and quietly shrink both this card and the chain header.
+                val resolvedTotal =
+                    if (resolved.size == vaults.size) {
+                        totalFiatValue(resolved)?.let { KaminoEarnTotal(it, currency) }
+                    } else {
+                        null
+                    }
                 _state.update { current ->
+                    // The previous total is only kept when this load produced none; it has already
+                    // been dropped above unless it still covers this selection and currency.
+                    val total = resolvedTotal ?: current.totalValue
                     current.copy(
                         isLoading = false,
                         // Keep the previous rows if every vault failed, rather than blanking
@@ -269,11 +305,11 @@ constructor(
                             resolved.ifEmpty {
                                 current.rows.filter { row -> row.vaultAddress in enabled }
                             },
-                        totalFiat =
-                            resolvedTotal?.let { currencyFormat.format(it) } ?: current.totalFiat,
-                        totalFiatValue = resolvedTotal ?: current.totalFiatValue,
+                        totalFiat = total?.let { currencyFormat.format(it.value) },
+                        totalValue = total,
                     )
                 }
+                if (resolvedTotal != null) totalCoverage = enabled
             }
     }
 
@@ -302,6 +338,7 @@ constructor(
         walletAddress: String,
         position: KaminoUserPositionJson?,
         positionsAreKnown: Boolean,
+        currency: AppCurrency,
     ): KaminoEarnRow = supervisorScope {
         val stateDeferred = async {
             runCatching { kaminoApi.getVaultState(vault.address) }.getOrNull()
@@ -348,7 +385,8 @@ constructor(
             depositedDisplay =
                 tokenAmount?.let { it.stripTrailingZeros().formatTokenAmount(coin?.ticker).trim() }
                     ?: FIAT_VALUE_UNAVAILABLE,
-            depositedFiat = tokenAmount?.let { amount -> coin?.let { fiatOrNull(amount, it) } },
+            depositedFiat =
+                tokenAmount?.let { amount -> coin?.let { fiatOrNull(amount, it, currency) } },
             apyDisplay = apy?.formatPercent(),
             pnlDisplay =
                 pnlToken?.let {
@@ -364,9 +402,10 @@ constructor(
                     pnlToken.signum() < 0 -> KaminoEarnRow.PnlDirection.DOWN
                     else -> KaminoEarnRow.PnlDirection.FLAT
                 },
+            // Null, not zero, when the position or its price could not be read: the totals that add
+            // these up treat an unread vault as unknown rather than as holding nothing.
             fiatValue =
-                tokenAmount?.let { amount -> coin?.let { fiatValueOrNull(amount, it) } }
-                    ?: BigDecimal.ZERO,
+                tokenAmount?.let { amount -> coin?.let { fiatValueOrNull(amount, it, currency) } },
             // Two different claims live in a zero here: "read, and holds nothing" and "not read
             // yet". Only the first may remove Withdraw. Hiding it on an unread position strands a
             // user who deposited on another device, or whose refresh failed right after depositing
@@ -382,9 +421,12 @@ constructor(
      * Fiat goes through the app's own price pipeline rather than Kamino's USD figures, because the
      * user may not be reading in dollars.
      */
-    private suspend fun fiatValueOrNull(amount: BigDecimal, coin: Coin): BigDecimal? {
+    private suspend fun fiatValueOrNull(
+        amount: BigDecimal,
+        coin: Coin,
+        currency: AppCurrency,
+    ): BigDecimal? {
         if (amount.signum() == 0) return BigDecimal.ZERO
-        val currency = appCurrencyRepository.currency.first()
         val price =
             runCatching {
                     tokenPriceRepository.getCachedPrice(tokenId = coin.id, appCurrency = currency)
@@ -397,17 +439,23 @@ constructor(
         return amount.multiply(price).setScale(2, RoundingMode.DOWN)
     }
 
-    private suspend fun fiatOrNull(amount: BigDecimal, coin: Coin): String? {
-        val value = fiatValueOrNull(amount, coin) ?: return null
+    private suspend fun fiatOrNull(amount: BigDecimal, coin: Coin, currency: AppCurrency): String? {
+        val value = fiatValueOrNull(amount, coin, currency) ?: return null
         return runCatching { appCurrencyRepository.getCurrencyFormat().format(value) }.getOrNull()
     }
 
     /**
      * Summed per row, because the vaults do not share an underlying token — dollars and SOL cannot
-     * be added before each has been priced.
+     * be added before each has been priced. Null as soon as one row is unpriced: that vault added
+     * in as a zero would report a total the user does not hold.
      */
-    private fun totalFiatValue(rows: List<KaminoEarnRow>): BigDecimal =
-        rows.fold(BigDecimal.ZERO) { running, row -> running.add(row.fiatValue) }
+    private fun totalFiatValue(rows: List<KaminoEarnRow>): BigDecimal? {
+        var total = BigDecimal.ZERO
+        for (row in rows) {
+            total = total.add(row.fiatValue ?: return null)
+        }
+        return total
+    }
 
     private suspend fun resolveSolanaAddress(): String {
         val vault =

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -276,8 +276,11 @@ constructor(
 
                 val walletAddress = resolveSolanaAddress()
                 val positions = fetchPositions(walletAddress)
+                // Pinned to the currency this load priced in, not read live: a switch part-way
+                // through would otherwise stamp the new currency's symbol on figures priced in the
+                // old one.
                 val currencyFormat =
-                    withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat() }
+                    withContext(ioDispatcher) { appCurrencyRepository.getCurrencyFormat(currency) }
 
                 // Each vault is independent: one failing call must not empty the other cards.
                 val rows = supervisorScope {
@@ -476,9 +479,16 @@ constructor(
         return amount.multiply(price).setScale(2, RoundingMode.DOWN)
     }
 
+    /**
+     * Formatted for the currency the value was priced in, not for whichever one is selected by the
+     * time the row is built: a switch mid-load would otherwise stamp the new symbol on a figure
+     * priced in the old one. Its own format instance, since rows are built concurrently and a
+     * NumberFormat is not safe to share.
+     */
     private suspend fun fiatOrNull(amount: BigDecimal, coin: Coin, currency: AppCurrency): String? {
         val value = fiatValueOrNull(amount, coin, currency) ?: return null
-        return runCatching { appCurrencyRepository.getCurrencyFormat().format(value) }.getOrNull()
+        return runCatching { appCurrencyRepository.getCurrencyFormat(currency).format(value) }
+            .getOrNull()
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -214,6 +214,9 @@ constructor(
                             hasEnabledVaults = false,
                             rows = emptyList(),
                             totalFiat = null,
+                            // Zero, not null: no vault enabled is a read that succeeded and found
+                            // nothing, so the chain header can still add it up.
+                            totalFiatValue = BigDecimal.ZERO,
                         )
                     }
                     return@safeLaunch
@@ -255,6 +258,7 @@ constructor(
                 }
 
                 val resolved = rows.filterNotNull()
+                val resolvedTotal = resolved.takeIf { it.isNotEmpty() }?.let(::totalFiatValue)
                 _state.update { current ->
                     current.copy(
                         isLoading = false,
@@ -266,10 +270,8 @@ constructor(
                                 current.rows.filter { row -> row.vaultAddress in enabled }
                             },
                         totalFiat =
-                            resolved
-                                .takeIf { it.isNotEmpty() }
-                                ?.let { currencyFormat.format(totalFiatValue(it)) }
-                                ?: current.totalFiat,
+                            resolvedTotal?.let { currencyFormat.format(it) } ?: current.totalFiat,
+                        totalFiatValue = resolvedTotal ?: current.totalFiatValue,
                     )
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -22,6 +22,7 @@ import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.DefiFiatTotal
 import com.vultisig.wallet.ui.screens.v2.defi.FIAT_VALUE_UNAVAILABLE
 import com.vultisig.wallet.ui.utils.formatPercent
 import com.vultisig.wallet.ui.utils.formatTokenAmount
@@ -80,6 +81,13 @@ constructor(
      * and is dropped rather than carried forward.
      */
     private var totalCoverage: Set<String> = emptySet()
+
+    /**
+     * The currency the cards on screen were priced in, null until a load has priced any. A switch
+     * invalidates every fiat figure they carry, so it is tracked separately from [totalCoverage]:
+     * the rows outlive a load that resolves no total.
+     */
+    private var pricedCurrency: AppCurrency? = null
 
     fun setData(vaultId: String) {
         this.vaultId = vaultId
@@ -231,6 +239,22 @@ constructor(
                     _state.update { it.copy(totalFiat = null, totalValue = null) }
                 }
 
+                // The cards carry their own fiat, priced in whatever currency was selected when
+                // they were built. A switch does not merely relabel those figures, it makes them
+                // wrong — and the rows survive both a failed reload and one that resolves no
+                // total, so they would sit there in the old currency indefinitely.
+                if (pricedCurrency != null && pricedCurrency != currency) {
+                    pricedCurrency = null
+                    _state.update { current ->
+                        current.copy(
+                            rows =
+                                current.rows.map { row ->
+                                    row.copy(depositedFiat = null, fiatValue = null)
+                                }
+                        )
+                    }
+                }
+
                 if (vaults.isEmpty()) {
                     _state.update {
                         it.copy(
@@ -240,7 +264,7 @@ constructor(
                             totalFiat = null,
                             // Zero, not null: no vault enabled is a read that succeeded and found
                             // nothing, so the chain header can still add it up.
-                            totalValue = KaminoEarnTotal(BigDecimal.ZERO, currency),
+                            totalValue = DefiFiatTotal(BigDecimal.ZERO, currency),
                         )
                     }
                     return@safeLaunch
@@ -288,7 +312,7 @@ constructor(
                 // in as a zero and quietly shrink both this card and the chain header.
                 val resolvedTotal =
                     if (resolved.size == vaults.size) {
-                        totalFiatValue(resolved)?.let { KaminoEarnTotal(it, currency) }
+                        totalFiatValue(resolved)?.let { DefiFiatTotal(it, currency) }
                     } else {
                         null
                     }
@@ -309,6 +333,7 @@ constructor(
                         totalValue = total,
                     )
                 }
+                pricedCurrency = currency
                 if (resolvedTotal != null) totalCoverage = enabled
             }
     }
@@ -355,12 +380,15 @@ constructor(
         val pnl = pnlDeferred.await()
 
         // A position that could not be read is not a zero one. Null keeps the balance blank rather
-        // than asserting "0", which on a real deposit reads as though it had gone.
+        // than asserting "0", which on a real deposit reads as though it had gone. Only the wallet
+        // having no position in this vault at all is a genuine zero: a position that is there but
+        // whose share balance will not parse is a deposit of unknown size, which is how
+        // `KaminoWithdraw` treats the same field failing to parse.
         val shares =
-            if (positionsAreKnown) {
-                KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
-            } else {
-                null
+            when {
+                !positionsAreKnown -> null
+                position == null -> BigDecimal.ZERO
+                else -> KaminoPositionMath.decimalOrNull(position.totalShares)
             }
         val tokensPerShare = KaminoPositionMath.decimalOrNull(metrics?.tokensPerShare)
         val tokenAmount =
@@ -431,11 +459,20 @@ constructor(
             runCatching {
                     tokenPriceRepository.getCachedPrice(tokenId = coin.id, appCurrency = currency)
                         ?: tokenPriceRepository.getPriceByContactAddress(
-                            coin.chain.id,
-                            coin.contractAddress,
+                            chainId = coin.chain.id,
+                            contractAddress = coin.contractAddress,
+                            // The currency this row is being priced in, not whichever one is
+                            // selected by the time the lookup returns: the app currency can change
+                            // mid-flight, and the quote would then be filed and added up under the
+                            // other one.
+                            appCurrency = currency,
                         )
                 }
-                .getOrNull() ?: return null
+                // A miss arrives from that lookup as a zero rather than as a throw — for a native
+                // token it does not even reach the network, since there is no contract to ask
+                // about. Counting that as "worth nothing" is the same lie as a zero balance.
+                .getOrNull()
+                ?.takeIf { it.signum() > 0 } ?: return null
         return amount.multiply(price).setScale(2, RoundingMode.DOWN)
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -383,7 +383,9 @@ private fun StakeAccountContent(
                 )
                 UiSpacer(2.dp)
                 Text(
-                    text = if (isBalanceVisible) row.stakedFiatDisplay else HIDE_BALANCE_CHARS,
+                    text =
+                        if (isBalanceVisible) row.stakedFiatDisplay ?: FIAT_VALUE_UNAVAILABLE
+                        else HIDE_BALANCE_CHARS,
                     style = Theme.brockmann.supplementary.caption,
                     color = Theme.v2.colors.text.tertiary,
                 )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -85,8 +85,8 @@ internal fun SolanaStakingPositionsScreen(
     // The header banner is the chain's total, so it needs both tabs' figures. Earn owns its own
     // load, so its total is handed to the staking view-model as it resolves rather than being
     // summed in the composition, where the user's currency format isn't available.
-    LaunchedEffect(kaminoState.totalFiatValue) {
-        viewModel.onKaminoTotalChanged(kaminoState.totalFiatValue)
+    LaunchedEffect(kaminoState.totalValue) {
+        viewModel.onKaminoTotalChanged(kaminoState.totalValue)
     }
 
     SolanaStakingPositionsContent(
@@ -150,9 +150,16 @@ internal fun SolanaStakingPositionsContent(
         ) {
             SolanaHeaderBanner(
                 totalValue = state.chainTotalFiatDisplay,
-                // Both halves gate the banner: showing the staking total the moment it lands would
-                // print a figure that then jumps as Earn resolves.
-                isLoading = state.isLoading || kaminoState.isLoading,
+                // Both halves gate the banner, but only until it first resolves: Earn reloads on
+                // every pull-to-refresh and vault toggle, and gating on that would swap an
+                // already-correct figure for a skeleton. The handover runs a frame behind Earn's
+                // own load, so a total that has arrived but not yet reached the staking view-model
+                // reads as still loading rather than as unavailable.
+                isLoading =
+                    state.chainTotalFiatDisplay == null &&
+                        (state.isLoading ||
+                            kaminoState.isLoading ||
+                            kaminoState.totalValue != state.kaminoTotal),
                 isBalanceVisible = state.isBalanceVisible,
             )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -79,6 +80,13 @@ internal fun SolanaStakingPositionsScreen(
         viewModel.setData(vaultId)
         kaminoViewModel.setData(vaultId)
         onPauseOrDispose {}
+    }
+
+    // The header banner is the chain's total, so it needs both tabs' figures. Earn owns its own
+    // load, so its total is handed to the staking view-model as it resolves rather than being
+    // summed in the composition, where the user's currency format isn't available.
+    LaunchedEffect(kaminoState.totalFiatValue) {
+        viewModel.onKaminoTotalChanged(kaminoState.totalFiatValue)
     }
 
     SolanaStakingPositionsContent(
@@ -141,8 +149,10 @@ internal fun SolanaStakingPositionsContent(
             horizontalAlignment = CenterHorizontally,
         ) {
             SolanaHeaderBanner(
-                totalValue = state.totalStakedFiatDisplay,
-                isLoading = state.isLoading,
+                totalValue = state.chainTotalFiatDisplay,
+                // Both halves gate the banner: showing the staking total the moment it lands would
+                // print a figure that then jumps as Earn resolves.
+                isLoading = state.isLoading || kaminoState.isLoading,
                 isBalanceVisible = state.isBalanceVisible,
             )
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModelTest.kt
@@ -1,0 +1,197 @@
+package com.vultisig.wallet.ui.models.solanastaking
+
+import com.vultisig.wallet.data.blockchain.solana.staking.BuildSolanaStakingKeysignPayloadUseCase
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakeAccount
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakeState
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingService
+import com.vultisig.wallet.data.blockchain.solana.staking.ValidatorMetadataProvider
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.repositories.TokenPriceRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.text.NumberFormat
+import java.util.Locale
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the header banner's total, which is the chain's whole DeFi holding rather than the staking
+ * half the Staked tab shows.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class SolanaStakingPositionsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var solanaStakingService: SolanaStakingService
+    private lateinit var validatorMetadataProvider: ValidatorMetadataProvider
+    private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
+    private lateinit var tokenPriceRepository: TokenPriceRepository
+    private lateinit var appCurrencyRepository: AppCurrencyRepository
+    private lateinit var blockChainSpecificRepository: BlockChainSpecificRepository
+    private lateinit var buildKeysignPayload: BuildSolanaStakingKeysignPayloadUseCase
+    private lateinit var depositTransactionRepository: DepositTransactionRepository
+    private lateinit var navigator: Navigator<Destination>
+
+    private val defaultLocale = Locale.getDefault()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        // The totals below are formatted for the user's locale, so pin the one the test runs under.
+        Locale.setDefault(Locale.US)
+        vaultRepository = mockk(relaxed = true)
+        solanaStakingService = mockk(relaxed = true)
+        validatorMetadataProvider = mockk(relaxed = true)
+        balanceVisibilityRepository = mockk(relaxed = true)
+        tokenPriceRepository = mockk(relaxed = true)
+        appCurrencyRepository = mockk(relaxed = true)
+        blockChainSpecificRepository = mockk(relaxed = true)
+        buildKeysignPayload = mockk(relaxed = true)
+        depositTransactionRepository = mockk(relaxed = true)
+        navigator = mockk(relaxed = true)
+
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
+        coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
+        coEvery { appCurrencyRepository.getCurrencyFormat() } returns
+            NumberFormat.getCurrencyInstance(Locale.US)
+        coEvery { tokenPriceRepository.getCachedPrice(SOL.id, AppCurrency.USD) } returns
+            BigDecimal("100")
+        coEvery { solanaStakingService.fetchStakeAccounts(ADDRESS) } returns listOf(stakeAccount())
+        coEvery { validatorMetadataProvider.metadata(any()) } returns emptyMap()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        Locale.setDefault(defaultLocale)
+    }
+
+    @Test
+    fun `the header adds Kamino Earn to native staking`() = runTest {
+        val vm = viewModel().apply { setData(VAULT_ID) }
+
+        vm.onKaminoTotalChanged(BigDecimal("54.25"))
+
+        // The Staked tab keeps reporting its own half.
+        assertEquals("$100.00", vm.state.value.totalStakedFiatDisplay)
+        assertEquals("$154.25", vm.state.value.chainTotalFiatDisplay)
+    }
+
+    @Test
+    fun `the header totals whichever half arrives first`() = runTest {
+        // Earn is loaded by its own view-model, so it can resolve before the stake accounts do.
+        val vm = viewModel()
+        vm.onKaminoTotalChanged(BigDecimal("54.25"))
+
+        vm.setData(VAULT_ID)
+
+        assertEquals("$154.25", vm.state.value.chainTotalFiatDisplay)
+    }
+
+    @Test
+    fun `no Kamino vault enabled still leaves the header showing the staked total`() = runTest {
+        val vm = viewModel().apply { setData(VAULT_ID) }
+
+        // A resolved zero, which the Earn view-model reports when nothing is enabled.
+        vm.onKaminoTotalChanged(BigDecimal.ZERO)
+
+        assertEquals("$100.00", vm.state.value.chainTotalFiatDisplay)
+    }
+
+    @Test
+    fun `an unresolved Kamino total leaves the header unavailable rather than short`() = runTest {
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        vm.onKaminoTotalChanged(BigDecimal("54.25"))
+
+        vm.onKaminoTotalChanged(null)
+
+        // Reporting the staking half alone would present a number short by a real position as the
+        // chain's whole DeFi balance.
+        assertNull(vm.state.value.chainTotalFiatDisplay)
+        assertEquals("$100.00", vm.state.value.totalStakedFiatDisplay)
+    }
+
+    @Test
+    fun `a vault without SOL reports no total at all`() = runTest {
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT.copy(coins = emptyList())
+
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        vm.onKaminoTotalChanged(BigDecimal("54.25"))
+
+        assertNull(vm.state.value.chainTotalFiatDisplay)
+    }
+
+    private fun viewModel() =
+        SolanaStakingPositionsViewModel(
+            vaultRepository = vaultRepository,
+            solanaStakingService = solanaStakingService,
+            validatorMetadataProvider = validatorMetadataProvider,
+            balanceVisibilityRepository = balanceVisibilityRepository,
+            tokenPriceRepository = tokenPriceRepository,
+            appCurrencyRepository = appCurrencyRepository,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            buildKeysignPayload = buildKeysignPayload,
+            depositTransactionRepository = depositTransactionRepository,
+            navigator = navigator,
+        )
+
+    /** One stake account holding 1 SOL, which at the stubbed price is $100.00. */
+    private fun stakeAccount() =
+        SolanaStakeAccount(
+            stakePubkey = "6nJqQF6ZMTZ3aM2Q9pQ4Gg8v8g8pQmYyWpUUZq4KaWWM",
+            voter = null,
+            lamports = BigInteger("1002282880"),
+            delegatedStake = BigInteger("1000000000"),
+            rentExemptReserve = BigInteger("2282880"),
+            activationEpoch = null,
+            deactivationEpoch = null,
+            state = SolanaStakeState.Active,
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+        const val ADDRESS = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+        val SOL = Coins.Solana.SOL.copy(address = ADDRESS)
+
+        val VAULT =
+            Vault(
+                id = VAULT_ID,
+                name = "vault",
+                pubKeyECDSA = "",
+                pubKeyEDDSA = "",
+                hexChainCode = "",
+                localPartyID = "",
+                signers = emptyList(),
+                resharePrefix = "",
+                libType = SigningLibType.DKLS,
+                coins = listOf(SOL),
+            )
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModelTest.kt
@@ -17,6 +17,9 @@ import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnTotal
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -24,10 +27,9 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.text.NumberFormat
 import java.util.Locale
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -96,22 +98,22 @@ internal class SolanaStakingPositionsViewModelTest {
     fun `the header adds Kamino Earn to native staking`() = runTest {
         val vm = viewModel().apply { setData(VAULT_ID) }
 
-        vm.onKaminoTotalChanged(BigDecimal("54.25"))
+        vm.onKaminoTotalChanged(kaminoTotal("54.25"))
 
         // The Staked tab keeps reporting its own half.
-        assertEquals("$100.00", vm.state.value.totalStakedFiatDisplay)
-        assertEquals("$154.25", vm.state.value.chainTotalFiatDisplay)
+        vm.state.value.totalStakedFiatDisplay shouldBe "$100.00"
+        vm.state.value.chainTotalFiatDisplay shouldBe "$154.25"
     }
 
     @Test
     fun `the header totals whichever half arrives first`() = runTest {
         // Earn is loaded by its own view-model, so it can resolve before the stake accounts do.
         val vm = viewModel()
-        vm.onKaminoTotalChanged(BigDecimal("54.25"))
+        vm.onKaminoTotalChanged(kaminoTotal("54.25"))
 
         vm.setData(VAULT_ID)
 
-        assertEquals("$154.25", vm.state.value.chainTotalFiatDisplay)
+        vm.state.value.chainTotalFiatDisplay shouldBe "$154.25"
     }
 
     @Test
@@ -119,22 +121,74 @@ internal class SolanaStakingPositionsViewModelTest {
         val vm = viewModel().apply { setData(VAULT_ID) }
 
         // A resolved zero, which the Earn view-model reports when nothing is enabled.
-        vm.onKaminoTotalChanged(BigDecimal.ZERO)
+        vm.onKaminoTotalChanged(kaminoTotal("0"))
 
-        assertEquals("$100.00", vm.state.value.chainTotalFiatDisplay)
+        vm.state.value.chainTotalFiatDisplay shouldBe "$100.00"
     }
 
     @Test
     fun `an unresolved Kamino total leaves the header unavailable rather than short`() = runTest {
         val vm = viewModel().apply { setData(VAULT_ID) }
-        vm.onKaminoTotalChanged(BigDecimal("54.25"))
+        vm.onKaminoTotalChanged(kaminoTotal("54.25"))
 
         vm.onKaminoTotalChanged(null)
 
         // Reporting the staking half alone would present a number short by a real position as the
         // chain's whole DeFi balance.
-        assertNull(vm.state.value.chainTotalFiatDisplay)
-        assertEquals("$100.00", vm.state.value.totalStakedFiatDisplay)
+        vm.state.value.chainTotalFiatDisplay.shouldBeNull()
+        vm.state.value.totalStakedFiatDisplay shouldBe "$100.00"
+    }
+
+    @Test
+    fun `the newest Kamino total wins, whatever order the handovers land in`() = runTest {
+        val vm = viewModel().apply { setData(VAULT_ID) }
+
+        vm.onKaminoTotalChanged(kaminoTotal("54.25"))
+        vm.onKaminoTotalChanged(kaminoTotal("70.00"))
+
+        // An earlier handover must never overwrite a later one — the banner would then sit on a
+        // figure the Earn tab has already moved past.
+        vm.state.value.chainTotalFiatDisplay shouldBe "$170.00"
+    }
+
+    @Test
+    fun `a Kamino half priced in another currency is not added to this one`() = runTest {
+        val vm = viewModel().apply { setData(VAULT_ID) }
+
+        // Mid-switch: Earn is still reporting the figure it priced before the change landed.
+        vm.onKaminoTotalChanged(KaminoEarnTotal(BigDecimal("54.25"), AppCurrency.EUR))
+
+        // €54.25 added to $100.00 is not a figure in either currency, so the banner waits.
+        vm.state.value.chainTotalFiatDisplay.shouldBeNull()
+    }
+
+    @Test
+    fun `a currency change re-prices the screen instead of relabelling it`() = runTest {
+        val currency = MutableStateFlow(AppCurrency.USD)
+        every { appCurrencyRepository.currency } returns currency
+        coEvery { appCurrencyRepository.getCurrencyFormat() } answers
+            {
+                NumberFormat.getCurrencyInstance(
+                    if (currency.value == AppCurrency.EUR) Locale.GERMANY else Locale.US
+                )
+            }
+        coEvery { tokenPriceRepository.getCachedPrice(SOL.id, AppCurrency.EUR) } returns
+            BigDecimal("90")
+
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        vm.onKaminoTotalChanged(kaminoTotal("10"))
+        vm.state.value.chainTotalFiatDisplay shouldBe "$110.00"
+
+        currency.value = AppCurrency.EUR
+
+        // Earn has not re-priced yet, and its dollar figure must not be added to a euro one.
+        vm.state.value.chainTotalFiatDisplay.shouldBeNull()
+
+        vm.onKaminoTotalChanged(KaminoEarnTotal(BigDecimal("10"), AppCurrency.EUR))
+
+        // The staked SOL is re-priced in euros rather than the dollar figure being restamped.
+        vm.state.value.chainTotalFiatDisplay shouldBe
+            NumberFormat.getCurrencyInstance(Locale.GERMANY).format(BigDecimal("100"))
     }
 
     @Test
@@ -142,10 +196,12 @@ internal class SolanaStakingPositionsViewModelTest {
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT.copy(coins = emptyList())
 
         val vm = viewModel().apply { setData(VAULT_ID) }
-        vm.onKaminoTotalChanged(BigDecimal("54.25"))
+        vm.onKaminoTotalChanged(kaminoTotal("54.25"))
 
-        assertNull(vm.state.value.chainTotalFiatDisplay)
+        vm.state.value.chainTotalFiatDisplay.shouldBeNull()
     }
+
+    private fun kaminoTotal(value: String) = KaminoEarnTotal(BigDecimal(value), AppCurrency.USD)
 
     private fun viewModel() =
         SolanaStakingPositionsViewModel(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModelTest.kt
@@ -17,7 +17,7 @@ import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
-import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnTotal
+import com.vultisig.wallet.ui.screens.v2.defi.DefiFiatTotal
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -27,6 +27,7 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import java.text.NumberFormat
 import java.util.Locale
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -156,7 +157,7 @@ internal class SolanaStakingPositionsViewModelTest {
         val vm = viewModel().apply { setData(VAULT_ID) }
 
         // Mid-switch: Earn is still reporting the figure it priced before the change landed.
-        vm.onKaminoTotalChanged(KaminoEarnTotal(BigDecimal("54.25"), AppCurrency.EUR))
+        vm.onKaminoTotalChanged(DefiFiatTotal(BigDecimal("54.25"), AppCurrency.EUR))
 
         // €54.25 added to $100.00 is not a figure in either currency, so the banner waits.
         vm.state.value.chainTotalFiatDisplay.shouldBeNull()
@@ -184,12 +185,73 @@ internal class SolanaStakingPositionsViewModelTest {
         // Earn has not re-priced yet, and its dollar figure must not be added to a euro one.
         vm.state.value.chainTotalFiatDisplay.shouldBeNull()
 
-        vm.onKaminoTotalChanged(KaminoEarnTotal(BigDecimal("10"), AppCurrency.EUR))
+        vm.onKaminoTotalChanged(DefiFiatTotal(BigDecimal("10"), AppCurrency.EUR))
 
         // The staked SOL is re-priced in euros rather than the dollar figure being restamped.
         vm.state.value.chainTotalFiatDisplay shouldBe
             NumberFormat.getCurrencyInstance(Locale.GERMANY).format(BigDecimal("100"))
     }
+
+    @Test
+    fun `a Kamino half that re-priced first is not added to a staked half that has not`() =
+        runTest {
+            val currency = MutableStateFlow(AppCurrency.USD)
+            every { appCurrencyRepository.currency } returns currency
+            coEvery { appCurrencyRepository.getCurrencyFormat() } answers
+                {
+                    NumberFormat.getCurrencyInstance(
+                        if (currency.value == AppCurrency.EUR) Locale.GERMANY else Locale.US
+                    )
+                }
+            coEvery { tokenPriceRepository.getCachedPrice(SOL.id, AppCurrency.EUR) } returns
+                BigDecimal("90")
+
+            val vm = viewModel().apply { setData(VAULT_ID) }
+            vm.onKaminoTotalChanged(kaminoTotal("10"))
+            vm.state.value.chainTotalFiatDisplay shouldBe "$110.00"
+
+            // The reload the switch triggers is still reading stake accounts...
+            val reload = CompletableDeferred<List<SolanaStakeAccount>>()
+            coEvery { solanaStakingService.fetchStakeAccounts(ADDRESS) } coAnswers
+                {
+                    reload.await()
+                }
+            currency.value = AppCurrency.EUR
+
+            // ...while Earn, whose no-vault-enabled answer needs no network call at all, has
+            // already re-priced and handed its half over.
+            vm.onKaminoTotalChanged(DefiFiatTotal(BigDecimal("10"), AppCurrency.EUR))
+
+            // $100 of staked SOL is not €100, so the banner waits rather than restamping it.
+            vm.state.value.chainTotalFiatDisplay.shouldBeNull()
+
+            reload.complete(listOf(stakeAccount()))
+
+            vm.state.value.chainTotalFiatDisplay shouldBe
+                NumberFormat.getCurrencyInstance(Locale.GERMANY).format(BigDecimal("100"))
+        }
+
+    @Test
+    fun `a currency change clears the fiat on each card, and a failed reload leaves it clear`() =
+        runTest {
+            val currency = MutableStateFlow(AppCurrency.USD)
+            every { appCurrencyRepository.currency } returns currency
+
+            val vm = viewModel().apply { setData(VAULT_ID) }
+            val staked = vm.state.value.positions.single()
+            staked.stakedFiatDisplay shouldBe "$100.00"
+
+            coEvery { solanaStakingService.fetchStakeAccounts(ADDRESS) } throws
+                RuntimeException("503")
+            currency.value = AppCurrency.EUR
+
+            val row = vm.state.value.positions.single()
+            // The euro value is not known yet and the dollar one is no longer true, so the card
+            // says nothing rather than wearing the wrong symbol — and this reload never rebuilds
+            // it. The staked SOL is priced in neither currency, so it stays.
+            row.stakedFiatDisplay.shouldBeNull()
+            row.stakedDisplay shouldBe staked.stakedDisplay
+        }
 
     @Test
     fun `a vault without SOL reports no total at all`() = runTest {
@@ -201,7 +263,7 @@ internal class SolanaStakingPositionsViewModelTest {
         vm.state.value.chainTotalFiatDisplay.shouldBeNull()
     }
 
-    private fun kaminoTotal(value: String) = KaminoEarnTotal(BigDecimal(value), AppCurrency.USD)
+    private fun kaminoTotal(value: String) = DefiFiatTotal(BigDecimal(value), AppCurrency.USD)
 
     private fun viewModel() =
         SolanaStakingPositionsViewModel(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/SolanaStakingPositionsViewModelTest.kt
@@ -81,7 +81,7 @@ internal class SolanaStakingPositionsViewModelTest {
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
         every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
-        coEvery { appCurrencyRepository.getCurrencyFormat() } returns
+        coEvery { appCurrencyRepository.getCurrencyFormat(any()) } returns
             NumberFormat.getCurrencyInstance(Locale.US)
         coEvery { tokenPriceRepository.getCachedPrice(SOL.id, AppCurrency.USD) } returns
             BigDecimal("100")
@@ -167,10 +167,10 @@ internal class SolanaStakingPositionsViewModelTest {
     fun `a currency change re-prices the screen instead of relabelling it`() = runTest {
         val currency = MutableStateFlow(AppCurrency.USD)
         every { appCurrencyRepository.currency } returns currency
-        coEvery { appCurrencyRepository.getCurrencyFormat() } answers
+        coEvery { appCurrencyRepository.getCurrencyFormat(any()) } answers
             {
                 NumberFormat.getCurrencyInstance(
-                    if (currency.value == AppCurrency.EUR) Locale.GERMANY else Locale.US
+                    if (firstArg<AppCurrency>() == AppCurrency.EUR) Locale.GERMANY else Locale.US
                 )
             }
         coEvery { tokenPriceRepository.getCachedPrice(SOL.id, AppCurrency.EUR) } returns
@@ -197,10 +197,11 @@ internal class SolanaStakingPositionsViewModelTest {
         runTest {
             val currency = MutableStateFlow(AppCurrency.USD)
             every { appCurrencyRepository.currency } returns currency
-            coEvery { appCurrencyRepository.getCurrencyFormat() } answers
+            coEvery { appCurrencyRepository.getCurrencyFormat(any()) } answers
                 {
                     NumberFormat.getCurrencyInstance(
-                        if (currency.value == AppCurrency.EUR) Locale.GERMANY else Locale.US
+                        if (firstArg<AppCurrency>() == AppCurrency.EUR) Locale.GERMANY
+                        else Locale.US
                     )
                 }
             coEvery { tokenPriceRepository.getCachedPrice(SOL.id, AppCurrency.EUR) } returns

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -20,6 +20,10 @@ import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import io.kotest.assertions.withClue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -27,11 +31,6 @@ import io.mockk.mockk
 import java.math.BigDecimal
 import java.text.NumberFormat
 import java.util.Locale
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNotNull
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -123,10 +122,10 @@ internal class KaminoEarnViewModelTest {
 
         val state = viewModel().apply { setData(VAULT_ID) }.state.value
 
-        assertFalse(state.hasEnabledVaults)
-        assertTrue(state.rows.isEmpty())
-        assertNull(state.totalFiat)
-        assertFalse(state.isLoading)
+        state.hasEnabledVaults shouldBe false
+        state.rows.isEmpty() shouldBe true
+        state.totalFiat.shouldBeNull()
+        state.isLoading shouldBe false
     }
 
     @Test
@@ -137,8 +136,8 @@ internal class KaminoEarnViewModelTest {
 
         val state = viewModel().apply { setData(VAULT_ID) }.state.value
 
-        assertEquals(0, BigDecimal.ZERO.compareTo(state.totalValue?.value))
-        assertEquals(AppCurrency.USD, state.totalValue?.currency)
+        BigDecimal.ZERO.compareTo(state.totalValue?.value) shouldBe 0
+        state.totalValue?.currency shouldBe AppCurrency.USD
     }
 
     @Test
@@ -149,8 +148,8 @@ internal class KaminoEarnViewModelTest {
 
         val state = viewModel().apply { setData(VAULT_ID) }.state.value
 
-        assertTrue(state.loadFailed)
-        assertNull(state.totalValue)
+        state.loadFailed shouldBe true
+        state.totalValue.shouldBeNull()
     }
 
     @Test
@@ -169,8 +168,9 @@ internal class KaminoEarnViewModelTest {
         coEvery { tokenPriceRepository.getCachedPrice(Coins.Solana.SOL.id, any()) } returns null
         coEvery {
             tokenPriceRepository.getPriceByContactAddress(
-                Chain.Solana.id,
-                Coins.Solana.SOL.contractAddress,
+                chainId = Chain.Solana.id,
+                contractAddress = Coins.Solana.SOL.contractAddress,
+                appCurrency = AppCurrency.USD,
             )
         } throws RuntimeException("503")
 
@@ -178,9 +178,9 @@ internal class KaminoEarnViewModelTest {
 
         // The USDC half alone is not what the wallet holds on Kamino, and the chain header adds
         // this figure to native staking — reporting it short would understate the whole chain.
-        assertEquals(2, state.rows.size)
-        assertNull(state.totalValue)
-        assertNull(state.totalFiat)
+        state.rows.size shouldBe 2
+        state.totalValue.shouldBeNull()
+        state.totalFiat.shouldBeNull()
     }
 
     @Test
@@ -198,7 +198,7 @@ internal class KaminoEarnViewModelTest {
                 KaminoVaultMetricsJson(tokensPerShare = "1.0")
 
             val vm = viewModel().apply { setData(VAULT_ID) }
-            assertEquals("$200.00", vm.state.value.totalFiat)
+            vm.state.value.totalFiat shouldBe "$200.00"
 
             // One vault is switched off, and the reload that follows never lands.
             coEvery { chainAccountAddressRepository.getAddress(Chain.Solana, VAULT) } throws
@@ -206,8 +206,8 @@ internal class KaminoEarnViewModelTest {
             selection.value = setOf(STEAKHOUSE.address)
 
             // $200 covered both vaults; leaving it up for one would report a deselected position.
-            assertNull(vm.state.value.totalValue)
-            assertNull(vm.state.value.totalFiat)
+            vm.state.value.totalValue.shouldBeNull()
+            vm.state.value.totalFiat.shouldBeNull()
         }
 
     @Test
@@ -221,16 +221,16 @@ internal class KaminoEarnViewModelTest {
 
         val state = viewModel().apply { setData(VAULT_ID) }.state.value
 
-        assertTrue(state.hasEnabledVaults)
-        assertEquals(1, state.rows.size)
+        state.hasEnabledVaults shouldBe true
+        state.rows.size shouldBe 1
         val row = state.rows.single()
-        assertEquals("Steakhouse USDC", row.name)
-        assertEquals("Steakhouse Financial", row.curator)
-        assertEquals(KaminoRiskTier.CONSERVATIVE, row.riskTier)
-        assertEquals("0 USDC", row.depositedDisplay)
-        assertEquals("4.00%", row.apyDisplay)
+        row.name shouldBe "Steakhouse USDC"
+        row.curator shouldBe "Steakhouse Financial"
+        row.riskTier shouldBe KaminoRiskTier.CONSERVATIVE
+        row.depositedDisplay shouldBe "0 USDC"
+        row.apyDisplay shouldBe "4.00%"
         // Zero is not a gain: an untouched vault must not render green.
-        assertEquals(KaminoEarnRow.PnlDirection.FLAT, row.pnlDirection)
+        row.pnlDirection shouldBe KaminoEarnRow.PnlDirection.FLAT
     }
 
     @Test
@@ -259,10 +259,10 @@ internal class KaminoEarnViewModelTest {
 
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
-        assertEquals("1,054.427822 USDC", row.depositedDisplay)
-        assertEquals("54.427822 USDC", row.pnlDisplay)
-        assertEquals(KaminoEarnRow.PnlDirection.UP, row.pnlDirection)
-        assertNotNull(row.depositedFiat)
+        row.depositedDisplay shouldBe "1,054.427822 USDC"
+        row.pnlDisplay shouldBe "54.427822 USDC"
+        row.pnlDirection shouldBe KaminoEarnRow.PnlDirection.UP
+        row.depositedFiat.shouldNotBeNull()
     }
 
     @Test
@@ -290,9 +290,9 @@ internal class KaminoEarnViewModelTest {
 
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
-        assertEquals("1\u00A0054,427822 USDC", row.depositedDisplay)
-        assertEquals("54,427822 USDC", row.pnlDisplay)
-        assertEquals("4,00%", row.apyDisplay)
+        row.depositedDisplay shouldBe "1\u00A0054,427822 USDC"
+        row.pnlDisplay shouldBe "54,427822 USDC"
+        row.apyDisplay shouldBe "4,00%"
     }
 
     @Test
@@ -308,7 +308,7 @@ internal class KaminoEarnViewModelTest {
 
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
-        assertEquals(KaminoEarnRow.PnlDirection.DOWN, row.pnlDirection)
+        row.pnlDirection shouldBe KaminoEarnRow.PnlDirection.DOWN
     }
 
     @Test
@@ -322,8 +322,8 @@ internal class KaminoEarnViewModelTest {
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
         // The vault is still one the user enabled; dropping the card would read as losing it.
-        assertEquals("Steakhouse USDC", row.name)
-        assertNull(row.apyDisplay)
+        row.name shouldBe "Steakhouse USDC"
+        row.apyDisplay.shouldBeNull()
     }
 
     @Test
@@ -337,7 +337,7 @@ internal class KaminoEarnViewModelTest {
 
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
-        assertEquals(STEAKHOUSE.fallbackName, row.name)
+        row.name shouldBe STEAKHOUSE.fallbackName
     }
 
     @Test
@@ -347,7 +347,7 @@ internal class KaminoEarnViewModelTest {
 
         val state = viewModel().apply { setData(VAULT_ID) }.state.value
 
-        assertTrue(state.rows.isEmpty())
+        state.rows.isEmpty() shouldBe true
     }
 
     @Test
@@ -365,11 +365,11 @@ internal class KaminoEarnViewModelTest {
 
         val state = viewModel().apply { setData(VAULT_ID) }.state.value
 
-        assertEquals(2, state.rows.size)
+        state.rows.size shouldBe 2
         // Priced at 1.0 each, 100 + 100 shares against a 1:1 share ratio.
-        assertEquals("$200.00", state.totalFiat)
+        state.totalFiat shouldBe "$200.00"
         // The same figure unformatted, which is what the chain header adds to native staking.
-        assertEquals(0, BigDecimal("200").compareTo(state.totalValue?.value))
+        BigDecimal("200").compareTo(state.totalValue?.value) shouldBe 0
     }
 
     @Test
@@ -377,7 +377,7 @@ internal class KaminoEarnViewModelTest {
         coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns false
         coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns flowOf(emptySet())
 
-        assertFalse(viewModel().apply { setData(VAULT_ID) }.state.value.isBalanceVisible)
+        viewModel().apply { setData(VAULT_ID) }.state.value.isBalanceVisible shouldBe false
     }
 
     @Test
@@ -392,13 +392,13 @@ internal class KaminoEarnViewModelTest {
         val vm = viewModel().apply { setData(VAULT_ID) }
         vm.openPicker()
 
-        assertTrue(vm.state.value.isShowingPicker)
-        assertEquals(setOf(STEAKHOUSE.address), vm.state.value.pendingSelection)
+        vm.state.value.isShowingPicker shouldBe true
+        vm.state.value.pendingSelection shouldBe setOf(STEAKHOUSE.address)
 
         vm.onVaultToggled(ALLEZ.address, true)
         vm.savePicker()
 
-        assertFalse(vm.state.value.isShowingPicker)
+        vm.state.value.isShowingPicker shouldBe false
         coVerify {
             selectionRepository.saveSelectedVaults(
                 VAULT_ID,
@@ -421,7 +421,7 @@ internal class KaminoEarnViewModelTest {
         vm.onVaultToggled(STEAKHOUSE.address, false)
         vm.closePicker()
 
-        assertFalse(vm.state.value.isShowingPicker)
+        vm.state.value.isShowingPicker shouldBe false
         coVerify(exactly = 0) { selectionRepository.saveSelectedVaults(any(), any()) }
     }
 
@@ -451,7 +451,7 @@ internal class KaminoEarnViewModelTest {
         vm.openPicker()
         vm.onVaultToggled("2Z6C84pCc2ri8t39jvRCXnTGFQqUJf1mMpUMtpeFfhyB", true)
 
-        assertTrue(vm.state.value.pendingSelection.isEmpty())
+        vm.state.value.pendingSelection.isEmpty() shouldBe true
     }
 
     @Test
@@ -468,9 +468,9 @@ internal class KaminoEarnViewModelTest {
 
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
-        assertTrue(row.hasPosition, "an unread position must not hide Withdraw")
+        withClue("an unread position must not hide Withdraw") { row.hasPosition shouldBe true }
         // The figures stay off the card either way — the form reads the position itself.
-        assertNull(row.depositedFiat)
+        row.depositedFiat.shouldBeNull()
     }
 
     @Test
@@ -484,7 +484,7 @@ internal class KaminoEarnViewModelTest {
 
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
-        assertFalse(row.hasPosition)
+        row.hasPosition shouldBe false
     }
 
     @Test
@@ -500,9 +500,63 @@ internal class KaminoEarnViewModelTest {
 
         val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
 
-        assertEquals(KaminoEarnRow.PnlDirection.DOWN, row.pnlDirection)
-        assertEquals("3 USDC", row.pnlDisplay)
+        row.pnlDirection shouldBe KaminoEarnRow.PnlDirection.DOWN
+        row.pnlDisplay shouldBe "3 USDC"
     }
+
+    @Test
+    fun `a position whose share balance cannot be read is unknown rather than zero`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        // The position is there — only the figure saying how large it is failed to parse.
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "n/a"))
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+        val row = state.rows.single()
+
+        withClue("a deposit whose size failed to read must not hide Withdraw") {
+            row.hasPosition shouldBe true
+        }
+        row.depositedFiat.shouldBeNull()
+        row.fiatValue.shouldBeNull()
+        // Counting it as a zero would report the whole wallet as short by a real deposit.
+        state.totalValue.shouldBeNull()
+    }
+
+    @Test
+    fun `a currency change clears the fiat on each card, and a failed reload leaves it clear`() =
+        runTest {
+            val currency = MutableStateFlow(AppCurrency.USD)
+            every { appCurrencyRepository.currency } returns currency
+            coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+                flowOf(setOf(STEAKHOUSE.address))
+            coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+                listOf(
+                    KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100")
+                )
+            coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+            coEvery { kaminoApi.getVaultMetrics(any()) } returns
+                KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+            val vm = viewModel().apply { setData(VAULT_ID) }
+            val priced = vm.state.value.rows.single()
+            priced.depositedFiat.shouldNotBeNull()
+
+            // The reload the switch triggers never lands, so nothing rebuilds these cards.
+            coEvery { chainAccountAddressRepository.getAddress(Chain.Solana, VAULT) } throws
+                RuntimeException("503")
+            currency.value = AppCurrency.EUR
+
+            val row = vm.state.value.rows.single()
+            row.depositedFiat.shouldBeNull()
+            row.fiatValue.shouldBeNull()
+            // What the vault holds is priced in neither currency, so the card keeps saying it.
+            row.depositedDisplay shouldBe priced.depositedDisplay
+        }
 
     private companion object {
         const val VAULT_ID = "vault-id"

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -128,6 +128,29 @@ internal class KaminoEarnViewModelTest {
     }
 
     @Test
+    fun `nothing enabled hands the chain header a resolved zero, not an unknown`() = runTest {
+        // The header adds this to native staking. Null there would read as "not loaded" and blank
+        // the whole banner for everyone who never turned Earn on.
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns flowOf(emptySet())
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+        assertEquals(0, BigDecimal.ZERO.compareTo(state.totalFiatValue))
+    }
+
+    @Test
+    fun `a failed load leaves the total unknown rather than reporting zero`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { vaultRepository.get(VAULT_ID) } returns null
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+        assertTrue(state.loadFailed)
+        assertNull(state.totalFiatValue)
+    }
+
+    @Test
     fun `an enabled vault with no deposit still gets a card at zero`() = runTest {
         coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
             flowOf(setOf(STEAKHOUSE.address))
@@ -285,6 +308,8 @@ internal class KaminoEarnViewModelTest {
         assertEquals(2, state.rows.size)
         // Priced at 1.0 each, 100 + 100 shares against a 1:1 share ratio.
         assertEquals("$200.00", state.totalFiat)
+        // The same figure unformatted, which is what the chain header adds to native staking.
+        assertEquals(0, BigDecimal("200").compareTo(state.totalFiatValue))
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.api.KaminoVaultStateJson
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.settings.AppCurrency
@@ -33,6 +34,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -135,7 +137,8 @@ internal class KaminoEarnViewModelTest {
 
         val state = viewModel().apply { setData(VAULT_ID) }.state.value
 
-        assertEquals(0, BigDecimal.ZERO.compareTo(state.totalFiatValue))
+        assertEquals(0, BigDecimal.ZERO.compareTo(state.totalValue?.value))
+        assertEquals(AppCurrency.USD, state.totalValue?.currency)
     }
 
     @Test
@@ -147,8 +150,65 @@ internal class KaminoEarnViewModelTest {
         val state = viewModel().apply { setData(VAULT_ID) }.state.value
 
         assertTrue(state.loadFailed)
-        assertNull(state.totalFiatValue)
+        assertNull(state.totalValue)
     }
+
+    @Test
+    fun `an unpriced vault leaves the total unknown rather than counting it as zero`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address, ALLEZ.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+            listOf(
+                KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100"),
+                KaminoUserPositionJson(vaultAddress = ALLEZ.address, totalShares = "100"),
+            )
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Vault")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+        // The SOL vault holds a real deposit that no price landed for this round.
+        coEvery { tokenPriceRepository.getCachedPrice(Coins.Solana.SOL.id, any()) } returns null
+        coEvery {
+            tokenPriceRepository.getPriceByContactAddress(
+                Chain.Solana.id,
+                Coins.Solana.SOL.contractAddress,
+            )
+        } throws RuntimeException("503")
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+        // The USDC half alone is not what the wallet holds on Kamino, and the chain header adds
+        // this figure to native staking — reporting it short would understate the whole chain.
+        assertEquals(2, state.rows.size)
+        assertNull(state.totalValue)
+        assertNull(state.totalFiat)
+    }
+
+    @Test
+    fun `a total from an earlier selection is dropped rather than reused for a new one`() =
+        runTest {
+            val selection = MutableStateFlow(setOf(STEAKHOUSE.address, ALLEZ.address))
+            coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns selection
+            coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+                listOf(
+                    KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100"),
+                    KaminoUserPositionJson(vaultAddress = ALLEZ.address, totalShares = "100"),
+                )
+            coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Vault")
+            coEvery { kaminoApi.getVaultMetrics(any()) } returns
+                KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+            val vm = viewModel().apply { setData(VAULT_ID) }
+            assertEquals("$200.00", vm.state.value.totalFiat)
+
+            // One vault is switched off, and the reload that follows never lands.
+            coEvery { chainAccountAddressRepository.getAddress(Chain.Solana, VAULT) } throws
+                RuntimeException("503")
+            selection.value = setOf(STEAKHOUSE.address)
+
+            // $200 covered both vaults; leaving it up for one would report a deselected position.
+            assertNull(vm.state.value.totalValue)
+            assertNull(vm.state.value.totalFiat)
+        }
 
     @Test
     fun `an enabled vault with no deposit still gets a card at zero`() = runTest {
@@ -309,7 +369,7 @@ internal class KaminoEarnViewModelTest {
         // Priced at 1.0 each, 100 + 100 shares against a 1:1 share ratio.
         assertEquals("$200.00", state.totalFiat)
         // The same figure unformatted, which is what the chain header adds to native staking.
-        assertEquals(0, BigDecimal("200").compareTo(state.totalFiatValue))
+        assertEquals(0, BigDecimal("200").compareTo(state.totalValue?.value))
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -24,6 +24,7 @@ import io.kotest.assertions.withClue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -79,7 +80,7 @@ internal class KaminoEarnViewModelTest {
         coEvery { chainAccountAddressRepository.getAddress(Chain.Solana, VAULT) } returns
             (WALLET_ADDRESS to "pubkey")
         every { appCurrencyRepository.currency } returns flowOf(AppCurrency.USD)
-        coEvery { appCurrencyRepository.getCurrencyFormat() } returns
+        coEvery { appCurrencyRepository.getCurrencyFormat(any()) } returns
             NumberFormat.getCurrencyInstance(Locale.US)
         coEvery { tokenPriceRepository.getCachedPrice(any(), any()) } returns BigDecimal.ONE
     }
@@ -557,6 +558,30 @@ internal class KaminoEarnViewModelTest {
             // What the vault holds is priced in neither currency, so the card keeps saying it.
             row.depositedDisplay shouldBe priced.depositedDisplay
         }
+
+    @Test
+    fun `fiat is stamped with the currency it was priced in, not a live read`() = runTest {
+        every { appCurrencyRepository.currency } returns flowOf(AppCurrency.EUR)
+        coEvery { appCurrencyRepository.getCurrencyFormat(AppCurrency.EUR) } returns
+            NumberFormat.getCurrencyInstance(Locale.GERMANY)
+        // Nothing may reach for the selection as it stands now: it can have moved on since this
+        // load priced its figures, and the symbol would then belong to a currency they were not
+        // priced in. Any such read shows up here as yen.
+        coEvery { appCurrencyRepository.getCurrencyFormat() } returns
+            NumberFormat.getCurrencyInstance(Locale.JAPAN)
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100"))
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+        state.rows.single().depositedFiat.shouldNotBeNull() shouldContain "€"
+        state.totalFiat.shouldNotBeNull() shouldContain "€"
+    }
 
     private companion object {
         const val VAULT_ID = "vault-id"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepository.kt
@@ -23,7 +23,16 @@ interface AppCurrencyRepository {
 
     fun getAllCurrencies(): List<AppCurrency>
 
+    /** The format for whichever currency is selected right now. */
     suspend fun getCurrencyFormat(): NumberFormat
+
+    /**
+     * The format for [currency] specifically, for callers that priced their figures in a currency
+     * they captured earlier. The selection can change while a load is in flight, and this stamps
+     * those values with the symbol they were priced in rather than whichever one happens to be
+     * selected by the time they are rendered.
+     */
+    suspend fun getCurrencyFormat(appCurrency: AppCurrency): NumberFormat
 }
 
 internal class AppCurrencyRepositoryImpl @Inject constructor(private val dataStore: AppDataStore) :
@@ -52,8 +61,9 @@ internal class AppCurrencyRepositoryImpl @Inject constructor(private val dataSto
         return CURRENCY_LIST
     }
 
-    override suspend fun getCurrencyFormat(): NumberFormat {
-        val appCurrency = currency.first()
+    override suspend fun getCurrencyFormat(): NumberFormat = getCurrencyFormat(currency.first())
+
+    override suspend fun getCurrencyFormat(appCurrency: AppCurrency): NumberFormat {
         return mutex.withLock {
             val currentLocale = resolveFormatLocale(Locale.getDefault())
             // Rebuild when either the format locale or the selected app currency changes. The

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AppCurrencyRepositoryImplTest.kt
@@ -101,6 +101,18 @@ class AppCurrencyRepositoryImplTest {
         assertEquals("£1.00", gbp)
     }
 
+    @Test
+    fun `format for a given currency ignores the selection, which may have moved on`() = runTest {
+        // A caller that priced its figures in euros asks for euros, even once the user has
+        // switched: the alternative stamps the new symbol on values priced in the old currency.
+        Locale.setDefault(Locale.US)
+        val repository = AppCurrencyRepositoryImpl(FakeCurrencyDataStore(AppCurrency.USD.ticker))
+
+        val formatted = repository.getCurrencyFormat(AppCurrency.EUR).format(1000)
+
+        assertEquals("€1,000.00", formatted)
+    }
+
     private class FakeCurrencyDataStore(var ticker: String) : AppDataStore {
         @Suppress("UNCHECKED_CAST")
         override fun <T> readData(key: Preferences.Key<T>, defaultValue: T): Flow<T> =


### PR DESCRIPTION
Fixes #5602

## Problem

The Solana DeFi banner is labelled with the chain and sits above the tab row, but it was fed
`state.totalStakedFiatDisplay` — the native-staking half on its own. A vault holding a Kamino Earn
position saw a figure short by exactly that amount, and a vault with no stake accounts read
"Solana / $0.00" directly above a funded card. `selectedTab` defaults to `EARN`, so the mismatch is
on the tab the screen opens on.

Both figures were already in scope: `kaminoState` is collected in the same composable and used a few
lines below.

## Changes

- `KaminoEarnUiModel.totalFiatValue` — the sum the Earn card already shows, kept unformatted so the
  header can add it. Zero when no vault is enabled, which is a read that succeeded and found
  nothing; null only while genuinely unresolved.
- The screen hands that to `SolanaStakingPositionsViewModel` as it resolves, and the view-model
  folds the two halves into one `chainTotalFiatDisplay`. The sum happens there rather than in the
  composition because that is where the user's currency format lives.
- Unknown wins over known: while either half is unresolved the banner shows the unavailable marker
  rather than the other half, since a number short by a real position reads as the chain's whole
  DeFi balance. The staking-only case still shows its figure, because "no Kamino vault enabled"
  resolves to zero rather than unknown.
- The banner's loading state waits on both loads, so it cannot print the staking total and then jump.

Neither tab loses anything: the Staked tab still shows Total Staked SOL and the Earn tab still shows
the Kamino total. The banner was the only thing claiming to be the chain's figure.

iOS sums the same two in `DefiBalanceService.totalBalanceInFiat`.

## Test plan

Seven tests, five of them in a new `SolanaStakingPositionsViewModelTest`:

- the header adds Earn to native staking
- either half may arrive first (Earn resolves before the stake accounts)
- no Kamino vault enabled still leaves the header showing the staked total
- an unresolved Earn total leaves the header unavailable rather than short
- a vault without SOL reports no total at all
- `KaminoEarnViewModelTest`: nothing enabled hands the header a resolved zero, not an unknown; the
  raw total matches the formatted one the tab renders

`:app` and `:data` unit suites pass, `ktfmtCheck` clean on both.

Checked on a vault holding both: the banner reads $75.91 against $75.36 staked and $0.55 in Earn,
and it stays put when switching between the two tabs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Solana staking screens now display a combined total for native staking and enabled Kamino Earn positions.
  * Combined totals update when the selected currency or Earn vaults change.
  * Empty Kamino Earn configurations correctly contribute a zero value.

* **Bug Fixes**
  * Unavailable balances and prices are no longer reported as zero.
  * Totals remain loading until required staking, Earn, and currency data is resolved.
  * Currency formatting remains accurate during currency changes and partial refreshes.
  * Correctly handles accounts without SOL and failed data loads.

* **Tests**
  * Added coverage for totals, currency changes, loading states, zero balances, and failed vault loads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->