### PR TITLE
fix(defi): pad Kamino deposit minimum past the program's check

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -207,9 +207,10 @@ constructor(
                             ?: vault.fallbackName,
                     ticker = coin.ticker,
                     available = available,
-                    // Token base units for a deposit — the endpoint's own denomination.
+                    // Token base units for a deposit — the endpoint's own denomination. Padded past
+                    // the kVault program's crank-fund deduction, see KaminoPositionMath.
                     minimum =
-                        KaminoPositionMath.baseUnitsToDecimal(
+                        KaminoPositionMath.depositMinimumWithMargin(
                             vaultState?.state?.minDepositAmount,
                             vault.tokenDecimals,
                         ),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -177,12 +177,15 @@ internal class KaminoAmountViewModelTest {
     }
 
     @Test
-    fun `the deposit minimum comes from vault state, converted out of base units`() = runTest {
-        givenTokenBalance("2500000000")
+    fun `the deposit minimum comes from vault state, padded past the program's minimum`() =
+        runTest {
+            givenTokenBalance("2500000000")
 
-        // 100000 base units at 6 decimals is 0.1 USDC — not 100,000.
-        assertEquals(0, BigDecimal("0.1").compareTo(viewModel().state.value.minimum!!))
-    }
+            // 100000 base units gets a 1/1000 margin (100 base units) added before the 6-decimal
+            // conversion, so the displayed and enforced minimum is 0.1001 USDC, not 0.1 — the
+            // published figure the kVault program actually refuses.
+            assertEquals(0, BigDecimal("0.1001").compareTo(viewModel().state.value.minimum!!))
+        }
 
     @Test
     fun `a withdraw caps against the position, not the wallet`() = runTest {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -184,7 +184,8 @@ internal class KaminoAmountViewModelTest {
             // 100000 base units gets a 1/1000 margin (100 base units) added before the 6-decimal
             // conversion, so the displayed and enforced minimum is 0.1001 USDC, not 0.1 — the
             // published figure the kVault program actually refuses.
-            assertEquals(0, BigDecimal("0.1001").compareTo(viewModel().state.value.minimum!!))
+            val minimum = requireNotNull(viewModel().state.value.minimum)
+            assertEquals(0, BigDecimal("0.1001").compareTo(minimum))
         }
 
     @Test

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMath.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMath.kt
@@ -68,10 +68,13 @@ object KaminoPositionMath {
      * rounded up, floored at 16 base units.
      */
     fun depositMinimumWithMargin(baseUnits: String?, tokenDecimals: Int): BigDecimal? =
-        decimalOrNull(baseUnits)?.let { minimum ->
-            val margin = minimum.divide(BigDecimal(1000), 0, RoundingMode.UP).max(BigDecimal(16))
-            minimum.add(margin).movePointLeft(tokenDecimals)
-        }
+        decimalOrNull(baseUnits)
+            ?.takeIf { it.signum() >= 0 && it.remainder(BigDecimal.ONE).signum() == 0 }
+            ?.let { minimum ->
+                val margin =
+                    minimum.divide(BigDecimal(1000), 0, RoundingMode.UP).max(BigDecimal(16))
+                minimum.add(margin).movePointLeft(tokenDecimals)
+            }
 
     private val ONE_HUNDRED = BigDecimal(100)
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMath.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMath.kt
@@ -57,5 +57,21 @@ object KaminoPositionMath {
     fun baseUnitsToDecimal(baseUnits: String?, tokenDecimals: Int): BigDecimal? =
         decimalOrNull(baseUnits)?.movePointLeft(tokenDecimals)
 
+    /**
+     * A vault's published `minDepositAmount`, padded so the figure the form displays and enforces
+     * also clears the kVault program's check.
+     *
+     * The program subtracts crank funds (reserve count × fee) from the deposit before comparing it
+     * to `min_deposit_amount`, so depositing exactly the published minimum always falls short by a
+     * few base units. That shortfall tracks the vault's reserve count, which curators change, so a
+     * fixed constant would drift — a proportional margin does not. Matches iOS: one part in 1,000,
+     * rounded up, floored at 16 base units.
+     */
+    fun depositMinimumWithMargin(baseUnits: String?, tokenDecimals: Int): BigDecimal? =
+        decimalOrNull(baseUnits)?.let { minimum ->
+            val margin = minimum.divide(BigDecimal(1000), 0, RoundingMode.UP).max(BigDecimal(16))
+            minimum.add(margin).movePointLeft(tokenDecimals)
+        }
+
     private val ONE_HUNDRED = BigDecimal(100)
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMathTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMathTest.kt
@@ -104,6 +104,15 @@ class KaminoPositionMathTest {
     }
 
     @Test
+    fun `deposit minimum gets a proportional margin so the advertised figure actually clears`() {
+        // 100000 base units: 1/1000 margin is 100, rounded up — above the 16 floor.
+        assertSameValue("0.1001", KaminoPositionMath.depositMinimumWithMargin("100000", 6))
+        // 1000 base units: 1/1000 margin is 1, rounded up — the 16 floor applies instead.
+        assertSameValue("0.001016", KaminoPositionMath.depositMinimumWithMargin("1000", 6))
+        assertNull(KaminoPositionMath.depositMinimumWithMargin(null, 6))
+    }
+
+    @Test
     fun `absent and malformed numbers read as missing, never as zero`() {
         // A row showing nothing is recoverable; a balance rendered as 0 reads as a lost deposit.
         assertNull(KaminoPositionMath.decimalOrNull(null))

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMathTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoPositionMathTest.kt
@@ -113,6 +113,14 @@ class KaminoPositionMathTest {
     }
 
     @Test
+    fun `deposit minimum rejects negative or fractional base units`() {
+        // A negative or fractional minimum is not a valid base-unit amount — treat it as missing
+        // rather than let it silently pass every deposit's minimum check.
+        assertNull(KaminoPositionMath.depositMinimumWithMargin("-100000", 6))
+        assertNull(KaminoPositionMath.depositMinimumWithMargin("1000.5", 6))
+    }
+
+    @Test
     fun `absent and malformed numbers read as missing, never as zero`() {
         // A row showing nothing is recoverable; a balance rendered as 0 reads as a lost deposit.
         assertNull(KaminoPositionMath.decimalOrNull(null))


### PR DESCRIPTION
## Summary
- The kVault program subtracts crank funds (allocated reserves × `crank_fund_fee_per_reserve`) from a deposit before comparing it to `min_deposit_amount`, so depositing exactly the vault's advertised minimum always fails preflight (`Custom(7026) DepositAmountBelowMinimum`).
- Added `KaminoPositionMath.depositMinimumWithMargin`, which pads the published minimum by a proportional margin (1/1000, rounded up, floored at 16 base units) before it becomes both the on-screen figure and the submit gate — matching iOS's `KaminoService.swift` behavior. A fixed constant would drift since the shortfall tracks each vault's reserve count.
- `KaminoAmountViewModel` now calls the padded function instead of the raw `baseUnitsToDecimal`.

## Issue
Closes #5600

## Test Plan
- [x] `./gradlew :data:testDebugUnitTest --tests "*.KaminoPositionMathTest"` — added a case covering the proportional margin and the 16-unit floor
- [x] `./gradlew :app:testDebugUnitTest --tests "*.KaminoAmountViewModelTest"` — updated the pinned deposit-minimum test to the padded value
- [x] `./gradlew lint`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Kamino staking deposit minimums to include a safety margin, helping ensure deposits meet vault requirements.
  - Minimum amounts now account for token precision and small-value rounding.

- **Tests**
  - Added coverage for proportional margins, minimum margin handling, rounding, and missing minimum values.
  - Updated expected minimum deposit display from `0.1 USDC` to `0.1001 USDC`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->