### PR TITLE
fix(defi): match the Kamino action buttons to their Figma component

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -271,6 +272,12 @@ fun ActionButton(
     contentColor: Color,
     iconCircleColor: Color,
     enabled: Boolean = true,
+    // The DeFi Button component measures these at 34dp and 16dp, which is what the Kamino cards
+    // pass. The defaults are the sizes every other caller was already drawing, left alone
+    // deliberately rather than corrected in passing: they reach screens this change has no business
+    // touching.
+    iconCircleSize: Dp = 30.dp,
+    iconSize: Dp = 12.dp,
     onClick: () -> Unit,
 ) {
     Button(
@@ -310,7 +317,7 @@ fun ActionButton(
                 Box(
                     modifier =
                         Modifier.align(Alignment.CenterStart)
-                            .size(30.dp)
+                            .size(iconCircleSize)
                             .background(
                                 if (enabled) iconCircleColor
                                 else iconCircleColor.copy(alpha = 0.5f),
@@ -321,7 +328,7 @@ fun ActionButton(
                     Icon(
                         painter = painterResource(id = icon),
                         contentDescription = null,
-                        modifier = Modifier.size(12.dp),
+                        modifier = Modifier.size(iconSize),
                         tint = if (enabled) contentColor else contentColor.copy(alpha = 0.5f),
                     )
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.screens.v2.defi.solana
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -394,14 +395,25 @@ private fun PnlRow(row: KaminoEarnRow, isLoading: Boolean, isBalanceVisible: Boo
 private fun VaultActions(hasPosition: Boolean, onDeposit: () -> Unit, onWithdraw: () -> Unit) {
     // Withdraw only appears once there is something to withdraw; an untouched vault offers the one
     // action that makes sense, across the full width.
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+    // Both buttons are the design system's DeFi Button, taken from its two Figma variants rather
+    // than styled here: Withdraw is `backgrounds/surface-2` #11284A with a 1dp
+    // `borders/extra-light`
+    // edge, Deposit is `buttons/cta-(primary)` #0B4EFF with a 1dp `primary/accent-3` edge, and both
+    // carry a filled glyph in a white-12% circle. The previous values were why Withdraw had no
+    // visible pill: `backgrounds.tertiary` (#0B1A3A) on a card painted `backgrounds.secondary`
+    // (#061B3A) is a difference the eye cannot find, and the icon's circle was the card colour
+    // exactly.
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
         if (hasPosition) {
             ActionButton(
                 title = stringResource(R.string.withdraw),
-                icon = R.drawable.circle_minus,
-                background = Theme.v2.colors.backgrounds.tertiary,
+                icon = R.drawable.circle_minus_filled,
+                background = Theme.v2.colors.backgrounds.tertiary_2,
+                border = BorderStroke(1.dp, Color.White.copy(alpha = 0.03f)),
                 contentColor = Theme.v2.colors.text.primary,
-                iconCircleColor = Theme.v2.colors.backgrounds.secondary,
+                iconCircleColor = Color.White.copy(alpha = 0.12f),
+                iconCircleSize = 34.dp,
+                iconSize = 16.dp,
                 modifier = Modifier.weight(1f),
                 onClick = onWithdraw,
             )
@@ -409,10 +421,13 @@ private fun VaultActions(hasPosition: Boolean, onDeposit: () -> Unit, onWithdraw
 
         ActionButton(
             title = stringResource(R.string.kamino_earn_deposit),
-            icon = R.drawable.circle_plus,
-            background = Theme.v2.colors.primary.accent4,
+            icon = R.drawable.circle_plus_filled,
+            background = Theme.v2.colors.buttons.ctaPrimary,
+            border = BorderStroke(1.dp, Theme.v2.colors.primary.accent3),
             contentColor = Theme.v2.colors.text.primary,
-            iconCircleColor = Theme.v2.colors.primary.accent3,
+            iconCircleColor = Color.White.copy(alpha = 0.12f),
+            iconCircleSize = 34.dp,
+            iconSize = 16.dp,
             modifier = Modifier.weight(1f),
             onClick = onDeposit,
         )

--- a/app/src/main/res/drawable/circle_minus_filled.xml
+++ b/app/src/main/res/drawable/circle_minus_filled.xml
@@ -1,0 +1,17 @@
+<!--
+  DeFi Button's leading glyph, filled rather than outlined. Figma names it `circle-minus-filled`
+  and insets it by 10% inside a 16dp box, which is why the 12.8-unit glyph is translated by 1.6.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group
+      android:translateX="1.6"
+      android:translateY="1.6">
+    <path
+        android:pathData="M6.4,0C2.8712,0 0,2.8712 0,6.4C0,9.9288 2.8712,12.8 6.4,12.8C9.9288,12.8 12.8,9.9288 12.8,6.4C12.8,2.8712 9.9288,0 6.4,0ZM9.2,7.2H3.6C3.1584,7.2 2.8,6.8416 2.8,6.4C2.8,5.9584 3.1584,5.6 3.6,5.6H9.2C9.6416,5.6 10,5.9584 10,6.4C10,6.8416 9.6416,7.2 9.2,7.2Z"
+        android:fillColor="#F0F4FC"/>
+  </group>
+</vector>

--- a/app/src/main/res/drawable/circle_plus_filled.xml
+++ b/app/src/main/res/drawable/circle_plus_filled.xml
@@ -1,0 +1,14 @@
+<!--
+  DeFi Button's leading glyph, filled rather than outlined. Figma names it `circle-plus-filled`.
+  Its path already spans 1.6..14.4 of a 16-unit box, which is the 10% inset the design applies, so
+  unlike the minus it needs no translation.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8.0006,1.6006C4.4718,1.6006 1.6006,4.4718 1.6006,8.0006C1.6006,11.5294 4.4718,14.4006 8.0006,14.4006C11.5294,14.4006 14.4006,11.5294 14.4006,8.0006C14.4006,4.4718 11.5294,1.6006 8.0006,1.6006ZM10.8006,8.8006H8.8006V10.8006C8.8006,11.2422 8.4422,11.6006 8.0006,11.6006C7.559,11.6006 7.2006,11.2422 7.2006,10.8006V8.8006H5.2006C4.759,8.8006 4.4006,8.4422 4.4006,8.0006C4.4006,7.559 4.759,7.2006 5.2006,7.2006H7.2006V5.2006C7.2006,4.759 7.559,4.4006 8.0006,4.4006C8.4422,4.4006 8.8006,4.759 8.8006,5.2006V7.2006H10.8006C11.2422,7.2006 11.6006,7.559 11.6006,8.0006C11.6006,8.4422 11.2422,8.8006 10.8006,8.8006Z"
+      android:fillColor="#F0F4FC"/>
+</vector>


### PR DESCRIPTION
## Summary

The Kamino Earn card's **Withdraw** button had no visible pill at all — an icon and a label floating on the card, with a stray hairline where its edge should have been. It was painted `backgrounds.tertiary` (#0B1A3A) on a card painted `backgrounds.secondary` (#061B3A), a difference the eye cannot find, and the icon's circle was set to the card colour exactly.

Both buttons now take their values from the two `DeFi Button` variants in Figma rather than from anything chosen here.

- Withdraw — [node 80871:75942](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=80871-75942)
- Deposit — [node 80871:75943](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=80871-75943)

## Changes

| Property | Figma | Before | After |
|---|---|---|---|
| Withdraw background | `backgrounds/surface-2` #11284A | `backgrounds.tertiary` #0B1A3A | `backgrounds.tertiary_2` |
| Withdraw border | 1dp `borders/extra-light` rgba(255,255,255,.03) | none | matches |
| Deposit background | `buttons/cta-(primary)` #0B4EFF | `primary.accent4` | `buttons.ctaPrimary` |
| Deposit border | 1dp `primary/accent-3` #2155DF | none | matches |
| Icon circle fill | rgba(255,255,255,.12) | `backgrounds.secondary` / `primary.accent3` | matches |
| Icon circle / glyph size | 34dp / 16dp | 30dp / 12dp | matches |
| Glyph | `circle-minus-filled`, `circle-plus-filled` | outline `circle_minus`, `circle_plus` | new filled drawables |
| Row spacing | — | 16dp | 8dp, as the sibling DeFi card |

The glyphs were the other half of the defect: the existing drawables are outlines — a stroked ring with a transparent centre — where the design calls for filled ones. Both are added from the exported vectors. The minus is translated by 1.6 because its path carries no inset of its own; the plus already spans 1.6..14.4 of its 16-unit box, which is the 10% inset the design applies.

### Scope of the shared component

The 34dp/16dp measurement lives in the shared `ActionButton`, so it is **passed by the Kamino cards rather than changed there**. The defaults stay exactly what every other DeFi screen was already drawing (30dp/12dp) and none of them move — the diff to `DeFiComponents.kt` is two parameters and their use.

Whether the rest of the DeFi buttons should follow the component is a real question, but it is answered on screens this change has no way to verify, so it is left alone. The other DeFi action row also still passes the outline `circle_minus`; same reasoning.

## Verification

Rendered on an emulator through `PreviewActivity`'s `solana_defi_earn` screen, before and after, with the same mock data. Both card shapes were checked: Steakhouse USDC, which has a position and shows both buttons, and Allez SOL, which has none and shows Deposit alone across the full width.

No screenshots are attached here by preference; the change is described by the value table above and is quickest to confirm by running that preview screen.

`:app:testDebugUnitTest`, `:app:lintDebug` and ktfmt pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refreshed deposit and withdrawal action buttons in Kamino Earn, including clearer filled icons, borders, spacing, and updated backgrounds.
  * Added new plus and minus circle icons for improved DeFi action controls.
  * Improved flexibility of action button sizing to support a more consistent visual experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->