### PR TITLE
fix(defi): count Kamino Earn deposits in the DeFi portfolio

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
@@ -16,7 +16,6 @@ import java.math.BigDecimal
 import java.math.BigInteger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
 import timber.log.Timber
@@ -89,22 +88,10 @@ internal class AccountsLoader(
                     scope.safeLaunch(onError = ::onLoadError) {
                         accountsRepository
                             .loadDeFiAddresses(vaultId, false)
-                            .spendableAccounts()
+                            .map { addrs -> addrs.spendableAccounts() }
                             .collect { publishLoaded(it, generation) }
                     }
             }
-    }
-
-    /**
-     * The accounts a form may offer, flattened out of an addresses flow.
-     *
-     * loadDeFiAddresses also carries an account for each position that is never a wallet token, so
-     * the DeFi tab can total it. Those are not holdings a form can draw on — the sRUJI receipt is
-     * spent through the position's own unstake flow, which synthesizes its account below — so they
-     * are dropped here rather than offered in the token picker.
-     */
-    private fun Flow<List<Address>>.spendableAccounts(): Flow<List<Account>> = map { addresses ->
-        addresses.flatMap { it.accounts }.filterNot { Coins.isDefiOnly(it.token) }
     }
 
     // Routes the autocompound switch through this single component so accountsState only
@@ -130,13 +117,26 @@ internal class AccountsLoader(
                     } else {
                         accountsRepository.loadDeFiAddresses(vaultId, false)
                     }
-                addressesFlow.spendableAccounts().collect { accounts ->
-                    if (publishLoaded(accounts, generation)) {
-                        onAccountsLoaded(accounts)
+                addressesFlow
+                    .map { addrs -> addrs.spendableAccounts() }
+                    .collect { accounts ->
+                        if (publishLoaded(accounts, generation)) {
+                            onAccountsLoaded(accounts)
+                        }
                     }
-                }
             }
     }
+
+    /**
+     * The accounts a form may draw on.
+     *
+     * loadDeFiAddresses also carries an account for each position that is never a wallet token —
+     * the sRUJI receipt kept out of token discovery, or a Kamino Earn deposit in a token the wallet
+     * itself has none of — so the DeFi tab can total it. Those are not holdings a form can draw on,
+     * so they are dropped here rather than offered in the token picker.
+     */
+    private fun List<Address>.spendableAccounts(): List<Account> =
+        flatMap { it.accounts }.filterNot { Coins.isDefiOnly(it.token) || it.isPositionOnly }
 
     private fun publishLoaded(accounts: List<Account>, generation: Long): Boolean {
         if (generation != currentGeneration) return false
@@ -348,9 +348,10 @@ internal class AccountsLoader(
     // iOS/Windows.
     private suspend fun loadUnbondAccount(vaultId: VaultId, generation: Long) {
         val bondedAmount = bondedAmountProvider()
-        accountsRepository.loadDeFiAddresses(vaultId, false).spendableAccounts().collect {
-            publishUnbond(it, bondedAmount, generation)
-        }
+        accountsRepository
+            .loadDeFiAddresses(vaultId, false)
+            .map { addrs -> addrs.spendableAccounts() }
+            .collect { accounts -> publishUnbond(accounts, bondedAmount, generation) }
     }
 
     private fun publishUnbond(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
@@ -153,6 +153,33 @@ internal class AccountsLoaderTest {
         }
 
     @Test
+    fun `the DeFi form path drops accounts that only ever hold a position`() =
+        runTest(mainDispatcher) {
+            // loadDeFiAddresses carries an account for a Kamino Earn deposit in a token the wallet
+            // holds none of, so the DeFi portfolio can total it. Its balance is the position, not
+            // something a form may spend, so it must not reach the token picker.
+            defiType = DeFiNavActions.UNSTAKE_TCY
+            val runeAccount = thorAccount(Coins.ThorChain.RUNE)
+            val positionOnly = thorAccount(Coins.Solana.USDC).copy(isPositionOnly = true)
+            coEvery { accountsRepository.loadDeFiAddresses(VAULT_ID, false) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.ThorChain,
+                            address = "thor1",
+                            accounts = listOf(runeAccount, positionOnly),
+                        )
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            assertEquals(listOf(runeAccount), loadedAccounts)
+        }
+
+    @Test
     fun `load with BOND uses the regular loadAddresses flow`() =
         runTest(mainDispatcher) {
             defiType = DeFiNavActions.BOND

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/BlockchainServicesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/BlockchainServicesModule.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.blockchain
 
 import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.api.KaminoApi
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.TronApi
 import com.vultisig.wallet.data.api.chains.ton.TonStakingApi
@@ -10,6 +11,8 @@ import com.vultisig.wallet.data.blockchain.ethereum.CircleDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService
 import com.vultisig.wallet.data.blockchain.maya.MayaCacaoStakingService
 import com.vultisig.wallet.data.blockchain.maya.MayaDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.solana.SolanaDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingService
 import com.vultisig.wallet.data.blockchain.solana.staking.ValidatorMetadataProvider
@@ -20,6 +23,8 @@ import com.vultisig.wallet.data.blockchain.thorchain.ThorchainDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.ton.TonDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.tron.TronDeFiBalanceService
 import com.vultisig.wallet.data.repositories.ActiveBondedNodeRepository
+import com.vultisig.wallet.data.repositories.KaminoPositionCacheRepository
+import com.vultisig.wallet.data.repositories.KaminoVaultSelectionRepository
 import com.vultisig.wallet.data.repositories.ScaCircleAccountRepository
 import com.vultisig.wallet.data.repositories.StakingDetailsRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
@@ -158,6 +163,30 @@ internal interface BlockchainServicesModule {
                 solanaStakingService = solanaStakingService,
                 validatorMetadataProvider = validatorMetadataProvider,
                 stakingDetailsRepository = stakingDetailsRepository,
+            )
+
+        @Provides
+        @Singleton
+        fun provideKaminoDeFiBalanceService(
+            kaminoApi: KaminoApi,
+            selectionRepository: KaminoVaultSelectionRepository,
+            positionCache: KaminoPositionCacheRepository,
+        ): KaminoDeFiBalanceService =
+            KaminoDeFiBalanceService(
+                kaminoApi = kaminoApi,
+                selectionRepository = selectionRepository,
+                positionCache = positionCache,
+            )
+
+        @Provides
+        @Singleton
+        fun provideSolanaDeFiBalanceService(
+            stakingBalanceService: SolanaStakingDeFiBalanceService,
+            kaminoBalanceService: KaminoDeFiBalanceService,
+        ): SolanaDeFiBalanceService =
+            SolanaDeFiBalanceService(
+                stakingBalanceService = stakingBalanceService,
+                kaminoBalanceService = kaminoBalanceService,
             )
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaDeFiBalanceService.kt
@@ -1,0 +1,62 @@
+package com.vultisig.wallet.data.blockchain.solana
+
+import com.vultisig.wallet.data.blockchain.DeFiService
+import com.vultisig.wallet.data.blockchain.model.DeFiBalance
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingDeFiBalanceService
+import com.vultisig.wallet.data.models.Chain
+import java.math.BigInteger
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+
+/**
+ * Solana's DeFi position, which is two independent things: native staking and the Kamino Earn
+ * vaults. Neither implies the other — a wallet may hold either, both or none — so the chain's
+ * balance is their sum, the way iOS totals it in `DefiBalanceService.totalBalanceInFiat`.
+ *
+ * Each side already falls back to its own last-known values rather than throwing, so one being
+ * unreachable leaves the other's figure standing.
+ */
+class SolanaDeFiBalanceService(
+    private val stakingBalanceService: SolanaStakingDeFiBalanceService,
+    private val kaminoBalanceService: KaminoDeFiBalanceService,
+) : DeFiService {
+
+    override suspend fun getRemoteDeFiBalance(address: String, vaultId: String): List<DeFiBalance> =
+        coroutineScope {
+            val staking = async { stakingBalanceService.getRemoteDeFiBalance(address, vaultId) }
+            val kamino = async { kaminoBalanceService.getRemoteDeFiBalance(address, vaultId) }
+            merge(staking.await() + kamino.await())
+        }
+
+    override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> =
+        merge(
+            stakingBalanceService.getCacheDeFiBalance(address, vaultId) +
+                kaminoBalanceService.getCacheDeFiBalance(address, vaultId)
+        )
+
+    /**
+     * Sums the two sides per coin.
+     *
+     * Not a concatenation: the SOL Earn vault reports in the same coin native staking does, and the
+     * balance pipeline resolves a chain's position by coin — matching on the first entry it finds
+     * on the refresh path and on the last one it saw on the cached path. Either way, one of the two
+     * SOL figures would be dropped and the row would silently disagree with itself between a cold
+     * start and a refresh.
+     */
+    private fun merge(balances: List<DeFiBalance>): List<DeFiBalance> {
+        val perCoin =
+            balances
+                .flatMap { it.balances }
+                .groupBy { it.coin.id.lowercase() }
+                .map { (_, group) ->
+                    group.reduce { running, balance ->
+                        running.copy(amount = running.amount + balance.amount)
+                    }
+                }
+                .filter { it.amount > BigInteger.ZERO }
+
+        return if (perCoin.isEmpty()) emptyList()
+        else listOf(DeFiBalance(chain = Chain.Solana, balances = perCoin))
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceService.kt
@@ -1,0 +1,151 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import com.vultisig.wallet.data.blockchain.DeFiService
+import com.vultisig.wallet.data.blockchain.model.DeFiBalance
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.repositories.KaminoPositionCacheRepository
+import com.vultisig.wallet.data.repositories.KaminoVaultSelectionRepository
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.supervisorScope
+import timber.log.Timber
+
+/**
+ * DeFi-balance provider for the Kamino Earn vaults on Solana.
+ *
+ * A position is held as vault shares, which are worth a live, per-vault multiple of the underlying
+ * token, so the balance reported here is the token amount those shares redeem for — denominated in
+ * the vault's own underlying (USDC, SOL) rather than in shares, which the app has no price for and
+ * deliberately keeps out of wallet-token discovery.
+ *
+ * Gated on the per-vault opt-in, matching the Earn tab: a vault the user has switched off shows no
+ * card there and must not show a balance here either, or the two surfaces disagree.
+ *
+ * Mirrors iOS `DefiBalanceService.kaminoEarnTotalBalanceFiatDecimal`.
+ */
+class KaminoDeFiBalanceService(
+    private val kaminoApi: KaminoApi,
+    private val selectionRepository: KaminoVaultSelectionRepository,
+    private val positionCache: KaminoPositionCacheRepository,
+) : DeFiService {
+
+    override suspend fun getRemoteDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
+        val enabled = enabledVaults(vaultId)
+        if (enabled.isEmpty()) return emptyList()
+
+        return try {
+            // One call for the whole wallet. An empty list is a real answer — the wallet holds no
+            // position — while a throw is not knowing, which is why it is caught below rather than
+            // collapsed into zero.
+            val positions = kaminoApi.getUserPositions(address).associateBy { it.vaultAddress }
+            val cached = positionCache.getPositions(vaultId)
+            Timber.d(
+                "KaminoDeFiBalanceService: %d enabled vaults, %d positions held",
+                enabled.size,
+                positions.size,
+            )
+
+            val amounts =
+                supervisorScope {
+                        enabled
+                            .map { vault ->
+                                async {
+                                    // A vault whose own read failed keeps its last known size:
+                                    // reporting zero would read as a deposit that has gone.
+                                    val amount =
+                                        amountOf(vault, positions[vault.address])
+                                            ?: cached[vault.address]
+                                    amount?.let { vault to it }
+                                }
+                            }
+                            .awaitAll()
+                    }
+                    .filterNotNull()
+                    .toMap()
+
+            positionCache.savePositions(vaultId, amounts.mapKeys { it.key.address })
+            balancesOf(amounts)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "KaminoDeFiBalanceService: failed to read positions")
+            getCacheDeFiBalance(address, vaultId)
+        }
+    }
+
+    override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
+        return try {
+            val enabled = enabledVaults(vaultId)
+            if (enabled.isEmpty()) return emptyList()
+            val cached = positionCache.getPositions(vaultId)
+            balancesOf(
+                enabled.mapNotNull { vault -> cached[vault.address]?.let { vault to it } }.toMap()
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "KaminoDeFiBalanceService: failed to read the cached positions")
+            emptyList()
+        }
+    }
+
+    private suspend fun enabledVaults(vaultId: String): List<KaminoVault> {
+        val enabled = selectionRepository.getSelectedVaults(vaultId).first()
+        return KaminoVaultRegistry.ALLOW_LIST.filter { it.address in enabled }
+    }
+
+    /**
+     * What the wallet's shares in [vault] redeem for, or null when that cannot be established.
+     *
+     * Zero shares need no share price, so a wallet holding nothing in a vault resolves without a
+     * metrics call — and cannot be left unknown by one failing.
+     */
+    private suspend fun amountOf(
+        vault: KaminoVault,
+        position: KaminoUserPositionJson?,
+    ): BigInteger? {
+        val shares = KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
+        if (shares.signum() == 0) return BigInteger.ZERO
+
+        val tokensPerShare =
+            runCatching { kaminoApi.getVaultMetrics(vault.address) }
+                .getOrNull()
+                ?.let { KaminoPositionMath.decimalOrNull(it.tokensPerShare) } ?: return null
+
+        return KaminoPositionMath.tokenAmount(shares, tokensPerShare, vault.tokenDecimals)
+            .movePointRight(vault.tokenDecimals)
+            .toBigInteger()
+    }
+
+    /**
+     * One balance per underlying token, not per vault: two of the curated vaults are USDC, and the
+     * balance pipeline resolves a chain's DeFi position by coin, so two entries for the same coin
+     * would leave whichever came second unread.
+     */
+    private fun balancesOf(amounts: Map<KaminoVault, BigInteger>): List<DeFiBalance> {
+        val balances =
+            amounts
+                .mapNotNull { (vault, amount) ->
+                    vault.coin?.takeIf { amount.signum() > 0 }?.let { coin -> coin to amount }
+                }
+                .groupBy { (coin, _) -> coin.id.lowercase() }
+                .map { (_, entries) ->
+                    DeFiBalance.Balance(
+                        coin = entries.first().first,
+                        amount =
+                            entries.fold(BigInteger.ZERO) { running, (_, amount) ->
+                                running + amount
+                            },
+                    )
+                }
+
+        return if (balances.isEmpty()) emptyList()
+        else listOf(DeFiBalance(chain = Chain.Solana, balances = balances))
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceService.kt
@@ -25,7 +25,12 @@ import timber.log.Timber
  * deliberately keeps out of wallet-token discovery.
  *
  * Gated on the per-vault opt-in, matching the Earn tab: a vault the user has switched off shows no
- * card there and must not show a balance here either, or the two surfaces disagree.
+ * card there and must not count here either.
+ *
+ * On a failed read the two surfaces do part company, deliberately. A card can say it does not know
+ * the position and the user reads that; a portfolio total has no such affordance, so leaving the
+ * position out would quietly understate every figure above it. This side therefore keeps the last
+ * known size while the card shows the position as unavailable.
  *
  * Mirrors iOS `DefiBalanceService.kaminoEarnTotalBalanceFiatDecimal`.
  */
@@ -36,22 +41,25 @@ class KaminoDeFiBalanceService(
 ) : DeFiService {
 
     override suspend fun getRemoteDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
-        val enabled = enabledVaults(vaultId)
-        if (enabled.isEmpty()) return emptyList()
+        val amounts =
+            try {
+                // The opt-in read is inside the guard like every other read here: this service is
+                // one of two the Solana provider awaits side by side, so an escaping throw would
+                // take the healthy staking figure down with it.
+                val enabled = enabledVaults(vaultId)
+                if (enabled.isEmpty()) return emptyList()
 
-        return try {
-            // One call for the whole wallet. An empty list is a real answer — the wallet holds no
-            // position — while a throw is not knowing, which is why it is caught below rather than
-            // collapsed into zero.
-            val positions = kaminoApi.getUserPositions(address).associateBy { it.vaultAddress }
-            val cached = positionCache.getPositions(vaultId)
-            Timber.d(
-                "KaminoDeFiBalanceService: %d enabled vaults, %d positions held",
-                enabled.size,
-                positions.size,
-            )
+                // One call for the whole wallet. An empty list is a real answer — the wallet holds
+                // no position — while a throw is not knowing, which is why it is caught below
+                // rather than collapsed into zero.
+                val positions = kaminoApi.getUserPositions(address).associateBy { it.vaultAddress }
+                val cached = positionCache.getPositions(vaultId)
+                Timber.d(
+                    "KaminoDeFiBalanceService: %d enabled vaults, %d positions held",
+                    enabled.size,
+                    positions.size,
+                )
 
-            val amounts =
                 supervisorScope {
                         enabled
                             .map { vault ->
@@ -68,15 +76,18 @@ class KaminoDeFiBalanceService(
                     }
                     .filterNotNull()
                     .toMap()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "KaminoDeFiBalanceService: failed to read positions")
+                return getCacheDeFiBalance(address, vaultId)
+            }
 
-            positionCache.savePositions(vaultId, amounts.mapKeys { it.key.address })
-            balancesOf(amounts)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Timber.w(e, "KaminoDeFiBalanceService: failed to read positions")
-            getCacheDeFiBalance(address, vaultId)
-        }
+        // Persisted outside the read's fallback: a snapshot the store refused to keep costs the
+        // next cold start a stale figure, whereas discarding what was just read costs this one its
+        // whole position.
+        persistSnapshot(vaultId, amounts)
+        return balancesOf(amounts)
     }
 
     override suspend fun getCacheDeFiBalance(address: String, vaultId: String): List<DeFiBalance> {
@@ -92,6 +103,16 @@ class KaminoDeFiBalanceService(
         } catch (e: Exception) {
             Timber.w(e, "KaminoDeFiBalanceService: failed to read the cached positions")
             emptyList()
+        }
+    }
+
+    private suspend fun persistSnapshot(vaultId: String, amounts: Map<KaminoVault, BigInteger>) {
+        try {
+            positionCache.savePositions(vaultId, amounts.mapKeys { it.key.address })
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "KaminoDeFiBalanceService: failed to persist the position snapshot")
         }
     }
 
@@ -113,10 +134,23 @@ class KaminoDeFiBalanceService(
         val shares = KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
         if (shares.signum() == 0) return BigInteger.ZERO
 
+        val metrics =
+            try {
+                kaminoApi.getVaultMetrics(vault.address)
+            } catch (e: CancellationException) {
+                // runCatching would hand a cancelled read back as "no metrics", so the vault would
+                // quietly resolve from cache instead of the load stopping.
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "KaminoDeFiBalanceService: failed to read the metrics of a vault")
+                null
+            }
+
+        // A share price of zero is not a price — it values a real deposit at nothing — so it counts
+        // as not knowing. Answering zero would also persist over the position's last known size.
         val tokensPerShare =
-            runCatching { kaminoApi.getVaultMetrics(vault.address) }
-                .getOrNull()
-                ?.let { KaminoPositionMath.decimalOrNull(it.tokensPerShare) } ?: return null
+            KaminoPositionMath.decimalOrNull(metrics?.tokensPerShare)?.takeIf { it.signum() > 0 }
+                ?: return null
 
         return KaminoPositionMath.tokenAmount(shares, tokensPerShare, vault.tokenDecimals)
             .movePointRight(vault.tokenDecimals)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceService.kt
@@ -7,7 +7,6 @@ import com.vultisig.wallet.data.blockchain.model.DeFiBalance
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.repositories.KaminoPositionCacheRepository
 import com.vultisig.wallet.data.repositories.KaminoVaultSelectionRepository
-import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.async
@@ -124,14 +123,20 @@ class KaminoDeFiBalanceService(
     /**
      * What the wallet's shares in [vault] redeem for, or null when that cannot be established.
      *
-     * Zero shares need no share price, so a wallet holding nothing in a vault resolves without a
-     * metrics call — and cannot be left unknown by one failing.
+     * No entry for the vault is a real answer — the wallet holds nothing in it — and zero shares
+     * need no share price, so either resolves without a metrics call and cannot be left unknown by
+     * one failing. A share count that will not parse, or one below zero, is not an answer: it is
+     * read as not knowing, so the last known size stands rather than being overwritten by a zero.
      */
     private suspend fun amountOf(
         vault: KaminoVault,
         position: KaminoUserPositionJson?,
     ): BigInteger? {
-        val shares = KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
+        if (position == null) return BigInteger.ZERO
+
+        val shares =
+            KaminoPositionMath.decimalOrNull(position.totalShares)?.takeIf { it.signum() >= 0 }
+                ?: return null
         if (shares.signum() == 0) return BigInteger.ZERO
 
         val metrics =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
@@ -15,6 +15,13 @@ data class Account(
     val tokenValue: TokenValue?,
     val fiatValue: FiatValue?,
     val price: FiatValue?,
+    /**
+     * The account exists only to carry a DeFi position, because the vault does not hold this token
+     * as a wallet balance — a Kamino Earn deposit in a token the wallet has none of, for instance.
+     * Its balance is the position, so it counts towards the DeFi portfolio but is never something a
+     * form may spend.
+     */
+    val isPositionOnly: Boolean = false,
 ) {
     companion object {
         val EMPTY = Account(token = Coin.EMPTY, tokenValue = null, fiatValue = null, price = null)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -3,6 +3,8 @@
 package com.vultisig.wallet.data.repositories
 
 import com.vultisig.wallet.data.api.models.thorchain.MergeAccount
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.blockchain.solana.kamino.coin
 import com.vultisig.wallet.data.mappers.ChainAndTokens
 import com.vultisig.wallet.data.mappers.ChainAndTokensToAddressMapper
 import com.vultisig.wallet.data.models.Account
@@ -427,14 +429,19 @@ constructor(
         val vault = getVault(vaultId)
         val defiCoins = vault.coins.filter { it.isValidForDeFi() }.distinctBy { it.id.lowercase() }
 
+        val groupedDefiCoins = defiCoins.groupBy { it.chain }
+        val positionOnlyTokensByChain =
+            groupedDefiCoins.mapValues { (chain, tokens) -> positionOnlyTokens(chain, tokens) }
         val coins =
-            defiCoins
-                .groupBy { it.chain }
-                .mapValues { (chain, tokens) -> tokens + defiOnlyTokens(chain, tokens) }
+            groupedDefiCoins.mapValues { (chain, tokens) ->
+                tokens + defiOnlyTokens(chain, tokens) + positionOnlyTokensByChain[chain].orEmpty()
+            }
+        val positionOnlyIds =
+            positionOnlyTokensByChain.values.flatten().mapTo(mutableSetOf()) { it.id.lowercase() }
 
-        // Price the DeFi-only positions alongside the vault's own coins: a price is cached under
-        // its own coin's token id, and that is the row the cached path reads, so a refresh that
-        // left them out would keep valuing a resolved position at $0.00.
+        // Price the injected tokens too: a price is cached under its own coin's token id, and that
+        // is the row the cached path reads, so leaving them out would keep valuing a resolved
+        // position at $0.00.
         val loadPrices =
             if (isRefresh) {
                 async { tokenPriceRepository.refresh(coins.values.flatten()) }
@@ -444,7 +451,9 @@ constructor(
 
         val addresses =
             coins.mapNotNullTo(mutableListOf()) { (chain, tokens) ->
-                chainAndTokensToAddressMapper.map(ChainAndTokens(chain, tokens))
+                chainAndTokensToAddressMapper
+                    .map(ChainAndTokens(chain, tokens))
+                    ?.markPositionOnly(positionOnlyIds)
             }
 
         // emit cached
@@ -502,8 +511,7 @@ constructor(
 
                         val updatedAccounts =
                             address.accounts.map { account ->
-                                val cachedBalance =
-                                    balancesByTicker[account.token.ticker.lowercase()]
+                                val cachedBalance = balancesByTicker[account.token.ticker.lowercase()]
                                 if (cachedBalance != null) {
                                     account.applyBalance(
                                         cachedBalance.tokenBalance,
@@ -529,7 +537,8 @@ constructor(
                         val canBeDeFiProvider = address.chain.isDeFiSupported
 
                         address.copy(
-                            accounts = updatedAccounts.dropUnfundedDefiOnly(),
+                            accounts =
+                                updatedAccounts.dropUnfundedDefiOnly().dropUnfundedPositionOnly(),
                             isDefiProvider = canBeDeFiProvider,
                         )
                     }
@@ -574,7 +583,8 @@ constructor(
                             val canBeDeFiProvider = account.chain.isDeFiSupported
 
                             account.copy(
-                                accounts = newAccounts.dropUnfundedDefiOnly(),
+                                accounts =
+                                    newAccounts.dropUnfundedDefiOnly().dropUnfundedPositionOnly(),
                                 isDefiProvider = canBeDeFiProvider,
                             )
                         } catch (e: Exception) {
@@ -665,6 +675,45 @@ constructor(
                     account.token.chain.id to account.token.contractAddress.lowercase()
                 }
         )
+
+    /**
+     * Tokens this chain's DeFi positions are denominated in that the vault does not carry as a
+     * wallet coin, stamped with the address and public key the chain's own tokens share.
+     *
+     * A Kamino Earn position is held in its vault's underlying token, and a wallet can hold one
+     * without ever holding that token itself — it may have deposited its whole balance, or
+     * deposited from another device. Accounts here are built from `vault.coins`, so without this
+     * the position resolves to an account that is not there and is silently dropped.
+     *
+     * Every curated vault's token is offered rather than only the enabled ones: an unfunded
+     * injection is dropped once its balance resolves, so opting out removes it either way.
+     */
+    private fun positionOnlyTokens(chain: Chain, tokens: List<Coin>): List<Coin> {
+        if (chain != Chain.Solana) return emptyList()
+        val template = tokens.firstOrNull() ?: return emptyList()
+        val held = tokens.mapTo(mutableSetOf()) { it.id.lowercase() }
+        return KaminoVaultRegistry.ALLOW_LIST.mapNotNull { it.coin }
+            .distinctBy { it.id.lowercase() }
+            .filterNot { it.id.lowercase() in held }
+            .map { it.copy(address = template.address, hexPublicKey = template.hexPublicKey) }
+    }
+
+    private fun Address.markPositionOnly(tokenIds: Set<String>): Address =
+        if (tokenIds.isEmpty()) this
+        else
+            copy(
+                accounts =
+                    accounts.map { it.copy(isPositionOnly = it.token.id.lowercase() in tokenIds) }
+            )
+
+    /**
+     * Drops injected accounts that resolved to nothing, so a token the vault holds neither in its
+     * wallet nor in a position never reaches the list — it would otherwise add an empty row and
+     * inflate the chain's asset count.
+     */
+    private fun List<Account>.dropUnfundedPositionOnly(): List<Account> = filterNot { account ->
+        account.isPositionOnly && (account.tokenValue?.value ?: BigInteger.ZERO) <= BigInteger.ZERO
+    }
 
     private fun Coin.isValidForDeFi(): Boolean {
         return when (this.chain) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -20,7 +20,7 @@ import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingDeFiBalan
 import com.vultisig.wallet.data.blockchain.ethereum.CircleDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.maya.MayaDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.model.DeFiBalance
-import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.solana.SolanaDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.thorchain.ThorchainDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.ton.TonDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.tron.TronDeFiBalanceService
@@ -163,7 +163,7 @@ constructor(
     private val tronDeFiBalanceService: TronDeFiBalanceService,
     private val tonDeFiBalanceService: TonDeFiBalanceService,
     private val cosmosStakingDeFiBalanceService: CosmosStakingDeFiBalanceService,
-    private val solanaStakingDeFiBalanceService: SolanaStakingDeFiBalanceService,
+    private val solanaDeFiBalanceService: SolanaDeFiBalanceService,
 ) : BalanceRepository {
 
     private val defiBalanceCache = SimpleCache<String, List<DeFiBalance>>(12 * 1000)
@@ -253,7 +253,7 @@ constructor(
                 MayaChain -> mayaDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
                 Chain.Tron -> tronDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
                 Chain.Ton -> tonDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
-                Solana -> solanaStakingDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
+                Solana -> solanaDeFiBalanceService.getCacheDeFiBalance(address, vaultId)
                 Chain.Terra,
                 Chain.TerraClassic,
                 Chain.Qbtc ->
@@ -428,7 +428,7 @@ constructor(
             MayaChain -> mayaDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
             Chain.Tron -> tronDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
             Chain.Ton -> tonDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
-            Solana -> solanaStakingDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
+            Solana -> solanaDeFiBalanceService.getRemoteDeFiBalance(address, vaultId)
             // Each staking chain has its own LCD (Terra / TerraClassic even share an address), so
             // the chain is passed explicitly.
             Chain.Terra,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/KaminoPositionCacheRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/KaminoPositionCacheRepository.kt
@@ -1,17 +1,12 @@
 package com.vultisig.wallet.data.repositories
 
-import android.content.Context
-import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringSetPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
-import dagger.hilt.android.qualifiers.ApplicationContext
+import com.vultisig.wallet.data.sources.AppDataStore
 import java.math.BigInteger
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.flow.first
-
-private val Context.kaminoPositionDataStore by preferencesDataStore(name = "kamino_positions")
 
 /**
  * The last known size of each Kamino Earn position, in the vault's underlying token base units.
@@ -26,27 +21,29 @@ private val Context.kaminoPositionDataStore by preferencesDataStore(name = "kami
  * token-keyed store could not tell their positions apart.
  */
 @Singleton
-class KaminoPositionCacheRepository
-@Inject
-constructor(@ApplicationContext private val context: Context) {
+class KaminoPositionCacheRepository @Inject constructor(private val dataStore: AppDataStore) {
 
     /**
      * Amounts by kVault address. Vaults the allow-list no longer carries are dropped on read, so a
      * retired vault cannot keep contributing to a total the app can no longer price.
      */
-    suspend fun getPositions(vaultId: String): Map<String, BigInteger> {
-        val stored = context.kaminoPositionDataStore.data.first()[positionsKey(vaultId)].orEmpty()
-        return stored
-            .mapNotNull(::decode)
-            .filter { KaminoVaultRegistry.isAllowed(it.first) }
-            .toMap()
-    }
+    suspend fun getPositions(vaultId: String): Map<String, BigInteger> =
+        decodeAll(dataStore.readData(positionsKey(vaultId)).first().orEmpty())
 
-    /** Replaces the snapshot wholesale, so a vault that no longer holds anything stops counting. */
+    /**
+     * Merges [positions] into the snapshot: a vault reported as holding nothing stops counting — it
+     * arrives as zero — while a vault this write says nothing about keeps what it had.
+     *
+     * Deliberately not a wholesale replace. The caller only ever reports the vaults the user has
+     * switched on, so replacing would wipe a switched-off vault's amount, and switching it back on
+     * would leave the next cold start short by that position until the network answered again.
+     */
     suspend fun savePositions(vaultId: String, positions: Map<String, BigInteger>) {
-        context.kaminoPositionDataStore.edit { preferences ->
-            preferences[positionsKey(vaultId)] =
-                positions.map { (address, amount) -> "$address$SEPARATOR$amount" }.toSet()
+        dataStore.editData { preferences ->
+            val key = positionsKey(vaultId)
+            val merged = decodeAll(preferences[key].orEmpty()) + positions
+            preferences[key] =
+                merged.map { (address, amount) -> "$address$SEPARATOR$amount" }.toSet()
         }
     }
 
@@ -54,6 +51,9 @@ constructor(@ApplicationContext private val context: Context) {
         const val SEPARATOR = "="
 
         fun positionsKey(vaultId: String) = stringSetPreferencesKey("kamino_positions_$vaultId")
+
+        fun decodeAll(stored: Set<String>): Map<String, BigInteger> =
+            stored.mapNotNull(::decode).filter { KaminoVaultRegistry.isAllowed(it.first) }.toMap()
 
         /** A malformed entry is dropped rather than read as zero, which would report a loss. */
         fun decode(entry: String): Pair<String, BigInteger>? {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/KaminoPositionCacheRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/KaminoPositionCacheRepository.kt
@@ -1,0 +1,66 @@
+package com.vultisig.wallet.data.repositories
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.math.BigInteger
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+
+private val Context.kaminoPositionDataStore by preferencesDataStore(name = "kamino_positions")
+
+/**
+ * The last known size of each Kamino Earn position, in the vault's underlying token base units.
+ *
+ * The DeFi portfolio reads balances from a cache first and only then from the network, so without a
+ * snapshot a position would render as nothing on every cold start until Kamino answered. Kamino has
+ * no cheap "just the balance" endpoint — a position is shares times a live share price — so the
+ * derived amount is what gets kept rather than the inputs. iOS persists the same snapshot for the
+ * same reason.
+ *
+ * Keyed by kVault address, not by token: two of the three curated vaults are USDC, and a
+ * token-keyed store could not tell their positions apart.
+ */
+@Singleton
+class KaminoPositionCacheRepository
+@Inject
+constructor(@ApplicationContext private val context: Context) {
+
+    /**
+     * Amounts by kVault address. Vaults the allow-list no longer carries are dropped on read, so a
+     * retired vault cannot keep contributing to a total the app can no longer price.
+     */
+    suspend fun getPositions(vaultId: String): Map<String, BigInteger> {
+        val stored = context.kaminoPositionDataStore.data.first()[positionsKey(vaultId)].orEmpty()
+        return stored
+            .mapNotNull(::decode)
+            .filter { KaminoVaultRegistry.isAllowed(it.first) }
+            .toMap()
+    }
+
+    /** Replaces the snapshot wholesale, so a vault that no longer holds anything stops counting. */
+    suspend fun savePositions(vaultId: String, positions: Map<String, BigInteger>) {
+        context.kaminoPositionDataStore.edit { preferences ->
+            preferences[positionsKey(vaultId)] =
+                positions.map { (address, amount) -> "$address$SEPARATOR$amount" }.toSet()
+        }
+    }
+
+    private companion object {
+        const val SEPARATOR = "="
+
+        fun positionsKey(vaultId: String) = stringSetPreferencesKey("kamino_positions_$vaultId")
+
+        /** A malformed entry is dropped rather than read as zero, which would report a loss. */
+        fun decode(entry: String): Pair<String, BigInteger>? {
+            val address = entry.substringBefore(SEPARATOR, missingDelimiterValue = "")
+            val amount = entry.substringAfter(SEPARATOR, missingDelimiterValue = "")
+            if (address.isEmpty()) return null
+            return amount.toBigIntegerOrNull()?.let { address to it }
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaDeFiBalanceServiceTest.kt
@@ -1,0 +1,111 @@
+package com.vultisig.wallet.data.blockchain.solana
+
+import com.vultisig.wallet.data.blockchain.model.DeFiBalance
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingDeFiBalanceService
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/** Covers the chain total being the sum of Solana's two independent DeFi surfaces. */
+internal class SolanaDeFiBalanceServiceTest {
+
+    private lateinit var staking: SolanaStakingDeFiBalanceService
+    private lateinit var kamino: KaminoDeFiBalanceService
+
+    @BeforeEach
+    fun setUp() {
+        staking = mockk(relaxed = true)
+        kamino = mockk(relaxed = true)
+        coEvery { staking.getRemoteDeFiBalance(any(), any()) } returns emptyList()
+        coEvery { kamino.getRemoteDeFiBalance(any(), any()) } returns emptyList()
+        coEvery { staking.getCacheDeFiBalance(any(), any()) } returns emptyList()
+        coEvery { kamino.getCacheDeFiBalance(any(), any()) } returns emptyList()
+    }
+
+    @Test
+    fun `staked SOL and a SOL Earn position are added together, not one dropped`() = runTest {
+        coEvery { staking.getRemoteDeFiBalance(ADDRESS, VAULT_ID) } returns
+            balances(Coins.Solana.SOL to BigInteger("1000000000"))
+        coEvery { kamino.getRemoteDeFiBalance(ADDRESS, VAULT_ID) } returns
+            balances(Coins.Solana.SOL to BigInteger("500000000"))
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        // The pipeline resolves one balance per coin, so leaving these as two entries would report
+        // whichever it matched first as the whole position.
+        assertEquals(BigInteger("1500000000"), balance.amount)
+    }
+
+    @Test
+    fun `positions in different tokens each keep their own balance`() = runTest {
+        coEvery { staking.getRemoteDeFiBalance(ADDRESS, VAULT_ID) } returns
+            balances(Coins.Solana.SOL to BigInteger("1000000000"))
+        coEvery { kamino.getRemoteDeFiBalance(ADDRESS, VAULT_ID) } returns
+            balances(Coins.Solana.USDC to BigInteger("250000000"))
+
+        val balances = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances
+
+        assertEquals(2, balances.size)
+        assertEquals(
+            BigInteger("1000000000"),
+            balances.first { it.coin.id == Coins.Solana.SOL.id }.amount,
+        )
+        assertEquals(
+            BigInteger("250000000"),
+            balances.first { it.coin.id == Coins.Solana.USDC.id }.amount,
+        )
+    }
+
+    @Test
+    fun `a vault with only native staking is reported exactly as before`() = runTest {
+        coEvery { staking.getRemoteDeFiBalance(ADDRESS, VAULT_ID) } returns
+            balances(Coins.Solana.SOL to BigInteger("1000000000"))
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(Coins.Solana.SOL.id, balance.coin.id)
+        assertEquals(BigInteger("1000000000"), balance.amount)
+    }
+
+    @Test
+    fun `a vault holding neither reports nothing at all`() = runTest {
+        assertTrue(service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).isEmpty())
+    }
+
+    @Test
+    fun `the cached read sums both sides too`() = runTest {
+        coEvery { staking.getCacheDeFiBalance(ADDRESS, VAULT_ID) } returns
+            balances(Coins.Solana.SOL to BigInteger("1000000000"))
+        coEvery { kamino.getCacheDeFiBalance(ADDRESS, VAULT_ID) } returns
+            balances(Coins.Solana.SOL to BigInteger("500000000"))
+
+        val balance = service().getCacheDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("1500000000"), balance.amount)
+    }
+
+    private fun service() =
+        SolanaDeFiBalanceService(stakingBalanceService = staking, kaminoBalanceService = kamino)
+
+    private fun balances(vararg entries: Pair<Coin, BigInteger>) =
+        listOf(
+            DeFiBalance(
+                chain = Chain.Solana,
+                balances = entries.map { (coin, amount) -> DeFiBalance.Balance(coin, amount) },
+            )
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+        const val ADDRESS = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceServiceTest.kt
@@ -11,9 +11,13 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigInteger
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -122,6 +126,60 @@ internal class KaminoDeFiBalanceServiceTest {
 
             assertEquals(BigInteger("500000000"), balance.amount)
         }
+
+    @Test
+    fun `a share price of zero counts as unknown rather than as an empty position`() = runTest {
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "1000"))
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "0")
+        coEvery { positionCache.getPositions(VAULT_ID) } returns
+            mapOf(STEAKHOUSE.address to BigInteger("500000000"))
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("500000000"), balance.amount)
+        // The zero must not reach the snapshot either, or it would erase the real position until a
+        // later good read.
+        coVerify(exactly = 0) {
+            positionCache.savePositions(VAULT_ID, mapOf(STEAKHOUSE.address to BigInteger.ZERO))
+        }
+    }
+
+    @Test
+    fun `a cancelled share-price read stops the load rather than falling back`() = runTest {
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "1000"))
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } throws
+            CancellationException("cancelled")
+
+        assertThrows(CancellationException::class.java) {
+            runBlocking { service().getRemoteDeFiBalance(ADDRESS, VAULT_ID) }
+        }
+    }
+
+    @Test
+    fun `an opt-in read that fails leaves the rest of the chain's load standing`() = runTest {
+        // The Solana provider awaits this service and staking side by side in one scope, so a throw
+        // escaping here would cancel the healthy staking figure too.
+        every { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flow { throw RuntimeException("datastore") }
+
+        assertTrue(service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).isEmpty())
+    }
+
+    @Test
+    fun `a snapshot the store refuses to keep does not discard the balance just read`() = runTest {
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "1000"))
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.05")
+        coEvery { positionCache.savePositions(any(), any()) } throws RuntimeException("disk full")
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("1050000000"), balance.amount)
+    }
 
     @Test
     fun `the cached read answers from the snapshot without touching the network`() = runTest {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceServiceTest.kt
@@ -147,6 +147,77 @@ internal class KaminoDeFiBalanceServiceTest {
     }
 
     @Test
+    fun `a share count that will not parse keeps the position at its last known size`() = runTest {
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "n/a"))
+        coEvery { positionCache.getPositions(VAULT_ID) } returns
+            mapOf(STEAKHOUSE.address to BigInteger("500000000"))
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("500000000"), balance.amount)
+        // The last known size is what goes back into the snapshot, so a run of unreadable answers
+        // cannot walk the position down to zero.
+        coVerify {
+            positionCache.savePositions(
+                VAULT_ID,
+                mapOf(STEAKHOUSE.address to BigInteger("500000000")),
+            )
+        }
+        // Unknown shares are not worth a share price either.
+        coVerify(exactly = 0) { kaminoApi.getVaultMetrics(any()) }
+    }
+
+    @Test
+    fun `a share count below zero counts as unknown rather than as an empty position`() = runTest {
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "-1000"))
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.05")
+        coEvery { positionCache.getPositions(VAULT_ID) } returns
+            mapOf(STEAKHOUSE.address to BigInteger("500000000"))
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("500000000"), balance.amount)
+        coVerify {
+            positionCache.savePositions(
+                VAULT_ID,
+                mapOf(STEAKHOUSE.address to BigInteger("500000000")),
+            )
+        }
+    }
+
+    @Test
+    fun `a position with no shares field is not read as an emptied vault`() = runTest {
+        // The field is optional on the wire, so an entry arriving without it says nothing about the
+        // size — and an entry only exists at all for a vault the wallet is in.
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = null))
+        coEvery { positionCache.getPositions(VAULT_ID) } returns
+            mapOf(STEAKHOUSE.address to BigInteger("500000000"))
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("500000000"), balance.amount)
+    }
+
+    @Test
+    fun `a share count of exactly zero is a real emptied vault`() = runTest {
+        // The other half of the rule: an answered zero must still erase the old figure, or a
+        // withdrawn position would linger on the portfolio for good.
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "0"))
+        coEvery { positionCache.getPositions(VAULT_ID) } returns
+            mapOf(STEAKHOUSE.address to BigInteger("500000000"))
+
+        assertTrue(service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).isEmpty())
+        coVerify {
+            positionCache.savePositions(VAULT_ID, mapOf(STEAKHOUSE.address to BigInteger.ZERO))
+        }
+    }
+
+    @Test
     fun `a cancelled share-price read stops the load rather than falling back`() = runTest {
         coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
             listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "1000"))

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceServiceTest.kt
@@ -1,0 +1,160 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.KaminoUserPositionJson
+import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.KaminoPositionCacheRepository
+import com.vultisig.wallet.data.repositories.KaminoVaultSelectionRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers what the DeFi portfolio reads for Kamino: a position valued in its underlying token, and
+ * the failure paths, where a read that did not happen must never be reported as an empty position.
+ */
+internal class KaminoDeFiBalanceServiceTest {
+
+    private lateinit var kaminoApi: KaminoApi
+    private lateinit var selectionRepository: KaminoVaultSelectionRepository
+    private lateinit var positionCache: KaminoPositionCacheRepository
+
+    @BeforeEach
+    fun setUp() {
+        kaminoApi = mockk(relaxed = true)
+        selectionRepository = mockk(relaxed = true)
+        positionCache = mockk(relaxed = true)
+
+        coEvery { positionCache.getPositions(VAULT_ID) } returns emptyMap()
+        every { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+    }
+
+    @Test
+    fun `a position is reported in the vault's underlying token`() = runTest {
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "1000"))
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.05")
+
+        val balances = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances
+
+        val balance = balances.single()
+        assertEquals(Coins.Solana.USDC.id, balance.coin.id)
+        // 1000 shares × 1.05, in USDC base units.
+        assertEquals(BigInteger("1050000000"), balance.amount)
+    }
+
+    @Test
+    fun `two vaults sharing a token are reported as one balance`() = runTest {
+        // The pipeline resolves a chain's DeFi position by coin, so a second USDC entry would go
+        // unread and the portfolio would be short by that vault.
+        every { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address, RWA.address))
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+            listOf(
+                KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100"),
+                KaminoUserPositionJson(vaultAddress = RWA.address, totalShares = "50"),
+            )
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val balances = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances
+
+        assertEquals(1, balances.size)
+        assertEquals(BigInteger("150000000"), balances.single().amount)
+    }
+
+    @Test
+    fun `a vault the user has not enabled is never read`() = runTest {
+        every { selectionRepository.getSelectedVaults(VAULT_ID) } returns flowOf(emptySet())
+
+        assertTrue(service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).isEmpty())
+
+        coVerify(exactly = 0) { kaminoApi.getUserPositions(any()) }
+    }
+
+    @Test
+    fun `a wallet holding nothing reports nothing`() = runTest {
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } returns emptyList()
+
+        assertTrue(service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).isEmpty())
+        // An answered call saying "no position" is a real zero, so the snapshot records it and the
+        // next cold start does not resurrect the old figure.
+        coVerify {
+            positionCache.savePositions(VAULT_ID, mapOf(STEAKHOUSE.address to BigInteger.ZERO))
+        }
+    }
+
+    @Test
+    fun `a failed read falls back to the last known position rather than zero`() = runTest {
+        coEvery { kaminoApi.getUserPositions(ADDRESS) } throws RuntimeException("503")
+        coEvery { positionCache.getPositions(VAULT_ID) } returns
+            mapOf(STEAKHOUSE.address to BigInteger("500000000"))
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("500000000"), balance.amount)
+    }
+
+    @Test
+    fun `a share price that could not be read keeps the position at its last known size`() =
+        runTest {
+            coEvery { kaminoApi.getUserPositions(ADDRESS) } returns
+                listOf(
+                    KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "1000")
+                )
+            coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } throws RuntimeException("503")
+            coEvery { positionCache.getPositions(VAULT_ID) } returns
+                mapOf(STEAKHOUSE.address to BigInteger("500000000"))
+
+            val balance =
+                service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+            assertEquals(BigInteger("500000000"), balance.amount)
+        }
+
+    @Test
+    fun `the cached read answers from the snapshot without touching the network`() = runTest {
+        coEvery { positionCache.getPositions(VAULT_ID) } returns
+            mapOf(STEAKHOUSE.address to BigInteger("250000000"))
+
+        val balance = service().getCacheDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("250000000"), balance.amount)
+        coVerify(exactly = 0) { kaminoApi.getUserPositions(any()) }
+    }
+
+    @Test
+    fun `a vault switched off stops counting even while its snapshot survives`() = runTest {
+        every { selectionRepository.getSelectedVaults(VAULT_ID) } returns flowOf(emptySet())
+        coEvery { positionCache.getPositions(VAULT_ID) } returns
+            mapOf(STEAKHOUSE.address to BigInteger("250000000"))
+
+        assertTrue(service().getCacheDeFiBalance(ADDRESS, VAULT_ID).isEmpty())
+    }
+
+    private fun service() =
+        KaminoDeFiBalanceService(
+            kaminoApi = kaminoApi,
+            selectionRepository = selectionRepository,
+            positionCache = positionCache,
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+        const val ADDRESS = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+        val STEAKHOUSE = KaminoVaultRegistry.STEAKHOUSE_USDC
+        val RWA = KaminoVaultRegistry.RWA_USDC
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
@@ -503,38 +504,73 @@ internal class AccountsRepositoryImplTest {
     }
 
     @Test
-    fun `a cached DeFi balance stays on the chain that reported it`() = runTest {
+    fun `a cached DeFi balance lands on its own chain's account, not another chain's`() = runTest {
+        // USDC is a DeFi position on two chains at once — Circle on Ethereum, Kamino on Solana —
+        // so a ticker that is not qualified by its chain applies one chain's balance to the other.
         val eth = Coins.Ethereum.ETH.copy(address = ETH_ADDRESS)
         val ethUsdc = Coins.Ethereum.USDC.copy(address = ETH_ADDRESS)
         val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
         val solUsdc = Coins.Solana.USDC.copy(address = SOL_ADDRESS)
+        stubVault(eth, ethUsdc, sol, solUsdc)
         coEvery { vaultRepository.get(VAULT_ID) } returns
             Vault(id = VAULT_ID, name = "Test Vault", coins = listOf(eth, ethUsdc, sol, solUsdc))
 
-        // Only Ethereum has a funded position — the Circle deposit, reported as Ethereum USDC.
         coEvery {
             balanceRepository.getDeFiCachedTokeBalanceAndPrice(ETH_ADDRESS, any(), VAULT_ID)
-        } returns listOf(defiBalance(Coins.Ethereum.USDC, amount = DEPOSIT, fiat = DEPOSIT_FIAT))
+        } returns listOf(balanceWithFiat(amount = ETH_DEFI, fiat = ETH_DEFI, coin = ethUsdc))
         coEvery {
             balanceRepository.getDeFiCachedTokeBalanceAndPrice(SOL_ADDRESS, any(), VAULT_ID)
-        } returns emptyList()
+        } returns listOf(balanceWithFiat(amount = SOL_DEFI, fiat = SOL_DEFI, coin = solUsdc))
 
-        val addresses = repository.loadDeFiAddresses(VAULT_ID, isRefresh = false).toList().last()
+        val addresses = repository.loadDeFiAddresses(VAULT_ID, isRefresh = false).first()
 
-        // Balances arrive carrying a ticker and nothing else, so a lookup pooled across chains
-        // handed this one deposit to the Solana USDC account as well.
-        val solanaUsdc =
-            addresses
-                .first { it.chain == Chain.Solana }
-                .accounts
-                .first { it.token.id == solUsdc.id }
-        assertEquals(0L, solanaUsdc.tokenValue?.value?.toLong())
+        assertEquals(ETH_DEFI, addresses.tokenValue(Chain.Ethereum, ethUsdc.ticker))
+        assertEquals(SOL_DEFI, addresses.tokenValue(Chain.Solana, solUsdc.ticker))
+    }
+
+    @Test
+    fun `a Kamino position lands on an account even when the vault holds none of the token`() =
+        runTest {
+            // The wallet deposited its whole USDC balance, so the vault carries only SOL. Without
+            // an account for USDC the position has nowhere to land and the row stays staking-only.
+            val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
+            val solUsdc = Coins.Solana.USDC.copy(address = SOL_ADDRESS)
+            stubVault(sol)
+            coEvery { vaultRepository.get(VAULT_ID) } returns
+                Vault(id = VAULT_ID, name = "Test Vault", coins = listOf(sol))
+
+            coEvery {
+                balanceRepository.getDeFiCachedTokeBalanceAndPrice(SOL_ADDRESS, any(), VAULT_ID)
+            } returns
+                listOf(
+                    balanceWithFiat(amount = SOL_DEFI, fiat = SOL_DEFI, coin = sol),
+                    balanceWithFiat(amount = ETH_DEFI, fiat = ETH_DEFI, coin = solUsdc),
+                )
+
+            val addresses = repository.loadDeFiAddresses(VAULT_ID, isRefresh = false).first()
+
+            assertEquals(ETH_DEFI, addresses.tokenValue(Chain.Solana, solUsdc.ticker))
+            assertEquals(SOL_DEFI, addresses.tokenValue(Chain.Solana, sol.ticker))
+        }
+
+    @Test
+    fun `a token held neither in the wallet nor in a position adds no account`() = runTest {
+        val sol = Coins.Solana.SOL.copy(address = SOL_ADDRESS)
+        stubVault(sol)
+        coEvery { vaultRepository.get(VAULT_ID) } returns
+            Vault(id = VAULT_ID, name = "Test Vault", coins = listOf(sol))
+
+        coEvery {
+            balanceRepository.getDeFiCachedTokeBalanceAndPrice(SOL_ADDRESS, any(), VAULT_ID)
+        } returns listOf(balanceWithFiat(amount = SOL_DEFI, fiat = SOL_DEFI, coin = sol))
+
+        val addresses = repository.loadDeFiAddresses(VAULT_ID, isRefresh = false).first()
+
+        // An injected account that resolved to nothing would otherwise show an empty row and
+        // inflate the chain's asset count.
         assertEquals(
-            DEPOSIT_FIAT,
-            addresses.sumOf { address ->
-                address.accounts.sumOf { it.fiatValue?.value?.toLong() ?: 0L }
-            },
-            "the DeFi total must count the deposit once, not once per chain sharing its ticker",
+            listOf(sol.ticker),
+            addresses.first { it.chain == Chain.Solana }.accounts.map { it.token.ticker },
         )
     }
 
@@ -632,6 +668,14 @@ internal class AccountsRepositoryImplTest {
             price = FiatValue(BigDecimal.ONE, currency),
         )
 
+    private fun List<Address>.tokenValue(chain: Chain, ticker: String): Long? =
+        firstOrNull { it.chain == chain }
+            ?.accounts
+            ?.firstOrNull { it.token.ticker == ticker }
+            ?.tokenValue
+            ?.value
+            ?.toLong()
+
     private fun stubVault(vararg coins: Coin) {
         val vault = Vault(id = VAULT_ID, name = "Test Vault", coins = coins.toList())
         every { vaultRepository.getAsFlow(VAULT_ID) } returns flowOf(vault)
@@ -709,5 +753,7 @@ internal class AccountsRepositoryImplTest {
         const val NETWORK = 10L
         const val ETH_NETWORK = 100L
         const val SOL_NETWORK = 200L
+        const val ETH_DEFI = 300L
+        const val SOL_DEFI = 700L
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/KaminoPositionCacheRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/KaminoPositionCacheRepositoryTest.kt
@@ -1,0 +1,107 @@
+package com.vultisig.wallet.data.repositories
+
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.sources.AppDataStore
+import io.kotest.matchers.shouldBe
+import java.math.BigInteger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the snapshot the DeFi portfolio renders from before the network answers: a write reports
+ * only the vaults the user has switched on, so it has to leave the others' amounts alone.
+ */
+internal class KaminoPositionCacheRepositoryTest {
+
+    /** In-memory [AppDataStore] so reads observe prior writes without Android DataStore. */
+    private val store = FakeAppDataStore()
+
+    private val repo = KaminoPositionCacheRepository(store)
+
+    @Test
+    fun `a position survives the write that recorded it`() = runTest {
+        repo.savePositions(VAULT_ID, mapOf(STEAKHOUSE to BigInteger("500000000")))
+
+        repo.getPositions(VAULT_ID) shouldBe mapOf(STEAKHOUSE to BigInteger("500000000"))
+    }
+
+    @Test
+    fun `a vault reported as holding nothing stops counting`() = runTest {
+        repo.savePositions(VAULT_ID, mapOf(STEAKHOUSE to BigInteger("500000000")))
+
+        repo.savePositions(VAULT_ID, mapOf(STEAKHOUSE to BigInteger.ZERO))
+
+        repo.getPositions(VAULT_ID) shouldBe mapOf(STEAKHOUSE to BigInteger.ZERO)
+    }
+
+    @Test
+    fun `a vault the write says nothing about keeps its amount`() = runTest {
+        // Switching a vault off drops it from every later write, and switching it back on must not
+        // find its position gone: a cold start would then under-report the DeFi total.
+        repo.savePositions(
+            VAULT_ID,
+            mapOf(STEAKHOUSE to BigInteger("500000000"), RWA to BigInteger("250000000")),
+        )
+
+        repo.savePositions(VAULT_ID, mapOf(STEAKHOUSE to BigInteger("600000000")))
+
+        repo.getPositions(VAULT_ID) shouldBe
+            mapOf(STEAKHOUSE to BigInteger("600000000"), RWA to BigInteger("250000000"))
+    }
+
+    @Test
+    fun `snapshots are independent per vault`() = runTest {
+        repo.savePositions(VAULT_ID, mapOf(STEAKHOUSE to BigInteger("500000000")))
+        repo.savePositions(OTHER_VAULT_ID, mapOf(STEAKHOUSE to BigInteger("120000000")))
+
+        repo.getPositions(VAULT_ID) shouldBe mapOf(STEAKHOUSE to BigInteger("500000000"))
+        repo.getPositions(OTHER_VAULT_ID) shouldBe mapOf(STEAKHOUSE to BigInteger("120000000"))
+    }
+
+    @Test
+    fun `a vault the allow-list no longer carries is dropped`() = runTest {
+        repo.savePositions(
+            VAULT_ID,
+            mapOf(STEAKHOUSE to BigInteger("500000000"), "retired-vault" to BigInteger("999")),
+        )
+
+        repo.getPositions(VAULT_ID) shouldBe mapOf(STEAKHOUSE to BigInteger("500000000"))
+    }
+
+    private class FakeAppDataStore : AppDataStore {
+        private val prefs = MutableStateFlow<Preferences>(emptyPreferences())
+
+        override suspend fun editData(
+            transform: suspend (MutablePreferences) -> Unit
+        ): Preferences {
+            val mutable = prefs.value.toMutablePreferences()
+            transform(mutable)
+            val updated = mutable.toPreferences()
+            prefs.value = updated
+            return updated
+        }
+
+        override fun <T> readData(key: Preferences.Key<T>, defaultValue: T): Flow<T> =
+            prefs.map { it[key] ?: defaultValue }
+
+        override suspend fun <T> set(key: Preferences.Key<T>, value: T) {
+            editData { it[key] = value }
+        }
+
+        override fun <T> readData(key: Preferences.Key<T>): Flow<T?> = prefs.map { it[key] }
+    }
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+        const val OTHER_VAULT_ID = "other-vault-id"
+
+        val STEAKHOUSE = KaminoVaultRegistry.STEAKHOUSE_USDC.address
+        val RWA = KaminoVaultRegistry.RWA_USDC.address
+    }
+}


### PR DESCRIPTION
Fixes #5616

## Problem

A Kamino Earn deposit left the DeFi Portfolio untouched: no `DeFiService` produced a Kamino balance
at all, so `loadDeFiAddresses` never saw the position and neither the Solana row nor the header
counted it. Combined with #5588 keeping the share mints out of SPL discovery — correct, or the same
deposit would count twice — the money left the wallet total when the deposit landed and arrived
nowhere. The Earn tab was the only surface in the app reporting it.

## Changes

**`KaminoDeFiBalanceService`** — reads the enabled vaults and the wallet's positions and reports each
one in its vault's underlying token, since shares have no price of their own and are deliberately
not wallet tokens. Gated on the same per-vault opt-in the Earn tab uses, so the two surfaces cannot
disagree. One balance per token rather than per vault: two curated vaults are USDC, and the pipeline
resolves a chain's position by coin, so a second entry for the same coin would go unread. A failed
read falls back to the last known size — reporting zero on a real deposit reads as a loss — and zero
shares resolve without a metrics call, so a wallet holding nothing cannot be left unknown by one
failing.

**`KaminoPositionCacheRepository`** — persists the derived amount per kVault, so the cache-first read
has an answer before the network lands. Kamino has no cheap balance endpoint (a position is shares
times a live share price), which is why the derived figure is kept rather than the inputs; iOS
persists the same snapshot. Keyed by vault address, not token, since two vaults share the USDC
ticker.

**`SolanaDeFiBalanceService`** — Solana's DeFi position is two independent things, so this sums
native staking and Kamino per coin. Not a concatenation: the SOL Earn vault reports in the coin
native staking already uses, and the pipeline matches the first entry on the refresh path and the
last one on the cached path, so leaving them separate would drop one of the two SOL figures and make
a cold start disagree with a refresh.

Two pieces of plumbing this needed:

- **Somewhere for the balance to land.** A wallet can hold a position in a token it holds none of —
  it may have deposited its whole balance, or deposited on another device. Accounts are built from
  `vault.coins`, so the balance resolved to an account that was not there and was dropped. The
  curated vaults' tokens are now injected when missing, marked `Account.isPositionOnly`, and dropped
  again once they resolve to nothing, so a vault with no position gains no empty row. `AccountsLoader`
  filters them out of the form paths: their balance is a position, never something to spend.
- **Per-chain balance keys.** The cached path keyed balances by ticker across every chain at once.
  USDC is a Circle position on Ethereum and a Kamino one on Solana, so the two collided and one
  chain's balance was applied to the other chain's account. Keyed per chain now.

iOS totals the same two in `DefiBalanceService.totalBalanceInFiat`, and counts Kamino in
`defiPositionCount`.

## Test plan

16 new tests:

`KaminoDeFiBalanceServiceTest` (8) — a position reported in its underlying token; two vaults sharing
a token reported as one balance; a vault not enabled is never read; a wallet holding nothing reports
nothing and records that; a failed positions read falls back to the last known size; a failed share
price keeps the last known size; the cached read answers from the snapshot without touching the
network; a vault switched off stops counting even while its snapshot survives.

`SolanaDeFiBalanceServiceTest` (5) — staked SOL and a SOL Earn position summed rather than one
dropped; different tokens keep their own balances; a staking-only vault reported exactly as before;
neither held reports nothing; the cached read sums both sides too.

`AccountsRepositoryImplTest` (2) — a cached DeFi balance lands on its own chain's account, not
another chain's (verified to fail against the current code, where the Ethereum USDC account took the
Solana figure); a Kamino position lands on an account even when the vault holds none of the token;
and a token held neither in the wallet nor in a position adds no account.

`AccountsLoaderTest` (1) — the DeFi form path drops accounts that only ever hold a position.

`:app` and `:data` unit suites pass, `ktfmtCheck` clean on both.

Checked against a vault holding 1 staked SOL and 0.555968 USDC in Steakhouse USDC: the Solana row
went from "$75.36 · 1 SOL" to "$75.81 · 2 Assets", matching the chain screen one tap deeper, and
disabling the vault under Manage Positions drops it back to the staking figure.

## Note for review

Touches `AccountsRepository.loadDeFiAddresses` and `AccountsLoader`, which #5615 also edits. Whichever
lands second needs a rebase. `dropUnfundedPositionOnly` / `isPositionOnly` here and
`dropUnfundedDefiOnly` / `Coins.isDefiOnly` there are the same mechanism for two different reasons —
worth collapsing into one once both are in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for viewing Kamino Earn positions alongside Solana native staking balances.
  - Added reliable DeFi balance aggregation, including cached values when network data is unavailable.
  - Added persistence for DeFi position balances between sessions.
  - Added eligible position tokens to portfolio displays, even when they are not directly spendable.

- **Bug Fixes**
  - Prevented position-only accounts from appearing as spendable accounts.
  - Improved token grouping across chains to prevent balance conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->