### PR TITLE
fix(passcode): correct the unreadable-keyshare copy and add a retry

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/ui/screens/passcode/PasscodeSettingsExplanationTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/ui/screens/passcode/PasscodeSettingsExplanationTest.kt
@@ -1,0 +1,56 @@
+package com.vultisig.wallet.ui.screens.passcode
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.passcode.AutoLockTimeout
+import com.vultisig.wallet.ui.models.passcode.PasscodeSettingsUiModel
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The rows under the switch are conditional on a passcode existing, so the caption sits one indent
+ * away from inheriting that condition, and it is worth most in the state the condition excludes.
+ */
+class PasscodeSettingsExplanationTest {
+
+    @get:Rule val compose = createComposeRule()
+
+    private val explanation =
+        InstrumentationRegistry.getInstrumentation()
+            .targetContext
+            .getString(R.string.passcode_settings_encryption_explanation)
+
+    @Test
+    fun theExplanationShowsBeforeAPasscodeIsSet() {
+        start(passcodeEnabled = false)
+
+        compose.onNodeWithText(explanation).assertIsDisplayed()
+    }
+
+    @Test
+    fun theExplanationShowsOnceAPasscodeIsSet() {
+        start(passcodeEnabled = true)
+
+        compose.onNodeWithText(explanation).assertIsDisplayed()
+    }
+
+    private fun start(passcodeEnabled: Boolean) {
+        compose.setContent {
+            PasscodeSettingsScreen(
+                state =
+                    PasscodeSettingsUiModel(
+                        isPasscodeEnabled = passcodeEnabled,
+                        autoLockTimeout = AutoLockTimeout.Never,
+                        isReady = true,
+                    ),
+                onBackClick = {},
+                onPasscodeEnabledChange = {},
+                onChangePasscodeClick = {},
+                onAutoLockClick = {},
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeGuardViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/passcode/PasscodeGuardViewModel.kt
@@ -75,6 +75,10 @@ constructor(private val passcodeRepository: PasscodeRepository) : ViewModel() {
         }
     }
 
+    fun onRetry() {
+        viewModelScope.safeLaunch { passcodeRepository.retry() }
+    }
+
     private fun MutableStateFlow<PasscodeGuardUiModel>.update(passcodeState: PasscodeState) {
         value =
             value.copy(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
@@ -2,23 +2,15 @@ package com.vultisig.wallet.ui.screens.passcode
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -26,6 +18,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.passcode.PasscodeState
 import com.vultisig.wallet.ui.components.BiometryAuthScreen
+import com.vultisig.wallet.ui.components.errors.ErrorState
+import com.vultisig.wallet.ui.components.errors.ErrorView
+import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
 import com.vultisig.wallet.ui.models.passcode.PasscodeGuardViewModel
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -59,7 +54,7 @@ internal fun PasscodeGuard(model: PasscodeGuardViewModel = hiltViewModel()) {
         // One call site for the whole closed gate rather than one per state: a second would be a
         // second composition slot, and moving between them would take the window down and put a new
         // one up at exactly the moment the lock appears.
-        LockWindow { GateContent(state.passcodeState) }
+        LockWindow { GateContent(state.passcodeState, model::onRetry) }
     }
 
     // The passcode was just turned off, so the user has already identified themselves this session;
@@ -71,18 +66,20 @@ internal fun PasscodeGuard(model: PasscodeGuardViewModel = hiltViewModel()) {
 
 /** What the gate shows, once there is something to show. */
 @Composable
-private fun GateContent(passcodeState: PasscodeState) {
+private fun GateContent(passcodeState: PasscodeState, onRetry: () -> Unit) {
     when (passcodeState) {
         PasscodeState.Locked -> PasscodeLockScreen()
         PasscodeState.KeyUnavailable ->
             DeadEndScreen(
                 title = stringResource(R.string.passcode_key_unavailable_title),
                 message = stringResource(R.string.passcode_key_unavailable_message),
+                onRetry = onRetry,
             )
         PasscodeState.StoreUnavailable ->
             DeadEndScreen(
                 title = stringResource(R.string.passcode_store_unavailable_title),
                 message = stringResource(R.string.passcode_store_unavailable_message),
+                onRetry = onRetry,
             )
         // Persisted state is still loading. The window is up regardless, because a dialog
         // destination restored with the back stack opens its own window while this read is still
@@ -131,37 +128,22 @@ private fun LockWindow(content: @Composable () -> Unit) {
 /**
  * Shown when encrypted keyshares cannot be opened at all — the credentials are gone
  * ([PasscodeState.KeyUnavailable]) or unreachable this launch ([PasscodeState.StoreUnavailable]).
- * Neither has a passcode that would work, so the screen says what happened rather than presenting a
- * prompt that could never succeed. The two differ only in what the user should do next, which is
- * exactly what [message] carries.
+ * Neither has a passcode that would work, so the screen says what happened rather than asking for
+ * one. The two differ only in what the user should do next, which is exactly what [message]
+ * carries.
+ *
+ * [onRetry] is the only way off this window, since back and outside taps belong to the gate. Both
+ * states rest on a keystore read that can come back, so it is worth offering.
  */
 @Composable
-private fun DeadEndScreen(title: String, message: String) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary),
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.padding(horizontal = 32.dp),
-        ) {
-            Text(
-                text = title,
-                color = Theme.v2.colors.text.primary,
-                style = Theme.brockmann.headings.title2,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth(),
-            )
-            Text(
-                text = message,
-                color = Theme.v2.colors.text.tertiary,
-                style = Theme.brockmann.supplementary.footnote,
-                textAlign = TextAlign.Center,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-    }
+private fun DeadEndScreen(title: String, message: String, onRetry: () -> Unit) {
+    ErrorView(
+        title = title,
+        description = message,
+        errorState = ErrorState.WARNING,
+        buttonUiModel =
+            ErrorViewButtonUiModel(text = stringResource(R.string.try_again), onClick = onRetry),
+    )
 }
 
 /** Consumes every pointer event that reaches this node so none of it falls through. */

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeSettingsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeSettingsScreen.kt
@@ -1,15 +1,21 @@
 package com.vultisig.wallet.ui.screens.passcode
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.passcode.AutoLockTimeout
+import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
@@ -17,6 +23,7 @@ import com.vultisig.wallet.ui.models.passcode.PasscodeSettingsUiModel
 import com.vultisig.wallet.ui.models.passcode.PasscodeSettingsViewModel
 import com.vultisig.wallet.ui.models.settings.SettingsItemUiModel
 import com.vultisig.wallet.ui.screens.settings.SettingItem
+import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.UiText
 
 @Composable
@@ -45,53 +52,67 @@ internal fun PasscodeSettingsScreen(
         title = stringResource(R.string.passcode_settings_title),
         onBackClick = onBackClick,
     ) {
-        V2Container(type = ContainerType.SECONDARY) {
-            Column {
-                SettingItem(
-                    item =
-                        SettingsItemUiModel(
-                            title =
-                                UiText.StringResource(R.string.passcode_settings_encryption_title),
-                            subTitle =
-                                UiText.StringResource(
-                                    R.string.passcode_settings_encryption_subtitle
+        Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+            V2Container(type = ContainerType.SECONDARY) {
+                Column {
+                    SettingItem(
+                        item =
+                            SettingsItemUiModel(
+                                title =
+                                    UiText.StringResource(
+                                        R.string.passcode_settings_encryption_title
+                                    ),
+                                subTitle =
+                                    UiText.StringResource(
+                                        R.string.passcode_settings_encryption_subtitle
+                                    ),
+                                leadingIcon = R.drawable.security,
+                                trailingSwitch = state.isPasscodeEnabled,
+                            ),
+                        onClick = {
+                            if (state.isReady) onPasscodeEnabledChange(!state.isPasscodeEnabled)
+                        },
+                        // Change and auto-lock only exist once a passcode does, so with the
+                        // switch off this row is both first and last.
+                        isLastItem = !state.isPasscodeEnabled,
+                    )
+
+                    if (state.isPasscodeEnabled) {
+                        SettingItem(
+                            item =
+                                SettingsItemUiModel(
+                                    title =
+                                        UiText.StringResource(R.string.passcode_settings_change),
+                                    leadingIcon = R.drawable.lock,
+                                    trailingIcon = R.drawable.ic_small_caret_right,
                                 ),
-                            leadingIcon = R.drawable.security,
-                            trailingSwitch = state.isPasscodeEnabled,
-                        ),
-                    onClick = {
-                        if (state.isReady) onPasscodeEnabledChange(!state.isPasscodeEnabled)
-                    },
-                    // Change and auto-lock only exist once a passcode does, so with the switch off
-                    // this row is both first and last.
-                    isLastItem = !state.isPasscodeEnabled,
-                )
+                            onClick = onChangePasscodeClick,
+                            isLastItem = false,
+                        )
 
-                if (state.isPasscodeEnabled) {
-                    SettingItem(
-                        item =
-                            SettingsItemUiModel(
-                                title = UiText.StringResource(R.string.passcode_settings_change),
-                                leadingIcon = R.drawable.lock,
-                                trailingIcon = R.drawable.ic_small_caret_right,
-                            ),
-                        onClick = onChangePasscodeClick,
-                        isLastItem = false,
-                    )
-
-                    SettingItem(
-                        item =
-                            SettingsItemUiModel(
-                                title = UiText.StringResource(R.string.passcode_settings_auto_lock),
-                                value = stringResource(state.autoLockTimeout.labelRes()),
-                                leadingIcon = R.drawable.ic_clock_filled,
-                                trailingIcon = R.drawable.ic_small_caret_right,
-                            ),
-                        onClick = onAutoLockClick,
-                        isLastItem = true,
-                    )
+                        SettingItem(
+                            item =
+                                SettingsItemUiModel(
+                                    title =
+                                        UiText.StringResource(R.string.passcode_settings_auto_lock),
+                                    value = stringResource(state.autoLockTimeout.labelRes()),
+                                    leadingIcon = R.drawable.ic_clock_filled,
+                                    trailingIcon = R.drawable.ic_small_caret_right,
+                                ),
+                            onClick = onAutoLockClick,
+                            isLastItem = true,
+                        )
+                    }
                 }
             }
+
+            // Outside the switch's branch: the warning is worth most before a passcode is set.
+            UiSpacer(size = 12.dp)
+            Text(
+                text = stringResource(R.string.passcode_settings_encryption_explanation),
+                style = Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.text.tertiary,
+            )
         }
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -173,6 +173,7 @@
     <string name="passcode_settings_title">Passcode-Verschlüsselung</string>
     <string name="passcode_settings_encryption_title">Passcode-Verschlüsselung</string>
     <string name="passcode_settings_encryption_subtitle">Verschlüsselt den Vault-Speicher auf diesem Gerät und sperrt die App.</string>
+    <string name="passcode_settings_encryption_explanation">Passcode-Verschlüsselung ist an dieses Gerät gebunden. Bewahren Sie ein .vult-Backup auf, um Ihre Vaults wiederherzustellen.</string>
     <string name="passcode_settings_change">Passcode ändern</string>
     <string name="passcode_settings_auto_lock">Automatische Sperre</string>
     <string name="auto_lock_setting_title">Automatische Sperre</string>
@@ -195,10 +196,10 @@
     <string name="passcode_entry_mismatch">Diese Passcodes stimmen nicht überein. Wählen Sie erneut.</string>
     <string name="passcode_operation_failed">Das hat nicht funktioniert. Ihr Passcode ist unverändert.</string>
     <string name="passcode_not_digits">Nur Ziffern eingeben.</string>
-    <string name="passcode_key_unavailable_title">Vaults nicht verfügbar</string>
-    <string name="passcode_key_unavailable_message">Die Schlüssel, die den Vault-Speicher dieses Geräts schützen, sind verloren, sodass die Vault-Freigaben nicht mehr gelesen werden können. Installieren Sie die App neu und stellen Sie Ihre Vaults aus einem Backup wieder her.</string>
-    <string name="passcode_store_unavailable_title">Vaults vorübergehend nicht verfügbar</string>
-    <string name="passcode_store_unavailable_message">Der sichere Speicher dieses Geräts konnte diesmal nicht geöffnet werden, daher bleiben Ihre Vaults gesperrt. Starten Sie die App neu, um es erneut zu versuchen. Ihre Vaults sind weiterhin auf diesem Gerät, eine Neuinstallation ist nicht erforderlich.</string>
+    <string name="passcode_key_unavailable_title">Diesem Gerät fehlt Ihr Vault-Schlüssel</string>
+    <string name="passcode_key_unavailable_message">Ihre Vaults sind noch auf diesem Gerät. Stellen Sie sie aus Ihrem .vult-Backup wieder her, um sie zu öffnen.</string>
+    <string name="passcode_store_unavailable_title">Ihre Vaults sind vorerst gesperrt</string>
+    <string name="passcode_store_unavailable_message">Der sichere Speicher dieses Geräts ließ sich diesmal nicht öffnen. Alles ist noch da, starten Sie also die App neu, statt sie neu zu installieren.</string>
     <string name="passcode_input_field_content_description">%1$d von %2$d Ziffern eingegeben</string>
     <string name="feature_item_learn_more">Erfahren Sie mehr</string>
     <string name="keysign">Keysign</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -174,6 +174,7 @@
     <string name="passcode_settings_title">Cifrado con código de acceso</string>
     <string name="passcode_settings_encryption_title">Cifrado con código de acceso</string>
     <string name="passcode_settings_encryption_subtitle">Cifra el almacenamiento de bóvedas de este dispositivo y bloquea la aplicación.</string>
+    <string name="passcode_settings_encryption_explanation">El cifrado con código de acceso está ligado a este dispositivo. Guarde una copia de seguridad .vult para restaurar sus bóvedas.</string>
     <string name="passcode_settings_change">Cambiar código de acceso</string>
     <string name="passcode_settings_auto_lock">Bloqueo automático</string>
     <string name="auto_lock_setting_title">Bloqueo automático</string>
@@ -196,10 +197,10 @@
     <string name="passcode_entry_mismatch">Los códigos de acceso no coinciden. Elija de nuevo.</string>
     <string name="passcode_operation_failed">No funcionó. Su código de acceso no ha cambiado.</string>
     <string name="passcode_not_digits">Introduzca solo dígitos.</string>
-    <string name="passcode_key_unavailable_title">Bóvedas no disponibles</string>
-    <string name="passcode_key_unavailable_message">Las claves que protegen el almacenamiento de bóvedas de este dispositivo se han perdido, por lo que ya no se pueden leer sus recursos compartidos de la bóveda. Reinstale la aplicación y restaure sus bóvedas desde una copia de seguridad.</string>
-    <string name="passcode_store_unavailable_title">Bóvedas temporalmente no disponibles</string>
-    <string name="passcode_store_unavailable_message">Esta vez no se ha podido abrir el almacenamiento seguro de este dispositivo, por lo que sus bóvedas permanecen bloqueadas. Reinicie la aplicación para volver a intentarlo. Sus bóvedas siguen en este dispositivo, así que no es necesario reinstalar.</string>
+    <string name="passcode_key_unavailable_title">A este dispositivo le falta su clave de bóveda</string>
+    <string name="passcode_key_unavailable_message">Sus bóvedas siguen en este dispositivo. Restáurelas desde su copia de seguridad .vult para volver a abrirlas.</string>
+    <string name="passcode_store_unavailable_title">Sus bóvedas están bloqueadas por ahora</string>
+    <string name="passcode_store_unavailable_message">El almacenamiento seguro de este dispositivo no se abrió esta vez. Todo sigue aquí, así que reinicie la aplicación en lugar de reinstalarla.</string>
     <string name="passcode_input_field_content_description">%1$d de %2$d dígitos introducidos</string>
     <string name="swap_form_from_title">De</string>
     <string name="swap_form_estimated_fees_title">Tarifa de intercambio</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -173,6 +173,7 @@
     <string name="passcode_settings_title">Šifriranje pristupnim kodom</string>
     <string name="passcode_settings_encryption_title">Šifriranje pristupnim kodom</string>
     <string name="passcode_settings_encryption_subtitle">Šifrira pohranu trezora na ovom uređaju i zaključava aplikaciju.</string>
+    <string name="passcode_settings_encryption_explanation">Šifriranje pristupnim kodom vezano je uz ovaj uređaj. Čuvajte .vult sigurnosnu kopiju da uvijek možete vratiti trezore.</string>
     <string name="passcode_settings_change">Promijeni pristupni kod</string>
     <string name="passcode_settings_auto_lock">Automatsko zaključavanje</string>
     <string name="auto_lock_setting_title">Automatsko zaključavanje</string>
@@ -195,10 +196,10 @@
     <string name="passcode_entry_mismatch">Pristupni kodovi se ne podudaraju. Odaberite ponovno.</string>
     <string name="passcode_operation_failed">To nije uspjelo. Vaš pristupni kod nije promijenjen.</string>
     <string name="passcode_not_digits">Unesite samo znamenke.</string>
-    <string name="passcode_key_unavailable_title">Trezori nisu dostupni</string>
-    <string name="passcode_key_unavailable_message">Ključevi koji štite pohranu trezora na ovom uređaju su izgubljeni, pa se njegova dijeljenja trezora više ne mogu pročitati. Ponovno instalirajte aplikaciju i vratite trezore iz sigurnosne kopije.</string>
-    <string name="passcode_store_unavailable_title">Trezori privremeno nisu dostupni</string>
-    <string name="passcode_store_unavailable_message">Sigurnu pohranu ovog uređaja ovaj put nije bilo moguće otvoriti, pa vaši trezori ostaju zaključani. Ponovno pokrenite aplikaciju da biste pokušali ponovno. Vaši su trezori i dalje na ovom uređaju, pa ponovna instalacija nije potrebna.</string>
+    <string name="passcode_key_unavailable_title">Ovom uređaju nedostaje ključ vašeg trezora</string>
+    <string name="passcode_key_unavailable_message">Vaši su trezori i dalje na ovom uređaju. Vratite ih iz .vult sigurnosne kopije da ih ponovno otvorite.</string>
+    <string name="passcode_store_unavailable_title">Vaši su trezori zasad zaključani</string>
+    <string name="passcode_store_unavailable_message">Ovaj se put sigurna pohrana ovog uređaja nije otvorila. Sve je i dalje tu, pa ponovno pokrenite aplikaciju umjesto ponovne instalacije.</string>
     <string name="passcode_input_field_content_description">Uneseno %1$d od %2$d znamenki</string>
     <string name="feature_item_learn_more">Saznajte više</string>
     <string name="keysign">Keysign</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -173,6 +173,7 @@
     <string name="passcode_settings_title">Crittografia con codice di accesso</string>
     <string name="passcode_settings_encryption_title">Crittografia con codice di accesso</string>
     <string name="passcode_settings_encryption_subtitle">Cripta le casseforti su questo dispositivo e blocca l’app.</string>
+    <string name="passcode_settings_encryption_explanation">La crittografia con codice di accesso è legata a questo dispositivo. Conserva un backup .vult per ripristinare i tuoi vault.</string>
     <string name="passcode_settings_change">Cambia codice di accesso</string>
     <string name="passcode_settings_auto_lock">Blocco automatico</string>
     <string name="auto_lock_setting_title">Blocco automatico</string>
@@ -195,10 +196,10 @@
     <string name="passcode_entry_mismatch">I codici di accesso non corrispondono. Scegli di nuovo.</string>
     <string name="passcode_operation_failed">Non ha funzionato. Il tuo codice di accesso non è cambiato.</string>
     <string name="passcode_not_digits">Inserisci solo cifre.</string>
-    <string name="passcode_key_unavailable_title">Vault non disponibili</string>
-    <string name="passcode_key_unavailable_message">Le chiavi che proteggono l\'archiviazione dei vault su questo dispositivo sono andate perse, quindi le sue condivisioni del vault non possono più essere lette. Reinstalla l\'app e ripristina i tuoi vault da un backup.</string>
-    <string name="passcode_store_unavailable_title">Vault temporaneamente non disponibili</string>
-    <string name="passcode_store_unavailable_message">Questa volta non è stato possibile aprire l\'archiviazione sicura di questo dispositivo, quindi i tuoi vault restano bloccati. Riavvia l\'app per riprovare. I tuoi vault sono ancora su questo dispositivo, quindi non è necessario reinstallare.</string>
+    <string name="passcode_key_unavailable_title">A questo dispositivo manca la chiave dei vault</string>
+    <string name="passcode_key_unavailable_message">I tuoi vault sono ancora su questo dispositivo. Ripristina dal backup .vult per riaprirli.</string>
+    <string name="passcode_store_unavailable_title">I tuoi vault sono bloccati per ora</string>
+    <string name="passcode_store_unavailable_message">L\'archiviazione sicura di questo dispositivo non si è aperta stavolta. C\'è ancora tutto, quindi riavvia l\'app invece di reinstallarla.</string>
     <string name="passcode_input_field_content_description">%1$d di %2$d cifre inserite</string>
     <string name="feature_item_learn_more">Saperne di più</string>
     <string name="keysign">Keysign</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -286,6 +286,7 @@
     <string name="passcode_settings_title">패스코드 암호화</string>
     <string name="passcode_settings_encryption_title">패스코드 암호화</string>
     <string name="passcode_settings_encryption_subtitle">이 기기의 볼트 저장소를 암호화하고 앱을 잠급니다.</string>
+    <string name="passcode_settings_encryption_explanation">패스코드 암호화는 이 기기에만 적용됩니다. 언제든 볼트를 복원할 수 있도록 .vult 백업을 보관하세요.</string>
     <string name="passcode_settings_change">패스코드 변경</string>
     <string name="passcode_settings_auto_lock">자동 잠금</string>
     <string name="auto_lock_setting_title">자동 잠금</string>
@@ -308,10 +309,10 @@
     <string name="passcode_entry_mismatch">패스코드가 일치하지 않습니다. 다시 선택하세요.</string>
     <string name="passcode_operation_failed">실패했습니다. 패스코드는 변경되지 않았습니다.</string>
     <string name="passcode_not_digits">숫자만 입력하세요.</string>
-    <string name="passcode_key_unavailable_title">볼트를 사용할 수 없음</string>
-    <string name="passcode_key_unavailable_message">이 기기의 볼트 저장소를 보호하는 키가 사라져 키셰어를 더 이상 읽을 수 없습니다. 앱을 다시 설치하고 백업에서 볼트를 복원하세요.</string>
-    <string name="passcode_store_unavailable_title">볼트를 일시적으로 사용할 수 없음</string>
-    <string name="passcode_store_unavailable_message">이번에는 이 기기의 보안 저장소를 열지 못해 볼트가 잠긴 상태로 유지됩니다. 앱을 다시 시작한 후 다시 시도하세요. 볼트는 이 기기에 그대로 있으므로 다시 설치할 필요는 없습니다.</string>
+    <string name="passcode_key_unavailable_title">이 기기에 볼트를 여는 키가 없습니다</string>
+    <string name="passcode_key_unavailable_message">볼트는 이 기기에 그대로 있습니다. 다시 열려면 .vult 백업에서 복원하세요.</string>
+    <string name="passcode_store_unavailable_title">지금은 볼트가 잠겨 있습니다</string>
+    <string name="passcode_store_unavailable_message">이번에는 이 기기의 보안 저장소가 열리지 않았습니다. 모두 그대로 있으니 다시 설치하지 말고 앱을 다시 시작하세요.</string>
     <string name="passcode_input_field_content_description">%2$d자리 중 %1$d자리 입력됨</string>
     <string name="swap_form_from_title">보내는 토큰</string>
     <string name="swap_form_estimated_fees_title">스왑 수수료</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -184,6 +184,7 @@
     <string name="passcode_settings_title">Toegangscodeversleuteling</string>
     <string name="passcode_settings_encryption_title">Toegangscodeversleuteling</string>
     <string name="passcode_settings_encryption_subtitle">Versleutelt de kluisopslag op dit apparaat en vergrendelt de app.</string>
+    <string name="passcode_settings_encryption_explanation">Toegangscodeversleuteling is gekoppeld aan dit apparaat. Bewaar een .vult-back-up, dan kun je je kluizen altijd herstellen.</string>
     <string name="passcode_settings_change">Toegangscode wijzigen</string>
     <string name="passcode_settings_auto_lock">Automatisch vergrendelen</string>
     <string name="auto_lock_setting_title">Automatisch vergrendelen</string>
@@ -206,10 +207,10 @@
     <string name="passcode_entry_mismatch">Die toegangscodes komen niet overeen. Kies opnieuw.</string>
     <string name="passcode_operation_failed">Dat is niet gelukt. Je toegangscode is ongewijzigd.</string>
     <string name="passcode_not_digits">Voer alleen cijfers in.</string>
-    <string name="passcode_key_unavailable_title">Kluizen niet beschikbaar</string>
-    <string name="passcode_key_unavailable_message">De sleutels die de kluisopslag van dit apparaat beschermen zijn verdwenen, waardoor de kluisshares niet meer gelezen kunnen worden. Installeer de app opnieuw en herstel je kluizen vanaf een back-up.</string>
-    <string name="passcode_store_unavailable_title">Kluizen tijdelijk niet beschikbaar</string>
-    <string name="passcode_store_unavailable_message">De beveiligde opslag van dit apparaat kon deze keer niet geopend worden, dus je kluizen blijven vergrendeld. Start de app opnieuw om het nog eens te proberen. Je kluizen staan nog op dit apparaat, dus opnieuw installeren is niet nodig.</string>
+    <string name="passcode_key_unavailable_title">Dit apparaat mist je kluissleutel</string>
+    <string name="passcode_key_unavailable_message">Je kluizen staan nog op dit apparaat. Herstel vanaf je .vult-back-up om ze weer te openen.</string>
+    <string name="passcode_store_unavailable_title">Je kluizen zijn even vergrendeld</string>
+    <string name="passcode_store_unavailable_message">De beveiligde opslag van dit apparaat ging deze keer niet open. Alles staat er nog, dus herstart de app in plaats van hem opnieuw te installeren.</string>
     <string name="passcode_input_field_content_description">%1$d van %2$d cijfers ingevoerd</string>
     <string name="swap_form_from_title">Van</string>
     <string name="swap_form_estimated_fees_title">Wisselkosten</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -173,6 +173,7 @@
     <string name="passcode_settings_title">Encriptação com código de acesso</string>
     <string name="passcode_settings_encryption_title">Encriptação com código de acesso</string>
     <string name="passcode_settings_encryption_subtitle">Encripta o armazenamento de cofres neste dispositivo e bloqueia a aplicação.</string>
+    <string name="passcode_settings_encryption_explanation">A encriptação com código de acesso está ligada a este dispositivo. Guarde um backup .vult para restaurar os seus cofres.</string>
     <string name="passcode_settings_change">Alterar código de acesso</string>
     <string name="passcode_settings_auto_lock">Bloqueio automático</string>
     <string name="auto_lock_setting_title">Bloqueio automático</string>
@@ -195,10 +196,10 @@
     <string name="passcode_entry_mismatch">Os códigos de acesso não coincidem. Escolha novamente.</string>
     <string name="passcode_operation_failed">Não funcionou. O seu código de acesso não foi alterado.</string>
     <string name="passcode_not_digits">Introduza apenas dígitos.</string>
-    <string name="passcode_key_unavailable_title">Cofres indisponíveis</string>
-    <string name="passcode_key_unavailable_message">As chaves que protegem o armazenamento de cofres deste dispositivo foram perdidas, pelo que as suas partilhas do cofre já não podem ser lidas. Reinstale a aplicação e restaure os seus cofres a partir de uma cópia de segurança.</string>
-    <string name="passcode_store_unavailable_title">Cofres temporariamente indisponíveis</string>
-    <string name="passcode_store_unavailable_message">Desta vez não foi possível abrir o armazenamento seguro deste dispositivo, pelo que os seus cofres permanecem bloqueados. Reinicie a aplicação para tentar novamente. Os seus cofres continuam neste dispositivo, pelo que não é necessário reinstalar.</string>
+    <string name="passcode_key_unavailable_title">Este dispositivo não tem a chave do seu cofre</string>
+    <string name="passcode_key_unavailable_message">Os seus cofres continuam neste dispositivo. Restaure a partir do backup .vult para os voltar a abrir.</string>
+    <string name="passcode_store_unavailable_title">Os cofres estão bloqueados por agora</string>
+    <string name="passcode_store_unavailable_message">O armazenamento seguro deste dispositivo não abriu desta vez. Continua tudo aqui, por isso reinicie a aplicação em vez de a reinstalar.</string>
     <string name="passcode_input_field_content_description">%1$d de %2$d dígitos introduzidos</string>
     <string name="feature_item_learn_more">Saber mais</string>
     <string name="keysign">Keysign</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -184,6 +184,7 @@
     <string name="passcode_settings_title">Шифрование код-паролем</string>
     <string name="passcode_settings_encryption_title">Шифрование код-паролем</string>
     <string name="passcode_settings_encryption_subtitle">Шифрует хранилище на этом устройстве и блокирует приложение.</string>
+    <string name="passcode_settings_encryption_explanation">Шифрование код-паролем привязано к этому устройству. Храните резервную копию .vult, и вы всегда сможете восстановить хранилища.</string>
     <string name="passcode_settings_change">Изменить код-пароль</string>
     <string name="passcode_settings_auto_lock">Автоблокировка</string>
     <string name="auto_lock_setting_title">Автоблокировка</string>
@@ -206,10 +207,10 @@
     <string name="passcode_entry_mismatch">Коды-пароли не совпадают. Придумайте заново.</string>
     <string name="passcode_operation_failed">Не удалось. Код-пароль не изменён.</string>
     <string name="passcode_not_digits">Вводите только цифры.</string>
-    <string name="passcode_key_unavailable_title">Хранилища недоступны</string>
-    <string name="passcode_key_unavailable_message">Ключи, защищающие данные хранилищ на этом устройстве, утрачены, поэтому его доли ключа больше нельзя прочитать. Переустановите приложение и восстановите хранилища из резервной копии.</string>
-    <string name="passcode_store_unavailable_title">Хранилища временно недоступны</string>
-    <string name="passcode_store_unavailable_message">На этот раз не удалось открыть защищённое хранилище ключей этого устройства, поэтому ваши хранилища остаются заблокированными. Перезапустите приложение и попробуйте снова. Ваши хранилища по-прежнему на этом устройстве, переустанавливать приложение не нужно.</string>
+    <string name="passcode_key_unavailable_title">На этом устройстве нет ключа от ваших хранилищ</string>
+    <string name="passcode_key_unavailable_message">Ваши хранилища всё ещё на этом устройстве. Восстановите их из резервной копии .vult, чтобы снова открыть.</string>
+    <string name="passcode_store_unavailable_title">Ваши хранилища пока заблокированы</string>
+    <string name="passcode_store_unavailable_message">На этот раз не удалось открыть защищённое хранилище ключей устройства. Всё на месте, поэтому перезапустите приложение, а не переустанавливайте его.</string>
     <string name="passcode_input_field_content_description">Введено %1$d из %2$d цифр</string>
     <string name="swap_form_from_title">Из</string>
     <string name="swap_form_estimated_fees_title">Комиссия за обмен</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -345,6 +345,7 @@
     <string name="passcode_settings_title">密码加密</string>
     <string name="passcode_settings_encryption_title">密码加密</string>
     <string name="passcode_settings_encryption_subtitle">加密本设备的保险库存储并锁定应用。</string>
+    <string name="passcode_settings_encryption_explanation">密码加密与本设备绑定。保留一份 .vult 备份，您随时都能恢复保险库。</string>
     <string name="passcode_settings_change">更改密码</string>
     <string name="passcode_settings_auto_lock">自动锁定</string>
     <string name="auto_lock_setting_title">自动锁定</string>
@@ -367,10 +368,10 @@
     <string name="passcode_entry_mismatch">两次输入的密码不一致，请重新设定。</string>
     <string name="passcode_operation_failed">操作失败。您的密码未更改。</string>
     <string name="passcode_not_digits">请仅输入数字。</string>
-    <string name="passcode_key_unavailable_title">保险库不可用</string>
-    <string name="passcode_key_unavailable_message">保护本设备保险库存储的密钥已丢失，其密钥分片无法再读取。请重新安装应用并从备份恢复您的保险库。</string>
-    <string name="passcode_store_unavailable_title">保险库暂时不可用</string>
-    <string name="passcode_store_unavailable_message">本次无法打开本设备的安全存储，因此您的保险库仍处于锁定状态。请重新启动应用后重试。您的保险库仍在本设备上，无需重新安装。</string>
+    <string name="passcode_key_unavailable_title">本设备缺少您的保险库密钥</string>
+    <string name="passcode_key_unavailable_message">您的保险库仍在本设备上。从您的 .vult 备份恢复，即可重新打开它们。</string>
+    <string name="passcode_store_unavailable_title">您的保险库暂时处于锁定状态</string>
+    <string name="passcode_store_unavailable_message">本设备的安全存储这次没能打开。所有内容都还在，重新启动应用即可，不必重新安装。</string>
     <string name="passcode_input_field_content_description">已输入 %2$d 位数字中的 %1$d 位</string>
 
     <!-- Swap Form -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,7 @@
     <string name="passcode_settings_title">Passcode Encryption</string>
     <string name="passcode_settings_encryption_title">Passcode encryption</string>
     <string name="passcode_settings_encryption_subtitle">Encrypt vault storage on this device and lock the app.</string>
+    <string name="passcode_settings_encryption_explanation">Passcode encryption is tied to this device. Keep a .vult backup so you can always restore your vaults.</string>
     <string name="passcode_settings_change">Change passcode</string>
     <string name="passcode_settings_auto_lock">Auto-lock</string>
     <string name="auto_lock_setting_title">Auto-lock</string>
@@ -312,10 +313,10 @@
     <string name="passcode_entry_mismatch">Those passcodes do not match. Choose again.</string>
     <string name="passcode_operation_failed">That did not work. Your passcode is unchanged.</string>
     <string name="passcode_not_digits">Enter digits only.</string>
-    <string name="passcode_key_unavailable_title">Vaults unavailable</string>
-    <string name="passcode_key_unavailable_message">The keys that protect this device\'s vault storage are gone, so its keyshares can no longer be read. Reinstall the app and restore your vaults from a backup.</string>
-    <string name="passcode_store_unavailable_title">Vaults temporarily unavailable</string>
-    <string name="passcode_store_unavailable_message">This device\'s secure storage could not be opened this time, so your vaults stay locked. Restart the app to try again. Your vaults are still on this device, so there is no need to reinstall.</string>
+    <string name="passcode_key_unavailable_title">This device is missing your vault key</string>
+    <string name="passcode_key_unavailable_message">Your vaults are still on this device. Restore from your .vult backup to open them again.</string>
+    <string name="passcode_store_unavailable_title">Your vaults are locked for now</string>
+    <string name="passcode_store_unavailable_message">This device\'s secure storage didn\'t open this time. Everything is still here, so restart the app instead of reinstalling.</string>
     <string name="passcode_input_field_content_description">%1$d of %2$d digits entered</string>
     <string name="swap_form_from_title">From</string>
     <string name="swap_form_estimated_fees_title">Swap Fee</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepository.kt
@@ -104,6 +104,16 @@ interface PasscodeRepository {
     suspend fun initialize()
 
     /**
+     * Reads the persisted state again after a launch that could not read it.
+     *
+     * Only [PasscodeState.KeyUnavailable] and [PasscodeState.StoreUnavailable] retry. Both are
+     * decided by what a keystore returned once, and a keystore that stalled can come back, so the
+     * alternative is telling the user to relaunch to repeat a read the app can just do again. Every
+     * other state is settled by something this cannot re-derive.
+     */
+    suspend fun retry()
+
+    /**
      * Configures [passcode] for the first time and leaves the app unlocked.
      *
      * Returns [PasscodeUnlockResult.Success] or [PasscodeUnlockResult.Failed]; the verification
@@ -152,8 +162,8 @@ internal interface PasscodeDataKeySource {
      * when no passcode is configured.
      *
      * Returns without waiting when the credentials are unreachable ([PasscodeState.KeyUnavailable],
-     * [PasscodeState.StoreUnavailable]): neither resolves without a relaunch, so waiting would be a
-     * hang rather than a delay.
+     * [PasscodeState.StoreUnavailable]): neither resolves without [PasscodeRepository.retry] or a
+     * relaunch, so waiting would be a hang rather than a delay.
      */
     suspend fun awaitUnlocked()
 }
@@ -223,24 +233,38 @@ internal class PasscodeRepositoryImpl(
     override suspend fun initialize() {
         mutex.withLock {
             if (_state.value != PasscodeState.Unknown) return
-            _state.value =
-                try {
-                    resolveInitialState()
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Reading the credentials is itself a keystore operation, and the database is
-                    // asked whether any ciphertext exists — either can fail. Neither leaving the
-                    // state Unknown nor letting this escape is survivable: the first leaves the
-                    // guard's blank cover over the whole app with nothing to move it, and the
-                    // second kills whichever coroutine happened to ask first. Reporting Disabled
-                    // is the one answer that would lose data, so it reports the truth — nothing
-                    // readable this launch — which at least says so on screen and names the fix.
-                    Timber.e(e, "Could not read the passcode state")
-                    PasscodeState.StoreUnavailable
-                }
+            _state.value = resolveOrReport()
         }
     }
+
+    override suspend fun retry() {
+        mutex.withLock {
+            when (_state.value) {
+                PasscodeState.KeyUnavailable,
+                PasscodeState.StoreUnavailable -> _state.value = resolveOrReport()
+                else -> Unit
+            }
+        }
+    }
+
+    /**
+     * Resolves the state, reporting a read that failed as one rather than letting it escape.
+     *
+     * Neither leaving the state Unknown nor throwing is survivable: the first leaves the guard's
+     * blank cover over the whole app with nothing to move it, and the second kills whichever
+     * coroutine happened to ask first. Disabled is the one answer that would lose data.
+     *
+     * Callers must hold [mutex].
+     */
+    private suspend fun resolveOrReport(): PasscodeState =
+        try {
+            resolveInitialState()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Could not read the passcode state")
+            PasscodeState.StoreUnavailable
+        }
 
     /** Callers must hold [mutex]. */
     private suspend fun resolveInitialState(): PasscodeState {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/passcode/PasscodeRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.passcode
 
+import io.kotest.matchers.shouldBe
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -426,6 +427,36 @@ internal class PasscodeRepositoryImplTest {
 
         assertEquals(PasscodeState.StoreUnavailable, repository.state.value)
         assertEquals(true, repository.isLocked(), "stored keyshares stay unreadable")
+    }
+
+    @Test
+    fun `retry re-reads a store that has come back`() = runTest {
+        // The screen it backs has no other way out, so a keystore that stalled once would
+        // otherwise cost the user a relaunch to repeat a read the app can just do again.
+        repository().setPasscode("123456")
+        store.readFailure = IllegalStateException("keystore is stalled")
+        val reopened = repository()
+        reopened.initialize()
+        reopened.state.value shouldBe PasscodeState.StoreUnavailable
+
+        store.readFailure = null
+        reopened.retry()
+
+        reopened.state.value shouldBe PasscodeState.Locked
+    }
+
+    @Test
+    fun `retry leaves a state that was already read alone`() = runTest {
+        repository().setPasscode("123456")
+        val reopened = repository()
+        reopened.initialize()
+        reopened.state.value shouldBe PasscodeState.Locked
+
+        // Would surface as StoreUnavailable if retry re-read a state nothing asked it to.
+        store.readFailure = IllegalStateException("keystore is stalled")
+        reopened.retry()
+
+        reopened.state.value shouldBe PasscodeState.Locked
     }
 
     @Test


### PR DESCRIPTION
Closes #5566.

## Summary

`PasscodeState.KeyUnavailable` told the user to reinstall the app. Reinstalling clears the Room database, which removes every vault on the device, not only the ones affected: `hasEncryptedKeyShares()` closes the gate app-wide off a single sealed row (`VaultDao.kt:59`), and plaintext shares can sit beside sealed ones (`VaultRepository.kt:222-223`, per #5553).

Neither unreadable state had an exit either. Back and outside taps belong to the gate, so the only way off the screen was a force stop.

## Changes

- Rewrote `passcode_key_unavailable_title` / `_message` and the sibling `passcode_store_unavailable_title` / `_message` across all 10 locales. The reinstall instruction is gone and the `.vult` backup is named as the recovery path. The sibling pair is included because the same composable renders it.
- `DeadEndScreen` now delegates to the shared `ErrorView` instead of two `Text` nodes, so both states get the standard hero, typography and layout.
- Added `PasscodeRepository.retry()` behind a **Try again** button. Both states are decided by one keystore read that `initialize()` latches for the process; `retry()` re-runs it. On `StoreUnavailable` that is the fix. On `KeyUnavailable` it also recovers a transient read fault, which `isPersistent()` cannot distinguish from a lost key because it is a DI type check rather than a readability check.
- Added `passcode_settings_encryption_explanation`, a caption under the Passcode Encryption toggle. The enable flow said nothing about the encryption being bound to one device. It renders outside the `if (state.isPasscodeEnabled)` block so it also shows before a passcode is set.
- `PasscodeSettingsScreen`'s body moves into a scrolling `Column` to host the caption, matching `NotificationsSettingsScreen`. Most of that file's diff is ktfmt re-indentation from the added nesting.

The German, Spanish, Croatian, Italian and Portuguese translations previously rendered "key shares" in the file-sharing sense; the rewrite corrects that. The same mistranslation remains in unrelated keys and is left alone.

Not included: `#5558`'s proven-absence criterion, closed NOT_PLANNED. The `.vult` import is still refused as a duplicate (`SaveVaultUseCase.kt:31-34`, tracked in #5623), so the copy names the backup without instructing an import.

## Before / After

| | Before | After |
|---|---|---|
| Key unavailable | ![before](https://i.imgur.com/uxVmmom.png) | ![after](https://i.imgur.com/jwk957q.png) |
| Storage unavailable | ![before](https://i.imgur.com/2mgDG3e.png) | ![after](https://i.imgur.com/CbAg6JQ.png) |
| Passcode settings | ![before](https://i.imgur.com/LtpqHN6.png) | ![after](https://i.imgur.com/bjMkHJ6.png) |

## Testing

```
./gradlew :app:assembleDebug
./gradlew :app:testDebugUnitTest
./gradlew :data:testDebugUnitTest
./gradlew :app:lintDebug
```

All pass. `lintDebug` is what enforces `MissingTranslation` across the 10 locales.

New tests: `PasscodeRepositoryImplTest` covers `retry` re-reading a store that has come back and leaving an already-read state alone; `PasscodeSettingsExplanationTest` asserts the caption renders with the passcode both off and on.
