### PR TITLE
fix(defi): read Kamino minWithdrawAmount as tokens, not shares

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -311,9 +311,10 @@ constructor(
     /**
      * Resolves what the withdraw form may offer, in shares first and tokens only as a projection.
      *
-     * Shares are the primary unit throughout: the endpoint takes shares, the vault's minimum is in
-     * shares, and a full withdraw must send the exact held share count. The token figure the form
-     * is denominated in is derived from those, never the other way round.
+     * Shares are the primary unit for the balance and the endpoint: the endpoint takes shares, and
+     * a full withdraw must send the exact held share count, so the token figure the form is
+     * denominated in is derived from that, never the other way round. The vault's *minimum*,
+     * though, is published in tokens — see [KaminoWithdrawMath.effectiveMinimumShares].
      */
     private suspend fun loadWithdrawState(vault: KaminoVault, coin: Coin) {
         val positions =
@@ -343,11 +344,22 @@ constructor(
 
         val vaultState =
             runCatchingCancellable { kaminoApi.getVaultState(vault.address) }.getOrNull()
-        // Share base units, not token — comparing it against a token amount would be wrong by the
-        // whole share rate (about 930x on the SOL vault).
-        val minimumShares =
+        // Token base units, not shares — the program compares this against the token value being
+        // withdrawn. Reading it as shares would be wrong by the whole share rate (about 930x on the
+        // SOL vault).
+        val publishedMinimum =
             vaultState?.state?.minWithdrawAmount?.let { raw ->
-                runCatching { KaminoShareAmount(BigInteger(raw), vault.sharesDecimals) }.getOrNull()
+                runCatching { KaminoTokenAmount(BigInteger(raw), vault.tokenDecimals) }.getOrNull()
+            }
+        val minimumShares =
+            if (publishedMinimum != null && rate != null) {
+                KaminoWithdrawMath.effectiveMinimumShares(
+                    publishedMinimum,
+                    rate,
+                    vault.sharesDecimals,
+                )
+            } else {
+                null
             }
         val minimum =
             if (minimumShares != null && rate != null) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -362,8 +362,14 @@ constructor(
                 null
             }
         val minimum =
-            if (minimumShares != null && rate != null) {
-                KaminoWithdrawMath.minimumTokens(minimumShares, rate, vault.tokenDecimals)
+            if (held != null && minimumShares != null && maximum != null && rate != null) {
+                KaminoWithdrawMath.effectiveMinimumTokens(
+                    held,
+                    minimumShares,
+                    maximum,
+                    rate,
+                    vault.tokenDecimals,
+                )
             } else {
                 null
             }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -205,9 +205,10 @@ internal class KaminoAmountViewModelTest {
         // 999999999 share base units (one below the balance, stepping back from the API's sentinel)
         // × 1.0544278224860290217, truncated to the token's 6 decimals.
         assertEquals(0, BigDecimal("1054.427821").compareTo(state.available))
-        // minWithdrawAmount is 1000 SHARE base units, so in tokens it is 0.001055 rounded up — not
-        // the 0.001 a token-denominated reading would give.
-        assertEquals(0, BigDecimal("0.001055").compareTo(state.minimum!!))
+        // minWithdrawAmount is 1000 TOKEN base units (0.001 USDC). The program's real floor sits
+        // above that, so the margined figure is 3x it converted to shares and back: 0.003001, not
+        // the 0.001 the raw published amount would suggest.
+        assertEquals(0, BigDecimal("0.003001").compareTo(state.minimum!!))
     }
 
     @Test
@@ -394,9 +395,10 @@ internal class KaminoAmountViewModelTest {
     }
 
     @Test
-    fun `the withdraw minimum is read as shares, not as the token amount`() = runTest {
-        // minWithdrawAmount is 1000 SHARE base units. Treated as token base units it would be
-        // 0.001 USDC; converted properly at the Steakhouse rate it is 0.001055.
+    fun `the withdraw minimum is read as tokens, padded past the program's real floor`() = runTest {
+        // minWithdrawAmount is 1000 TOKEN base units — 0.001 USDC. Read as shares it would convert
+        // to 0.001055; the program's real floor sits above the published figure, so this pads it 3x
+        // (matching iOS) before converting to shares and back: 0.003001.
         givenTokenBalance("0")
         coEvery { kaminoApi.getUserPositions(WALLET) } returns
             listOf(
@@ -411,7 +413,7 @@ internal class KaminoAmountViewModelTest {
             KaminoVaultMetricsJson(tokensPerShare = "1.0544278224860290217")
 
         val minimum = viewModel(isWithdraw = true).state.value.minimum
-        assertEquals(0, BigDecimal("0.001055").compareTo(minimum!!))
+        assertEquals(0, BigDecimal("0.003001").compareTo(minimum!!))
     }
 
     @Test

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/KaminoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/KaminoApi.kt
@@ -183,8 +183,9 @@ data class KaminoVaultStateJson(
         /** In the **token's** base units, not decimal — 100000 is 0.1 USDC at 6 decimals. */
         @SerialName("minDepositAmount") val minDepositAmount: String? = null,
         /**
-         * In the **share** base units, matching the withdraw endpoint's own denomination — not the
-         * token's. Comparing it against a token amount is wrong by the share rate.
+         * In the **token's** base units too, like [minDepositAmount] — not the share base units the
+         * withdraw endpoint itself takes. The kVault program compares this against the token value
+         * being withdrawn, not a share count; reading it as shares is wrong by the share rate.
          */
         @SerialName("minWithdrawAmount") val minWithdrawAmount: String? = null,
         @SerialName("performanceFeeBps") val performanceFeeBps: Int? = null,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
@@ -450,6 +450,34 @@ object KaminoWithdrawMath {
     ): KaminoTokenAmount? = minimumShares.tokenValueRoundedUp(rate, tokenDecimals)
 
     /**
+     * The minimum the form should display and gate on, clamped to [maximumTokens] for a position
+     * that already clears the minimum in share terms.
+     *
+     * [minimumTokens] rounds up and [maximumTokens] rounds down the same rate, so a position held
+     * at (or just above) [minimumShares] can see its ceil-rounded token minimum land one base unit
+     * above its own floor-rounded token maximum — a position the vault would accept (`held >=
+     * minimumShares`) for which the form could then offer no amount at all: every value is either
+     * over the maximum or under the minimum. Where the position genuinely holds fewer shares than
+     * the minimum, the unclamped figure stands so the user can see what they are short of.
+     */
+    fun effectiveMinimumTokens(
+        held: KaminoShareAmount,
+        minimumShares: KaminoShareAmount,
+        maximumTokens: KaminoTokenAmount,
+        rate: KaminoRate,
+        tokenDecimals: Int,
+    ): KaminoTokenAmount? {
+        val minimum = minimumTokens(minimumShares, rate, tokenDecimals) ?: return null
+        return if (
+            held.baseUnits >= minimumShares.baseUnits && minimum.baseUnits > maximumTokens.baseUnits
+        ) {
+            maximumTokens
+        } else {
+            minimum
+        }
+    }
+
+    /**
      * The shares a withdraw of [tokens] burns, or null when no withdraw of that size can be sized
      * safely.
      *

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdraw.kt
@@ -144,7 +144,25 @@ data class KaminoTokenAmount(val baseUnits: BigInteger, val decimals: Int) {
      * Rounding down is a safety property, not a preference: an over-request by a single base unit
      * is rewritten by the API to a full exit.
      */
-    fun shareAmount(rate: KaminoRate, shareDecimals: Int): KaminoShareAmount? {
+    fun shareAmount(rate: KaminoRate, shareDecimals: Int): KaminoShareAmount? =
+        shareAmount(rate, shareDecimals, roundUp = false)
+
+    /**
+     * The same conversion rounded up. Used for one thing only: turning a token-denominated minimum
+     * into the share count a withdraw has to name to clear it — rounding down there would produce a
+     * share figure worth fractionally less than the minimum.
+     *
+     * Never use this to size an actual withdraw. Rounding up is exactly the direction that turns a
+     * partial withdraw into an over-request, which the API rewrites to a full exit.
+     */
+    fun shareAmountRoundedUp(rate: KaminoRate, shareDecimals: Int): KaminoShareAmount? =
+        shareAmount(rate, shareDecimals, roundUp = true)
+
+    private fun shareAmount(
+        rate: KaminoRate,
+        shareDecimals: Int,
+        roundUp: Boolean,
+    ): KaminoShareAmount? {
         if (!rate.isPositive || baseUnits.signum() < 0) return null
         if (!scalesAreSane(shareDecimals, decimals) || rate.scale !in 0..(MAX_DECIMALS * 4)) {
             return null
@@ -152,7 +170,13 @@ data class KaminoTokenAmount(val baseUnits: BigInteger, val decimals: Int) {
         // sharesBase = tokensBase × 10^(rateScale + shareDecimals) ÷ (10^tokenDecimals × numerator)
         val numerator = baseUnits.multiply(tenPow(rate.scale + shareDecimals))
         val denominator = tenPow(decimals).multiply(rate.numerator)
-        return KaminoShareAmount(numerator.divide(denominator), shareDecimals)
+        val quotient =
+            if (roundUp) {
+                numerator.add(denominator).subtract(BigInteger.ONE).divide(denominator)
+            } else {
+                numerator.divide(denominator)
+            }
+        return KaminoShareAmount(quotient, shareDecimals)
     }
 
     companion object {
@@ -386,6 +410,34 @@ object KaminoWithdrawMath {
         rate: KaminoRate,
         tokenDecimals: Int,
     ): KaminoTokenAmount? = shares.tokenValue(rate, tokenDecimals)
+
+    /**
+     * The vault's minimum withdraw, in SHARES, padded for the kVault program's real floor.
+     *
+     * `minWithdrawAmount` is TOKEN base units — the program compares it against the token value
+     * being withdrawn, `available_to_send_to_user + invested_liquidity_to_send_to_user`, not
+     * against a share count. Measured on chain the real floor sits above the published figure,
+     * roughly double it, and that gap is a live value rather than a fixed boundary, so this matches
+     * iOS's tested margin (3x the published figure) instead of hard-coding the measured one.
+     *
+     * Rounded up on the way back to shares so a share count worth fractionally less than the
+     * required token amount is never offered as if it cleared the minimum.
+     */
+    fun effectiveMinimumShares(
+        published: KaminoTokenAmount,
+        rate: KaminoRate,
+        shareDecimals: Int,
+    ): KaminoShareAmount? {
+        val required =
+            KaminoTokenAmount(
+                published.baseUnits.multiply(MINIMUM_WITHDRAW_MULTIPLE),
+                published.decimals,
+            )
+        return required.shareAmountRoundedUp(rate, shareDecimals)
+    }
+
+    /** A margin of this many times the published minimum, matching iOS's tested multiple. */
+    private val MINIMUM_WITHDRAW_MULTIPLE = BigInteger.valueOf(3)
 
     /**
      * The vault's share-denominated minimum expressed in the token, rounded up so anything at or

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
@@ -144,6 +144,63 @@ class KaminoWithdrawTest {
     }
 
     @Test
+    fun `a position sitting exactly on the effective minimum still has a submittable amount`() {
+        // Steakhouse USDC, minWithdrawAmount 1000 -> effective minimum 2846 shares (see the 3x-
+        // margin test above). A position holding exactly that many shares clears the vault's real
+        // floor, but minimumTokens rounds up and maximumTokens rounds down the same non-terminating
+        // product, so the raw minimum (3001) lands one base unit above the raw maximum (3000) with
+        // nothing in between for the form to offer.
+        val minimumShares = shares("2846")
+        val held = minimumShares
+        val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, tokenDecimals = 6)!!
+        assertEquals(BigInteger("3000"), maximum.baseUnits)
+        assertEquals(
+            BigInteger("3001"),
+            KaminoWithdrawMath.minimumTokens(minimumShares, usdcRate, tokenDecimals = 6)!!
+                .baseUnits,
+            "the raw minimum must be the one base unit over, or this test isn't exercising the bug",
+        )
+
+        val effectiveMinimum =
+            KaminoWithdrawMath.effectiveMinimumTokens(
+                held = held,
+                minimumShares = minimumShares,
+                maximumTokens = maximum,
+                rate = usdcRate,
+                tokenDecimals = 6,
+            )
+
+        assertEquals(
+            maximum.baseUnits,
+            effectiveMinimum!!.baseUnits,
+            "clamped to the maximum so Max — amount == available — clears the minimum too",
+        )
+    }
+
+    @Test
+    fun `a position short of the effective minimum still shows the real figure`() {
+        // Held less than the 2846-share minimum: the vault genuinely would refuse this withdraw, so
+        // the unclamped minimum must stand to tell the user what they are short of, not silently
+        // shrink to match their smaller balance.
+        val minimumShares = shares("2846")
+        val held = shares("2000")
+        val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, tokenDecimals = 6)!!
+        val rawMinimum =
+            KaminoWithdrawMath.minimumTokens(minimumShares, usdcRate, tokenDecimals = 6)!!
+
+        val effectiveMinimum =
+            KaminoWithdrawMath.effectiveMinimumTokens(
+                held = held,
+                minimumShares = minimumShares,
+                maximumTokens = maximum,
+                rate = usdcRate,
+                tokenDecimals = 6,
+            )
+
+        assertEquals(rawMinimum.baseUnits, effectiveMinimum!!.baseUnits)
+    }
+
+    @Test
     fun `a withdraw above the maximum is refused rather than clamped`() {
         val held = shares("1000000000")
         val maximum = KaminoWithdrawMath.maximumTokens(held, usdcRate, 6)!!

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoWithdrawTest.kt
@@ -80,8 +80,8 @@ class KaminoWithdrawTest {
 
     @Test
     fun `the vault minimum rounds up so it converts back to at least the minimum`() {
-        // minWithdrawAmount is 1000 SHARE base units. Rounded down it would be 1054 token units,
-        // which converts back to fewer shares than the vault accepts.
+        // A share minimum of 1000 base units. Rounded down it would be 1054 token units, which
+        // converts back to fewer shares than the vault accepts.
         val minimum = KaminoWithdrawMath.minimumTokens(shares("1000"), usdcRate, tokenDecimals = 6)
         assertEquals(BigInteger("1055"), minimum!!.baseUnits)
 
@@ -90,6 +90,32 @@ class KaminoWithdrawTest {
             backToShares.baseUnits >= BigInteger("1000"),
             "rounding up must survive the round trip, was ${backToShares.baseUnits}",
         )
+    }
+
+    @Test
+    fun `the effective withdraw minimum is read as tokens, margined 3x, and converted to shares`() {
+        // minWithdrawAmount is 1000 TOKEN base units (0.001 USDC), not shares — the program
+        // compares
+        // it against the token value being withdrawn. The real floor sits above the published
+        // figure, so this margins it 3x (0.003 USDC) before converting to the shares a withdraw has
+        // to name, rounded up so the share figure is never worth fractionally less than that.
+        val published = tokens("1000", 6)
+        val minimumShares =
+            KaminoWithdrawMath.effectiveMinimumShares(published, usdcRate, shareDecimals = 6)
+        assertEquals(BigInteger("2846"), minimumShares!!.baseUnits)
+
+        val backToTokens = minimumShares.tokenValueRoundedUp(usdcRate, tokenDecimals = 6)!!
+        assertTrue(
+            backToTokens.baseUnits >= BigInteger("3000"),
+            "the margined minimum must survive the round trip, was ${backToTokens.baseUnits}",
+        )
+
+        // Allez SOL: 9-decimal token against 6-decimal shares, rate far below 1 — the shape that
+        // makes a shares-vs-tokens mixup differ by orders of magnitude rather than rounding away.
+        val publishedSol = tokens("1000", 9)
+        val minimumSharesSol =
+            KaminoWithdrawMath.effectiveMinimumShares(publishedSol, solRate, shareDecimals = 6)
+        assertEquals(BigInteger("2789"), minimumSharesSol!!.baseUnits)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- The kVault program checks `minWithdrawAmount` against the token value being withdrawn (`available_to_send_to_user + invested_liquidity_to_send_to_user`), not against a share count — but `KaminoAmountViewModel.loadWithdrawState` read it as SHARE base units, so the withdraw form's displayed and enforced minimum was off by the vault's share rate (about 930x on the SOL vault). Matches iOS's reading (`KaminoService.swift:120-125`).
- Added `KaminoWithdrawMath.effectiveMinimumShares`, which parses the field as `KaminoTokenAmount`, applies iOS's tested margin (3x the published figure, since the real on-chain floor sits above it and is a live value rather than a fixed boundary), and converts to the share count a withdraw has to name, rounded up via a new `KaminoTokenAmount.shareAmountRoundedUp`.
- `KaminoAmountViewModel` now reads `minWithdrawAmount` as tokens and calls the new function instead of constructing a `KaminoShareAmount` directly from the raw field.

## Issue
Closes #5608

## Test Plan
- [x] `./gradlew :data:testDebugUnitTest --tests "*.KaminoWithdrawTest"` — added a case covering the token reading, 3x margin, and round-up conversion for both USDC and SOL-shaped vaults
- [x] `./gradlew :app:testDebugUnitTest --tests "*.KaminoAmountViewModelTest"` — updated the two tests pinning the old share-denominated reading
- [x] `./gradlew lint`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Kamino withdrawal minimum calculations to use token units.
  * Added appropriate rate conversion, safety margin, and upward rounding.
  * Ensured positions at the minimum threshold remain valid for withdrawal.
  * Improved handling of positions below the minimum to show accurate limits.

* **Documentation**
  * Clarified that published withdrawal minimums are specified in token base units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->