### PR TITLE
Fix Kamino SOL deposit shown as bogus SOL->WSOL swap on join device

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -720,7 +720,13 @@ constructor(
                     buildHeroContent(
                         simulation = result.simulation,
                         decodedFunctionName = decodedFunctionName,
-                        didLoadSimulation = true,
+                        // A network failure or an undecodable payload never produced a real
+                        // Blockaid verdict (see [BlockaidKeysignScanResult.didLoadSimulation]) —
+                        // only a completed scan (including a legitimate "no balance change" empty
+                        // one) is eligible to flip the hero to Unverified below. Otherwise a
+                        // Blockaid outage would hide the trustworthy native amount on every
+                        // in-app raw-Solana flow (staking, Kamino) that also sets [signSolana].
+                        didLoadSimulation = result.didLoadSimulation,
                         // Solana never decodes a function name (no ABI to decode against), so a
                         // raw dApp-signed Solana transaction (Kamino, other program calls) is the
                         // only other signal that the payload's wire amount is unverified rather

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -721,6 +721,11 @@ constructor(
                         simulation = result.simulation,
                         decodedFunctionName = decodedFunctionName,
                         didLoadSimulation = true,
+                        // Solana never decodes a function name (no ABI to decode against), so a
+                        // raw dApp-signed Solana transaction (Kamino, other program calls) is the
+                        // only other signal that the payload's wire amount is unverified rather
+                        // than a plain transfer's trustworthy amount.
+                        isRawDappTransaction = payload.signSolana != null,
                     )
                 updateSendUiModel(verifyUiModel) { current ->
                     current.copy(transaction = current.transaction.copy(heroContent = hero))

--- a/app/src/main/java/com/vultisig/wallet/ui/usecases/BuildHeroContentUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/usecases/BuildHeroContentUseCase.kt
@@ -26,11 +26,16 @@ private const val MAX_FRACTION_SCALE = 18
  *
  * Truth table:
  * - simulation present → resolved [HeroContent.Send] / [HeroContent.Swap]
- * - simulation loaded but null AND function name decoded → [HeroContent.Unverified]. The decoded
- *   name is intentionally NOT surfaced in the hero — it lives in the function-signature row below
- *   so it doesn't read as the action.
- * - simulation loaded but null AND no function name → null (caller falls back to the existing
- *   native-amount hero)
+ * - simulation loaded but null AND (function name decoded OR a raw dApp transaction) →
+ *   [HeroContent.Unverified]. The decoded name is intentionally NOT surfaced in the hero — it lives
+ *   in the function-signature row below so it doesn't read as the action. Solana never decodes a
+ *   function name (there is no EVM-style ABI to decode against), so [isRawDappTransaction] is its
+ *   only signal that the payload is an opaque dApp-signed transaction rather than a plain transfer
+ *   — without it, a Solana program call whose simulation comes back null (e.g. the SOL/WSOL
+ *   swap-noise guard) would fall through to the native-amount hero and show the payload's
+ *   unverified wire amount as a bogus "You're sending" transfer.
+ * - simulation loaded but null AND no function name AND not a raw dApp transaction → null (caller
+ *   falls back to the existing native-amount hero, trustworthy for a plain transfer)
  * - simulation not yet loaded → null (caller treats this as "loading")
  */
 class BuildHeroContentUseCase @Inject constructor() {
@@ -39,6 +44,7 @@ class BuildHeroContentUseCase @Inject constructor() {
         simulation: BlockaidSimulationInfo?,
         decodedFunctionName: String?,
         didLoadSimulation: Boolean,
+        isRawDappTransaction: Boolean = false,
     ): HeroContent? =
         when (simulation) {
             is BlockaidSimulationInfo.Transfer ->
@@ -53,7 +59,8 @@ class BuildHeroContentUseCase @Inject constructor() {
                     to = simulation.toCoin.toHeroAmount(simulation.toAmountText()),
                 )
             null ->
-                if (didLoadSimulation && decodedFunctionName != null) HeroContent.Unverified
+                if (didLoadSimulation && (decodedFunctionName != null || isRawDappTransaction))
+                    HeroContent.Unverified
                 else null
         }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/usecases/BuildHeroContentUseCaseTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/usecases/BuildHeroContentUseCaseTest.kt
@@ -95,6 +95,22 @@ class BuildHeroContentUseCaseTest {
     }
 
     @Test
+    fun `no simulation but raw dapp transaction renders Unverified even without function name`() {
+        // Solana never decodes a function name, so a raw dApp-signed Solana transaction (e.g. a
+        // program call the SOL-WSOL swap-noise guard punted on) needs this flag to avoid falling
+        // through to the native-amount hero and showing the payload's unverified wire amount.
+        val hero =
+            build(
+                simulation = null,
+                decodedFunctionName = null,
+                didLoadSimulation = true,
+                isRawDappTransaction = true,
+            )
+
+        assertSame(HeroContent.Unverified, hero)
+    }
+
+    @Test
     fun `simulation not loaded yet returns null even with function name`() {
         // Pre-load tick: we don't want to flash "Unverified function" before
         // the simulation has even had a chance to come back. Caller should

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationInfo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationInfo.kt
@@ -51,12 +51,26 @@ data class BlockaidSimulationCoin(
  * Pairs the parsed [simulation] (drives the dApp hero) with the existing [scannerResult] (drives
  * the security badge). Allows verify → sign → done to resolve both pieces of state from one cached
  * lookup.
+ *
+ * [didLoadSimulation] distinguishes a genuine Blockaid verdict (including a legitimate "no balance
+ * change" empty result) from a scan that never completed (network failure, malformed payload). Both
+ * shapes carry a null [simulation], but only the former is safe to combine with a raw-dApp-tx
+ * marker to show the [com.vultisig.wallet.ui.components.hero.HeroContent.Unverified] hero — an
+ * incomplete scan must fall back to the existing native-amount hero instead of manufacturing a
+ * false warning.
  */
 data class BlockaidKeysignScanResult(
     val simulation: BlockaidSimulationInfo?,
     val scannerResult: com.vultisig.wallet.data.securityscanner.SecurityScannerResult?,
+    val didLoadSimulation: Boolean = true,
 ) {
     companion object {
         val EMPTY = BlockaidKeysignScanResult(simulation = null, scannerResult = null)
+        val FAILED =
+            BlockaidKeysignScanResult(
+                simulation = null,
+                scannerResult = null,
+                didLoadSimulation = false,
+            )
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
@@ -219,28 +219,38 @@ internal object BlockaidSimulationParser {
         val outAmount = parseRawAmount(outRaw) ?: return null
         val fromCoin = buildSolanaCoin(outSource.asset, outSource.assetType) ?: return null
 
-        val inSource = inSources.firstOrNull()
+        // Native SOL and wrapped SOL are normalised to the same mint in buildSolanaCoin (the WSOL
+        // address doubles as the native-SOL sentinel), so a same-asset in-leg is wrap/unwrap noise,
+        // not a real swap destination — e.g. a Kamino deposit's wSOL rent-exempt residual nets out
+        // as a small "incoming" diff. Prefer an in-leg that is a genuinely different asset (the
+        // same
+        // search order parseEvmSwap uses), so a batched signAllTransactions that also contains a
+        // real swap doesn't get shadowed by an unrelated SOL/WSOL leg landing first in `inSources`.
+        val inSource =
+            inSources.firstOrNull {
+                val coin = buildSolanaCoin(it.asset, it.assetType)
+                coin != null && !coin.address.equals(fromCoin.address, ignoreCase = true)
+            } ?: inSources.firstOrNull()
         val inRaw = inSource?.incoming?.rawValue?.toRawValueString()
         val inAmount = inRaw?.let(::parseRawAmount)
         val toCoin = inSource?.let { buildSolanaCoin(it.asset, it.assetType) }
-
-        // Native SOL and wrapped SOL are normalised to the same mint in buildSolanaCoin (the WSOL
-        // address doubles as the native-SOL sentinel), so a SOL-out/WSOL-in pair is the same asset
-        // on both sides — never a genuine swap. It shows up when a transaction wraps SOL and spends
-        // it in the same instruction (e.g. a Kamino deposit): the wSOL account's rent-exempt
-        // residual nets out as a small "incoming" diff, which would otherwise be read as the swap's
-        // destination amount. Falls back to a Transfer of the real out leg instead.
         val sameAsset = toCoin != null && toCoin.address.equals(fromCoin.address, ignoreCase = true)
 
-        return if (inAmount != null && toCoin != null && !sameAsset) {
-            BlockaidSimulationInfo.Swap(
-                fromCoin = fromCoin,
-                toCoin = toCoin,
-                fromAmount = outAmount,
-                toAmount = inAmount,
-            )
-        } else {
-            BlockaidSimulationInfo.Transfer(fromCoin = fromCoin, fromAmount = outAmount)
+        return when {
+            inAmount != null && toCoin != null && !sameAsset ->
+                BlockaidSimulationInfo.Swap(
+                    fromCoin = fromCoin,
+                    toCoin = toCoin,
+                    fromAmount = outAmount,
+                    toAmount = inAmount,
+                )
+            // Same asset on both legs with a bigger in-leg is a Kamino-style withdraw: the
+            // "outgoing" leg is just the temp wSOL account being debited before it closes, and the
+            // amount the user actually receives is the in-leg, not the out-leg. Pure-incoming diffs
+            // are intentionally not represented in the hero (see parseSolanaTransfer), so fall back
+            // to the generic title instead of showing a misleading outgoing transfer.
+            sameAsset && inAmount != null && inAmount > outAmount -> null
+            else -> BlockaidSimulationInfo.Transfer(fromCoin = fromCoin, fromAmount = outAmount)
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
@@ -215,10 +215,19 @@ internal object BlockaidSimulationParser {
         // Regular swap path: pick by amount, not position. Blockaid does not contractually order
         // diffs, so a batch with a real outgoing leg plus a small network-fee leg (both
         // outgoing-only native SOL) must not have `firstOrNull` land on whichever happens to come
-        // first — the fee is always far smaller than a genuine outgoing leg.
+        // first — the fee is always far smaller than a genuine outgoing leg. Amounts are compared
+        // decimal-normalised (not raw): Blockaid nets one row per asset, so out rows always carry
+        // different decimals (e.g. a 2,039,280-lamport wSOL rent residual at 9 decimals is only
+        // 0.00203928 SOL, smaller than a 2,000,000-raw USDC leg at 6 decimals, i.e. $2 — but the
+        // raw
+        // integers alone rank the residual first).
         val outSource =
-            outSources.maxByOrNull {
-                it.outgoing?.rawValue?.toRawValueString()?.let(::parseRawAmount) ?: BigInteger.ZERO
+            outSources.maxByOrNull { diff ->
+                val raw =
+                    diff.outgoing?.rawValue?.toRawValueString()?.let(::parseRawAmount)
+                        ?: BigInteger.ZERO
+                val decimals = diff.asset.decimals?.clampDecimals() ?: 0
+                raw.toBigDecimal().movePointLeft(decimals)
             } ?: return null
         val outRaw = outSource.outgoing?.rawValue?.toRawValueString() ?: return null
         val outAmount = parseRawAmount(outRaw) ?: return null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
@@ -224,7 +224,15 @@ internal object BlockaidSimulationParser {
         val inAmount = inRaw?.let(::parseRawAmount)
         val toCoin = inSource?.let { buildSolanaCoin(it.asset, it.assetType) }
 
-        return if (inAmount != null && toCoin != null) {
+        // Native SOL and wrapped SOL are normalised to the same mint in buildSolanaCoin (the WSOL
+        // address doubles as the native-SOL sentinel), so a SOL-out/WSOL-in pair is the same asset
+        // on both sides — never a genuine swap. It shows up when a transaction wraps SOL and spends
+        // it in the same instruction (e.g. a Kamino deposit): the wSOL account's rent-exempt
+        // residual nets out as a small "incoming" diff, which would otherwise be read as the swap's
+        // destination amount. Falls back to a Transfer of the real out leg instead.
+        val sameAsset = toCoin != null && toCoin.address.equals(fromCoin.address, ignoreCase = true)
+
+        return if (inAmount != null && toCoin != null && !sameAsset) {
             BlockaidSimulationInfo.Swap(
                 fromCoin = fromCoin,
                 toCoin = toCoin,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
@@ -75,16 +75,28 @@ internal object BlockaidSimulationParser {
         // silently lose the user's actual swap result. Both `asset.type == "SOL"` and
         // `assetType == "SOL"` are checked because Blockaid is inconsistent about which field
         // carries the marker.
+        //
+        // Among outgoing-only native-SOL candidates, the fee is the SMALLEST one, not the first:
+        // a Kamino SOL deposit can emit [big SOL out (real leg), WSOL in (rent residual), tiny SOL
+        // out (fee)] — both the real leg and the fee are outgoing-only native SOL, and
+        // `indexOfFirst`
+        // would drop the real leg instead of the 5000-lamport fee just because it comes first.
         val relevant: List<BlockaidSolanaSimulationJson.AccountAssetDiff> =
             if (all.size == 3) {
                 val solFeeIndex =
-                    all.indexOfFirst {
-                        val isNative = it.isNativeSol()
-                        val outgoingOnly =
-                            it.outgoing?.rawValue?.toRawValueString() != null &&
-                                it.incoming?.rawValue?.toRawValueString() == null
-                        isNative && outgoingOnly
-                    }
+                    all.withIndex()
+                        .filter { (_, diff) ->
+                            val isNative = diff.isNativeSol()
+                            val outgoingOnly =
+                                diff.outgoing?.rawValue?.toRawValueString() != null &&
+                                    diff.incoming?.rawValue?.toRawValueString() == null
+                            isNative && outgoingOnly
+                        }
+                        .minByOrNull { (_, diff) ->
+                            diff.outgoing?.rawValue?.toRawValueString()?.let(::parseRawAmount)
+                                ?: BigInteger.ZERO
+                        }
+                        ?.index ?: -1
                 if (solFeeIndex >= 0) all.filterIndexed { idx, _ -> idx != solFeeIndex } else all
             } else {
                 all

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParser.kt
@@ -212,9 +212,14 @@ internal object BlockaidSimulationParser {
             return BlockaidSimulationInfo.Transfer(fromCoin = coin, fromAmount = total)
         }
 
-        // Regular swap path: pick by field presence rather than position. Blockaid does not
-        // contractually order diffs.
-        val outSource = outSources.firstOrNull() ?: return null
+        // Regular swap path: pick by amount, not position. Blockaid does not contractually order
+        // diffs, so a batch with a real outgoing leg plus a small network-fee leg (both
+        // outgoing-only native SOL) must not have `firstOrNull` land on whichever happens to come
+        // first — the fee is always far smaller than a genuine outgoing leg.
+        val outSource =
+            outSources.maxByOrNull {
+                it.outgoing?.rawValue?.toRawValueString()?.let(::parseRawAmount) ?: BigInteger.ZERO
+            } ?: return null
         val outRaw = outSource.outgoing?.rawValue?.toRawValueString() ?: return null
         val outAmount = parseRawAmount(outRaw) ?: return null
         val fromCoin = buildSolanaCoin(outSource.asset, outSource.assetType) ?: return null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationServiceImpl.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationServiceImpl.kt
@@ -80,7 +80,10 @@ internal class BlockaidSimulationServiceImpl(private val rpcClient: BlockaidRpcC
         // allowed to propagate so they surface as bugs rather than being silently muted into
         // EMPTY; the calling coroutine in [JoinKeysignViewModel.loadBlockaidSimulation] is wrapped
         // in `safeLaunch` so a propagated defect still cannot crash the verify flow.
-        var result = BlockaidKeysignScanResult.EMPTY
+        // Defaults to FAILED (not EMPTY) so a NetworkException — or a cancellation racing the
+        // leader's own completion below — is never mistaken for a genuine "no balance change"
+        // verdict; only a value assigned by a completed [dispatchScan] call overwrites it.
+        var result = BlockaidKeysignScanResult.FAILED
         var failure: NetworkException? = null
         var cancellation: CancellationException? = null
         try {
@@ -174,7 +177,10 @@ internal class BlockaidSimulationServiceImpl(private val rpcClient: BlockaidRpcC
                 runCatching { Base58.encodeNoCheck(base64.decodeBase64Bytes()) }
                     .getOrElse {
                         Timber.w(it, "Solana raw transaction base64 decode failed")
-                        return BlockaidKeysignScanResult.EMPTY
+                        // FAILED, not EMPTY: a malformed payload never reached Blockaid, so this
+                        // carries no "no balance change" verdict — the caller must not treat it as
+                        // one (see [BlockaidKeysignScanResult.didLoadSimulation]).
+                        return BlockaidKeysignScanResult.FAILED
                     }
             }
         val response =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
@@ -299,6 +299,56 @@ internal class BlockaidSimulationParserTest {
     }
 
     @Test
+    fun `solana three-diff SOL deposit with a separate fee leg keeps the real out amount`() {
+        // Same Kamino SOL-deposit shape as above, but Blockaid emits the network fee as its own
+        // outgoing-only native-SOL row, landing the response at exactly 3 diffs: [big SOL out (real
+        // leg), WSOL in (rent residual), tiny SOL out (fee)]. `parseSolana`'s 3-diff pre-filter
+        // must
+        // drop the 5000-lamport fee — the smallest outgoing-only native-SOL diff — not the first
+        // one,
+        // or it discards the real 59435000-lamport leg and the deposit renders as unverifiable
+        // instead of a 0.059435 SOL transfer.
+        val response =
+            solanaResponse(
+                """{
+                    "result": {
+                      "simulation": {
+                        "account_summary": {
+                          "account_assets_diff": [
+                            {
+                              "asset": { "type": "SOL", "decimals": 9, "symbol": "SOL", "address": null },
+                              "out": { "raw_value": "59435000" }
+                            },
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "So11111111111111111111111111111111111111112",
+                                "symbol": "WSOL",
+                                "decimals": 9
+                              },
+                              "in": { "raw_value": "2039280" }
+                            },
+                            {
+                              "asset": { "type": "SOL", "decimals": 9, "symbol": "SOL", "address": null },
+                              "out": { "raw_value": "5000" }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                """
+                    .trimIndent()
+            )
+
+        val transfer =
+            BlockaidSimulationParser.parseSolana(response) as BlockaidSimulationInfo.Transfer
+
+        assertEquals("SOL", transfer.fromCoin.ticker)
+        assertEquals(BigInteger("59435000"), transfer.fromAmount)
+    }
+
+    @Test
     fun `solana WSOL-out SOL-in pair with a bigger in-leg is dropped, not a bogus transfer`() {
         // A Kamino SOL-vault withdraw closes the payout wSOL account before returning native SOL to
         // the signer (KaminoComputeBudget.kt:59), so the "outgoing" leg is just that temp account

--- a/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
@@ -257,6 +257,48 @@ internal class BlockaidSimulationParserTest {
     }
 
     @Test
+    fun `solana SOL-out WSOL-in pair is a transfer, not a swap`() {
+        // A Kamino SOL-vault deposit wraps SOL and immediately spends it, leaving only the wSOL
+        // account's rent-exempt residual as an "incoming" diff. WSOL's real mint is the same
+        // address the parser uses as the native-SOL sentinel, so this must collapse to a Transfer
+        // of the real 0.059435 SOL leg rather than a misleading "SOL -> 0.00203928 WSOL" swap.
+        val response =
+            solanaResponse(
+                """{
+                    "result": {
+                      "simulation": {
+                        "account_summary": {
+                          "account_assets_diff": [
+                            {
+                              "asset": { "type": "SOL", "decimals": 9, "symbol": "SOL", "address": null },
+                              "out": { "raw_value": "59435000" }
+                            },
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "So11111111111111111111111111111111111111112",
+                                "symbol": "WSOL",
+                                "decimals": 9
+                              },
+                              "in": { "raw_value": "2039280" }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                """
+                    .trimIndent()
+            )
+
+        val transfer =
+            BlockaidSimulationParser.parseSolana(response) as BlockaidSimulationInfo.Transfer
+
+        assertEquals("SOL", transfer.fromCoin.ticker)
+        assertEquals(BigInteger("59435000"), transfer.fromAmount)
+    }
+
+    @Test
     fun `solana native SOL transfer maps to wrapped sol mint`() {
         val response =
             solanaResponse(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
@@ -394,6 +394,62 @@ internal class BlockaidSimulationParserTest {
 
         assertEquals("SOL", swap.fromCoin.ticker)
         assertEquals("USDC", swap.toCoin.ticker)
+        assertEquals(BigInteger("59435000"), swap.fromAmount)
+        assertEquals(BigInteger("10000000"), swap.toAmount)
+    }
+
+    @Test
+    fun `solana batch picks the real outgoing leg over a fee leg that comes first`() {
+        // Same fixture as above with the tiny fee diff moved to the front. `outSources` must be
+        // picked by amount, not by list position, or the fee's 5000 lamports gets shown as the
+        // swap's fromAmount instead of the real 59435000 lamports leg.
+        val response =
+            solanaResponse(
+                """{
+                    "result": {
+                      "simulation": {
+                        "account_summary": {
+                          "account_assets_diff": [
+                            {
+                              "asset": { "type": "SOL", "decimals": 9, "symbol": "SOL", "address": null },
+                              "out": { "raw_value": "5000" }
+                            },
+                            {
+                              "asset": { "type": "SOL", "decimals": 9, "symbol": "SOL", "address": null },
+                              "out": { "raw_value": "59435000" }
+                            },
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "So11111111111111111111111111111111111111112",
+                                "symbol": "WSOL",
+                                "decimals": 9
+                              },
+                              "in": { "raw_value": "2039280" }
+                            },
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                                "symbol": "USDC",
+                                "decimals": 6
+                              },
+                              "in": { "raw_value": "10000000" }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                """
+                    .trimIndent()
+            )
+
+        val swap = BlockaidSimulationParser.parseSolana(response) as BlockaidSimulationInfo.Swap
+
+        assertEquals("SOL", swap.fromCoin.ticker)
+        assertEquals("USDC", swap.toCoin.ticker)
+        assertEquals(BigInteger("59435000"), swap.fromAmount)
         assertEquals(BigInteger("10000000"), swap.toAmount)
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
@@ -454,6 +454,59 @@ internal class BlockaidSimulationParserTest {
     }
 
     @Test
+    fun `solana batch ranks out legs by decimal-normalised amount, not raw integer`() {
+        // A wSOL rent-residual out-leg (2,039,280 raw @ 9 decimals = 0.00203928 SOL) has a bigger
+        // raw integer than a 2 USDC out-leg (2,000,000 raw @ 6 decimals), even though 2 USDC is the
+        // real swap leg and the wSOL row is exactly the noise this PR exists to suppress. Comparing
+        // raw integers across mismatched decimals would rank the residual first; the parser must
+        // normalise by decimals before picking the max.
+        val response =
+            solanaResponse(
+                """{
+                    "result": {
+                      "simulation": {
+                        "account_summary": {
+                          "account_assets_diff": [
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                                "symbol": "USDC",
+                                "decimals": 6
+                              },
+                              "out": { "raw_value": "2000000" }
+                            },
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "So11111111111111111111111111111111111111112",
+                                "symbol": "WSOL",
+                                "decimals": 9
+                              },
+                              "out": { "raw_value": "2039280" }
+                            },
+                            {
+                              "asset": { "type": "TOKEN", "address": "MintB", "symbol": "BONK", "decimals": 5 },
+                              "in": { "raw_value": "9999" }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                """
+                    .trimIndent()
+            )
+
+        val swap = BlockaidSimulationParser.parseSolana(response) as BlockaidSimulationInfo.Swap
+
+        assertEquals("USDC", swap.fromCoin.ticker)
+        assertEquals("BONK", swap.toCoin.ticker)
+        assertEquals(BigInteger("2000000"), swap.fromAmount)
+        assertEquals(BigInteger("9999"), swap.toAmount)
+    }
+
+    @Test
     fun `solana native SOL transfer maps to wrapped sol mint`() {
         val response =
             solanaResponse(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationParserTest.kt
@@ -299,6 +299,105 @@ internal class BlockaidSimulationParserTest {
     }
 
     @Test
+    fun `solana WSOL-out SOL-in pair with a bigger in-leg is dropped, not a bogus transfer`() {
+        // A Kamino SOL-vault withdraw closes the payout wSOL account before returning native SOL to
+        // the signer (KaminoComputeBudget.kt:59), so the "outgoing" leg is just that temp account
+        // being debited, not real value the user sent. The in-leg (native SOL) is what the user
+        // actually receives and is bigger than the out-leg, so this must not collapse to a Transfer
+        // of the out-leg — that would misrepresent an incoming withdraw as an outgoing send.
+        val response =
+            solanaResponse(
+                """{
+                    "result": {
+                      "simulation": {
+                        "account_summary": {
+                          "account_assets_diff": [
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "So11111111111111111111111111111111111111112",
+                                "symbol": "WSOL",
+                                "decimals": 9
+                              },
+                              "out": { "raw_value": "2039280" }
+                            },
+                            {
+                              "asset": { "type": "SOL", "decimals": 9, "symbol": "SOL", "address": null },
+                              "in": { "raw_value": "59435000" }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                """
+                    .trimIndent()
+            )
+
+        assertNull(BlockaidSimulationParser.parseSolana(response))
+    }
+
+    @Test
+    fun `solana batch skips the SOL-WSOL leg to find the real swap destination`() {
+        // A signAllTransactions batch scanned as one diff set can contain both a Kamino SOL-wrap
+        // leg (same asset on both sides) and a genuine swap leg. The wrap leg must not be picked as
+        // `inSource` just because it comes first in `inSources` — the real destination asset (USDC)
+        // has to be found instead, or the swap renders as a one-way send. A trailing outgoing-only
+        // native-SOL fee diff is included so the count lands on 4, not the 3-diff shape
+        // `parseSolana`
+        // special-cases as "one of these three is the fee leg" (which would otherwise strip the
+        // real
+        // SOL out-leg here, since it too is outgoing-only native SOL).
+        val response =
+            solanaResponse(
+                """{
+                    "result": {
+                      "simulation": {
+                        "account_summary": {
+                          "account_assets_diff": [
+                            {
+                              "asset": { "type": "SOL", "decimals": 9, "symbol": "SOL", "address": null },
+                              "out": { "raw_value": "59435000" }
+                            },
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "So11111111111111111111111111111111111111112",
+                                "symbol": "WSOL",
+                                "decimals": 9
+                              },
+                              "in": { "raw_value": "2039280" }
+                            },
+                            {
+                              "asset": {
+                                "type": "TOKEN",
+                                "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                                "symbol": "USDC",
+                                "decimals": 6
+                              },
+                              "in": { "raw_value": "10000000" }
+                            },
+                            {
+                              "asset": { "type": "SOL", "decimals": 9, "symbol": "SOL", "address": null },
+                              "out": { "raw_value": "5000" }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                """
+                    .trimIndent()
+            )
+
+        val swap = BlockaidSimulationParser.parseSolana(response) as BlockaidSimulationInfo.Swap
+
+        assertEquals("SOL", swap.fromCoin.ticker)
+        assertEquals("USDC", swap.toCoin.ticker)
+        assertEquals(BigInteger("10000000"), swap.toAmount)
+    }
+
+    @Test
     fun `solana native SOL transfer maps to wrapped sol mint`() {
         val response =
             solanaResponse(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationServiceImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/securityscanner/blockaid/BlockaidSimulationServiceImplTest.kt
@@ -20,12 +20,14 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import vultisig.keysign.v1.SignSolana
 
 internal class BlockaidSimulationServiceImplTest {
 
@@ -59,8 +61,9 @@ internal class BlockaidSimulationServiceImplTest {
     fun `evm scan does not cache on operational RPC failure`() = runTest {
         // Operational failures from the RPC layer are wrapped in [NetworkException] (transport
         // errors and HTTP non-2xx alike — see RpcExtensions.bodyOrThrow + HttpCallValidator).
-        // These MUST be swallowed into EMPTY so the next screen can retry; failures must not
-        // poison the cache.
+        // These MUST be swallowed into FAILED (not the plain EMPTY "no balance change" verdict) so
+        // the next screen can retry; failures must not poison the cache, and callers must be able
+        // to tell a genuine empty verdict apart from a scan that never happened.
         val rpc = FakeRpc(evmThrows = NetworkException(503, "boom"))
         val service = BlockaidSimulationServiceImpl(rpc)
         val payload = evmPayload(memo = "0xfeed")
@@ -70,9 +73,41 @@ internal class BlockaidSimulationServiceImplTest {
         rpc.evmResponse = singleTransferEvmResponse()
         val second = service.scan(payload)
 
-        assertSame(BlockaidKeysignScanResult.EMPTY, first)
+        assertSame(BlockaidKeysignScanResult.FAILED, first)
         assertNotNull(second.simulation)
         assertEquals(2, rpc.evmCalls, "operational failure should not poison the cache")
+    }
+
+    @Test
+    fun `solana scan on network failure returns FAILED, not a legitimate empty verdict`() =
+        runTest {
+            // A joining device on a plain in-app raw-Solana flow (staking, Kamino) must fall back
+            // to
+            // the trustworthy native-amount hero when Blockaid is unreachable, not the Unverified
+            // hero
+            // — that requires telling this apart from a completed scan that legitimately found no
+            // balance change, which `didLoadSimulation` exists to do.
+            val rpc = FakeRpc(solanaThrows = NetworkException(503, "boom"))
+            val service = BlockaidSimulationServiceImpl(rpc)
+            val payload = solanaPayload(rawTransactions = listOf("dGVzdA=="))
+
+            val result = service.scan(payload)
+
+            assertSame(BlockaidKeysignScanResult.FAILED, result)
+            assertFalse(result.didLoadSimulation)
+        }
+
+    @Test
+    fun `solana scan on undecodable raw transaction returns FAILED`() = runTest {
+        val rpc = FakeRpc()
+        val service = BlockaidSimulationServiceImpl(rpc)
+        val payload = solanaPayload(rawTransactions = listOf("not-valid-base64!!!"))
+
+        val result = service.scan(payload)
+
+        assertSame(BlockaidKeysignScanResult.FAILED, result)
+        assertFalse(result.didLoadSimulation)
+        assertEquals(0, rpc.solanaCalls, "malformed payload must never reach the RPC")
     }
 
     @Test
@@ -286,6 +321,20 @@ internal class BlockaidSimulationServiceImplTest {
             every { signSolana } returns null
             every { toAddress } returns to
             every { toAmount } returns BigInteger.ZERO
+        }
+    }
+
+    private fun solanaPayload(rawTransactions: List<String>): KeysignPayload {
+        val coin =
+            mockk<Coin>(relaxed = true) {
+                every { chain } returns Chain.Solana
+                every { address } returns "Sol1..."
+            }
+        val solana = SignSolana(rawTransactions = rawTransactions)
+        return mockk<KeysignPayload>(relaxed = true) {
+            every { this@mockk.coin } returns coin
+            every { memo } returns null
+            every { signSolana } returns solana
         }
     }
 


### PR DESCRIPTION
## Summary
- A Kamino SOL-vault deposit wraps SOL and spends it in the same transaction, so its wSOL account nets down to just its rent-exempt residual (2,039,280 lamports / 0.00203928 SOL) in Blockaid's simulation diff — the wrap-in and spend-out cancel out and never show as their own diff.
- `BlockaidSimulationParser.parseSolanaMulti` picked that residual up as the "received" leg of a `Swap`, so a 0.059435 SOL deposit into Allez SOL was shown on the joining device as `0.059435 SOL -> 0.00203928 WSOL` instead of the real amount being sent.
- Native SOL and wrapped SOL are already normalised to the same mint address in this parser (the WSOL mint doubles as the sentinel for native SOL), so this adds a same-asset guard mirroring the existing EVM same-asset check a few lines above: when both legs resolve to the same asset, collapse to a `Transfer` of the real outgoing amount instead of a `Swap`.
- Not Kamino-specific: this is a general fix for any transaction that wraps and spends SOL in one shot.

## Testing
- `./gradlew :data:testDebugUnitTest --tests com.vultisig.wallet.data.securityscanner.blockaid.BlockaidSimulationParserTest` (added a regression test reproducing the reported numbers)
- `./gradlew :data:ktfmtCheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Solana transaction interpretation for swaps, transfers, and SOL/WSOL conversions.
  * Prevented temporary native or wrapped SOL amounts from being incorrectly identified as swap destinations.
  * Correctly filters out withdrawal-like asset changes.
  * Raw dApp transactions now display an unverified status when simulation details are unavailable.

* **Tests**
  * Added coverage for SOL wrapping, WSOL withdrawals, batched wrapping, genuine swaps, and unverified raw dApp transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->