### PR TITLE
fix(defi): stop folding failed Kamino reads into zero

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -337,9 +337,15 @@ constructor(
         // A real position whose rate could not be read is not "nothing to withdraw" — it is a
         // failed read, same as the positions call failing outright. Without this, a `/metrics`
         // outage would publish `Withdrawable` with a zero maximum, which reads as an emptied
-        // position rather than an unresolved one.
+        // position rather than an unresolved one. `rate == null` alone misses a `tokensPerShare`
+        // of `"0"`: `KaminoRate.parse` accepts it as a valid non-positive rate, so it must be
+        // caught via `!rate.isPositive` too, or `maximumTokens` rejecting it downstream leaves the
+        // same zero-maximum-with-no-warning fold this guard exists to close.
         val resolvedEligibility =
-            if (eligibility is KaminoWithdrawEligibility.Withdrawable && rate == null) {
+            if (
+                eligibility is KaminoWithdrawEligibility.Withdrawable &&
+                    (rate == null || !rate.isPositive)
+            ) {
                 KaminoWithdrawEligibility.Unreadable
             } else {
                 eligibility

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -334,6 +334,17 @@ constructor(
         val rate = KaminoRate.parse(metrics?.tokensPerShare)
         val held = eligibility.withdrawableShares?.maximum
 
+        // A real position whose rate could not be read is not "nothing to withdraw" — it is a
+        // failed read, same as the positions call failing outright. Without this, a `/metrics`
+        // outage would publish `Withdrawable` with a zero maximum, which reads as an emptied
+        // position rather than an unresolved one.
+        val resolvedEligibility =
+            if (eligibility is KaminoWithdrawEligibility.Withdrawable && rate == null) {
+                KaminoWithdrawEligibility.Unreadable
+            } else {
+                eligibility
+            }
+
         val maximum =
             if (held != null && rate != null) {
                 KaminoWithdrawMath.maximumTokens(held, rate, vault.tokenDecimals)
@@ -370,7 +381,7 @@ constructor(
                 ticker = coin.ticker,
                 available = maximum.toDecimalOrZero(vault.tokenDecimals),
                 minimum = minimum?.let { m -> BigDecimal(m.baseUnits).movePointLeft(m.decimals) },
-                eligibility = eligibility,
+                eligibility = resolvedEligibility,
             )
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnUiModel.kt
@@ -50,9 +50,10 @@ data class KaminoEarnRow(
     val pnlDirection: PnlDirection,
     /**
      * The row's fiat value, kept alongside its formatted form so the screen total can be summed
-     * without re-parsing display strings. Zero when the position or its price is unresolved.
+     * without re-parsing display strings. Null when the position or its price is unresolved — never
+     * folded to zero, which would silently understate the total by this row's real value.
      */
-    val fiatValue: BigDecimal = BigDecimal.ZERO,
+    val fiatValue: BigDecimal? = null,
     /**
      * Whether the wallet actually holds shares here. Kept separate from [fiatValue] because a
      * failed price lookup leaves that at zero, and a position must not disappear because it could

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -256,20 +256,36 @@ constructor(
 
                 val resolved = rows.filterNotNull()
                 _state.update { current ->
+                    // A row whose fiat value did not resolve this refresh keeps its last known
+                    // value rather than going blank or zero — same principle as keeping the whole
+                    // card standing on a failed vault call, one row at a time.
+                    val previousFiatByVault =
+                        current.rows.associate { it.vaultAddress to it.fiatValue }
+                    val merged =
+                        resolved.map { row ->
+                            if (row.fiatValue != null) row
+                            else
+                                previousFiatByVault[row.vaultAddress]?.let { fiatValue ->
+                                    row.copy(fiatValue = fiatValue)
+                                } ?: row
+                        }
                     current.copy(
                         isLoading = false,
                         // Keep the previous rows if every vault failed, rather than blanking
                         // positions the user holds because one refresh did not land — but only for
                         // vaults still enabled, or disabling one would leave its card on screen.
                         rows =
-                            resolved.ifEmpty {
+                            merged.ifEmpty {
                                 current.rows.filter { row -> row.vaultAddress in enabled }
                             },
+                        // Null when any row is still unresolved after the merge above: a total
+                        // short by one row's real value is not a smaller total, so the last
+                        // confirmed total is kept on screen instead.
                         totalFiat =
-                            resolved
+                            merged
                                 .takeIf { it.isNotEmpty() }
-                                ?.let { currencyFormat.format(totalFiatValue(it)) }
-                                ?: current.totalFiat,
+                                ?.let { totalFiatValue(it) }
+                                ?.let { currencyFormat.format(it) } ?: current.totalFiat,
                     )
                 }
             }
@@ -316,12 +332,15 @@ constructor(
         val pnl = pnlDeferred.await()
 
         // A position that could not be read is not a zero one. Null keeps the balance blank rather
-        // than asserting "0", which on a real deposit reads as though it had gone.
+        // than asserting "0", which on a real deposit reads as though it had gone. An absent entry
+        // is a real zero (the wallet holds nothing in this vault); an entry present but whose
+        // `totalShares` will not parse is a failed read of a real row, and must not be folded into
+        // the same zero.
         val shares =
-            if (positionsAreKnown) {
-                KaminoPositionMath.decimalOrNull(position?.totalShares) ?: BigDecimal.ZERO
-            } else {
-                null
+            when {
+                !positionsAreKnown -> null
+                position == null -> BigDecimal.ZERO
+                else -> KaminoPositionMath.decimalOrNull(position.totalShares)
             }
         val tokensPerShare = KaminoPositionMath.decimalOrNull(metrics?.tokensPerShare)
         val tokenAmount =
@@ -362,9 +381,10 @@ constructor(
                     pnlToken.signum() < 0 -> KaminoEarnRow.PnlDirection.DOWN
                     else -> KaminoEarnRow.PnlDirection.FLAT
                 },
-            fiatValue =
-                tokenAmount?.let { amount -> coin?.let { fiatValueOrNull(amount, it) } }
-                    ?: BigDecimal.ZERO,
+            // Null, not zero, when the position or its price could not be resolved this refresh —
+            // folding a failed read into zero would silently drop this row's real value out of the
+            // total below.
+            fiatValue = tokenAmount?.let { amount -> coin?.let { fiatValueOrNull(amount, it) } },
             // Two different claims live in a zero here: "read, and holds nothing" and "not read
             // yet". Only the first may remove Withdraw. Hiding it on an unread position strands a
             // user who deposited on another device, or whose refresh failed right after depositing
@@ -402,10 +422,14 @@ constructor(
 
     /**
      * Summed per row, because the vaults do not share an underlying token — dollars and SOL cannot
-     * be added before each has been priced.
+     * be added before each has been priced. Null when any row's value is still unresolved: a sum
+     * missing one row is not a smaller total, it is not a total.
      */
-    private fun totalFiatValue(rows: List<KaminoEarnRow>): BigDecimal =
-        rows.fold(BigDecimal.ZERO) { running, row -> running.add(row.fiatValue) }
+    private fun totalFiatValue(rows: List<KaminoEarnRow>): BigDecimal? {
+        val values = rows.map { it.fiatValue }
+        if (values.any { it == null }) return null
+        return values.fold(BigDecimal.ZERO) { running, value -> running.add(value) }
+    }
 
     private suspend fun resolveSolanaAddress(): String {
         val vault =

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -344,10 +344,15 @@ constructor(
             }
         val tokensPerShare = KaminoPositionMath.decimalOrNull(metrics?.tokensPerShare)
         val tokenAmount =
-            if (tokensPerShare == null || shares == null) {
-                null
-            } else {
-                KaminoPositionMath.tokenAmount(shares, tokensPerShare, vault.tokenDecimals)
+            when {
+                shares == null -> null
+                // A confirmed-zero position is worth zero regardless of the rate — no need to
+                // wait on a `/metrics` read that may have failed this refresh. Folding this case
+                // into the `tokensPerShare == null` branch below would show "Unavailable" on a
+                // real full withdrawal instead of the true zero.
+                shares.signum() == 0 -> BigDecimal.ZERO.setScale(vault.tokenDecimals)
+                tokensPerShare == null -> null
+                else -> KaminoPositionMath.tokenAmount(shares, tokensPerShare, vault.tokenDecimals)
             }
 
         val coin = vault.coin

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -417,6 +417,31 @@ internal class KaminoAmountViewModelTest {
     }
 
     @Test
+    fun `a real position with a zero metrics rate is unreadable, not a zero balance`() = runTest {
+        // `KaminoRate.parse` accepts "0" as a valid (non-positive) rate rather than rejecting it,
+        // so a `rate == null` check alone would miss this: eligibility would stay `Withdrawable`
+        // while `maximumTokens` separately rejects the non-positive rate, publishing the same
+        // zero-available-with-no-warning fold a failed metrics read is guarded against above.
+        givenTokenBalance("0")
+        coEvery { kaminoApi.getUserPositions(WALLET) } returns
+            listOf(
+                KaminoUserPositionJson(
+                    vaultAddress = STEAKHOUSE.address,
+                    stakedShares = "0",
+                    unstakedShares = "1000",
+                    totalShares = "1000",
+                )
+            )
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "0")
+
+        val state = viewModel(isWithdraw = true).state.value
+
+        assertEquals(KaminoWithdrawEligibility.Unreadable, state.eligibility)
+        assertEquals(0, BigDecimal.ZERO.compareTo(state.available))
+    }
+
+    @Test
     fun `the withdraw minimum is read as shares, not as the token amount`() = runTest {
         // minWithdrawAmount is 1000 SHARE base units. Treated as token base units it would be
         // 0.001 USDC; converted properly at the Steakhouse rate it is 0.001055.

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -394,6 +394,29 @@ internal class KaminoAmountViewModelTest {
     }
 
     @Test
+    fun `a real position with a failed metrics read is unreadable, not a zero balance`() = runTest {
+        // The position itself read fine and holds real shares — only the rate needed to value them
+        // failed. Publishing `Withdrawable` here would show a live deposit as a $0 available
+        // balance instead of naming the read as unresolved.
+        givenTokenBalance("0")
+        coEvery { kaminoApi.getUserPositions(WALLET) } returns
+            listOf(
+                KaminoUserPositionJson(
+                    vaultAddress = STEAKHOUSE.address,
+                    stakedShares = "0",
+                    unstakedShares = "1000",
+                    totalShares = "1000",
+                )
+            )
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } throws RuntimeException("503")
+
+        val state = viewModel(isWithdraw = true).state.value
+
+        assertEquals(KaminoWithdrawEligibility.Unreadable, state.eligibility)
+        assertEquals(0, BigDecimal.ZERO.compareTo(state.available))
+    }
+
+    @Test
     fun `the withdraw minimum is read as shares, not as the token amount`() = runTest {
         // minWithdrawAmount is 1000 SHARE base units. Treated as token base units it would be
         // 0.001 USDC; converted properly at the Steakhouse rate it is 0.001055.

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -441,6 +441,59 @@ internal class KaminoEarnViewModelTest {
         }
 
     @Test
+    fun `a confirmed full withdrawal with a failed metrics call still shows a real zero`() =
+        runTest {
+            // The entry is present with totalShares "0" — a confirmed real zero, not the "wallet
+            // holds nothing at all" absent-entry case. `tokenAmount` must not wait on a rate read
+            // to know that zero shares are worth zero: requiring `tokensPerShare` here would show
+            // "Unavailable" on a real full withdrawal instead of the true balance.
+            coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+                flowOf(setOf(STEAKHOUSE.address))
+            coEvery { kaminoApi.getUserPositions(any()) } returns
+                listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "0"))
+            coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+            coEvery { kaminoApi.getVaultMetrics(any()) } throws RuntimeException("503")
+
+            val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+            assertEquals("0 USDC", row.depositedDisplay)
+            assertNotNull(row.fiatValue)
+            assertEquals(0, BigDecimal.ZERO.compareTo(row.fiatValue!!))
+            assertFalse(row.hasPosition)
+        }
+
+    @Test
+    fun `a full withdrawal does not leave the pre-withdrawal fiat value in the total`() = runTest {
+        // First refresh: a real, priced deposit. Second refresh (after a full withdrawal):
+        // totalShares confirms zero, but this same refresh's metrics call fails. The merge must
+        // not splice the first refresh's nonzero fiatValue back in — the row is a confirmed zero,
+        // not an unresolved read, so the total must reflect zero rather than money the user no
+        // longer holds.
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(any()) } returnsMany
+            listOf(
+                listOf(
+                    KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100")
+                ),
+                listOf(KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "0")),
+            )
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+        coEvery { kaminoApi.getVaultMetrics(any()) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0") andThenThrows
+            RuntimeException("503")
+
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        val firstTotal = vm.state.value.totalFiat
+        assertEquals("$100.00", firstTotal)
+
+        vm.refresh()
+        val secondTotal = vm.state.value.totalFiat
+
+        assertEquals("$0.00", secondTotal)
+    }
+
+    @Test
     fun `a read position holding nothing does hide Withdraw`() = runTest {
         coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
             flowOf(setOf(STEAKHOUSE.address))

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -389,6 +389,58 @@ internal class KaminoEarnViewModelTest {
     }
 
     @Test
+    fun `a position present but with an unparseable share count keeps Withdraw available`() =
+        runTest {
+            // The vault entry exists — this is not "the wallet holds nothing" — but its
+            // `totalShares` field will not parse. That is a failed read of a real row, and must not
+            // be folded into the same zero as a confirmed empty position.
+            coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+                flowOf(setOf(STEAKHOUSE.address))
+            coEvery { kaminoApi.getUserPositions(any()) } returns
+                listOf(
+                    KaminoUserPositionJson(
+                        vaultAddress = STEAKHOUSE.address,
+                        totalShares = "garbage",
+                    )
+                )
+            coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Steakhouse USDC")
+            coEvery { kaminoApi.getVaultMetrics(any()) } returns
+                KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+            val row = viewModel().apply { setData(VAULT_ID) }.state.value.rows.single()
+
+            assertTrue(row.hasPosition, "an unreadable position must not hide Withdraw")
+            assertNull(row.depositedFiat)
+        }
+
+    @Test
+    fun `a total kept partial by one unresolved row does not silently drop to that row's share`() =
+        runTest {
+            coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+                flowOf(setOf(STEAKHOUSE.address, ALLEZ.address))
+            coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returns
+                listOf(
+                    KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100"),
+                    KaminoUserPositionJson(vaultAddress = ALLEZ.address, totalShares = "100"),
+                )
+            coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Vault")
+            // Steakhouse's rate fails this refresh; Allez's resolves.
+            coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } throws RuntimeException("503")
+            coEvery { kaminoApi.getVaultMetrics(ALLEZ.address) } returns
+                KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+            val state = viewModel().apply { setData(VAULT_ID) }.state.value
+
+            val steakhouseRow = state.rows.single { it.vaultAddress == STEAKHOUSE.address }
+            val allezRow = state.rows.single { it.vaultAddress == ALLEZ.address }
+            assertNull(steakhouseRow.fiatValue)
+            assertNotNull(allezRow.fiatValue)
+            // No prior total exists yet, so a total short by the unresolved row must not be shown
+            // as if it were confirmed — $100 would read as the whole position, not half of it.
+            assertNull(state.totalFiat)
+        }
+
+    @Test
     fun `a read position holding nothing does hide Withdraw`() = runTest {
         coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
             flowOf(setOf(STEAKHOUSE.address))

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -529,6 +529,43 @@ internal class KaminoEarnViewModelTest {
         }
 
     @Test
+    fun `a total never blends a fresh row with another row's stale splice`() = runTest {
+        // First refresh: both vaults price cleanly. Second refresh: Allez genuinely grows (a real,
+        // freshly priced increase) while Steakhouse's metrics call merely fails — not a confirmed
+        // zero, just unresolved this round. The row-level splice keeps Steakhouse's card showing
+        // its
+        // last known figure, but the total must not add that spliced value to Allez's new one: that
+        // combination was never true of any single confirmed state, fresh and stale alike.
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flowOf(setOf(STEAKHOUSE.address, ALLEZ.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } returnsMany
+            listOf(
+                listOf(
+                    KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100"),
+                    KaminoUserPositionJson(vaultAddress = ALLEZ.address, totalShares = "100"),
+                ),
+                listOf(
+                    KaminoUserPositionJson(vaultAddress = STEAKHOUSE.address, totalShares = "100"),
+                    KaminoUserPositionJson(vaultAddress = ALLEZ.address, totalShares = "300"),
+                ),
+            )
+        coEvery { kaminoApi.getVaultState(any()) } returns stubVault("Vault")
+        coEvery { kaminoApi.getVaultMetrics(STEAKHOUSE.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0") andThenThrows
+            RuntimeException("503")
+        coEvery { kaminoApi.getVaultMetrics(ALLEZ.address) } returns
+            KaminoVaultMetricsJson(tokensPerShare = "1.0")
+
+        val vm = viewModel().apply { setData(VAULT_ID) }
+        val firstTotal = vm.state.value.totalFiat
+        firstTotal.shouldNotBeNull()
+
+        vm.refresh()
+
+        vm.state.value.totalFiat shouldBe firstTotal
+    }
+
+    @Test
     fun `a confirmed full withdrawal with a failed metrics call still shows a real zero`() =
         runTest {
             // The entry is present with totalShares "0" — a confirmed real zero, not the "wallet


### PR DESCRIPTION
## Summary
- `KaminoAmountViewModel.loadWithdrawState`: a real position whose rate could not be read (`/metrics` failure) now becomes `Unreadable` instead of `Withdrawable` with a zero maximum — a live deposit no longer reads as a $0 available balance.
- `KaminoEarnViewModel.buildRow`: an unparseable `totalShares` on a position entry that *is* present is now treated as unreadable (keeps the Withdraw button) rather than folded into the same zero as a confirmed empty position (absent entry).
- `KaminoEarnRow.fiatValue` is now nullable. A row whose fiat value fails to resolve on a refresh keeps its last known value instead of zeroing, and the screen-wide total is left at its last confirmed value rather than being recomputed short by an unresolved row.

## Issue
Closes #5601

## Test Plan
- [x] Added unit tests for all three sites: metrics outage on a real position, unparseable-but-present share count, partial-refresh total
- [x] `./gradlew :app:testDebugUnitTest --tests "com.vultisig.wallet.ui.models.solanastaking.KaminoAmountViewModelTest" --tests "com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnViewModelTest"`
- [x] `./gradlew lint`
- [ ] Manual verification on device/emulator against a live Kamino position

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Solana Kamino staking balance and withdrawal eligibility handling when vault pricing data is unavailable or invalid.
  - Prevented unavailable values from appearing as zero, avoiding understated portfolio totals.
  - Preserved previously displayed values during temporary pricing failures.
  - Correctly displays confirmed zero-balance positions and clears stale totals after a full withdrawal.
- **Tests**
  - Added coverage for unavailable metrics, partial pricing failures, zero balances, and stale total cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->