### PR TITLE
fix(passcode): recover a vault whose keyshare key the device lost

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/usecases/SaveVaultUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/SaveVaultUseCase.kt
@@ -29,9 +29,8 @@ constructor(
         if (shouldOverrideVault) {
             vaultRepository.upsert(vault)
         } else if (!supersedeUnopenableVault(vault)) {
-            // Reached unless the vault replaced one whose keyshares this device can no longer open
-            // — the single collision a restore may resolve rather than refuse. The use case holds
-            // every guard on when that applies.
+            // Reached unless the vault replaced one this device can no longer open — the single
+            // collision a restore may resolve rather than refuse.
             vaultRepository.getByEcdsa(vault.pubKeyECDSA)?.let {
                 Timber.d("saveVault: vault already exists, updating")
                 throw DuplicateVaultException()

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/SaveVaultUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/SaveVaultUseCase.kt
@@ -23,11 +23,15 @@ constructor(
     private val defaultChainsRepository: DefaultChainsRepository,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val discoverTokenUseCase: DiscoverTokenUseCase,
+    private val supersedeUnopenableVault: SupersedeUnopenableVaultUseCase,
 ) : SaveVaultUseCase {
     override suspend fun invoke(vault: Vault, shouldOverrideVault: Boolean) {
         if (shouldOverrideVault) {
             vaultRepository.upsert(vault)
-        } else {
+        } else if (!supersedeUnopenableVault(vault)) {
+            // Reached unless the vault replaced one whose keyshares this device can no longer open
+            // — the single collision a restore may resolve rather than refuse. The use case holds
+            // every guard on when that applies.
             vaultRepository.getByEcdsa(vault.pubKeyECDSA)?.let {
                 Timber.d("saveVault: vault already exists, updating")
                 throw DuplicateVaultException()

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/StoreImportedVaultUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/StoreImportedVaultUseCase.kt
@@ -11,11 +11,10 @@ import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
 
 /**
- * Stores a vault parsed out of a backup file, and does the two things that only an import owes it.
+ * Stores a vault parsed out of a backup file, and does the two things only an import owes it.
  *
- * Shared by the import screen and by the recovery the passcode gate offers when a device can no
- * longer open its own keyshares — the second cannot route to the first, because the import screen
- * draws in the window the gate covers.
+ * Shared with the recovery the passcode gate offers, which cannot route to the import screen
+ * because that screen draws in the window the gate covers.
  */
 internal interface StoreImportedVaultUseCase {
     /**

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/StoreImportedVaultUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/StoreImportedVaultUseCase.kt
@@ -1,0 +1,85 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
+
+/**
+ * Stores a vault parsed out of a backup file, and does the two things that only an import owes it.
+ *
+ * Shared by the import screen and by the recovery the passcode gate offers when a device can no
+ * longer open its own keyshares — the second cannot route to the first, because the import screen
+ * draws in the window the gate covers.
+ */
+internal interface StoreImportedVaultUseCase {
+    /**
+     * @param fileName the name the backup was read from, or null when it is not known.
+     * @return the vault as stored, which is what later steps must refer to.
+     * @throws DuplicateVaultException when the device already holds this vault and can open it.
+     */
+    suspend operator fun invoke(vault: Vault, fileName: String?): Vault
+}
+
+internal class StoreImportedVaultUseCaseImpl
+@Inject
+constructor(
+    private val saveVault: SaveVaultUseCase,
+    private val vaultRepository: VaultRepository,
+    private val vaultDataStoreRepository: VaultDataStoreRepository,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+) : StoreImportedVaultUseCase {
+
+    // saveVault is the point of no return. Every step after it runs best-effort so a datastore or
+    // derivation glitch can't surface as an import failure over a vault that is already stored.
+    override suspend fun invoke(vault: Vault, fileName: String?): Vault {
+        val adjusted = vault.withInferredLibType(fileName)
+
+        saveVault(adjusted, false)
+        runBestEffort("Failed to set backup status") {
+            vaultDataStoreRepository.setBackupStatus(adjusted.id, true)
+        }
+        if (adjusted.pubKeyMLDSA.isNotBlank()) attachQbtcToken(adjusted)
+
+        return adjusted
+    }
+
+    private suspend fun attachQbtcToken(vault: Vault) =
+        runBestEffort("Failed to add QBTC token") {
+            val qbtc = Coins.Qbtc.QBTC
+            val (address, pubKey) = chainAccountAddressRepository.getAddress(qbtc, vault)
+            vaultRepository.addTokenToVault(
+                vault.id,
+                qbtc.copy(address = address, hexPublicKey = pubKey),
+            )
+        }
+
+    private suspend inline fun runBestEffort(message: String, block: () -> Unit) {
+        try {
+            block()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, message)
+        }
+    }
+
+    // Older DKLS backups were sometimes persisted with libType=GG20. Recover the real type from the
+    // share-NofM filename convention, but leave KeyImport vaults alone — they also use that naming
+    // and must keep their declared libType.
+    private fun Vault.withInferredLibType(fileName: String?): Vault =
+        if (libType == SigningLibType.GG20 && fileName?.contains(SHARE_FILENAME_REGEX) == true) {
+            copy(libType = SigningLibType.DKLS)
+        } else {
+            this
+        }
+
+    private companion object {
+        private val SHARE_FILENAME_REGEX = "share\\d+of\\d+".toRegex()
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/UseCasesModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/UseCasesModule.kt
@@ -30,6 +30,12 @@ internal interface UseCasesModule {
 
     @Binds
     @Singleton
+    fun bindStoreImportedVaultUseCase(
+        impl: StoreImportedVaultUseCaseImpl
+    ): StoreImportedVaultUseCase
+
+    @Binds
+    @Singleton
     fun bindParseVaultFromStringUseCase(
         impl: ParseVaultFromStringUseCaseImpl
     ): ParseVaultFromStringUseCase

--- a/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/errors/ErrorView.kt
@@ -39,7 +39,11 @@ import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonSize
 import com.vultisig.wallet.ui.components.v2.buttons.VsCircleButtonType
 import com.vultisig.wallet.ui.theme.Theme
 
-internal data class ErrorViewButtonUiModel(val text: String, val onClick: () -> Unit)
+internal data class ErrorViewButtonUiModel(
+    val text: String,
+    val onClick: () -> Unit,
+    val isLoading: Boolean = false,
+)
 
 @Composable
 internal fun ErrorView(
@@ -76,6 +80,7 @@ internal fun ErrorView(
                     variant = VsButtonVariant.Secondary,
                     label = it.text,
                     modifier = Modifier.fillMaxWidth(),
+                    isLoading = it.isLoading,
                     onClick = it.onClick,
                 )
                 UiSpacer(12.dp)
@@ -86,6 +91,7 @@ internal fun ErrorView(
                     variant = VsButtonVariant.CTA,
                     label = it.text,
                     modifier = Modifier.fillMaxWidth(),
+                    isLoading = it.isLoading,
                     onClick = it.onClick,
                 )
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ImportFileViewModel.kt
@@ -12,16 +12,11 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.DefaultDispatcher
 import com.vultisig.wallet.data.common.AppZipEntry
-import com.vultisig.wallet.data.models.Coins
-import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
-import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DuplicateVaultException
 import com.vultisig.wallet.data.usecases.MalformedVaultException
 import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCase
-import com.vultisig.wallet.data.usecases.SaveVaultUseCase
+import com.vultisig.wallet.data.usecases.StoreImportedVaultUseCase
 import com.vultisig.wallet.data.usecases.WrongPasswordException
 import com.vultisig.wallet.data.usecases.backup.FILE_ALLOWED_EXTENSIONS
 import com.vultisig.wallet.data.usecases.file.UriFileReaderUseCase
@@ -66,11 +61,8 @@ internal class ImportFileViewModel
 constructor(
     savedStateHandle: SavedStateHandle,
     private val navigator: Navigator<Destination>,
-    private val vaultDataStoreRepository: VaultDataStoreRepository,
-    private val saveVault: SaveVaultUseCase,
+    private val storeImportedVault: StoreImportedVaultUseCase,
     private val parseVaultFromString: ParseVaultFromStringUseCase,
-    private val vaultRepository: VaultRepository,
-    private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val snackBarFlow: SnackbarFlow,
     private val uriFileReader: UriFileReaderUseCase,
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
@@ -124,7 +116,7 @@ constructor(
         try {
             val vault =
                 withContext(defaultDispatcher) { parseVaultFromString(fileContent, password) }
-            insertVaultToDb(vault)
+            finishImport(storeImportedVault(vault, uiModel.value.fileName))
             SaveResult.Success
         } catch (e: CancellationException) {
             throw e
@@ -207,31 +199,6 @@ constructor(
         Failed,
     }
 
-    // saveVault is the point of no return — failure there surfaces as SaveResult.Failed. Every
-    // step after runs best-effort so a datastore / network / derivation glitch can't orphan a
-    // saved vault or surface as a misleading top-level error.
-    private suspend fun insertVaultToDb(vault: Vault) {
-        val adjusted = vault.withInferredLibType(uiModel.value.fileName)
-
-        saveVault(adjusted, false)
-        runBestEffort("Failed to set backup status") {
-            vaultDataStoreRepository.setBackupStatus(adjusted.id, true)
-        }
-        if (adjusted.pubKeyMLDSA.isNotBlank()) attachQbtcToken(adjusted)
-
-        finishImport(adjusted)
-    }
-
-    private suspend fun attachQbtcToken(vault: Vault) =
-        runBestEffort("Failed to add QBTC token") {
-            val qbtc = Coins.Qbtc.QBTC
-            val (address, pubKey) = chainAccountAddressRepository.getAddress(qbtc, vault)
-            vaultRepository.addTokenToVault(
-                vault.id,
-                qbtc.copy(address = address, hexPublicKey = pubKey),
-            )
-        }
-
     private suspend fun finishImport(vault: Vault) {
         if (uiModel.value.isZip != true) {
             navigateToHome(vault)
@@ -266,16 +233,6 @@ constructor(
             Timber.w(e, message)
         }
     }
-
-    // Older DKLS backups were sometimes persisted with libType=GG20. Recover the real type
-    // from the share-NofM filename convention, but leave KeyImport vaults alone — they also
-    // use that naming and must keep their declared libType.
-    private fun Vault.withInferredLibType(fileName: String?): Vault =
-        if (libType == SigningLibType.GG20 && fileName?.contains(SHARE_FILENAME_REGEX) == true) {
-            copy(libType = SigningLibType.DKLS)
-        } else {
-            this
-        }
 
     fun saveFileToAppDir() {
         val uri = uiModel.value.fileUri ?: return
@@ -383,9 +340,5 @@ constructor(
             val target = state.activeVault?.takeIf { state.canNavigateToHome }
             if (target != null) navigateToHome(target) else navigator.back()
         }
-    }
-
-    private companion object {
-        private val SHARE_FILENAME_REGEX = "share\\d+of\\d+".toRegex()
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/passcode/KeyshareRecoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/passcode/KeyshareRecoveryViewModel.kt
@@ -1,0 +1,214 @@
+package com.vultisig.wallet.ui.models.passcode
+
+import android.net.Uri
+import androidx.annotation.StringRes
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.DefaultDispatcher
+import com.vultisig.wallet.data.common.AppZipEntry
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeState
+import com.vultisig.wallet.data.usecases.DuplicateVaultException
+import com.vultisig.wallet.data.usecases.MalformedVaultException
+import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCase
+import com.vultisig.wallet.data.usecases.StoreImportedVaultUseCase
+import com.vultisig.wallet.data.usecases.WrongPasswordException
+import com.vultisig.wallet.data.usecases.file.UriFileReaderUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+@Immutable
+internal data class KeyshareRecoveryUiModel(
+    /**
+     * What the screen says below its title: the standing instruction until a backup has been tried,
+     * and what came of that attempt afterwards.
+     */
+    @StringRes val message: Int = R.string.passcode_key_unavailable_message,
+    val isRestoring: Boolean = false,
+    val isPasswordPromptVisible: Boolean = false,
+    val isPasswordObfuscated: Boolean = true,
+    @StringRes val passwordError: Int? = null,
+)
+
+/**
+ * Restores vaults from their backup file while the gate is closed over an unreadable keystore.
+ *
+ * The import cannot be routed to from here — the import screen draws in the window this one covers
+ * — so the file is read and stored on the spot, and the gate is asked to resolve again afterwards.
+ * It opens once no sealed keyshare is left on the device, which takes a backup per vault.
+ */
+@HiltViewModel
+internal class KeyshareRecoveryViewModel
+@Inject
+constructor(
+    private val uriFileReader: UriFileReaderUseCase,
+    private val parseVaultFromString: ParseVaultFromStringUseCase,
+    private val storeImportedVault: StoreImportedVaultUseCase,
+    private val passcodeRepository: PasscodeRepository,
+    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher,
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(KeyshareRecoveryUiModel())
+    val state: StateFlow<KeyshareRecoveryUiModel> = _state.asStateFlow()
+
+    val passwordTextFieldState = TextFieldState()
+
+    /** The shares the picked file holds, kept while a password for them is being asked for. */
+    private var picked: List<AppZipEntry> = emptyList()
+
+    fun onBackupPicked(uri: Uri?) {
+        uri ?: return
+        viewModelScope.safeLaunch {
+            val shares = read(uri)
+            if (shares.isEmpty()) {
+                report(R.string.import_file_not_supported)
+                return@safeLaunch
+            }
+            picked = shares
+            // Every share in an archive was exported together, under one password, and the prompt
+            // below opens on whatever the field holds.
+            passwordTextFieldState.clearText()
+            restore(password = null)
+        }
+    }
+
+    fun onPasswordEntered() {
+        if (picked.isEmpty()) return
+        viewModelScope.safeLaunch { restore(passwordTextFieldState.text.toString()) }
+    }
+
+    fun onPasswordPromptDismissed() {
+        _state.update { it.copy(isPasswordPromptVisible = false, passwordError = null) }
+    }
+
+    fun onPasswordVisibilityToggled() {
+        _state.update { it.copy(isPasswordObfuscated = !it.isPasswordObfuscated) }
+    }
+
+    fun onRetry() {
+        viewModelScope.safeLaunch { passcodeRepository.retry() }
+    }
+
+    /**
+     * The vault shares [uri] holds: the entries of a multi-vault archive, or the one file itself.
+     *
+     * An archive is what "back up all vaults" writes, and the gate needs a share per vault before
+     * it opens — so refusing one here would name the only file the user has as the wrong file. Each
+     * share keeps its own name, which is what tells a mislabelled older backup from a GG20 one; see
+     * [StoreImportedVaultUseCase].
+     */
+    private suspend fun read(uri: Uri): List<AppZipEntry> {
+        val shares =
+            if (uriFileReader.isValidZip(uri)) {
+                uriFileReader.extractZipEntries(uri).entries
+            } else {
+                val content = uriFileReader.readContent(uri) ?: return emptyList()
+                listOf(AppZipEntry(name = uriFileReader.readName(uri).orEmpty(), content = content))
+            }
+        return shares.filter { it.content.isNotBlank() }
+    }
+
+    /**
+     * Stores every share the picked file holds, and asks the gate to resolve again if any landed.
+     *
+     * One outcome for the whole file rather than one per share: an archive holds a share per vault,
+     * and the ones it carries for vaults this device never lost are duplicates by design.
+     */
+    private suspend fun restore(password: String?) {
+        // Deriving an address per default chain takes seconds. Without this, the second tap of a
+        // double tap starts a second restore of the same file, which finds the row the first one
+        // just wrote and reports a duplicate over its success. Read and set before this suspends,
+        // on a scope that dispatches to one thread, so the two cannot both pass.
+        if (state.value.isRestoring) return
+        _state.update {
+            it.copy(message = R.string.passcode_key_unavailable_message, isRestoring = true)
+        }
+        try {
+            var restored: Vault? = null
+            var refusal: Int? = null
+            for (share in picked) {
+                val vault =
+                    try {
+                        withContext(defaultDispatcher) {
+                            parseVaultFromString(share.content, password)
+                        }
+                    } catch (e: WrongPasswordException) {
+                        // Asked once for the whole file, since one password covers all of it.
+                        Timber.d(e, "Wrong or missing backup password")
+                        promptForPassword(isRetry = password != null)
+                        return
+                    } catch (e: MalformedVaultException) {
+                        Timber.w(e, "Backup share is malformed")
+                        refusal = refusal ?: R.string.import_file_not_supported
+                        continue
+                    }
+                when (val outcome = store(vault, share.name)) {
+                    null -> restored = vault
+                    else -> refusal = refusal ?: outcome
+                }
+            }
+            settle(restored, refusal)
+        } finally {
+            _state.update { it.copy(isRestoring = false) }
+        }
+    }
+
+    /** Stores [vault], answering null when it landed and the message to show when it did not. */
+    private suspend fun store(vault: Vault, fileName: String): Int? =
+        try {
+            storeImportedVault(vault, fileName)
+            null
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: DuplicateVaultException) {
+            Timber.d(e, "Backup share does not restore a vault this device is missing")
+            R.string.import_file_screen_duplicate_vault
+        } catch (e: Exception) {
+            Timber.e(e, "Restoring from a backup failed unexpectedly")
+            R.string.dialog_default_error_body
+        }
+
+    private suspend fun settle(restored: Vault?, @StringRes refusal: Int?) {
+        if (restored == null) {
+            report(refusal ?: R.string.import_file_not_supported)
+            return
+        }
+        picked = emptyList()
+        passcodeRepository.retry()
+        // Only the last vault's restore takes the gate down. Said after the state has settled, so
+        // it
+        // is never claimed over a gate that is already lifting.
+        if (passcodeRepository.state.value == PasscodeState.KeyUnavailable) {
+            report(R.string.passcode_key_unavailable_restored)
+        }
+    }
+
+    private fun promptForPassword(isRetry: Boolean) {
+        _state.update {
+            it.copy(
+                isPasswordPromptVisible = true,
+                passwordError = R.string.import_file_screen_password_error.takeIf { _ -> isRetry },
+            )
+        }
+    }
+
+    private fun report(@StringRes message: Int) {
+        _state.update {
+            it.copy(message = message, isPasswordPromptVisible = false, passwordError = null)
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/passcode/KeyshareRecoveryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/passcode/KeyshareRecoveryViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.DefaultDispatcher
+import com.vultisig.wallet.data.common.AppZipContents
 import com.vultisig.wallet.data.common.AppZipEntry
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.passcode.PasscodeRepository
@@ -33,10 +34,7 @@ import timber.log.Timber
 
 @Immutable
 internal data class KeyshareRecoveryUiModel(
-    /**
-     * What the screen says below its title: the standing instruction until a backup has been tried,
-     * and what came of that attempt afterwards.
-     */
+    /** The standing instruction until a backup has been tried, then what came of that attempt. */
     @StringRes val message: Int = R.string.passcode_key_unavailable_message,
     val isRestoring: Boolean = false,
     val isPasswordPromptVisible: Boolean = false,
@@ -47,9 +45,9 @@ internal data class KeyshareRecoveryUiModel(
 /**
  * Restores vaults from their backup file while the gate is closed over an unreadable keystore.
  *
- * The import cannot be routed to from here — the import screen draws in the window this one covers
- * — so the file is read and stored on the spot, and the gate is asked to resolve again afterwards.
- * It opens once no sealed keyshare is left on the device, which takes a backup per vault.
+ * The import screen cannot be routed to — it draws in the window this one covers — so the file is
+ * read and stored here, then the gate is asked to resolve again. It opens once no sealed keyshare
+ * is left on the device, which takes a backup per vault.
  */
 @HiltViewModel
 internal class KeyshareRecoveryViewModel
@@ -67,27 +65,20 @@ constructor(
 
     val passwordTextFieldState = TextFieldState()
 
-    /** The shares the picked file holds, kept while a password for them is being asked for. */
-    private var picked: List<AppZipEntry> = emptyList()
+    private var picked = AppZipContents(entries = emptyList(), isComplete = true)
 
     fun onBackupPicked(uri: Uri?) {
         uri ?: return
         viewModelScope.safeLaunch {
-            val shares = read(uri)
-            if (shares.isEmpty()) {
-                report(R.string.import_file_not_supported)
-                return@safeLaunch
-            }
-            picked = shares
-            // Every share in an archive was exported together, under one password, and the prompt
-            // below opens on whatever the field holds.
+            picked = read(uri)
+            // Each file has its own password, and the prompt opens on whatever the field holds.
             passwordTextFieldState.clearText()
             restore(password = null)
         }
     }
 
     fun onPasswordEntered() {
-        if (picked.isEmpty()) return
+        if (picked.entries.isEmpty()) return
         viewModelScope.safeLaunch { restore(passwordTextFieldState.text.toString()) }
     }
 
@@ -106,41 +97,42 @@ constructor(
     /**
      * The vault shares [uri] holds: the entries of a multi-vault archive, or the one file itself.
      *
-     * An archive is what "back up all vaults" writes, and the gate needs a share per vault before
-     * it opens — so refusing one here would name the only file the user has as the wrong file. Each
-     * share keeps its own name, which is what tells a mislabelled older backup from a GG20 one; see
-     * [StoreImportedVaultUseCase].
+     * "Back up all vaults" writes an archive and the gate needs a share per vault, so refusing one
+     * would name the only file the user has as the wrong file. Each share keeps its own name, which
+     * is what [StoreImportedVaultUseCase] reads to correct a mislabelled older backup.
      */
-    private suspend fun read(uri: Uri): List<AppZipEntry> {
-        val shares =
-            if (uriFileReader.isValidZip(uri)) {
-                uriFileReader.extractZipEntries(uri).entries
-            } else {
-                val content = uriFileReader.readContent(uri) ?: return emptyList()
-                listOf(AppZipEntry(name = uriFileReader.readName(uri).orEmpty(), content = content))
-            }
-        return shares.filter { it.content.isNotBlank() }
+    private suspend fun read(uri: Uri): AppZipContents {
+        if (uriFileReader.isValidZip(uri)) {
+            val contents = uriFileReader.extractZipEntries(uri)
+            return contents.copy(entries = contents.entries.filter { it.content.isNotBlank() })
+        }
+        val content = uriFileReader.readContent(uri)?.takeUnless { it.isBlank() }
+        val name = uriFileReader.readName(uri).orEmpty()
+        return AppZipContents(
+            entries = listOfNotNull(content?.let { AppZipEntry(name = name, content = it) }),
+            isComplete = true,
+        )
     }
 
     /**
      * Stores every share the picked file holds, and asks the gate to resolve again if any landed.
      *
-     * One outcome for the whole file rather than one per share: an archive holds a share per vault,
-     * and the ones it carries for vaults this device never lost are duplicates by design.
+     * Parsed through before anything is stored, so a share needing a password cannot leave the ones
+     * ahead of it stored with nothing said about them. One outcome for the whole file, too: the
+     * shares an archive carries for vaults this device never lost are duplicates by design.
      */
     private suspend fun restore(password: String?) {
-        // Deriving an address per default chain takes seconds. Without this, the second tap of a
-        // double tap starts a second restore of the same file, which finds the row the first one
-        // just wrote and reports a duplicate over its success. Read and set before this suspends,
-        // on a scope that dispatches to one thread, so the two cannot both pass.
+        // Read and set before this suspends, on a scope that dispatches to one thread, so a double
+        // tap cannot start a second restore that finds the row the first just wrote and reports a
+        // duplicate over its success.
         if (state.value.isRestoring) return
         _state.update {
             it.copy(message = R.string.passcode_key_unavailable_message, isRestoring = true)
         }
         try {
-            var restored: Vault? = null
+            val parsed = mutableListOf<Pair<AppZipEntry, Vault>>()
             var refusal: Int? = null
-            for (share in picked) {
+            for (share in picked.entries) {
                 val vault =
                     try {
                         withContext(defaultDispatcher) {
@@ -156,6 +148,11 @@ constructor(
                         refusal = refusal ?: R.string.import_file_not_supported
                         continue
                     }
+                parsed += share to vault
+            }
+
+            var restored: Vault? = null
+            for ((share, vault) in parsed) {
                 when (val outcome = store(vault, share.name)) {
                     null -> restored = vault
                     else -> refusal = refusal ?: outcome
@@ -183,18 +180,21 @@ constructor(
         }
 
     private suspend fun settle(restored: Vault?, @StringRes refusal: Int?) {
-        if (restored == null) {
-            report(refusal ?: R.string.import_file_not_supported)
-            return
-        }
-        picked = emptyList()
+        val wasComplete = picked.isComplete
+        if (restored != null) picked = AppZipContents(entries = emptyList(), isComplete = true)
+        // Asked whatever the outcome: a store can throw after the replacement has committed, and
+        // the gate would then stay closed over a vault that is in fact restored.
         passcodeRepository.retry()
-        // Only the last vault's restore takes the gate down. Said after the state has settled, so
-        // it
-        // is never claimed over a gate that is already lifting.
-        if (passcodeRepository.state.value == PasscodeState.KeyUnavailable) {
-            report(R.string.passcode_key_unavailable_restored)
-        }
+        if (passcodeRepository.state.value != PasscodeState.KeyUnavailable) return
+        report(
+            when {
+                // A truncated archive holds shares that were never read, so this — not a missing
+                // backup — is what the user has to act on.
+                !wasComplete -> R.string.import_file_zip_incomplete
+                restored != null -> R.string.passcode_key_unavailable_restored
+                else -> refusal ?: R.string.import_file_not_supported
+            }
+        )
     }
 
     private fun promptForPassword(isRetry: Boolean) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/KeyshareRecoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/KeyshareRecoveryScreen.kt
@@ -21,14 +21,12 @@ import com.vultisig.wallet.ui.utils.ActivityResultContractsGetContentWithMimeTyp
 import com.vultisig.wallet.ui.utils.UiText
 
 /**
- * Shown when encrypted keyshares outlive the credentials that unwrap them: no passcode can open
- * them again, and the backup the user already holds is the way back.
+ * Shown when encrypted keyshares outlive the credentials that unwrap them.
  *
- * The picker is launched from here rather than routed to: the import screen renders in the
- * activity's own window, which is under this one and behind the gate's cover. Launching it from a
- * dialog window works all the same — the result registry resolves through the wrapped context to
- * the host activity — and backgrounding for the picker cannot move this state, since locking only
- * ever demotes an unlocked app.
+ * The picker is launched from here rather than routed to, because the import screen renders in the
+ * activity's own window — under this one, and behind the gate's cover. From a dialog window it
+ * still resolves its result registry through the wrapped context to the host activity, and
+ * backgrounding for it cannot move this state, since locking only ever demotes an unlocked app.
  */
 @Composable
 internal fun KeyshareRecoveryScreen(model: KeyshareRecoveryViewModel = hiltViewModel()) {
@@ -86,12 +84,9 @@ private fun KeyshareRecoveryScreen(
             ErrorViewButtonUiModel(
                 text = stringResource(R.string.passcode_key_unavailable_restore),
                 onClick = onRestoreClick,
-                // Deriving the restored vault's addresses takes seconds, and nothing else on this
-                // screen moves while it runs.
                 isLoading = state.isRestoring,
             ),
-        // Above the restore button, because a keystore that came back is the outcome that costs
-        // the user nothing.
+        // Drawn above the restore button: a keystore that came back costs the user nothing.
         secondaryButtonUiModel =
             ErrorViewButtonUiModel(
                 text = stringResource(R.string.try_again),

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/KeyshareRecoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/KeyshareRecoveryScreen.kt
@@ -1,0 +1,101 @@
+package com.vultisig.wallet.ui.screens.passcode
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.errors.ErrorState
+import com.vultisig.wallet.ui.components.errors.ErrorView
+import com.vultisig.wallet.ui.components.errors.ErrorViewButtonUiModel
+import com.vultisig.wallet.ui.models.FILE_ALLOWED_MIME_TYPES
+import com.vultisig.wallet.ui.models.keysign.KeysignPasswordUiModel
+import com.vultisig.wallet.ui.models.passcode.KeyshareRecoveryUiModel
+import com.vultisig.wallet.ui.models.passcode.KeyshareRecoveryViewModel
+import com.vultisig.wallet.ui.screens.keysign.KeysignPasswordBottomSheet
+import com.vultisig.wallet.ui.utils.ActivityResultContractsGetContentWithMimeTypes
+import com.vultisig.wallet.ui.utils.UiText
+
+/**
+ * Shown when encrypted keyshares outlive the credentials that unwrap them: no passcode can open
+ * them again, and the backup the user already holds is the way back.
+ *
+ * The picker is launched from here rather than routed to: the import screen renders in the
+ * activity's own window, which is under this one and behind the gate's cover. Launching it from a
+ * dialog window works all the same — the result registry resolves through the wrapped context to
+ * the host activity — and backgrounding for the picker cannot move this state, since locking only
+ * ever demotes an unlocked app.
+ */
+@Composable
+internal fun KeyshareRecoveryScreen(model: KeyshareRecoveryViewModel = hiltViewModel()) {
+    val state by model.state.collectAsStateWithLifecycle()
+
+    val picker =
+        rememberLauncherForActivityResult(
+            ActivityResultContractsGetContentWithMimeTypes(FILE_ALLOWED_MIME_TYPES)
+        ) { uri: Uri? ->
+            model.onBackupPicked(uri)
+        }
+
+    KeyshareRecoveryScreen(
+        state = state,
+        passwordFieldState = model.passwordTextFieldState,
+        onRestoreClick = { picker.launch("*/*") },
+        onRetryClick = model::onRetry,
+        onPasswordVisibilityToggle = model::onPasswordVisibilityToggled,
+        onPasswordEntered = model::onPasswordEntered,
+        onPasswordPromptDismissed = model::onPasswordPromptDismissed,
+    )
+}
+
+@Composable
+private fun KeyshareRecoveryScreen(
+    state: KeyshareRecoveryUiModel,
+    passwordFieldState: TextFieldState,
+    onRestoreClick: () -> Unit,
+    onRetryClick: () -> Unit,
+    onPasswordVisibilityToggle: () -> Unit,
+    onPasswordEntered: () -> Unit,
+    onPasswordPromptDismissed: () -> Unit,
+) {
+    if (state.isPasswordPromptVisible) {
+        KeysignPasswordBottomSheet(
+            subtitle = stringResource(R.string.import_file_screen_enter_password_sub),
+            confirmButtonLabel = stringResource(R.string.fast_vault_password_screen_next),
+            state =
+                KeysignPasswordUiModel(
+                    isPasswordVisible = !state.isPasswordObfuscated,
+                    passwordError = state.passwordError?.let { UiText.StringResource(it) },
+                ),
+            passwordFieldState = passwordFieldState,
+            onPasswordVisibilityToggle = onPasswordVisibilityToggle,
+            onContinueClick = onPasswordEntered,
+            onBackClick = onPasswordPromptDismissed,
+        )
+    }
+
+    ErrorView(
+        title = stringResource(R.string.passcode_key_unavailable_title),
+        description = stringResource(state.message),
+        errorState = ErrorState.WARNING,
+        buttonUiModel =
+            ErrorViewButtonUiModel(
+                text = stringResource(R.string.passcode_key_unavailable_restore),
+                onClick = onRestoreClick,
+                // Deriving the restored vault's addresses takes seconds, and nothing else on this
+                // screen moves while it runs.
+                isLoading = state.isRestoring,
+            ),
+        // Above the restore button, because a keystore that came back is the outcome that costs
+        // the user nothing.
+        secondaryButtonUiModel =
+            ErrorViewButtonUiModel(
+                text = stringResource(R.string.try_again),
+                onClick = onRetryClick,
+            ),
+    )
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/passcode/PasscodeGuard.kt
@@ -69,12 +69,7 @@ internal fun PasscodeGuard(model: PasscodeGuardViewModel = hiltViewModel()) {
 private fun GateContent(passcodeState: PasscodeState, onRetry: () -> Unit) {
     when (passcodeState) {
         PasscodeState.Locked -> PasscodeLockScreen()
-        PasscodeState.KeyUnavailable ->
-            DeadEndScreen(
-                title = stringResource(R.string.passcode_key_unavailable_title),
-                message = stringResource(R.string.passcode_key_unavailable_message),
-                onRetry = onRetry,
-            )
+        PasscodeState.KeyUnavailable -> KeyshareRecoveryScreen()
         PasscodeState.StoreUnavailable ->
             DeadEndScreen(
                 title = stringResource(R.string.passcode_store_unavailable_title),
@@ -126,14 +121,13 @@ private fun LockWindow(content: @Composable () -> Unit) {
 }
 
 /**
- * Shown when encrypted keyshares cannot be opened at all — the credentials are gone
- * ([PasscodeState.KeyUnavailable]) or unreachable this launch ([PasscodeState.StoreUnavailable]).
- * Neither has a passcode that would work, so the screen says what happened rather than asking for
- * one. The two differ only in what the user should do next, which is exactly what [message]
- * carries.
+ * Shown when the credential store could not be opened this launch
+ * ([PasscodeState.StoreUnavailable]) — there is no passcode that would work, so the screen says
+ * what happened rather than asking for one.
  *
- * [onRetry] is the only way off this window, since back and outside taps belong to the gate. Both
- * states rest on a keystore read that can come back, so it is worth offering.
+ * [onRetry] is the only way off this window, since back and outside taps belong to the gate. The
+ * state rests on a keystore read that can come back, so it is worth offering. The credentials-gone
+ * state has more to offer than a retry and gets its own screen — see [KeyshareRecoveryScreen].
  */
 @Composable
 private fun DeadEndScreen(title: String, message: String, onRetry: () -> Unit) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -198,6 +198,8 @@
     <string name="passcode_not_digits">Nur Ziffern eingeben.</string>
     <string name="passcode_key_unavailable_title">Diesem Gerät fehlt Ihr Vault-Schlüssel</string>
     <string name="passcode_key_unavailable_message">Ihre Vaults sind noch auf diesem Gerät. Stellen Sie sie aus Ihrem .vult-Backup wieder her, um sie zu öffnen.</string>
+    <string name="passcode_key_unavailable_restore">Aus Backup wiederherstellen</string>
+    <string name="passcode_key_unavailable_restored">Vault wiederhergestellt. Ein weiterer Vault auf diesem Gerät braucht noch sein Backup.</string>
     <string name="passcode_store_unavailable_title">Ihre Vaults sind vorerst gesperrt</string>
     <string name="passcode_store_unavailable_message">Der sichere Speicher dieses Geräts ließ sich diesmal nicht öffnen. Alles ist noch da, starten Sie also die App neu, statt sie neu zu installieren.</string>
     <string name="passcode_input_field_content_description">%1$d von %2$d Ziffern eingegeben</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -199,6 +199,8 @@
     <string name="passcode_not_digits">Introduzca solo dígitos.</string>
     <string name="passcode_key_unavailable_title">A este dispositivo le falta su clave de bóveda</string>
     <string name="passcode_key_unavailable_message">Sus bóvedas siguen en este dispositivo. Restáurelas desde su copia de seguridad .vult para volver a abrirlas.</string>
+    <string name="passcode_key_unavailable_restore">Restaurar desde copia de seguridad</string>
+    <string name="passcode_key_unavailable_restored">Bóveda restaurada. Otra bóveda de este dispositivo todavía necesita su copia de seguridad.</string>
     <string name="passcode_store_unavailable_title">Sus bóvedas están bloqueadas por ahora</string>
     <string name="passcode_store_unavailable_message">El almacenamiento seguro de este dispositivo no se abrió esta vez. Todo sigue aquí, así que reinicie la aplicación en lugar de reinstalarla.</string>
     <string name="passcode_input_field_content_description">%1$d de %2$d dígitos introducidos</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -198,6 +198,8 @@
     <string name="passcode_not_digits">Unesite samo znamenke.</string>
     <string name="passcode_key_unavailable_title">Ovom uređaju nedostaje ključ vašeg trezora</string>
     <string name="passcode_key_unavailable_message">Vaši su trezori i dalje na ovom uređaju. Vratite ih iz .vult sigurnosne kopije da ih ponovno otvorite.</string>
+    <string name="passcode_key_unavailable_restore">Vrati iz sigurnosne kopije</string>
+    <string name="passcode_key_unavailable_restored">Trezor je vraćen. Još jedan trezor na ovom uređaju treba svoju sigurnosnu kopiju.</string>
     <string name="passcode_store_unavailable_title">Vaši su trezori zasad zaključani</string>
     <string name="passcode_store_unavailable_message">Ovaj se put sigurna pohrana ovog uređaja nije otvorila. Sve je i dalje tu, pa ponovno pokrenite aplikaciju umjesto ponovne instalacije.</string>
     <string name="passcode_input_field_content_description">Uneseno %1$d od %2$d znamenki</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -198,6 +198,8 @@
     <string name="passcode_not_digits">Inserisci solo cifre.</string>
     <string name="passcode_key_unavailable_title">A questo dispositivo manca la chiave dei vault</string>
     <string name="passcode_key_unavailable_message">I tuoi vault sono ancora su questo dispositivo. Ripristina dal backup .vult per riaprirli.</string>
+    <string name="passcode_key_unavailable_restore">Ripristina dal backup</string>
+    <string name="passcode_key_unavailable_restored">Vault ripristinato. Un altro vault su questo dispositivo ha ancora bisogno del suo backup.</string>
     <string name="passcode_store_unavailable_title">I tuoi vault sono bloccati per ora</string>
     <string name="passcode_store_unavailable_message">L\'archiviazione sicura di questo dispositivo non si è aperta stavolta. C\'è ancora tutto, quindi riavvia l\'app invece di reinstallarla.</string>
     <string name="passcode_input_field_content_description">%1$d di %2$d cifre inserite</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -311,6 +311,8 @@
     <string name="passcode_not_digits">숫자만 입력하세요.</string>
     <string name="passcode_key_unavailable_title">이 기기에 볼트를 여는 키가 없습니다</string>
     <string name="passcode_key_unavailable_message">볼트는 이 기기에 그대로 있습니다. 다시 열려면 .vult 백업에서 복원하세요.</string>
+    <string name="passcode_key_unavailable_restore">백업에서 복원</string>
+    <string name="passcode_key_unavailable_restored">볼트를 복원했습니다. 이 기기의 다른 볼트에도 백업이 필요합니다.</string>
     <string name="passcode_store_unavailable_title">지금은 볼트가 잠겨 있습니다</string>
     <string name="passcode_store_unavailable_message">이번에는 이 기기의 보안 저장소가 열리지 않았습니다. 모두 그대로 있으니 다시 설치하지 말고 앱을 다시 시작하세요.</string>
     <string name="passcode_input_field_content_description">%2$d자리 중 %1$d자리 입력됨</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -209,6 +209,8 @@
     <string name="passcode_not_digits">Voer alleen cijfers in.</string>
     <string name="passcode_key_unavailable_title">Dit apparaat mist je kluissleutel</string>
     <string name="passcode_key_unavailable_message">Je kluizen staan nog op dit apparaat. Herstel vanaf je .vult-back-up om ze weer te openen.</string>
+    <string name="passcode_key_unavailable_restore">Herstellen vanaf back-up</string>
+    <string name="passcode_key_unavailable_restored">Kluis hersteld. Een andere kluis op dit apparaat heeft nog zijn back-up nodig.</string>
     <string name="passcode_store_unavailable_title">Je kluizen zijn even vergrendeld</string>
     <string name="passcode_store_unavailable_message">De beveiligde opslag van dit apparaat ging deze keer niet open. Alles staat er nog, dus herstart de app in plaats van hem opnieuw te installeren.</string>
     <string name="passcode_input_field_content_description">%1$d van %2$d cijfers ingevoerd</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -198,6 +198,8 @@
     <string name="passcode_not_digits">Introduza apenas dígitos.</string>
     <string name="passcode_key_unavailable_title">Este dispositivo não tem a chave do seu cofre</string>
     <string name="passcode_key_unavailable_message">Os seus cofres continuam neste dispositivo. Restaure a partir do backup .vult para os voltar a abrir.</string>
+    <string name="passcode_key_unavailable_restore">Restaurar a partir do backup</string>
+    <string name="passcode_key_unavailable_restored">Cofre restaurado. Outro cofre neste dispositivo ainda precisa do seu backup.</string>
     <string name="passcode_store_unavailable_title">Os cofres estão bloqueados por agora</string>
     <string name="passcode_store_unavailable_message">O armazenamento seguro deste dispositivo não abriu desta vez. Continua tudo aqui, por isso reinicie a aplicação em vez de a reinstalar.</string>
     <string name="passcode_input_field_content_description">%1$d de %2$d dígitos introduzidos</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -209,6 +209,8 @@
     <string name="passcode_not_digits">Вводите только цифры.</string>
     <string name="passcode_key_unavailable_title">На этом устройстве нет ключа от ваших хранилищ</string>
     <string name="passcode_key_unavailable_message">Ваши хранилища всё ещё на этом устройстве. Восстановите их из резервной копии .vult, чтобы снова открыть.</string>
+    <string name="passcode_key_unavailable_restore">Восстановить из резервной копии</string>
+    <string name="passcode_key_unavailable_restored">Хранилище восстановлено. Ещё одному хранилищу на этом устройстве нужна его резервная копия.</string>
     <string name="passcode_store_unavailable_title">Ваши хранилища пока заблокированы</string>
     <string name="passcode_store_unavailable_message">На этот раз не удалось открыть защищённое хранилище ключей устройства. Всё на месте, поэтому перезапустите приложение, а не переустанавливайте его.</string>
     <string name="passcode_input_field_content_description">Введено %1$d из %2$d цифр</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -370,6 +370,8 @@
     <string name="passcode_not_digits">请仅输入数字。</string>
     <string name="passcode_key_unavailable_title">本设备缺少您的保险库密钥</string>
     <string name="passcode_key_unavailable_message">您的保险库仍在本设备上。从您的 .vult 备份恢复，即可重新打开它们。</string>
+    <string name="passcode_key_unavailable_restore">从备份恢复</string>
+    <string name="passcode_key_unavailable_restored">保险库已恢复。本设备上还有一个保险库需要它的备份。</string>
     <string name="passcode_store_unavailable_title">您的保险库暂时处于锁定状态</string>
     <string name="passcode_store_unavailable_message">本设备的安全存储这次没能打开。所有内容都还在，重新启动应用即可，不必重新安装。</string>
     <string name="passcode_input_field_content_description">已输入 %2$d 位数字中的 %1$d 位</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,6 +315,8 @@
     <string name="passcode_not_digits">Enter digits only.</string>
     <string name="passcode_key_unavailable_title">This device is missing your vault key</string>
     <string name="passcode_key_unavailable_message">Your vaults are still on this device. Restore from your .vult backup to open them again.</string>
+    <string name="passcode_key_unavailable_restore">Restore from backup</string>
+    <string name="passcode_key_unavailable_restored">Vault restored. Another vault on this device still needs its backup.</string>
     <string name="passcode_store_unavailable_title">Your vaults are locked for now</string>
     <string name="passcode_store_unavailable_message">This device\'s secure storage didn\'t open this time. Everything is still here, so restart the app instead of reinstalling.</string>
     <string name="passcode_input_field_content_description">%1$d of %2$d digits entered</string>

--- a/app/src/test/java/com/vultisig/wallet/data/usecases/SaveVaultUseCaseImplTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/usecases/SaveVaultUseCaseImplTest.kt
@@ -32,6 +32,7 @@ internal class SaveVaultUseCaseImplTest {
     private lateinit var defaultChainsRepository: DefaultChainsRepository
     private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
     private lateinit var discoverTokenUseCase: DiscoverTokenUseCase
+    private lateinit var supersedeUnopenableVault: SupersedeUnopenableVaultUseCase
 
     private lateinit var useCase: SaveVaultUseCaseImpl
 
@@ -58,6 +59,8 @@ internal class SaveVaultUseCaseImplTest {
         chainAccountAddressRepository = mockk()
         discoverTokenUseCase = mockk()
         every { discoverTokenUseCase(any(), any()) } just Runs
+        supersedeUnopenableVault = mockk()
+        coEvery { supersedeUnopenableVault(any()) } returns false
 
         // Default: nativeTokens returns coins for all chains we test with
         val nativeTokens =
@@ -77,6 +80,7 @@ internal class SaveVaultUseCaseImplTest {
                 defaultChainsRepository = defaultChainsRepository,
                 chainAccountAddressRepository = chainAccountAddressRepository,
                 discoverTokenUseCase = discoverTokenUseCase,
+                supersedeUnopenableVault = supersedeUnopenableVault,
             )
     }
 
@@ -225,5 +229,52 @@ internal class SaveVaultUseCaseImplTest {
         useCase(vault, true)
 
         coVerify { vaultRepository.upsert(vault) }
+    }
+
+    @Test
+    fun `a vault replacing an unopenable one is neither refused nor added again`() = runTest {
+        val vault = dklsVault().copy(coins = listOf(nativeCoin(Chain.Ethereum)))
+        coEvery { supersedeUnopenableVault(vault) } returns true
+
+        useCase(vault, false)
+
+        coVerify(exactly = 0) { vaultRepository.add(any()) }
+        coVerify(exactly = 0) { vaultRepository.getByEcdsa(any()) }
+    }
+
+    /** A restored vault carries no coins, so it needs the same default set a fresh import gets. */
+    @Test
+    fun `a vault replacing an unopenable one still gets its default chains and discovery`() =
+        runTest {
+            val vault = dklsVault()
+            coEvery { supersedeUnopenableVault(vault) } returns true
+            coEvery { vaultRepository.get(vaultId) } returns vault
+            every { defaultChainsRepository.selectedDefaultChains } returns
+                flowOf(listOf(Chain.Bitcoin, Chain.Ethereum))
+
+            useCase(vault, false)
+
+            coVerify(exactly = 2) { vaultRepository.addTokenToVault(vaultId, any()) }
+            verify(exactly = 1) { discoverTokenUseCase(vaultId, null) }
+        }
+
+    /** The override path is keygen's, and reshare must never displace a row by public key. */
+    @Test
+    fun `the override path never supersedes`() = runTest {
+        val vault = dklsVault().copy(coins = listOf(nativeCoin(Chain.Ethereum)))
+
+        useCase(vault, true)
+
+        coVerify(exactly = 0) { supersedeUnopenableVault(any()) }
+        coVerify { vaultRepository.upsert(vault) }
+    }
+
+    @Test
+    fun `a duplicate is still refused when nothing was superseded`() = runTest {
+        val vault = keyImportVault()
+        coEvery { supersedeUnopenableVault(vault) } returns false
+        coEvery { vaultRepository.getByEcdsa(any()) } returns vault
+
+        assertFailsWith<DuplicateVaultException> { useCase(vault, false) }
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/data/usecases/StoreImportedVaultUseCaseTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/usecases/StoreImportedVaultUseCaseTest.kt
@@ -1,0 +1,131 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class StoreImportedVaultUseCaseTest {
+
+    private lateinit var saveVault: SaveVaultUseCase
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
+    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
+    private lateinit var useCase: StoreImportedVaultUseCaseImpl
+
+    @BeforeEach
+    fun setUp() {
+        saveVault = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        vaultDataStoreRepository = mockk(relaxed = true)
+        chainAccountAddressRepository = mockk(relaxed = true)
+        useCase =
+            StoreImportedVaultUseCaseImpl(
+                saveVault = saveVault,
+                vaultRepository = vaultRepository,
+                vaultDataStoreRepository = vaultDataStoreRepository,
+                chainAccountAddressRepository = chainAccountAddressRepository,
+            )
+    }
+
+    private fun testVault(libType: SigningLibType = SigningLibType.DKLS, pubKeyMLDSA: String = "") =
+        Vault(
+            id = "test-vault-id",
+            name = "Test Vault",
+            libType = libType,
+            pubKeyMLDSA = pubKeyMLDSA,
+        )
+
+    private suspend fun storedLibType(vault: Vault, fileName: String?): SigningLibType {
+        useCase(vault, fileName)
+        val stored = slot<Vault>()
+        coVerify { saveVault(capture(stored), false) }
+        return stored.captured.libType
+    }
+
+    @Test
+    fun `KeyImport vault with share filename keeps KeyImport libType`() = runTest {
+        storedLibType(testVault(SigningLibType.KeyImport), "share1of2-test.bak") shouldBe
+            SigningLibType.KeyImport
+    }
+
+    @Test
+    fun `GG20 vault with share filename gets overridden to DKLS`() = runTest {
+        storedLibType(testVault(SigningLibType.GG20), "share1of2-test.bak") shouldBe
+            SigningLibType.DKLS
+    }
+
+    @Test
+    fun `DKLS vault without share filename keeps DKLS`() = runTest {
+        storedLibType(testVault(SigningLibType.DKLS), "test.bak") shouldBe SigningLibType.DKLS
+    }
+
+    @Test
+    fun `GG20 vault keeps GG20 when the backup has no file name`() = runTest {
+        storedLibType(testVault(SigningLibType.GG20), fileName = null) shouldBe SigningLibType.GG20
+    }
+
+    @Test
+    fun `storing an MLDSA-capable vault re-adds the QBTC token`() = runTest {
+        coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), any<Vault>()) } returns
+            Pair("qbtc1address", "qbtc-derived-pubkey")
+
+        useCase(testVault(pubKeyMLDSA = "mldsa-pubkey"), "share1of2-test.bak")
+
+        val token = slot<Coin>()
+        coVerify { vaultRepository.addTokenToVault("test-vault-id", capture(token)) }
+        token.captured.ticker shouldBe Coins.Qbtc.QBTC.ticker
+        token.captured.address shouldBe "qbtc1address"
+        token.captured.hexPublicKey shouldBe "qbtc-derived-pubkey"
+    }
+
+    @Test
+    fun `storing a vault without MLDSA leaves QBTC alone`() = runTest {
+        useCase(testVault(), "share1of2-test.bak")
+
+        coVerify(exactly = 0) { vaultRepository.addTokenToVault(any(), any()) }
+    }
+
+    @Test
+    fun `the stored vault is marked as backed up`() = runTest {
+        useCase(testVault(), "vault.bak")
+
+        coVerify { vaultDataStoreRepository.setBackupStatus("test-vault-id", true) }
+    }
+
+    @Test
+    fun `import succeeds when setBackupStatus fails`() = runTest {
+        coEvery { vaultDataStoreRepository.setBackupStatus(any(), any()) } throws
+            RuntimeException("datastore")
+
+        useCase(testVault(), "vault.bak").id shouldBe "test-vault-id"
+    }
+
+    @Test
+    fun `import succeeds when QBTC address derivation fails on MLDSA vault`() = runTest {
+        coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), any<Vault>()) } throws
+            RuntimeException("derivation failed")
+
+        useCase(testVault(pubKeyMLDSA = "mldsa-pub-key"), "vault.bak").id shouldBe "test-vault-id"
+    }
+
+    /** The save is the point of no return, so its failure has to reach the caller. */
+    @Test
+    fun `a refused duplicate propagates`() = runTest {
+        coEvery { saveVault(any(), false) } throws DuplicateVaultException()
+
+        assertFailsWith<DuplicateVaultException> { useCase(testVault(), "vault.bak") }
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ImportFileViewModelTest.kt
@@ -7,17 +7,12 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.AppZipEntry
-import com.vultisig.wallet.data.models.Coin
-import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
-import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
-import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
-import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DuplicateVaultException
 import com.vultisig.wallet.data.usecases.MalformedVaultException
 import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCase
-import com.vultisig.wallet.data.usecases.SaveVaultUseCase
+import com.vultisig.wallet.data.usecases.StoreImportedVaultUseCase
 import com.vultisig.wallet.data.usecases.WrongPasswordException
 import com.vultisig.wallet.data.usecases.file.UriFileReaderUseCase
 import com.vultisig.wallet.ui.navigation.Destination
@@ -30,7 +25,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.slot
 import io.mockk.unmockkStatic
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
@@ -54,11 +48,8 @@ internal class ImportFileViewModelTest {
     private val testDispatcher = UnconfinedTestDispatcher()
 
     private lateinit var navigator: Navigator<Destination>
-    private lateinit var vaultDataStoreRepository: VaultDataStoreRepository
-    private lateinit var saveVault: SaveVaultUseCase
+    private lateinit var storeImportedVault: StoreImportedVaultUseCase
     private lateinit var parseVaultFromString: ParseVaultFromStringUseCase
-    private lateinit var vaultRepository: VaultRepository
-    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
     private lateinit var snackbarFlow: SnackbarFlow
     private lateinit var uriFileReader: UriFileReaderUseCase
 
@@ -68,11 +59,11 @@ internal class ImportFileViewModelTest {
         mockkStatic("androidx.navigation.SavedStateHandleKt")
         every { any<SavedStateHandle>().toRoute<Route.ImportVault>() } returns Route.ImportVault()
         navigator = mockk(relaxed = true)
-        vaultDataStoreRepository = mockk(relaxed = true)
-        saveVault = mockk(relaxed = true)
+        storeImportedVault = mockk()
+        // Stores whatever it is handed, as the real one does once any libType correction is
+        // applied.
+        coEvery { storeImportedVault(any(), any()) } answers { firstArg() }
         parseVaultFromString = mockk(relaxed = true)
-        vaultRepository = mockk(relaxed = true)
-        chainAccountAddressRepository = mockk(relaxed = true)
         snackbarFlow = mockk(relaxed = true)
         uriFileReader = mockk(relaxed = true)
     }
@@ -95,11 +86,8 @@ internal class ImportFileViewModelTest {
             ImportFileViewModel(
                 savedStateHandle = savedStateHandle,
                 navigator = navigator,
-                vaultDataStoreRepository = vaultDataStoreRepository,
-                saveVault = saveVault,
+                storeImportedVault = storeImportedVault,
                 parseVaultFromString = parseVaultFromString,
-                vaultRepository = vaultRepository,
-                chainAccountAddressRepository = chainAccountAddressRepository,
                 snackBarFlow = snackbarFlow,
                 uriFileReader = uriFileReader,
                 defaultDispatcher = testDispatcher,
@@ -117,91 +105,6 @@ internal class ImportFileViewModelTest {
 
     private fun testVault(libType: SigningLibType = SigningLibType.DKLS) =
         Vault(id = "test-vault-id", name = "Test Vault", libType = libType)
-
-    // --- libType heuristics (preserved from original test file) --------------
-
-    @Test
-    fun `KeyImport vault with share filename keeps KeyImport libType`() = runTest {
-        val vault = testVault(libType = SigningLibType.KeyImport)
-        coEvery { parseVaultFromString(any(), any()) } returns vault
-        val vm = createViewModel(fileName = "share1of2-test.bak")
-
-        vm.decryptVaultData()
-
-        val savedVaultSlot = slot<Vault>()
-        coVerify { saveVault(capture(savedVaultSlot), false) }
-        assertEquals(SigningLibType.KeyImport, savedVaultSlot.captured.libType)
-    }
-
-    @Test
-    fun `GG20 vault with share filename gets overridden to DKLS`() = runTest {
-        val vault = testVault(libType = SigningLibType.GG20)
-        coEvery { parseVaultFromString(any(), any()) } returns vault
-        val vm = createViewModel(fileName = "share1of2-test.bak")
-
-        vm.decryptVaultData()
-
-        val savedVaultSlot = slot<Vault>()
-        coVerify { saveVault(capture(savedVaultSlot), false) }
-        assertEquals(SigningLibType.DKLS, savedVaultSlot.captured.libType)
-    }
-
-    @Test
-    fun `DKLS vault without share filename keeps DKLS`() = runTest {
-        val vault = testVault(libType = SigningLibType.DKLS)
-        coEvery { parseVaultFromString(any(), any()) } returns vault
-        val vm = createViewModel(fileName = "test.bak")
-
-        vm.decryptVaultData()
-
-        val savedVaultSlot = slot<Vault>()
-        coVerify { saveVault(capture(savedVaultSlot), false) }
-        assertEquals(SigningLibType.DKLS, savedVaultSlot.captured.libType)
-    }
-
-    @Test
-    fun `restoring an MLDSA-capable vault re-adds the QBTC token`() = runTest {
-        val vault =
-            Vault(
-                id = "test-vault-id",
-                name = "Test Vault",
-                libType = SigningLibType.KeyImport,
-                pubKeyMLDSA = "mldsa-pubkey",
-            )
-        coEvery { parseVaultFromString(any(), any()) } returns vault
-        coEvery { saveVault(any(), false) } returns Unit
-        coEvery { vaultDataStoreRepository.setBackupStatus(any(), any()) } returns Unit
-        coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), any<Vault>()) } returns
-            Pair("qbtc1address", "qbtc-derived-pubkey")
-        coEvery { vaultRepository.addTokenToVault(any(), any()) } returns Unit
-
-        val vm = createViewModel(fileName = "share1of2-test.bak")
-        vm.uiModel.value = vm.uiModel.value.copy(showPasswordPrompt = true)
-        vm.decryptVaultData()
-        vm.uiModel.first { !it.showPasswordPrompt }
-
-        val tokenSlot = slot<Coin>()
-        coVerify { vaultRepository.addTokenToVault("test-vault-id", capture(tokenSlot)) }
-        assertEquals(Coins.Qbtc.QBTC.ticker, tokenSlot.captured.ticker)
-        assertEquals("qbtc1address", tokenSlot.captured.address)
-        assertEquals("qbtc-derived-pubkey", tokenSlot.captured.hexPublicKey)
-    }
-
-    @Test
-    fun `restoring a vault without MLDSA leaves QBTC alone`() = runTest {
-        val vault =
-            Vault(
-                id = "test-vault-id",
-                name = "Test Vault",
-                libType = SigningLibType.DKLS,
-                pubKeyMLDSA = "",
-            )
-        coEvery { parseVaultFromString(any(), any()) } returns vault
-
-        createViewModel(fileName = "share1of2-test.bak").decryptVaultData()
-
-        coVerify(exactly = 0) { vaultRepository.addTokenToVault(any(), any()) }
-    }
 
     // --- decryptVaultData: SaveResult routing --------------------------------
 
@@ -249,7 +152,7 @@ internal class ImportFileViewModelTest {
     @Test
     fun `decryptVaultData on SQLiteConstraintException also treated as Duplicate`() = runTest {
         coEvery { parseVaultFromString(any(), any()) } returns testVault()
-        coEvery { saveVault(any(), false) } throws SQLiteConstraintException()
+        coEvery { storeImportedVault(any(), any()) } throws SQLiteConstraintException()
         val vm = createViewModel(fileName = "vault.bak", showPasswordPrompt = true)
 
         vm.decryptVaultData()
@@ -301,7 +204,7 @@ internal class ImportFileViewModelTest {
     @Test
     fun `decryptVaultData on generic failure closes dialog and keeps file for retry`() = runTest {
         coEvery { parseVaultFromString(any(), any()) } returns testVault()
-        coEvery { saveVault(any(), false) } throws RuntimeException("db locked")
+        coEvery { storeImportedVault(any(), any()) } throws RuntimeException("db locked")
         val vm = createViewModel(fileName = "vault.bak", showPasswordPrompt = true)
 
         vm.decryptVaultData()
@@ -321,7 +224,7 @@ internal class ImportFileViewModelTest {
             // to SaveResult.Failed. If the generic `catch (e: Exception)` swallowed
             // CancellationException, saveToDb would return SaveResult.Failed, which would
             // trigger showGenericError and set `state.error`. Asserting state unchanged
-            // AND that saveVault was never reached proves the rethrow path fired.
+            // AND that the store was never reached proves the rethrow path fired.
             coEvery { parseVaultFromString(any(), any()) } throws CancellationException("cancelled")
             val vm = createViewModel(fileName = "vault.bak", showPasswordPrompt = true)
 
@@ -334,7 +237,7 @@ internal class ImportFileViewModelTest {
                 state.showPasswordPrompt,
                 "cancellation must not flip UI state as if the save completed",
             )
-            coVerify(exactly = 0) { saveVault(any(), any()) }
+            coVerify(exactly = 0) { storeImportedVault(any(), any()) }
         }
 
     // --- parseFileContent: SaveResult routing (no-password first pass) -------
@@ -393,7 +296,9 @@ internal class ImportFileViewModelTest {
         val state = vm.uiModel.value
         assertFalse(state.showPasswordPrompt, "success must not pop the password prompt")
         assertNull(state.error)
-        coVerify { saveVault(any(), false) }
+        // The name goes with it: it is the only thing that tells a mislabelled older DKLS backup
+        // from a GG20 one.
+        coVerify { storeImportedVault(any(), "vault.bak") }
     }
 
     @Test
@@ -402,7 +307,7 @@ internal class ImportFileViewModelTest {
 
         coEvery { uriFileReader.readContent(uri) } returns "unencrypted-duplicate"
         coEvery { parseVaultFromString(any(), null) } returns testVault()
-        coEvery { saveVault(any(), false) } throws DuplicateVaultException()
+        coEvery { storeImportedVault(any(), any()) } throws DuplicateVaultException()
 
         val vm = createViewModel(fileContent = null, isZip = false, fileName = "dup.bak")
         vm.uiModel.value = vm.uiModel.value.copy(fileUri = uri, fileName = "dup.bak")
@@ -429,7 +334,7 @@ internal class ImportFileViewModelTest {
 
         coEvery { uriFileReader.readContent(uri) } returns "valid-unencrypted"
         coEvery { parseVaultFromString(any(), null) } returns testVault()
-        coEvery { saveVault(any(), false) } throws RuntimeException("db locked")
+        coEvery { storeImportedVault(any(), any()) } throws RuntimeException("db locked")
 
         val vm = createViewModel(fileContent = null, isZip = false, fileName = "vault.bak")
         vm.uiModel.value = vm.uiModel.value.copy(fileUri = uri, fileName = "vault.bak")
@@ -504,7 +409,7 @@ internal class ImportFileViewModelTest {
     @Test
     fun `decryptVaultData zip generic Failed shows snackbar and keeps file intact`() = runTest {
         coEvery { parseVaultFromString(any(), any()) } returns testVault()
-        coEvery { saveVault(any(), false) } throws RuntimeException("db locked")
+        coEvery { storeImportedVault(any(), any()) } throws RuntimeException("db locked")
         val entry = AppZipEntry(name = "vault.bak", content = "keep-me")
         val vm =
             createViewModel(
@@ -530,7 +435,7 @@ internal class ImportFileViewModelTest {
 
         coEvery { uriFileReader.readContent(uri) } returns "test-content"
         coEvery { parseVaultFromString(any(), any()) } returns testVault()
-        coEvery { saveVault(any(), false) } throws SQLiteConstraintException()
+        coEvery { storeImportedVault(any(), any()) } throws SQLiteConstraintException()
 
         val vm = createViewModel(fileContent = null)
         vm.uiModel.value = vm.uiModel.value.copy(fileUri = uri)
@@ -544,43 +449,6 @@ internal class ImportFileViewModelTest {
         )
         assertNull(state.fileName)
         assertNull(state.fileContent)
-    }
-
-    // --- Post-save hardening: non-fatal downstream failures ------------------
-
-    @Test
-    fun `import succeeds when setBackupStatus fails`() = runTest {
-        coEvery { parseVaultFromString(any(), any()) } returns testVault()
-        coEvery { vaultDataStoreRepository.setBackupStatus(any(), any()) } throws
-            RuntimeException("datastore")
-        val vm = createViewModel(fileName = "vault.bak")
-
-        vm.decryptVaultData()
-
-        val state = vm.uiModel.value
-        assertNull(state.error)
-        coVerify { saveVault(any(), false) }
-    }
-
-    @Test
-    fun `import succeeds when QBTC address derivation fails on MLDSA vault`() = runTest {
-        val mldsaVault =
-            Vault(
-                id = "v",
-                name = "V",
-                libType = SigningLibType.DKLS,
-                pubKeyMLDSA = "mldsa-pub-key",
-            )
-        coEvery { parseVaultFromString(any(), any()) } returns mldsaVault
-        coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), any<Vault>()) } throws
-            RuntimeException("derivation failed")
-        val vm = createViewModel(fileName = "vault.bak")
-
-        vm.decryptVaultData()
-
-        val state = vm.uiModel.value
-        assertNull(state.error, "QBTC derivation failure must not block import")
-        coVerify { saveVault(any(), false) }
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/passcode/KeyshareRecoveryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/passcode/KeyshareRecoveryViewModelTest.kt
@@ -1,0 +1,318 @@
+package com.vultisig.wallet.ui.models.passcode
+
+import android.net.Uri
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.common.AppZipContents
+import com.vultisig.wallet.data.common.AppZipEntry
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeState
+import com.vultisig.wallet.data.usecases.DuplicateVaultException
+import com.vultisig.wallet.data.usecases.MalformedVaultException
+import com.vultisig.wallet.data.usecases.ParseVaultFromStringUseCase
+import com.vultisig.wallet.data.usecases.StoreImportedVaultUseCase
+import com.vultisig.wallet.data.usecases.WrongPasswordException
+import com.vultisig.wallet.data.usecases.file.UriFileReaderUseCase
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class KeyshareRecoveryViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val uri = mockk<Uri>()
+    private val passcodeState = MutableStateFlow<PasscodeState>(PasscodeState.KeyUnavailable)
+
+    private lateinit var uriFileReader: UriFileReaderUseCase
+    private lateinit var parseVaultFromString: ParseVaultFromStringUseCase
+    private lateinit var storeImportedVault: StoreImportedVaultUseCase
+    private lateinit var passcodeRepository: PasscodeRepository
+    private lateinit var model: KeyshareRecoveryViewModel
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        uriFileReader = mockk()
+        parseVaultFromString = mockk()
+        storeImportedVault = mockk()
+        passcodeRepository = mockk(relaxUnitFun = true)
+        every { passcodeRepository.state } returns passcodeState
+        coEvery { uriFileReader.isValidZip(uri) } returns false
+        coEvery { uriFileReader.readContent(uri) } returns "backup-file-content"
+        coEvery { uriFileReader.readName(uri) } returns "Main-share2of2.vult"
+        coEvery { parseVaultFromString(any(), any()) } returns vault
+        coEvery { storeImportedVault(any(), any()) } returns vault
+        model =
+            KeyshareRecoveryViewModel(
+                uriFileReader = uriFileReader,
+                parseVaultFromString = parseVaultFromString,
+                storeImportedVault = storeImportedVault,
+                passcodeRepository = passcodeRepository,
+                defaultDispatcher = testDispatcher,
+            )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    /** Makes the picked file an archive carrying [entries]. */
+    private fun archiveOf(vararg entries: AppZipEntry) {
+        coEvery { uriFileReader.isValidZip(uri) } returns true
+        coEvery { uriFileReader.extractZipEntries(uri) } returns
+            AppZipContents(entries = entries.toList(), isComplete = true)
+    }
+
+    // ---- the recovery -------------------------------------------------------
+
+    @Test
+    fun `a restored backup asks the gate to resolve again`() = runTest {
+        model.onBackupPicked(uri)
+
+        coVerify { passcodeRepository.retry() }
+    }
+
+    /**
+     * The file name is what tells a mislabelled older DKLS backup from a GG20 one, and getting it
+     * wrong stores a vault that runs the wrong signing protocol.
+     */
+    @Test
+    fun `the backup's file name is stored with it`() = runTest {
+        model.onBackupPicked(uri)
+
+        coVerify { storeImportedVault(vault, "Main-share2of2.vult") }
+    }
+
+    /**
+     * Only the last vault's restore takes the gate down, so a restore that leaves others sealed has
+     * to say so — the screen is otherwise unchanged and would read as a button that did nothing.
+     */
+    @Test
+    fun `a restore that leaves the gate closed says what it did`() = runTest {
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.passcode_key_unavailable_restored
+    }
+
+    /** Claiming another vault still needs its backup once the gate is lifting would be false. */
+    @Test
+    fun `a restore that lifts the gate claims nothing about other vaults`() = runTest {
+        coEvery { passcodeRepository.retry() } answers
+            {
+                passcodeState.value = PasscodeState.Disabled
+            }
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.passcode_key_unavailable_message
+    }
+
+    @Test
+    fun `picking nothing leaves the screen alone`() = runTest {
+        model.onBackupPicked(null)
+
+        model.state.value shouldBe KeyshareRecoveryUiModel()
+        coVerify(exactly = 0) { storeImportedVault(any(), any()) }
+    }
+
+    // ---- multi-vault archives -----------------------------------------------
+
+    /** "Back up all vaults" writes one archive, and the gate needs a share per vault to open. */
+    @Test
+    fun `every share an archive carries is restored`() = runTest {
+        archiveOf(
+            AppZipEntry(name = "Main-share2of2.vult", content = "share-a"),
+            AppZipEntry(name = "Savings-share2of2.vult", content = "share-b"),
+        )
+
+        model.onBackupPicked(uri)
+
+        coVerify { parseVaultFromString("share-a", null) }
+        coVerify { parseVaultFromString("share-b", null) }
+        coVerify { storeImportedVault(vault, "Savings-share2of2.vult") }
+    }
+
+    /** The shares an archive holds for vaults this device never lost are duplicates by design. */
+    @Test
+    fun `an archive still counts as restored when only some of its shares are new`() = runTest {
+        archiveOf(
+            AppZipEntry(name = "Main-share2of2.vult", content = "share-a"),
+            AppZipEntry(name = "Savings-share2of2.vult", content = "share-b"),
+        )
+        coEvery { storeImportedVault(any(), "Main-share2of2.vult") } throws
+            DuplicateVaultException()
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.passcode_key_unavailable_restored
+    }
+
+    @Test
+    fun `an archive whose shares all fail reports the refusal`() = runTest {
+        archiveOf(AppZipEntry(name = "Main-share2of2.vult", content = "share-a"))
+        coEvery { storeImportedVault(any(), any()) } throws DuplicateVaultException()
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.import_file_screen_duplicate_vault
+        coVerify(exactly = 0) { passcodeRepository.retry() }
+    }
+
+    @Test
+    fun `an empty archive is reported as unsupported`() = runTest {
+        archiveOf()
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.import_file_not_supported
+    }
+
+    // ---- password-protected backups -----------------------------------------
+
+    @Test
+    fun `a backup that needs a password opens the prompt without accusing the user`() = runTest {
+        coEvery { parseVaultFromString(any(), null) } throws WrongPasswordException()
+
+        model.onBackupPicked(uri)
+
+        model.state.value.isPasswordPromptVisible shouldBe true
+        model.state.value.passwordError shouldBe null
+    }
+
+    @Test
+    fun `a wrong password keeps the prompt open and says so`() = runTest {
+        coEvery { parseVaultFromString(any(), any()) } throws WrongPasswordException()
+        model.onBackupPicked(uri)
+        model.passwordTextFieldState.setTextAndPlaceCursorAtEnd("hunter2")
+
+        model.onPasswordEntered()
+
+        model.state.value.isPasswordPromptVisible shouldBe true
+        model.state.value.passwordError shouldBe R.string.import_file_screen_password_error
+    }
+
+    @Test
+    fun `the right password restores the same file the prompt was opened for`() = runTest {
+        coEvery { parseVaultFromString(any(), null) } throws WrongPasswordException()
+        model.onBackupPicked(uri)
+        model.passwordTextFieldState.setTextAndPlaceCursorAtEnd("hunter2")
+
+        model.onPasswordEntered()
+
+        coVerify { parseVaultFromString("backup-file-content", "hunter2") }
+        model.state.value.isPasswordPromptVisible shouldBe false
+        model.state.value.message shouldBe R.string.passcode_key_unavailable_restored
+    }
+
+    /** A password typed for one backup must not be submitted against the next. */
+    @Test
+    fun `picking another backup clears the password that was typed for the last one`() = runTest {
+        coEvery { parseVaultFromString(any(), null) } throws WrongPasswordException()
+        model.onBackupPicked(uri)
+        model.passwordTextFieldState.setTextAndPlaceCursorAtEnd("hunter2")
+
+        model.onBackupPicked(uri)
+
+        model.passwordTextFieldState.text.toString() shouldBe ""
+    }
+
+    @Test
+    fun `entering a password before a backup is picked does nothing`() = runTest {
+        model.onPasswordEntered()
+
+        coVerify(exactly = 0) { parseVaultFromString(any(), any()) }
+    }
+
+    // ---- what the screen says when a backup does not work -------------------
+
+    @Test
+    fun `an unreadable file is reported as unsupported`() = runTest {
+        coEvery { uriFileReader.readContent(uri) } returns null
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.import_file_not_supported
+        coVerify(exactly = 0) { parseVaultFromString(any(), any()) }
+    }
+
+    @Test
+    fun `an empty file is reported as unsupported`() = runTest {
+        coEvery { uriFileReader.readContent(uri) } returns "   "
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.import_file_not_supported
+    }
+
+    @Test
+    fun `a malformed backup is reported as unsupported`() = runTest {
+        coEvery { parseVaultFromString(any(), any()) } throws MalformedVaultException()
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.import_file_not_supported
+        coVerify(exactly = 0) { passcodeRepository.retry() }
+    }
+
+    /** A vault the device can still open, or one already restored this session. */
+    @Test
+    fun `a backup that restores nothing this device is missing is reported as a duplicate`() =
+        runTest {
+            coEvery { storeImportedVault(any(), any()) } throws DuplicateVaultException()
+
+            model.onBackupPicked(uri)
+
+            model.state.value.message shouldBe R.string.import_file_screen_duplicate_vault
+            coVerify(exactly = 0) { passcodeRepository.retry() }
+        }
+
+    @Test
+    fun `an unexpected failure is reported without claiming anything was restored`() = runTest {
+        coEvery { storeImportedVault(any(), any()) } throws RuntimeException("db locked")
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.dialog_default_error_body
+        coVerify(exactly = 0) { passcodeRepository.retry() }
+    }
+
+    /** A failed attempt must not leave its message standing where the instruction belongs. */
+    @Test
+    fun `a new attempt clears the last one's message`() = runTest {
+        coEvery { parseVaultFromString(any(), any()) } throws MalformedVaultException()
+        model.onBackupPicked(uri)
+        coEvery { parseVaultFromString(any(), null) } throws WrongPasswordException()
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.passcode_key_unavailable_message
+    }
+
+    // ---- the retry the gate already offered ---------------------------------
+
+    @Test
+    fun `retry re-reads the keystore`() = runTest {
+        model.onRetry()
+
+        coVerify { passcodeRepository.retry() }
+    }
+
+    private companion object {
+        val vault = Vault(id = "restored-vault-id", name = "Main")
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/passcode/KeyshareRecoveryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/passcode/KeyshareRecoveryViewModelTest.kt
@@ -72,10 +72,10 @@ internal class KeyshareRecoveryViewModelTest {
     }
 
     /** Makes the picked file an archive carrying [entries]. */
-    private fun archiveOf(vararg entries: AppZipEntry) {
+    private fun archiveOf(vararg entries: AppZipEntry, isComplete: Boolean = true) {
         coEvery { uriFileReader.isValidZip(uri) } returns true
         coEvery { uriFileReader.extractZipEntries(uri) } returns
-            AppZipContents(entries = entries.toList(), isComplete = true)
+            AppZipContents(entries = entries.toList(), isComplete = isComplete)
     }
 
     // ---- the recovery -------------------------------------------------------
@@ -170,7 +170,6 @@ internal class KeyshareRecoveryViewModelTest {
         model.onBackupPicked(uri)
 
         model.state.value.message shouldBe R.string.import_file_screen_duplicate_vault
-        coVerify(exactly = 0) { passcodeRepository.retry() }
     }
 
     @Test
@@ -180,6 +179,64 @@ internal class KeyshareRecoveryViewModelTest {
         model.onBackupPicked(uri)
 
         model.state.value.message shouldBe R.string.import_file_not_supported
+    }
+
+    /** An archive that stopped part-way is not the file being unsupported. */
+    @Test
+    fun `an archive that could not be read through says so`() = runTest {
+        archiveOf(isComplete = false)
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.import_file_zip_incomplete
+    }
+
+    /**
+     * Otherwise the user is sent hunting for a backup they are already holding, when the cause is
+     * that the app stopped reading their archive.
+     */
+    @Test
+    fun `a partly read archive says so even when a share landed`() = runTest {
+        archiveOf(
+            AppZipEntry(name = "Main-share2of2.vult", content = "share-a"),
+            isComplete = false,
+        )
+
+        model.onBackupPicked(uri)
+
+        model.state.value.message shouldBe R.string.import_file_zip_incomplete
+    }
+
+    /**
+     * A store can throw after `SupersedeUnopenableVaultUseCase` has already replaced the row, so
+     * the gate is re-read whatever the outcome — otherwise it stays closed over a restored vault.
+     */
+    @Test
+    fun `the gate is re-read even when the store reports a failure`() = runTest {
+        coEvery { storeImportedVault(any(), any()) } throws RuntimeException("derivation failed")
+
+        model.onBackupPicked(uri)
+
+        coVerify { passcodeRepository.retry() }
+    }
+
+    /**
+     * The password is asked for before anything is stored, so a share needing one cannot leave the
+     * shares ahead of it stored with the screen saying nothing about them.
+     */
+    @Test
+    fun `a share needing a password stores nothing until it is given`() = runTest {
+        archiveOf(
+            AppZipEntry(name = "Main-share2of2.vult", content = "share-a"),
+            AppZipEntry(name = "Savings-share2of2.vult", content = "share-b"),
+        )
+        coEvery { parseVaultFromString("share-b", null) } throws WrongPasswordException()
+
+        model.onBackupPicked(uri)
+
+        model.state.value.isPasswordPromptVisible shouldBe true
+        coVerify(exactly = 0) { storeImportedVault(any(), any()) }
+        coVerify(exactly = 0) { passcodeRepository.retry() }
     }
 
     // ---- password-protected backups -----------------------------------------
@@ -266,7 +323,6 @@ internal class KeyshareRecoveryViewModelTest {
         model.onBackupPicked(uri)
 
         model.state.value.message shouldBe R.string.import_file_not_supported
-        coVerify(exactly = 0) { passcodeRepository.retry() }
     }
 
     /** A vault the device can still open, or one already restored this session. */
@@ -278,7 +334,6 @@ internal class KeyshareRecoveryViewModelTest {
             model.onBackupPicked(uri)
 
             model.state.value.message shouldBe R.string.import_file_screen_duplicate_vault
-            coVerify(exactly = 0) { passcodeRepository.retry() }
         }
 
     @Test
@@ -288,7 +343,6 @@ internal class KeyshareRecoveryViewModelTest {
         model.onBackupPicked(uri)
 
         model.state.value.message shouldBe R.string.dialog_default_error_body
-        coVerify(exactly = 0) { passcodeRepository.retry() }
     }
 
     /** A failed attempt must not leave its message standing where the instruction belongs. */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
@@ -35,7 +35,6 @@ interface VaultDao {
     @Query("SELECT * FROM vault")
     suspend fun loadAll(): List<VaultWithKeySharesAndTokens>
 
-    /** The vault rows alone, for callers that only compare public keys. */
     @Query("SELECT * FROM vault") suspend fun loadAllVaults(): List<VaultEntity>
 
     @Query("SELECT * FROM keyShare WHERE vaultId = :vaultId")
@@ -100,11 +99,8 @@ interface VaultDao {
     }
 
     /**
-     * Stores [vault] in place of [supersededVaultId], in one transaction.
-     *
-     * The delete cascades every row belonging to the vault it removes, keyshares included. Both
-     * statements land together or neither does, so process death part-way cannot leave the device
-     * holding neither the vault it took away nor the one that replaces it.
+     * The delete cascades the vault's keyshares, and both statements land together or neither does
+     * — so process death part-way cannot leave the device holding neither vault.
      */
     @Transaction
     suspend fun replace(supersededVaultId: String, vault: VaultWithKeySharesAndTokens) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/VaultDao.kt
@@ -35,6 +35,12 @@ interface VaultDao {
     @Query("SELECT * FROM vault")
     suspend fun loadAll(): List<VaultWithKeySharesAndTokens>
 
+    /** The vault rows alone, for callers that only compare public keys. */
+    @Query("SELECT * FROM vault") suspend fun loadAllVaults(): List<VaultEntity>
+
+    @Query("SELECT * FROM keyShare WHERE vaultId = :vaultId")
+    suspend fun loadKeyShares(vaultId: String): List<KeyShareEntity>
+
     @Transaction
     @Query("SELECT * FROM vault")
     fun loadAllAsFlow(): Flow<List<VaultWithKeySharesAndTokens>>
@@ -91,6 +97,19 @@ interface VaultDao {
         insertKeyshares(vault.keyShares)
         insertSigners(vault.signers)
         insertChainPublicKeys(vault.chainPublicKeys)
+    }
+
+    /**
+     * Stores [vault] in place of [supersededVaultId], in one transaction.
+     *
+     * The delete cascades every row belonging to the vault it removes, keyshares included. Both
+     * statements land together or neither does, so process death part-way cannot leave the device
+     * holding neither the vault it took away nor the one that replaces it.
+     */
+    @Transaction
+    suspend fun replace(supersededVaultId: String, vault: VaultWithKeySharesAndTokens) {
+        delete(supersededVaultId)
+        insert(vault)
     }
 
     @Transaction

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
@@ -69,11 +69,9 @@ interface VaultRepository {
     suspend fun upsert(vault: Vault)
 
     /**
-     * Stores [vault] and removes [supersededVaultId] as one atomic step.
-     *
-     * For a vault whose keyshares this device can no longer open, where the row has to go but only
-     * once what replaces it is provably stored — see `SupersedeUnopenableVaultUseCase`, which is
-     * the one caller and holds every guard on when that is allowed.
+     * Stores [vault] and removes [supersededVaultId] as one atomic step. Only for a vault whose
+     * keyshares this device can no longer open; `SupersedeUnopenableVaultUseCase` holds every guard
+     * on when that is allowed.
      */
     suspend fun replace(supersededVaultId: VaultId, vault: Vault)
 
@@ -148,8 +146,9 @@ constructor(
     }
 
     override suspend fun replace(supersededVaultId: VaultId, vault: Vault) {
-        // Mapped before the call: a suspend @Transaction body may only reach the DAO, and this
-        // reads the data key.
+        // Mapped out here because a suspend @Transaction body may only reach the DAO, and this
+        // reads
+        // the data key.
         vaultDao.replace(supersededVaultId, vault.toVaultDb())
     }
 
@@ -235,10 +234,9 @@ constructor(
      * the data key; the states that can never unlock leave it in the clear.
      */
     private fun protect(keyShare: String, identity: KeyShareIdentity, dataKey: ByteArray?): String {
-        // Only [KeyShareCipher.encrypt] may write the marker, and a share reaching here has already
-        // come back through decrypt. So one carrying it was supplied by a backup file, and storing
-        // it verbatim would leave the table holding ciphertext no key opens — the app-wide
-        // unreadable state, on a device that may never have had a passcode.
+        // Only the cipher writes this marker, so a share arriving with one came from a backup file.
+        // Stored verbatim it would leave ciphertext no key opens, which every later launch reads as
+        // credentials gone — on a device that may never have had a passcode.
         check(!keyShareCipher.isEncrypted(keyShare)) {
             "Refusing to store a keyshare that claims to be encrypted"
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
@@ -68,6 +68,15 @@ interface VaultRepository {
 
     suspend fun upsert(vault: Vault)
 
+    /**
+     * Stores [vault] and removes [supersededVaultId] as one atomic step.
+     *
+     * For a vault whose keyshares this device can no longer open, where the row has to go but only
+     * once what replaces it is provably stored — see `SupersedeUnopenableVaultUseCase`, which is
+     * the one caller and holds every guard on when that is allowed.
+     */
+    suspend fun replace(supersededVaultId: VaultId, vault: Vault)
+
     suspend fun setVaultName(vaultId: VaultId, name: String)
 
     suspend fun delete(vaultId: VaultId)
@@ -136,6 +145,12 @@ constructor(
 
     override suspend fun upsert(vault: Vault) {
         vaultDao.upsert(vault.toVaultDb())
+    }
+
+    override suspend fun replace(supersededVaultId: VaultId, vault: Vault) {
+        // Mapped before the call: a suspend @Transaction body may only reach the DAO, and this
+        // reads the data key.
+        vaultDao.replace(supersededVaultId, vault.toVaultDb())
     }
 
     override suspend fun setVaultName(vaultId: String, name: String) {
@@ -219,8 +234,17 @@ constructor(
      * already considers created. The next successful unlock sweeps every plaintext row back under
      * the data key; the states that can never unlock leave it in the clear.
      */
-    private fun protect(keyShare: String, identity: KeyShareIdentity, dataKey: ByteArray?): String =
-        if (dataKey != null) keyShareCipher.encrypt(keyShare, dataKey, identity) else keyShare
+    private fun protect(keyShare: String, identity: KeyShareIdentity, dataKey: ByteArray?): String {
+        // Only [KeyShareCipher.encrypt] may write the marker, and a share reaching here has already
+        // come back through decrypt. So one carrying it was supplied by a backup file, and storing
+        // it verbatim would leave the table holding ciphertext no key opens — the app-wide
+        // unreadable state, on a device that may never have had a passcode.
+        check(!keyShareCipher.isEncrypted(keyShare)) {
+            "Refusing to store a keyshare that claims to be encrypted"
+        }
+        return if (dataKey != null) keyShareCipher.encrypt(keyShare, dataKey, identity)
+        else keyShare
+    }
 
     private suspend fun VaultWithKeySharesAndTokens.toVault(): Vault {
         val vault = this

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -292,6 +292,12 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
+    fun bindSupersedeUnopenableVaultUseCase(
+        impl: SupersedeUnopenableVaultUseCaseImpl
+    ): SupersedeUnopenableVaultUseCase
+
+    @Binds
+    @Singleton
     fun bindBuildCosmosStakingKeysignPayloadUseCase(
         impl:
             com.vultisig.wallet.data.blockchain.cosmos.staking.BuildCosmosStakingKeysignPayloadUseCaseImpl

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SupersedeUnopenableVaultUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SupersedeUnopenableVaultUseCase.kt
@@ -1,0 +1,142 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.IoDispatcher
+import com.vultisig.wallet.data.db.dao.VaultDao
+import com.vultisig.wallet.data.db.models.KeyShareEntity
+import com.vultisig.wallet.data.db.models.VaultEntity
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.passcode.KeyShareCipher
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeState
+import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.repositories.order.VaultOrderRepository
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Stores a backup in place of the stored vault it restores, when that vault is one this device can
+ * no longer open.
+ *
+ * Without this the backup is refused as a duplicate and the vault is unrecoverable in the app: the
+ * orphaned row still resolves to a `Vault`, so the import's collision check finds it, and its
+ * sealed keyshares keep every launch from then on in [PasscodeState.KeyUnavailable].
+ */
+interface SupersedeUnopenableVaultUseCase {
+    /**
+     * Returns true when [backup] was stored in place of a vault, and false when nothing changed.
+     */
+    suspend operator fun invoke(backup: Vault): Boolean
+}
+
+internal class SupersedeUnopenableVaultUseCaseImpl
+@Inject
+constructor(
+    private val vaultDao: VaultDao,
+    private val vaultRepository: VaultRepository,
+    private val vaultOrderRepository: VaultOrderRepository,
+    private val lastOpenedVaultRepository: LastOpenedVaultRepository,
+    private val keyShareCipher: KeyShareCipher,
+    private val passcodeRepository: PasscodeRepository,
+    @IoDispatcher private val dispatcher: CoroutineDispatcher,
+) : SupersedeUnopenableVaultUseCase {
+
+    override suspend fun invoke(backup: Vault): Boolean =
+        withContext(dispatcher) {
+            val superseded = supersededBy(backup) ?: return@withContext false
+
+            vaultRepository.replace(superseded.id, backup)
+            // Two pointers to the row that just went, neither of them a foreign key. The ordering
+            // row would outlive it — the delete flow removes it by hand for the same reason, and
+            // the replacement is given its place in the list the way any new vault is. The
+            // last-opened id is what the home screen resolves the vault it shows from, and it is
+            // read once: left dangling, the screen behind the gate stays bound to a vault that no
+            // longer exists, and sends and swaps route with its id.
+            vaultOrderRepository.delete(parentId = null, name = superseded.id)
+            lastOpenedVaultRepository.setLastOpenedVaultId(backup.id)
+            Timber.i("Restored a vault whose keyshares this device could no longer open")
+            true
+        }
+
+    /**
+     * The one stored vault [backup] is allowed to replace, or null when there is none.
+     *
+     * This re-enables, in one bounded path, the replacement the import gate exists to refuse, so
+     * every clause below is the difference between a recovery and a loss:
+     * - **The credentials are confirmed gone, as of now.** The state is read back through
+     *   [PasscodeRepository.retry] first, so a keystore that has come back since launch resolves to
+     *   [PasscodeState.Locked] and refuses here rather than after the delete.
+     *   [PasscodeState.StoreUnavailable] never qualifies: there the wrap is most likely still on
+     *   disk and the shares open again once the keystore returns, so a replacement would destroy a
+     *   vault that was only ever unreadable for a launch. Together these stand in for the "was the
+     *   wrapped key absent" question iOS asks its keychain directly, which Android's store cannot
+     *   answer — a value it fails to decrypt reads exactly like one that was never written.
+     * - **Exactly one stored vault collides.** A backup matching two of them is a question this
+     *   cannot answer, and answering it by picking one destroys the other's key material.
+     * - **Every share of that vault is sealed, and it has at least one.** A vault with no shares
+     *   has nothing to be orphaned about, and a row still holding one in the clear is one this
+     *   device wrote after the credentials went — a vault it is keeping, not losing.
+     * - **The backup *is* that vault, not merely overlapping with it.** Matching one public key is
+     *   what makes something a duplicate; it takes every signing identity the stored row holds to
+     *   make it a replacement. An identity the backup adds is fine, one it leaves out is not.
+     * - **The backup carries a share for every key — its own and the stored row's.** An empty or
+     *   blank-filled `keyshares` list round-trips perfectly well and would buy the deletion with
+     *   nothing.
+     *
+     * Deliberately not done: nothing here parses a share to confirm its bytes really derive the
+     * public key they are filed under. That is work behind the TSS boundary, and the ordinary
+     * import path extends a backup the same trust — these clauses keep this path from extending it
+     * any further.
+     */
+    private suspend fun supersededBy(backup: Vault): VaultEntity? {
+        // Re-reads the keystore before anything is deleted rather than trusting the answer a launch
+        // hours ago got. A no-op unless the state is already one of the unreadable two.
+        passcodeRepository.retry()
+        if (passcodeRepository.state.value != PasscodeState.KeyUnavailable) return null
+
+        val stored =
+            vaultDao.loadAllVaults().filter { it.collidesWith(backup) }.singleOrNull()
+                ?: return null
+
+        val storedShares = vaultDao.loadKeyShares(stored.id)
+        if (
+            storedShares.isEmpty() || storedShares.any { !keyShareCipher.isEncrypted(it.keyShare) }
+        ) {
+            return null
+        }
+
+        val preservesEveryIdentity =
+            preserves(stored.pubKeyEcdsa, backup.pubKeyECDSA) &&
+                preserves(stored.pubKeyEddsa, backup.pubKeyEDDSA) &&
+                preserves(stored.pubKeyMldsa, backup.pubKeyMLDSA)
+
+        return stored.takeIf { preservesEveryIdentity && backup.carriesSharesFor(storedShares) }
+    }
+}
+
+/** Whether [backup] names any of the same signing identities, which no other vault can. */
+private fun VaultEntity.collidesWith(backup: Vault): Boolean =
+    pubKeyEcdsa.sameAs(backup.pubKeyECDSA) ||
+        pubKeyEddsa.sameAs(backup.pubKeyEDDSA) ||
+        pubKeyMldsa.sameAs(backup.pubKeyMLDSA)
+
+/**
+ * Whether a signing identity the stored vault holds survives the replacement unchanged. One it does
+ * not have is nothing to preserve; one it has and the backup omits or spells differently is key
+ * material the replacement would take away with the row.
+ */
+private fun preserves(stored: String, backup: String): Boolean =
+    stored.isBlank() || stored == backup
+
+/** Whether this backup carries a usable keyshare for every key it and [stored] declare. */
+private fun Vault.carriesSharesFor(stored: List<KeyShareEntity>): Boolean {
+    if (keyshares.isEmpty() || keyshares.any { it.keyShare.isBlank() }) return false
+    val carried = keyshares.mapTo(mutableSetOf()) { it.pubKey }
+    val declared = listOf(pubKeyECDSA, pubKeyEDDSA, pubKeyMLDSA).filter { it.isNotBlank() }
+    return carried.containsAll(declared) && carried.containsAll(stored.map { it.pubKey })
+}
+
+/** Public keys identify a vault only when both sides actually carry one. */
+private fun String.sameAs(other: String): Boolean = isNotBlank() && this == other

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SupersedeUnopenableVaultUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SupersedeUnopenableVaultUseCase.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.repositories.order.VaultOrderRepository
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
@@ -20,14 +21,12 @@ import timber.log.Timber
  * Stores a backup in place of the stored vault it restores, when that vault is one this device can
  * no longer open.
  *
- * Without this the backup is refused as a duplicate and the vault is unrecoverable in the app: the
- * orphaned row still resolves to a `Vault`, so the import's collision check finds it, and its
- * sealed keyshares keep every launch from then on in [PasscodeState.KeyUnavailable].
+ * Without it the backup is refused as a duplicate: the orphaned row still resolves to a `Vault`, so
+ * the import's collision check finds it, while its sealed keyshares hold every later launch in
+ * [PasscodeState.KeyUnavailable].
  */
 interface SupersedeUnopenableVaultUseCase {
-    /**
-     * Returns true when [backup] was stored in place of a vault, and false when nothing changed.
-     */
+    /** True when [backup] was stored in place of a vault, false when nothing changed. */
     suspend operator fun invoke(backup: Vault): Boolean
 }
 
@@ -48,14 +47,14 @@ constructor(
             val superseded = supersededBy(backup) ?: return@withContext false
 
             vaultRepository.replace(superseded.id, backup)
-            // Two pointers to the row that just went, neither of them a foreign key. The ordering
-            // row would outlive it — the delete flow removes it by hand for the same reason, and
-            // the replacement is given its place in the list the way any new vault is. The
-            // last-opened id is what the home screen resolves the vault it shows from, and it is
-            // read once: left dangling, the screen behind the gate stays bound to a vault that no
-            // longer exists, and sends and swaps route with its id.
-            vaultOrderRepository.delete(parentId = null, name = superseded.id)
-            lastOpenedVaultRepository.setLastOpenedVaultId(backup.id)
+            // Two pointers at the row that just went, neither of them a foreign key. Home reads the
+            // last-opened id once, so leaving it dangling keeps that screen — and the sends it
+            // routes — on a vault that is gone. The row is deleted by the time these run, so they
+            // are not the caller's to cancel.
+            withContext(NonCancellable) {
+                vaultOrderRepository.delete(parentId = null, name = superseded.id)
+                lastOpenedVaultRepository.setLastOpenedVaultId(backup.id)
+            }
             Timber.i("Restored a vault whose keyshares this device could no longer open")
             true
         }
@@ -63,36 +62,26 @@ constructor(
     /**
      * The one stored vault [backup] is allowed to replace, or null when there is none.
      *
-     * This re-enables, in one bounded path, the replacement the import gate exists to refuse, so
-     * every clause below is the difference between a recovery and a loss:
-     * - **The credentials are confirmed gone, as of now.** The state is read back through
-     *   [PasscodeRepository.retry] first, so a keystore that has come back since launch resolves to
-     *   [PasscodeState.Locked] and refuses here rather than after the delete.
-     *   [PasscodeState.StoreUnavailable] never qualifies: there the wrap is most likely still on
-     *   disk and the shares open again once the keystore returns, so a replacement would destroy a
-     *   vault that was only ever unreadable for a launch. Together these stand in for the "was the
-     *   wrapped key absent" question iOS asks its keychain directly, which Android's store cannot
-     *   answer — a value it fails to decrypt reads exactly like one that was never written.
-     * - **Exactly one stored vault collides.** A backup matching two of them is a question this
-     *   cannot answer, and answering it by picking one destroys the other's key material.
-     * - **Every share of that vault is sealed, and it has at least one.** A vault with no shares
-     *   has nothing to be orphaned about, and a row still holding one in the clear is one this
-     *   device wrote after the credentials went — a vault it is keeping, not losing.
-     * - **The backup *is* that vault, not merely overlapping with it.** Matching one public key is
-     *   what makes something a duplicate; it takes every signing identity the stored row holds to
-     *   make it a replacement. An identity the backup adds is fine, one it leaves out is not.
-     * - **The backup carries a share for every key — its own and the stored row's.** An empty or
-     *   blank-filled `keyshares` list round-trips perfectly well and would buy the deletion with
-     *   nothing.
+     * This re-enables the replacement the import gate exists to refuse, so every clause is the
+     * difference between a recovery and a loss:
+     * - Two colliding vaults is a question this cannot answer, and picking one destroys the other's
+     *   key material.
+     * - A row holding a share in the clear is one this device can still read.
+     * - Matching one public key makes a duplicate; it takes every identity the row holds to make a
+     *   replacement. An identity the backup adds is fine, one it leaves out is key material lost.
+     * - An empty or blank-filled `keyshares` list round-trips perfectly well and would buy the
+     *   deletion with nothing.
      *
-     * Deliberately not done: nothing here parses a share to confirm its bytes really derive the
-     * public key they are filed under. That is work behind the TSS boundary, and the ordinary
-     * import path extends a backup the same trust — these clauses keep this path from extending it
-     * any further.
+     * Nothing here parses a share to confirm its bytes derive the key it is filed under: that is
+     * work behind the TSS boundary, and the ordinary import path extends a backup the same trust.
      */
     private suspend fun supersededBy(backup: Vault): VaultEntity? {
-        // Re-reads the keystore before anything is deleted rather than trusting the answer a launch
-        // hours ago got. A no-op unless the state is already one of the unreadable two.
+        // Re-read before anything is deleted rather than trusting what a launch hours ago found; a
+        // keystore that has come back resolves to Locked here instead of after the row is gone.
+        // [PasscodeState.StoreUnavailable] must never qualify — there the wrap is probably still on
+        // disk. Together these stand in for the "was the wrapped key absent" question iOS asks its
+        // keychain, which this store cannot answer: a value it fails to decrypt reads like one that
+        // was never written.
         passcodeRepository.retry()
         if (passcodeRepository.state.value != PasscodeState.KeyUnavailable) return null
 
@@ -122,11 +111,7 @@ private fun VaultEntity.collidesWith(backup: Vault): Boolean =
         pubKeyEddsa.sameAs(backup.pubKeyEDDSA) ||
         pubKeyMldsa.sameAs(backup.pubKeyMLDSA)
 
-/**
- * Whether a signing identity the stored vault holds survives the replacement unchanged. One it does
- * not have is nothing to preserve; one it has and the backup omits or spells differently is key
- * material the replacement would take away with the row.
- */
+/** An identity the stored vault does not hold is nothing to preserve. */
 private fun preserves(stored: String, backup: String): Boolean =
     stored.isBlank() || stored == backup
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
@@ -184,6 +184,21 @@ internal class VaultRepositoryImplTest {
         assertEquals("Ethereum", captured.captured.coins[0].chain)
     }
 
+    // ---- replace ------------------------------------------------------------
+
+    /** Both statements have to reach the DAO as one call, or an interruption loses both vaults. */
+    @Test
+    fun `replace hands the dao one call carrying the superseded id and the replacement`() =
+        runTest {
+            val stored = slot<VaultWithKeySharesAndTokens>()
+            coJustRun { vaultDao.replace("old-id", capture(stored)) }
+
+            repository.replace("old-id", makeVault().copy(keyshares = listOf(KeyShare("p", "s"))))
+
+            assertEquals("vault-1", stored.captured.vault.id)
+            assertEquals("s", stored.captured.keyShares.single().keyShare)
+        }
+
     // ---- delete -------------------------------------------------------------
 
     /** Verifies [delete] passes the vault id to the DAO delete method. */
@@ -638,6 +653,24 @@ internal class VaultRepositoryImplTest {
         repository.upsert(makeVault().copy(keyshares = listOf(KeyShare("pub-1", "share-1"))))
 
         assertEquals("share-1", stored.captured.keyShares.single().keyShare)
+    }
+
+    /**
+     * Verifies a backup cannot smuggle in a share that claims to be encrypted.
+     *
+     * Only the cipher writes that marker, so a share carrying one came from a file. Stored as-is it
+     * would leave the table holding ciphertext no key opens, which every launch from then on reads
+     * as "the credentials are gone" — locking a device that may never have had a passcode.
+     */
+    @Test
+    fun `add refuses a keyshare that already carries the encrypted marker`() = runTest {
+        val forged = keyShareCipher.encrypt("share-1", dataKey, keyShareIdentity)
+
+        assertFailsWith<IllegalStateException> {
+            repository.add(makeVault().copy(keyshares = listOf(KeyShare("pub-1", forged))))
+        }
+
+        coVerify(exactly = 0) { vaultDao.insert(any()) }
     }
 
     /** Returns a minimal domain [Vault]. */

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SupersedeUnopenableVaultUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SupersedeUnopenableVaultUseCaseTest.kt
@@ -1,0 +1,341 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.db.dao.VaultDao
+import com.vultisig.wallet.data.db.models.KeyShareEntity
+import com.vultisig.wallet.data.db.models.VaultEntity
+import com.vultisig.wallet.data.models.KeyShare
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.passcode.KeyShareCipher
+import com.vultisig.wallet.data.passcode.KeyShareIdentity
+import com.vultisig.wallet.data.passcode.PasscodeRepository
+import com.vultisig.wallet.data.passcode.PasscodeState
+import com.vultisig.wallet.data.repositories.LastOpenedVaultRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.repositories.order.VaultOrderRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class SupersedeUnopenableVaultUseCaseTest {
+
+    private val cipher = KeyShareCipher()
+    private val dataKey = ByteArray(32) { it.toByte() }
+    private val passcodeState = MutableStateFlow<PasscodeState>(PasscodeState.KeyUnavailable)
+
+    private lateinit var vaultDao: VaultDao
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var vaultOrderRepository: VaultOrderRepository
+    private lateinit var lastOpenedVaultRepository: LastOpenedVaultRepository
+    private lateinit var passcodeRepository: PasscodeRepository
+    private lateinit var useCase: SupersedeUnopenableVaultUseCaseImpl
+
+    @BeforeEach
+    fun setUp() {
+        vaultDao = mockk(relaxUnitFun = true)
+        vaultRepository = mockk(relaxUnitFun = true)
+        vaultOrderRepository = mockk(relaxUnitFun = true)
+        lastOpenedVaultRepository = mockk(relaxUnitFun = true)
+        passcodeRepository = mockk(relaxUnitFun = true)
+        every { passcodeRepository.state } returns passcodeState
+        useCase =
+            SupersedeUnopenableVaultUseCaseImpl(
+                vaultDao = vaultDao,
+                vaultRepository = vaultRepository,
+                vaultOrderRepository = vaultOrderRepository,
+                lastOpenedVaultRepository = lastOpenedVaultRepository,
+                keyShareCipher = cipher,
+                passcodeRepository = passcodeRepository,
+                dispatcher = UnconfinedTestDispatcher(),
+            )
+    }
+
+    private fun storedVault(
+        id: String = "stored-id",
+        ecdsa: String = ECDSA,
+        eddsa: String = EDDSA,
+        mldsa: String = "",
+    ) =
+        VaultEntity(
+            id = id,
+            name = "Main",
+            localPartyID = "device-1",
+            pubKeyEcdsa = ecdsa,
+            pubKeyEddsa = eddsa,
+            pubKeyMldsa = mldsa,
+            hexChainCode = "chaincode",
+            resharePrefix = "",
+            libType = SigningLibType.DKLS,
+        )
+
+    /** A stored keyshare as the passcode sweep leaves it — sealed under a key that is now gone. */
+    private fun sealedShare(pubKey: String, vaultId: String = "stored-id") =
+        KeyShareEntity(
+            vaultId = vaultId,
+            pubKey = pubKey,
+            keyShare = cipher.encrypt("share-$pubKey", dataKey, KeyShareIdentity(vaultId, pubKey)),
+        )
+
+    private fun plaintextShare(pubKey: String, vaultId: String = "stored-id") =
+        KeyShareEntity(vaultId = vaultId, pubKey = pubKey, keyShare = "share-$pubKey")
+
+    private fun backup(
+        ecdsa: String = ECDSA,
+        eddsa: String = EDDSA,
+        mldsa: String = "",
+        sharePubKeys: List<String> = listOf(ECDSA, EDDSA),
+        shareValue: String = "restored-share",
+    ) =
+        Vault(
+            id = "fresh-uuid",
+            name = "Main",
+            pubKeyECDSA = ecdsa,
+            pubKeyEDDSA = eddsa,
+            pubKeyMLDSA = mldsa,
+            hexChainCode = "chaincode",
+            localPartyID = "device-1",
+            keyshares = sharePubKeys.map { KeyShare(pubKey = it, keyShare = shareValue) },
+        )
+
+    private fun onDevice(vaults: List<VaultEntity>, shares: List<KeyShareEntity>) {
+        coEvery { vaultDao.loadAllVaults() } returns vaults
+        vaults.forEach { vault ->
+            coEvery { vaultDao.loadKeyShares(vault.id) } returns
+                shares.filter { it.vaultId == vault.id }
+        }
+    }
+
+    // ---- the recovery this exists for ---------------------------------------
+
+    @Test
+    fun `a backup replaces the sealed vault it restores`() = runTest {
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+        val backup = backup()
+
+        useCase(backup) shouldBe true
+
+        coVerify { vaultRepository.replace("stored-id", backup) }
+        coVerify { vaultOrderRepository.delete(parentId = null, name = "stored-id") }
+        coVerify { lastOpenedVaultRepository.setLastOpenedVaultId("fresh-uuid") }
+    }
+
+    @Test
+    fun `a backup carrying more keys than the stored vault still replaces it`() = runTest {
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup(mldsa = MLDSA, sharePubKeys = listOf(ECDSA, EDDSA, MLDSA))) shouldBe true
+    }
+
+    @Test
+    fun `a backup colliding on EdDSA alone replaces the vault it restores`() = runTest {
+        onDevice(listOf(storedVault(ecdsa = "")), listOf(sealedShare(EDDSA)))
+
+        useCase(backup(ecdsa = "", sharePubKeys = listOf(EDDSA))) shouldBe true
+    }
+
+    // ---- what it must refuse ------------------------------------------------
+
+    /** The load-bearing case: a vault this device can still read is not an orphan. */
+    @Test
+    fun `a backup does not replace a vault whose shares are in the clear`() = runTest {
+        onDevice(listOf(storedVault()), listOf(plaintextShare(ECDSA), plaintextShare(EDDSA)))
+
+        useCase(backup()) shouldBe false
+
+        coVerify(exactly = 0) { vaultRepository.replace(any(), any()) }
+    }
+
+    /**
+     * A row holding one share in the clear is one this device wrote itself. Refused, not guessed.
+     */
+    @Test
+    fun `a backup does not replace a vault only some of whose shares are sealed`() = runTest {
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), plaintextShare(EDDSA)))
+
+        useCase(backup()) shouldBe false
+    }
+
+    @Test
+    fun `a backup does not replace a vault that holds no shares at all`() = runTest {
+        onDevice(listOf(storedVault()), shares = emptyList())
+
+        useCase(backup()) shouldBe false
+    }
+
+    /**
+     * A key the stored row holds and the backup leaves out is key material the replacement would
+     * take away with the row.
+     */
+    @Test
+    fun `a backup that drops a key the stored vault holds is refused`() = runTest {
+        onDevice(
+            listOf(storedVault(mldsa = MLDSA)),
+            listOf(sealedShare(ECDSA), sealedShare(EDDSA), sealedShare(MLDSA)),
+        )
+
+        // Carries a share for every key either side names, so only the dropped identity refuses it.
+        useCase(backup(mldsa = "", sharePubKeys = listOf(ECDSA, EDDSA, MLDSA))) shouldBe false
+    }
+
+    @Test
+    fun `a backup that spells a stored key differently is refused`() = runTest {
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        // Carries a share for the stored key as well as its own, so only the spelling refuses it.
+        useCase(
+            backup(eddsa = "other-eddsa", sharePubKeys = listOf(ECDSA, "other-eddsa", EDDSA))
+        ) shouldBe false
+    }
+
+    /** The stored row names no EdDSA key, so only the backup's own declaration can refuse this. */
+    @Test
+    fun `a backup declaring a key it carries no share for is refused`() = runTest {
+        onDevice(listOf(storedVault(eddsa = "")), listOf(sealedShare(ECDSA)))
+
+        useCase(backup(sharePubKeys = listOf(ECDSA))) shouldBe false
+    }
+
+    /** MLDSA is the only key either side names, so only that arm can match them up. */
+    @Test
+    fun `a backup colliding on MLDSA alone replaces the vault it restores`() = runTest {
+        onDevice(
+            listOf(storedVault(ecdsa = "", eddsa = "", mldsa = MLDSA)),
+            listOf(sealedShare(MLDSA)),
+        )
+
+        useCase(
+            backup(ecdsa = "", eddsa = "", mldsa = MLDSA, sharePubKeys = listOf(MLDSA))
+        ) shouldBe true
+    }
+
+    /** An empty share list normalises perfectly well and would buy the deletion with nothing. */
+    @Test
+    fun `a backup carrying no shares is refused`() = runTest {
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup(sharePubKeys = emptyList())) shouldBe false
+    }
+
+    @Test
+    fun `a backup carrying a blank share is refused`() = runTest {
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup(shareValue = "")) shouldBe false
+    }
+
+    @Test
+    fun `a backup missing a share for a key it declares is refused`() = runTest {
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup(sharePubKeys = listOf(ECDSA))) shouldBe false
+    }
+
+    @Test
+    fun `a backup missing a share the stored vault holds is refused`() = runTest {
+        onDevice(
+            listOf(storedVault()),
+            listOf(sealedShare(ECDSA), sealedShare(EDDSA), sealedShare(DERIVED)),
+        )
+
+        useCase(backup()) shouldBe false
+    }
+
+    /** Picking one of two would destroy the other's key material. */
+    @Test
+    fun `a backup colliding with two stored vaults is refused`() = runTest {
+        onDevice(
+            listOf(storedVault(), storedVault(id = "other-id", eddsa = "other-eddsa")),
+            listOf(sealedShare(ECDSA), sealedShare(EDDSA), sealedShare(ECDSA, "other-id")),
+        )
+
+        useCase(backup()) shouldBe false
+    }
+
+    @Test
+    fun `a backup colliding with nothing on the device is refused`() = runTest {
+        onDevice(listOf(storedVault(ecdsa = "other", eddsa = "other")), listOf(sealedShare(ECDSA)))
+
+        useCase(backup()) shouldBe false
+    }
+
+    /** Blank keys carry no identity, so two vaults lacking one are not the same vault. */
+    @Test
+    fun `a blank key does not make two vaults collide`() = runTest {
+        onDevice(listOf(storedVault(ecdsa = "", eddsa = "")), listOf(sealedShare(ECDSA)))
+
+        useCase(backup(ecdsa = "", eddsa = "")) shouldBe false
+    }
+
+    // ---- the states that must never supersede -------------------------------
+
+    /**
+     * The wrap is most likely still on disk and the shares open again once the keystore comes back,
+     * so replacing here would destroy a vault that was only ever unreadable for a launch.
+     */
+    @Test
+    fun `nothing is replaced while the credential store is merely unavailable`() = runTest {
+        passcodeState.value = PasscodeState.StoreUnavailable
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup()) shouldBe false
+
+        coVerify(exactly = 0) { vaultRepository.replace(any(), any()) }
+    }
+
+    /**
+     * The state authorising the delete is re-read first, so a keystore that has come back since
+     * launch refuses here rather than after the row is gone.
+     */
+    @Test
+    fun `nothing is replaced when the keystore comes back on the re-read`() = runTest {
+        coEvery { passcodeRepository.retry() } answers
+            {
+                passcodeState.value = PasscodeState.Locked
+            }
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup()) shouldBe false
+
+        coVerify(exactly = 0) { vaultRepository.replace(any(), any()) }
+    }
+
+    @Test
+    fun `nothing is replaced while the app is merely locked`() = runTest {
+        passcodeState.value = PasscodeState.Locked
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup()) shouldBe false
+    }
+
+    @Test
+    fun `nothing is replaced when no passcode is configured`() = runTest {
+        passcodeState.value = PasscodeState.Disabled
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup()) shouldBe false
+    }
+
+    @Test
+    fun `nothing is replaced before the passcode state has been read`() = runTest {
+        passcodeState.value = PasscodeState.Unknown
+        onDevice(listOf(storedVault()), listOf(sealedShare(ECDSA), sealedShare(EDDSA)))
+
+        useCase(backup()) shouldBe false
+    }
+
+    private companion object {
+        const val ECDSA = "ecdsa-pub-key"
+        const val EDDSA = "eddsa-pub-key"
+        const val MLDSA = "mldsa-pub-key"
+        const val DERIVED = "derived-chain-pub-key"
+    }
+}


### PR DESCRIPTION
`PasscodeState.KeyUnavailable` had no way out. The screen named the `.vult` backup as the way back but had no way to reach it, and re-importing that backup was refused as a duplicate — the orphaned row still resolves to a non-null `Vault`, so the import's collision check finds it, while its sealed keyshares hold every later launch in the same state.

The gate now shows a recovery screen whose primary action opens the file picker. It launches from inside the lock's own window rather than routing to `Route.ImportVault`, which is an ordinary `composable<>` and draws under the lock, behind its cover. Whatever the file holds — one share, or the archive "back up all vaults" writes — is stored on the spot, then the gate re-resolves. It opens once no sealed share is left, which takes a backup per vault.

`SupersedeUnopenableVaultUseCase` decides when the unopenable row may be replaced, porting iOS's `orphanedVault(collidingWith:in:)` clause for clause: the credentials are re-read and still gone (so a keystore that came back refuses before the delete, not after), exactly one stored vault collides on a public key, all of its shares are sealed, every identity it holds is declared identically by the backup, and the backup carries a share for every key either side names. `VaultDao.replace` then deletes and inserts in one `@Transaction`. The ordering row and the last-opened vault id are re-pointed with it — both name the row by id and neither is a foreign key.

Also refuses to store a keyshare that already carries the `vlpc1:` marker. Only the cipher writes it, so one arriving from a backup file would leave ciphertext no key opens, which every later launch reads as credentials gone — on a device that may never have had a passcode. The sealed-share clause reads that marker as proof, so it has to be unforgeable.

The parse-and-store half of the import moves into `StoreImportedVaultUseCase` so both screens share it, keeping the `libType` correction and the QBTC token re-add on the recovery path.

## Before / After

Same device, same vault, same state — a sealed vault whose keystore credentials were deleted.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/zYW5flD.png) | ![after](https://i.imgur.com/JW7t3rG.png) |

## Testing

- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — 4988 tests, 0 failures.
- `./gradlew :app:lintDebug :data:lintDebug`, `./gradlew ktfmtFormat`.
- End to end on an API 36 emulator: imported a `.vult`, turned on passcode encryption, deleted the keystore-backed prefs file, relaunched into `KeyUnavailable`, restored. Verified the database then holds one vault row, zero `vlpc1:` rows, no stale ordering row, and a `last_opened_vault_id` matching the row that exists. Repeated with the same backup inside a `.zip`.
- Checked the guards by mutation: disabling `preserves`, the declared-superset clause, the MLDSA collision arm, or either `fileName` seam each fails at least one test.

Closes #5623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyshare recovery from individual backup files and ZIP archives when passcode access is unavailable.
  * Added password prompts, progress indicators, retry actions, and clearer recovery error handling.
  * Improved imported-vault restoration, including legacy backup handling and token recovery.
  * Vault backups can now replace eligible unreadable vaults while preserving supported data.

* **Improvements**
  * Added localized recovery messaging across supported languages.
  * Prevented invalid encrypted keyshares from being stored.
  * Added loading states to error-screen actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->