### PR TITLE
fix(defi): re-read the DeFi list when home comes back to the front

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -599,7 +599,7 @@ constructor(
                             .loadDeFiAddresses(vaultId, readsNetwork)
                             .map { addresses -> addresses.sortByAccountsTotalFiatValue() }
                             .catch { error ->
-                                Timber.e(error, "Error loading DeFi balances for vault: $vaultId")
+                                Timber.e(error, "Error loading DeFi balances for vault: %s", vaultId)
                             }
                             // This load, not the wallet stream, is what a pull on the DeFi tab is
                             // waiting on. A cancelled one is superseded by the load that replaced

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -347,6 +347,26 @@ constructor(
         val vaultId = vaultId ?: return
         updateRefreshing(true)
         loadAccounts(vaultId)
+        // A pull on the DeFi tab has to reload the DeFi rows: they come from their own load, so
+        // refreshing only the wallet accounts left the list the user was pulling on untouched.
+        if (uiState.value.cryptoConnectionType == CryptoConnectionType.Defi) {
+            loadDeFiBalances(vaultId, isRefresh = true)
+        }
+    }
+
+    /**
+     * Re-reads the DeFi list when home comes back to the front.
+     *
+     * Positions are changed a screen deeper — a Kamino vault switched on under Manage Positions, a
+     * deposit signed — and nothing on the way back asks this list to look again, so it kept
+     * rendering the figures it had loaded before the change. The wallet tab has its own streaming
+     * load and is left alone.
+     */
+    fun onScreenResumed() {
+        val vaultId = vaultId ?: return
+        if (uiState.value.cryptoConnectionType == CryptoConnectionType.Defi) {
+            loadDeFiBalances(vaultId, isRefresh = true)
+        }
     }
 
     fun send() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -56,10 +56,12 @@ import com.vultisig.wallet.ui.utils.throttleLatest
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -69,6 +71,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -166,6 +169,15 @@ constructor(
     private var loadAccountsJob: Job? = null
     private var loadDeFiBalancesJob: Job? = null
     private var bannerJob: Job? = null
+    private var deFiRefreshThrottleJob: Job? = null
+
+    // The tab a pull-to-refresh was started on, and the only load allowed to take the spinner back
+    // down. On the DeFi tab the rows under the user's finger come from loadDeFiBalances, so the
+    // wallet stream reaching isComplete says nothing about whether they are still stale.
+    private var refreshOwner: CryptoConnectionType? = null
+
+    // True while a network DeFi read is recent enough to stand in for a resume-triggered one.
+    private var isDeFiRefreshThrottled = false
 
     // Last merged snapshot per stream (wallet / DeFi), keyed in-memory so a chain that comes back
     // with a null balance mid-refetch can carry its previously-shown value forward (#4768). Reset
@@ -345,11 +357,13 @@ constructor(
 
     fun refreshData() {
         val vaultId = vaultId ?: return
+        val pulledTab = uiState.value.cryptoConnectionType
+        refreshOwner = pulledTab
         updateRefreshing(true)
         loadAccounts(vaultId)
         // A pull on the DeFi tab has to reload the DeFi rows: they come from their own load, so
         // refreshing only the wallet accounts left the list the user was pulling on untouched.
-        if (uiState.value.cryptoConnectionType == CryptoConnectionType.Defi) {
+        if (pulledTab == CryptoConnectionType.Defi) {
             loadDeFiBalances(vaultId, isRefresh = true)
         }
     }
@@ -361,12 +375,17 @@ constructor(
      * deposit signed — and nothing on the way back asks this list to look again, so it kept
      * rendering the figures it had loaded before the change. The wallet tab has its own streaming
      * load and is left alone.
+     *
+     * Every return to home resumes, including ones that changed nothing (Receive, the vault list)
+     * and ones that already asked for the list themselves ([openAddChainAccount] reloads once the
+     * chain picker's result lands), so a read that recent stands in for this one — the same
+     * throttled-on-appear iOS puts on its DeFi screen.
      */
     fun onScreenResumed() {
         val vaultId = vaultId ?: return
-        if (uiState.value.cryptoConnectionType == CryptoConnectionType.Defi) {
-            loadDeFiBalances(vaultId, isRefresh = true)
-        }
+        if (uiState.value.cryptoConnectionType != CryptoConnectionType.Defi) return
+        if (isDeFiRefreshThrottled) return
+        loadDeFiBalances(vaultId, isRefresh = true)
     }
 
     fun send() {
@@ -528,10 +547,12 @@ constructor(
                             .throttleLatest(BALANCE_RENDER_WINDOW) { it.isComplete }
                             // Keep the pull-to-refresh spinner up until every chain has resolved,
                             // matching iOS/Windows, instead of clearing it on the cached snapshot.
-                            .onEach { if (it.isComplete) updateRefreshing(false) }
+                            .onEach {
+                                if (it.isComplete) finishRefreshing(CryptoConnectionType.Wallet)
+                            }
                             .map { it.addresses.sortByAccountsTotalFiatValue() }
                             .catch {
-                                updateRefreshing(false)
+                                finishRefreshing(CryptoConnectionType.Wallet)
                                 Timber.e(it)
                             },
                         uiState.value.searchTextFieldState.textAsFlow(),
@@ -555,6 +576,9 @@ constructor(
 
     private fun loadDeFiBalances(vaultId: String, isRefresh: Boolean = false) {
         loadDeFiBalancesJob?.cancel()
+        // Only a network read covers a later resume; the cached-only load fetches nothing, so it
+        // must not stand in for one.
+        if (isRefresh) throttleDeFiRefresh()
         loadDeFiBalancesJob =
             viewModelScope.safeLaunch {
                 combine(
@@ -562,8 +586,13 @@ constructor(
                             .loadDeFiAddresses(vaultId, isRefresh)
                             .map { addresses -> addresses.sortByAccountsTotalFiatValue() }
                             .catch { error ->
-                                updateRefreshing(false)
                                 Timber.e(error, "Error loading DeFi balances for vault: $vaultId")
+                            }
+                            // This load, not the wallet stream, is what a pull on the DeFi tab is
+                            // waiting on. A cancelled one is superseded by the load that replaced
+                            // it, which clears the spinner in its turn.
+                            .onCompletion { cause ->
+                                if (cause == null) finishRefreshing(CryptoConnectionType.Defi)
                             },
                         uiState.value.searchTextFieldState.textAsFlow(),
                         defaultDeFiChainsRepository.getDefaultChains(vaultId),
@@ -682,6 +711,27 @@ constructor(
     private fun updateRefreshing(isRefreshing: Boolean) {
         Timber.d("UpdateRefresh $isRefreshing")
         uiState.update { it.copy(isRefreshing = isRefreshing) }
+    }
+
+    /**
+     * Takes the pull-to-refresh spinner down once [source] — the tab the pull was started on — has
+     * finished loading. The other tab's load runs on its own schedule and is ignored: it would
+     * otherwise report the refresh done while the rows the user is looking at are still stale.
+     */
+    private fun finishRefreshing(source: CryptoConnectionType) {
+        if (refreshOwner != source) return
+        refreshOwner = null
+        updateRefreshing(false)
+    }
+
+    private fun throttleDeFiRefresh() {
+        deFiRefreshThrottleJob?.cancel()
+        isDeFiRefreshThrottled = true
+        deFiRefreshThrottleJob =
+            viewModelScope.launch {
+                delay(DEFI_REFRESH_THROTTLE)
+                isDeFiRefreshThrottled = false
+            }
     }
 
     fun toggleBalanceVisibility() {
@@ -880,5 +930,9 @@ constructor(
         // Window for coalescing per-chain balance updates so rows settle once per window instead
         // of reordering on every chain arrival; matches the leading debounce iOS uses (#4337).
         private val BALANCE_RENDER_WINDOW = 250.milliseconds
+
+        // How recent a network DeFi read has to be for a resume to reuse it rather than fetch
+        // again; the interval iOS throttles its DeFi screen's on-appear refresh by.
+        private val DEFI_REFRESH_THROTTLE = 15.seconds
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -590,9 +590,15 @@ constructor(
                             }
                             // This load, not the wallet stream, is what a pull on the DeFi tab is
                             // waiting on. A cancelled one is superseded by the load that replaced
-                            // it, which clears the spinner in its turn.
+                            // it, which clears the spinner in its turn. Gated on isRefresh so a
+                            // cache-only reload (e.g. one an unrelated AppDataStore write races in
+                            // while a refresh's network fetch is still in flight) can't complete
+                            // first and clear the spinner off the cache instead of the network
+                            // read.
                             .onCompletion { cause ->
-                                if (cause == null) finishRefreshing(CryptoConnectionType.Defi)
+                                if (cause == null && isRefresh) {
+                                    finishRefreshing(CryptoConnectionType.Defi)
+                                }
                             },
                         uiState.value.searchTextFieldState.textAsFlow(),
                         defaultDeFiChainsRepository.getDefaultChains(vaultId),

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -66,7 +66,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
@@ -247,6 +246,11 @@ constructor(
         viewModelScope.safeLaunch {
             updateLastOpenedVault()
             lastOpenedVaultRepository.lastOpenedVaultId
+                // AppDataStore reads the whole preferences file, so every unrelated write
+                // re-emits the same id. Without this, each one re-ran loadData: cancelling the
+                // balance loads in flight and starting them over, a cached DeFi read landing on
+                // top of a pull's network read among them.
+                .distinctUntilChanged()
                 .map { lastOpenedVaultId ->
                     lastOpenedVaultId?.let { vaultRepository.get(it) }
                         ?: vaultRepository.getAll().firstOrNull()
@@ -529,8 +533,12 @@ constructor(
                         isChainSelectionEnabled = vault.libType != SigningLibType.KeyImport,
                     )
                 }
-                val isVaultBackedUp = vaultDataStoreRepository.readBackupStatus(vaultId).first()
-                uiState.update { it.copy(showBackupWarning = !isVaultBackedUp) }
+                // Collected, not read once: backing the vault up is what takes this warning
+                // down, and it happens on another screen while this one is still alive.
+                vaultDataStoreRepository.readBackupStatus(vaultId).distinctUntilChanged().collect {
+                    isBackedUp ->
+                    uiState.update { it.copy(showBackupWarning = !isBackedUp) }
+                }
             }
     }
 
@@ -575,28 +583,31 @@ constructor(
     }
 
     private fun loadDeFiBalances(vaultId: String, isRefresh: Boolean = false) {
+        // A load that replaces the one an outstanding DeFi pull is waiting on has to carry that
+        // pull's network read forward: the job it cancels never clears the spinner, and answering
+        // the pull off the cache would take the spinner down over the very rows it was pulled to
+        // replace.
+        val readsNetwork = isRefresh || refreshOwner == CryptoConnectionType.Defi
         loadDeFiBalancesJob?.cancel()
         // Only a network read covers a later resume; the cached-only load fetches nothing, so it
         // must not stand in for one.
-        if (isRefresh) throttleDeFiRefresh()
+        if (readsNetwork) throttleDeFiRefresh()
         loadDeFiBalancesJob =
             viewModelScope.safeLaunch {
                 combine(
                         accountsRepository
-                            .loadDeFiAddresses(vaultId, isRefresh)
+                            .loadDeFiAddresses(vaultId, readsNetwork)
                             .map { addresses -> addresses.sortByAccountsTotalFiatValue() }
                             .catch { error ->
                                 Timber.e(error, "Error loading DeFi balances for vault: $vaultId")
                             }
                             // This load, not the wallet stream, is what a pull on the DeFi tab is
                             // waiting on. A cancelled one is superseded by the load that replaced
-                            // it, which clears the spinner in its turn. Gated on isRefresh so a
-                            // cache-only reload (e.g. one an unrelated AppDataStore write races in
-                            // while a refresh's network fetch is still in flight) can't complete
-                            // first and clear the spinner off the cache instead of the network
-                            // read.
+                            // it, which clears the spinner in its turn. Gated on the network
+                            // read so a cache-only load can't clear the spinner off the cache
+                            // instead of the fetch the pull is waiting on.
                             .onCompletion { cause ->
-                                if (cause == null && isRefresh) {
+                                if (cause == null && readsNetwork) {
                                     finishRefreshing(CryptoConnectionType.Defi)
                                 }
                             },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
@@ -77,6 +78,13 @@ internal fun VaultAccountsScreen(viewModel: VaultAccountsViewModel = hiltViewMod
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
             viewModel.onNotificationPermissionResult(granted)
         }
+
+    // Positions are managed one screen deeper, so the list is re-read on the way back rather than
+    // only when the tab is switched.
+    LifecycleResumeEffect(Unit) {
+        viewModel.onScreenResumed()
+        onPauseOrDispose {}
+    }
 
     LaunchedEffect(Unit) {
         viewModel.requestNotificationPermission.collect {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/VaultAccountsViewModelTest.kt
@@ -11,6 +11,8 @@ import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.CryptoConnectionTypeRepository
 import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
 import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
+import com.vultisig.wallet.data.repositories.RequestResultRepository
+import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
 import io.kotest.matchers.shouldBe
@@ -18,13 +20,16 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -51,6 +56,8 @@ internal class VaultAccountsViewModelTest {
     private lateinit var cryptoConnectionTypeRepository: CryptoConnectionTypeRepository
     private lateinit var defaultDeFiChainsRepository: DefaultDeFiChainsRepository
     private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
+    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
+    private lateinit var requestResultRepository: RequestResultRepository
     private lateinit var hasCircleAccount: HasCircleAccountUseCase
 
     private val connectionType = MutableStateFlow(CryptoConnectionType.Wallet)
@@ -64,6 +71,8 @@ internal class VaultAccountsViewModelTest {
         cryptoConnectionTypeRepository = mockk(relaxed = true)
         defaultDeFiChainsRepository = mockk(relaxed = true)
         balanceVisibilityRepository = mockk(relaxed = true)
+        vaultDataStoreRepository = mockk(relaxed = true)
+        requestResultRepository = mockk(relaxed = true)
         hasCircleAccount = mockk(relaxed = true)
 
         every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf(VAULT_ID)
@@ -75,6 +84,8 @@ internal class VaultAccountsViewModelTest {
         every { defaultDeFiChainsRepository.getDefaultChains(VAULT_ID) } returns flowOf(emptySet())
         coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
         coEvery { hasCircleAccount(any()) } returns false
+        coEvery { vaultDataStoreRepository.readBackupStatus(VAULT_ID) } returns flowOf(true)
+        coEvery { requestResultRepository.request<Unit>(any()) } returns Unit
     }
 
     @AfterEach
@@ -189,15 +200,81 @@ internal class VaultAccountsViewModelTest {
         viewModel.uiState.value.isRefreshing shouldBe false
     }
 
+    @Test
+    fun `an unrelated preference write does not reload the vault`() = runTest {
+        connectionType.value = CryptoConnectionType.Defi
+        val vaultIds = MutableSharedFlow<String?>(replay = 1)
+        vaultIds.emit(VAULT_ID)
+        every { lastOpenedVaultRepository.lastOpenedVaultId } returns vaultIds
+
+        viewModel()
+        advanceUntilIdle()
+
+        // AppDataStore reads the whole preferences file, so a write to any other key re-emits the
+        // id already on screen. Emitted from a SharedFlow, like the DataStore one it stands in
+        // for: a StateFlow would conflate the repeat away before the screen ever saw it.
+        vaultIds.emit(VAULT_ID)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { accountsRepository.loadAddressBalances(VAULT_ID) }
+        coVerify(exactly = 1) { accountsRepository.loadDeFiAddresses(VAULT_ID, any()) }
+    }
+
+    @Test
+    fun `a reload landing mid-pull still takes the spinner down`() = runTest {
+        connectionType.value = CryptoConnectionType.Defi
+        val deFiAddresses = Channel<List<Address>>(Channel.UNLIMITED)
+        coEvery { accountsRepository.loadDeFiAddresses(VAULT_ID, true) } returns
+            deFiAddresses.receiveAsFlow()
+        val viewModel = viewModel()
+        runCurrent()
+
+        viewModel.refreshData()
+        runCurrent()
+
+        viewModel.uiState.value.isRefreshing shouldBe true
+
+        // Reachable from the wallet tab: its chain picker reloads everything on the way back, the
+        // DeFi list included, cancelling the fetch the pull started on the other tab is waiting on.
+        viewModel.setCryptoConnectionType(CryptoConnectionType.Wallet)
+        viewModel.openAddChainAccount()
+        runCurrent()
+
+        // The replacement carries the pull's read forward instead of answering it from the cache,
+        // so the pull still ends on a fetch rather than leaving the spinner up for good.
+        coVerify(exactly = 2) { accountsRepository.loadDeFiAddresses(VAULT_ID, true) }
+
+        deFiAddresses.close()
+        runCurrent()
+
+        viewModel.uiState.value.isRefreshing shouldBe false
+    }
+
+    @Test
+    fun `backing the vault up takes the warning down`() = runTest {
+        val isBackedUp = MutableStateFlow(false)
+        coEvery { vaultDataStoreRepository.readBackupStatus(VAULT_ID) } returns isBackedUp
+        val viewModel = viewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.value.showBackupWarning shouldBe true
+
+        // Backing up happens a screen away while this one is still alive.
+        isBackedUp.value = true
+        advanceUntilIdle()
+
+        viewModel.uiState.value.showBackupWarning shouldBe false
+    }
+
     private fun viewModel() =
         VaultAccountsViewModel(
             savedStateHandle = SavedStateHandle(),
             navigator = mockk(relaxed = true),
-            requestResultRepository = mockk(relaxed = true),
+            requestResultRepository = requestResultRepository,
             addressToUiModelMapper = mockk(relaxed = true),
             fiatValueToStringMapper = mockk(relaxed = true),
             vaultRepository = vaultRepository,
-            vaultDataStoreRepository = mockk(relaxed = true),
+            vaultDataStoreRepository = vaultDataStoreRepository,
             accountsRepository = accountsRepository,
             balanceVisibilityRepository = balanceVisibilityRepository,
             vaultMetadataRepo = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/VaultAccountsViewModelTest.kt
@@ -1,0 +1,158 @@
+package com.vultisig.wallet.ui.models
+
+import androidx.lifecycle.SavedStateHandle
+import com.vultisig.wallet.data.models.CryptoConnectionType
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
+import com.vultisig.wallet.data.repositories.CryptoConnectionTypeRepository
+import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
+import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the DeFi list being re-read when home comes back to the front: positions are managed a
+ * screen deeper, and nothing else on the way back asks the list to look again.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class VaultAccountsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var accountsRepository: AccountsRepository
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var lastOpenedVaultRepository: LastOpenedVaultRepository
+    private lateinit var cryptoConnectionTypeRepository: CryptoConnectionTypeRepository
+    private lateinit var defaultDeFiChainsRepository: DefaultDeFiChainsRepository
+    private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
+    private lateinit var hasCircleAccount: HasCircleAccountUseCase
+
+    private val connectionType = MutableStateFlow(CryptoConnectionType.Wallet)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        accountsRepository = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        lastOpenedVaultRepository = mockk(relaxed = true)
+        cryptoConnectionTypeRepository = mockk(relaxed = true)
+        defaultDeFiChainsRepository = mockk(relaxed = true)
+        balanceVisibilityRepository = mockk(relaxed = true)
+        hasCircleAccount = mockk(relaxed = true)
+
+        every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf(VAULT_ID)
+        coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
+        every { cryptoConnectionTypeRepository.activeCryptoConnectionFlow } returns connectionType
+        every { accountsRepository.loadAddressBalances(VAULT_ID) } returns flowOf()
+        coEvery { accountsRepository.loadDeFiAddresses(VAULT_ID, any()) } returns
+            flowOf(emptyList())
+        every { defaultDeFiChainsRepository.getDefaultChains(VAULT_ID) } returns flowOf(emptySet())
+        coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
+        coEvery { hasCircleAccount(any()) } returns false
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `returning to the DeFi tab re-reads the positions`() = runTest {
+        connectionType.value = CryptoConnectionType.Defi
+        val viewModel = viewModel()
+        advanceUntilIdle()
+
+        viewModel.onScreenResumed()
+        advanceUntilIdle()
+
+        // A network read, not the cached one the first load settles for: the position that changed
+        // one screen deeper is only visible once its balance is fetched again.
+        coVerify(atLeast = 1) { accountsRepository.loadDeFiAddresses(VAULT_ID, true) }
+    }
+
+    @Test
+    fun `returning to the wallet tab leaves the DeFi list alone`() = runTest {
+        connectionType.value = CryptoConnectionType.Wallet
+        val viewModel = viewModel()
+        advanceUntilIdle()
+
+        viewModel.onScreenResumed()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { accountsRepository.loadDeFiAddresses(VAULT_ID, true) }
+    }
+
+    @Test
+    fun `pulling to refresh on the DeFi tab refreshes the list being pulled`() = runTest {
+        connectionType.value = CryptoConnectionType.Defi
+        val viewModel = viewModel()
+        advanceUntilIdle()
+
+        viewModel.refreshData()
+        advanceUntilIdle()
+
+        coVerify(atLeast = 1) { accountsRepository.loadDeFiAddresses(VAULT_ID, true) }
+    }
+
+    private fun viewModel() =
+        VaultAccountsViewModel(
+            savedStateHandle = SavedStateHandle(),
+            navigator = mockk(relaxed = true),
+            requestResultRepository = mockk(relaxed = true),
+            addressToUiModelMapper = mockk(relaxed = true),
+            fiatValueToStringMapper = mockk(relaxed = true),
+            vaultRepository = vaultRepository,
+            vaultDataStoreRepository = mockk(relaxed = true),
+            accountsRepository = accountsRepository,
+            balanceVisibilityRepository = balanceVisibilityRepository,
+            vaultMetadataRepo = mockk(relaxed = true),
+            isGlobalBackupReminderRequired = mockk(relaxed = true),
+            setNeverShowGlobalBackupReminder = mockk(relaxed = true),
+            lastOpenedVaultRepository = lastOpenedVaultRepository,
+            enableTokenUseCase = mockk(relaxed = true),
+            promoBannerDismissalRepository = mockk(relaxed = true),
+            cryptoConnectionTypeRepository = cryptoConnectionTypeRepository,
+            defaultDeFiChainsRepository = defaultDeFiChainsRepository,
+            hasCircleAccount = hasCircleAccount,
+            tiersNFTRepository = mockk(relaxed = true),
+            remoteNFTService = mockk(relaxed = true),
+            pushNotificationManager = mockk(relaxed = true),
+            snackbarFlow = mockk(relaxed = true),
+            ioDispatcher = testDispatcher,
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+
+        val VAULT =
+            Vault(
+                id = VAULT_ID,
+                name = "vault",
+                pubKeyECDSA = "",
+                pubKeyEDDSA = "",
+                hexChainCode = "",
+                localPartyID = "",
+                signers = emptyList(),
+                resharePrefix = "",
+                libType = SigningLibType.DKLS,
+            )
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/VaultAccountsViewModelTest.kt
@@ -1,27 +1,35 @@
 package com.vultisig.wallet.ui.models
 
 import androidx.lifecycle.SavedStateHandle
+import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.CryptoConnectionType
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.AddressBalancesUpdate
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.CryptoConnectionTypeRepository
 import com.vultisig.wallet.data.repositories.DefaultDeFiChainsRepository
 import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
@@ -112,6 +120,75 @@ internal class VaultAccountsViewModelTest {
         coVerify(atLeast = 1) { accountsRepository.loadDeFiAddresses(VAULT_ID, true) }
     }
 
+    @Test
+    fun `resuming right after a read reuses it instead of fetching again`() = runTest {
+        connectionType.value = CryptoConnectionType.Defi
+        val viewModel = viewModel()
+        runCurrent()
+
+        // Stands in for anything that reloads the list on its own on the way back — the chain
+        // picker does exactly this once its result lands, a step before home resumes behind it.
+        viewModel.refreshData()
+        runCurrent()
+        viewModel.onScreenResumed()
+        runCurrent()
+
+        coVerify(exactly = 1) { accountsRepository.loadDeFiAddresses(VAULT_ID, true) }
+    }
+
+    @Test
+    fun `resuming once the read has gone stale fetches again`() = runTest {
+        connectionType.value = CryptoConnectionType.Defi
+        val viewModel = viewModel()
+        runCurrent()
+
+        viewModel.refreshData()
+        runCurrent()
+        advanceTimeBy(THROTTLE_WINDOW + 1.seconds)
+        viewModel.onScreenResumed()
+        runCurrent()
+
+        coVerify(exactly = 2) { accountsRepository.loadDeFiAddresses(VAULT_ID, true) }
+    }
+
+    @Test
+    fun `pulling on the DeFi tab keeps the spinner up until the DeFi list lands`() = runTest {
+        connectionType.value = CryptoConnectionType.Defi
+        val deFiAddresses = Channel<List<Address>>(Channel.UNLIMITED)
+        coEvery { accountsRepository.loadDeFiAddresses(VAULT_ID, true) } returns
+            deFiAddresses.consumeAsFlow()
+        // The wallet stream is done as soon as the pull starts; it says nothing about the DeFi
+        // rows the user is actually pulling on.
+        every { accountsRepository.loadAddressBalances(VAULT_ID) } returns
+            flowOf(AddressBalancesUpdate(addresses = emptyList(), isComplete = true))
+        val viewModel = viewModel()
+        runCurrent()
+
+        viewModel.refreshData()
+        runCurrent()
+
+        viewModel.uiState.value.isRefreshing shouldBe true
+
+        deFiAddresses.close()
+        runCurrent()
+
+        viewModel.uiState.value.isRefreshing shouldBe false
+    }
+
+    @Test
+    fun `pulling on the wallet tab still ends with the wallet stream`() = runTest {
+        connectionType.value = CryptoConnectionType.Wallet
+        every { accountsRepository.loadAddressBalances(VAULT_ID) } returns
+            flowOf(AddressBalancesUpdate(addresses = emptyList(), isComplete = true))
+        val viewModel = viewModel()
+        runCurrent()
+
+        viewModel.refreshData()
+        runCurrent()
+
+        viewModel.uiState.value.isRefreshing shouldBe false
+    }
+
     private fun viewModel() =
         VaultAccountsViewModel(
             savedStateHandle = SavedStateHandle(),
@@ -141,6 +218,9 @@ internal class VaultAccountsViewModelTest {
 
     private companion object {
         const val VAULT_ID = "vault-id"
+
+        // Mirrors DEFI_REFRESH_THROTTLE, which is private to the ViewModel.
+        val THROTTLE_WINDOW = 15.seconds
 
         val VAULT =
             Vault(


### PR DESCRIPTION
Fixes #5618

## Problem

The DeFi Portfolio kept the figures it loaded before a position changed. `loadDeFiBalances` has three
callers — app start / vault switch (cache-only on the first load), switching onto the DeFi tab, and
the chain picker closing. Returning from a chain screen is none of them, so enabling a Kamino vault,
toggling a THORChain position or signing a deposit and pressing back left the rows and the header on
their pre-change values until the user happened to switch tabs.

Pull-to-refresh did not cover it either: `refreshData` reloaded the wallet accounts, which is the
other list, leaving the one being pulled on untouched.

The data was already fine — `BroadcastKeysignUseCase` invalidates the chain's DeFi balance cache
after every broadcast — nothing performed the re-read.

## Changes

- `onScreenResumed()`, called from a `LifecycleResumeEffect` on the home screen, re-reads the DeFi
  list when home comes back to the front. Guarded to the DeFi tab, so the wallet's streaming load is
  untouched.
- `refreshData()` now also refreshes the DeFi rows when that tab is the one in view.

The first load is cache-only, so the resume read is not a duplicate fetch — it upgrades that first
cached render to a real one.

## Test plan

Three tests in a new `VaultAccountsViewModelTest`:

- returning to the DeFi tab re-reads the positions (a network read, not the cached one the first
  load settles for)
- returning to the wallet tab leaves the DeFi list alone
- pulling to refresh on the DeFi tab refreshes the list being pulled

`:app` and `:data` unit suites pass, `ktfmtCheck` clean on both.

Checked on device with a Kamino position: unticking the vault under Manage Positions and pressing
back drops the Solana row to $75.16 · 1 SOL immediately, matching the chain header, and ticking it
back restores $75.72 · 2 Assets — both without switching tabs or pulling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DeFi balances now refresh when returning to the home screen, reopening a DeFi account, or manually refreshing from the DeFi tab.
  * Account information is re-read after navigating back from deeper screens.
  * Refresh indicators accurately reflect completed, interrupted, or failed wallet and DeFi loads.
  * Automatic refreshes are throttled, duplicate vault entries are avoided, and backup warnings update promptly.

* **Tests**
  * Added coverage for refresh behavior, throttling, navigation, and backup status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->