### PR TITLE
fix(defi): drop the inner bevel that drew a line across action buttons

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -33,16 +33,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.RoundRect
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.res.painterResource
@@ -131,44 +124,6 @@ private val HIDE_BALANCE_CHARS = "• ".repeat(8).trim()
  * hidden outright, which looked identical to the value having been dropped.
  */
 internal const val FIAT_VALUE_UNAVAILABLE = "—"
-
-private val ActionButtonBevelTopColor = Color.White.copy(alpha = 0.10f)
-private val ActionButtonBevelBottomColor = Color(0xFF0F1C3E)
-
-/**
- * Draws a 1dp top highlight and a 1dp bottom shadow inset on a pill-shaped button to match the
- * Figma `DeFi Button` bevel spec. Applies a 0.5 alpha multiplier when [enabled] is `false` so the
- * bevel dims with the rest of the disabled-state styling.
- */
-private fun Modifier.actionButtonInnerBevel(enabled: Boolean): Modifier = drawWithContent {
-    drawContent()
-    val alphaMultiplier = if (enabled) 1f else 0.5f
-    val strokePx = 1.dp.toPx()
-    val path =
-        Path().apply {
-            addRoundRect(
-                RoundRect(
-                    rect = Rect(offset = Offset.Zero, size = size),
-                    cornerRadius = CornerRadius(size.height / 2f),
-                )
-            )
-        }
-    clipPath(path) {
-        drawRect(
-            color =
-                ActionButtonBevelTopColor.copy(
-                    alpha = ActionButtonBevelTopColor.alpha * alphaMultiplier
-                ),
-            topLeft = Offset.Zero,
-            size = Size(size.width, strokePx),
-        )
-        drawRect(
-            color = ActionButtonBevelBottomColor.copy(alpha = alphaMultiplier),
-            topLeft = Offset(0f, size.height - strokePx),
-            size = Size(size.width, strokePx),
-        )
-    }
-}
 
 @Preview(showBackground = true, name = "Balance Banner - With Value")
 @Composable
@@ -308,7 +263,7 @@ fun ActionButton(
             },
         shape = Theme.v2.radius.pill,
         contentPadding = PaddingValues(horizontal = 4.dp, vertical = 6.dp),
-        modifier = modifier.height(42.dp).actionButtonInnerBevel(enabled = enabled),
+        modifier = modifier.height(42.dp),
     ) {
         // Figma docks the icon to the button's leading edge while the label stays centered across
         // the full width, so the icon is absolutely positioned and the text is centered on top.

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronFreezePositionCard.kt
@@ -22,17 +22,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.geometry.CornerRadius
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.geometry.RoundRect
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -46,43 +37,6 @@ import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.theme.Theme
 
 private val TronFreezeCardIconCircleColor = Color.White.copy(alpha = 0.12f)
-private val TronFreezeButtonBevelTopColor = Color.White.copy(alpha = 0.10f)
-private val TronFreezeButtonBevelBottomColor = Color(0xFF0F1C3E)
-
-/**
- * Strokes the pill perimeter with a vertical gradient (highlight → transparent → shadow) so the
- * bevel reads as a soft top shine fading to a dark bottom edge, matching Figma `inset` shadows `0
- * 1px 1px 0 rgba(255,255,255,0.10)` and `0 -1px 0.5px 0 #0F1C3E` without hard clip seams on the
- * side curves.
- */
-private fun Modifier.tronFreezeButtonBevel(enabled: Boolean): Modifier = drawWithContent {
-    drawContent()
-    val alphaMultiplier = if (enabled) 1f else 0.5f
-    val strokePx = 1.dp.toPx()
-    val cornerRadius = CornerRadius(size.height / 2f)
-    val shapePath = Path().apply { addRoundRect(RoundRect(Rect(Offset.Zero, size), cornerRadius)) }
-    val bevelBrush =
-        Brush.verticalGradient(
-            colorStops =
-                arrayOf(
-                    0f to
-                        TronFreezeButtonBevelTopColor.copy(
-                            alpha = TronFreezeButtonBevelTopColor.alpha * alphaMultiplier
-                        ),
-                    0.5f to Color.Transparent,
-                    1f to TronFreezeButtonBevelBottomColor.copy(alpha = alphaMultiplier),
-                )
-        )
-    clipPath(shapePath) {
-        drawRoundRect(
-            brush = bevelBrush,
-            topLeft = Offset.Zero,
-            size = size,
-            cornerRadius = cornerRadius,
-            style = Stroke(width = strokePx * 2f),
-        )
-    }
-}
 
 /**
  * Card showing frozen TRX balance with Freeze/Unfreeze actions; shows placeholders and disables
@@ -238,7 +192,7 @@ private fun TronFreezeActionButton(
         border = resolvedBorder,
         shape = Theme.v2.radius.pill,
         contentPadding = PaddingValues(start = 4.dp, top = 6.dp, end = 16.dp, bottom = 6.dp),
-        modifier = modifier.height(46.dp).tronFreezeButtonBevel(enabled = enabled),
+        modifier = modifier.height(46.dp),
     ) {
         Box(
             modifier =


### PR DESCRIPTION
## Summary

Every DeFi action button had a horizontal line drawn through it.

The cause was `Modifier.actionButtonInnerBevel` in `DeFiComponents.kt`: it painted a 1dp white-10% strip along the button's top edge and a 1dp `#0F1C3E` strip along the bottom, clipped to the pill. Across the flat top and bottom of the pill those strips run edge to edge, so they read as a stray line drawn through the button rather than as a bevel.

- Removed the bevel from `ActionButton` — Kamino Withdraw/Deposit, Bond/Unbond, and every other DeFi action button.
- Removed the same effect from the Tron Freeze/Unfreeze buttons (`tronFreezeButtonBevel`), where it was drawn as a gradient perimeter stroke, so the DeFi buttons stay consistent.
- Dropped the now-unused colour constants and imports in both files.

No layout, size, colour, or border change — only the overlay strips are gone.

## Before / After

Solana DeFi — Earn tab (the reported case: Withdraw / Deposit)

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/b3Dnnwv.png) | ![after](https://i.imgur.com/MObXxgT.png) |

## Test plan

- [x] `:app:compileDebugKotlin` passes
- [x] Real Android renders on emulator (API 33) via `PreviewActivity`, before and after, for the three Solana DeFi previews above
- [ ] Tron DeFi positions screen — Freeze/Unfreeze buttons render without the line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified DeFi action button visuals by removing custom bevel effects.
  * Simplified Tron freeze action button visuals by removing gradient bevel effects.
  * Preserved existing button sizing, behavior, and remaining styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->