### PR TITLE
THORChain LP: surface pending half-deposits, show both remove legs

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -112,6 +112,9 @@ import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingPositionsUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyUiState
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyValidatorRow
+import com.vultisig.wallet.ui.models.defi.LpTabUiModel
+import com.vultisig.wallet.ui.models.defi.PendingLpDepositUiModel
+import com.vultisig.wallet.ui.models.defi.ThorchainDefiPositionsUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
 import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
@@ -222,11 +225,13 @@ import com.vultisig.wallet.ui.screens.transaction.toUiTransactionInfo
 import com.vultisig.wallet.ui.screens.v2.chaintokens.ChainTokensScreen
 import com.vultisig.wallet.ui.screens.v2.defi.DeFiTab
 import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
+import com.vultisig.wallet.ui.screens.v2.defi.maya.RemoveLpScreenContent
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoAmountContent
 import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnRow
 import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnUiModel
 import com.vultisig.wallet.ui.screens.v2.defi.solana.SolanaStakingPositionsContent
+import com.vultisig.wallet.ui.screens.v2.defi.thorchain.ThorchainDefiPositionScreenContent
 import com.vultisig.wallet.ui.screens.v2.home.components.AccountList
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionButton
@@ -242,6 +247,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
 import java.math.BigDecimal
+import java.math.BigInteger
 import kotlin.math.sin
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.delay
@@ -296,6 +302,49 @@ class PreviewActivity : ComponentActivity() {
                                     error = PasscodeLockError.Wrong(remainingAttempts = 2)
                                 ),
                             textFieldState = TextFieldState(),
+                        )
+                    "remove_thor_lp" ->
+                        RemoveLpScreenContent(
+                            state =
+                                DepositFormUiModel(
+                                    removeLpPercent = 0.92f,
+                                    removeLpCacaoDisplay = "1.84",
+                                    removeLpTokenSymbol = "RUNE",
+                                    removeLpAssetDisplay = "0.07149251",
+                                    removeLpAssetSymbol = "VVV",
+                                    availableLpUnits = "1000",
+                                    removeLpUnitsDivisor = BigInteger("1000"),
+                                    balance = UiText.DynamicString("2.083 RUNE"),
+                                )
+                        )
+                    "thor_lp_pending" ->
+                        ThorchainDefiPositionScreenContent(
+                            state =
+                                ThorchainDefiPositionsUiModel(
+                                    totalAmountPrice = "$1,204.55",
+                                    isTotalAmountLoading = false,
+                                    selectedTab = R.string.defi_tab_lp,
+                                    lpDialogLoaded = true,
+                                    selectedPositions = emptyList(),
+                                    lp =
+                                        LpTabUiModel(
+                                            pendingDeposits =
+                                                listOf(
+                                                    PendingLpDepositUiModel(
+                                                        poolId = "BASE.VVV",
+                                                        icon = R.drawable.base,
+                                                        chainLogo = R.drawable.base,
+                                                        awaitedTicker = "VVV",
+                                                        depositedAmount = "2 RUNE",
+                                                        pairedAddress = "0x14F6…89B6",
+                                                        refundsIn = UiText.DynamicString("21h 14m"),
+                                                    )
+                                                )
+                                        ),
+                                ),
+                            onClickBondToNode = {},
+                            onClickUnbond = {},
+                            onClickBond = {},
                         )
                     "limit_swap_form" -> LimitSwapFormPreview()
                     "limit_swap_form_assets" ->

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
@@ -51,6 +51,32 @@ internal data class StakingTabUiModel(val positions: List<StakePositionUiModel> 
 internal data class LpTabUiModel(
     val isLoading: Boolean = false,
     val positions: List<LpPositionUiModel> = emptyList(),
+    /**
+     * Half-finished symmetric adds, listed above the positions. They are deliberately not gated on
+     * the pool being selected in the Manage-Positions dialog: a deposit the user cannot see is the
+     * one that silently gets refunded.
+     */
+    val pendingDeposits: List<PendingLpDepositUiModel> = emptyList(),
+)
+
+/**
+ * A symmetric add-liquidity that THORChain is still holding because only one side has arrived.
+ * Mirrors [com.vultisig.wallet.data.models.ThorChainPendingLpDeposit] for display.
+ */
+internal data class PendingLpDepositUiModel(
+    val poolId: String,
+    val icon: ImageModel,
+    val chainLogo: Int? = null,
+    /** Ticker of the side still missing — the one the user has to send to complete the add. */
+    val awaitedTicker: String,
+    /** What already arrived, e.g. `"2 RUNE"`. */
+    val depositedAmount: String,
+    /** Address the missing side must be sent from, shortened for display. */
+    val pairedAddress: String?,
+    /** Time left before THORChain refunds the deposit, or `null` when it could not be resolved. */
+    val refundsIn: UiText?,
+    /** False when the missing side is on a chain this vault has no account for. */
+    val canComplete: Boolean = true,
 )
 
 internal data class LpPositionUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
@@ -57,6 +57,12 @@ internal data class LpTabUiModel(
      * one that silently gets refunded.
      */
     val pendingDeposits: List<PendingLpDepositUiModel> = emptyList(),
+    /**
+     * Flips true once the pending scan settles, success or failure. An empty [pendingDeposits] is
+     * only meaningful after that: before it, "no pending deposits" is indistinguishable from "not
+     * asked yet", and the tab would flash its no-positions state at the one user who has to act.
+     */
+    val pendingDepositsLoaded: Boolean = false,
 )
 
 /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -17,6 +17,8 @@ import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.data.models.ThorChainLpPosition
+import com.vultisig.wallet.data.models.ThorChainPendingLpDeposit
+import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.data.models.coinType
 import com.vultisig.wallet.data.models.getCoinLogo
@@ -30,6 +32,7 @@ import com.vultisig.wallet.data.repositories.DefiPositionsRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionsUseCase
+import com.vultisig.wallet.data.usecases.GetThorChainPendingLpDepositsUseCase
 import com.vultisig.wallet.data.usecases.ThorchainBondUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.data.utils.toValue
@@ -55,6 +58,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.thorchainSupportStakingDeFi
 import com.vultisig.wallet.ui.screens.v2.defi.toUiModel
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.formatTokenAmount
+import com.vultisig.wallet.ui.utils.lpRefundsInUiText
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -133,6 +137,7 @@ constructor(
     private val defaultStakingPositionService: DefaultStakingPositionService,
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val getThorChainLpPositionsUseCase: GetThorChainLpPositionsUseCase,
+    private val getThorChainPendingLpDepositsUseCase: GetThorChainPendingLpDepositsUseCase,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -173,6 +178,7 @@ constructor(
     private var currencyJob: Job? = null
     private var lpDialogJob: Job? = null
     private var loadLpJob: Job? = null
+    private var loadPendingLpJob: Job? = null
     private var loadBondedNodesJob: Job? = null
     private var loadStakingPositionsJob: Job? = null
 
@@ -489,7 +495,89 @@ constructor(
             loadStakingPositions()
 
             reloadLpTab()
+
+            loadPendingLpDeposits()
         }
+    }
+
+    /**
+     * Loads half-finished symmetric adds. Deliberately independent of [reloadLpTab]: those are
+     * gated on the pools the user picked in Manage Positions, and a deposit stuck in a pool they
+     * never selected is exactly the one that would otherwise be refunded unseen.
+     */
+    private fun loadPendingLpDeposits() {
+        loadPendingLpJob?.cancel()
+        loadPendingLpJob =
+            viewModelScope.launch {
+                try {
+                    val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
+                    val runeCoin =
+                        vault?.coins?.find { it.ticker == "RUNE" && it.chain == Chain.ThorChain }
+                            ?: return@launch
+
+                    val pending =
+                        withContext(ioDispatcher) {
+                            getThorChainPendingLpDepositsUseCase(
+                                runeAddress = runeCoin.address,
+                                resolveAssetAddress = { poolId ->
+                                    vault.assetAddressForPool(poolId)
+                                },
+                            )
+                        }
+
+                    val models = pending.map { it.toUiModel(vault.assetAddressForPool(it.pool)) }
+                    state.update { it.copy(lp = it.lp.copy(pendingDeposits = models)) }
+                } catch (e: Throwable) {
+                    if (e is CancellationException) throw e
+                    Timber.e(e, "Failed to load pending THORChain LP deposits")
+                }
+            }
+    }
+
+    private fun String.shortenForDisplay(): String =
+        if (length > 12) "${take(6)}…${takeLast(4)}" else this
+
+    /** The vault's address on a pool's non-RUNE chain, or `null` when it holds no account there. */
+    private fun Vault.assetAddressForPool(poolId: String): String? {
+        val assetChain = parseThorChainPool(poolId).chain ?: return null
+        if (assetChain == Chain.ThorChain) return null
+        val coin =
+            coins.firstOrNull { it.chain == assetChain && it.isNativeToken }
+                ?: coins.firstOrNull { it.chain == assetChain }
+        return coin?.address
+    }
+
+    private fun ThorChainPendingLpDeposit.toUiModel(
+        assetAddress: String?
+    ): PendingLpDepositUiModel {
+        val parsed = parseThorChainPool(pool)
+        val assetTicker = parsed.ticker
+        val runeTicker = Coins.ThorChain.RUNE.ticker
+        val depositedAmount =
+            if (isRunePending) {
+                CoinType.THORCHAIN.toValue(pendingRune)
+                    .stripTrailingZeros()
+                    .formatTokenAmount(runeTicker)
+            } else {
+                CoinType.THORCHAIN.toValue(pendingAsset)
+                    .stripTrailingZeros()
+                    .formatTokenAmount(assetTicker)
+            }
+
+        return PendingLpDepositUiModel(
+            poolId = pool,
+            icon =
+                lpAssetLogoRes(parsed.chain, assetTicker, parsed.contractAddress)
+                    ?: getCoinLogo(assetTicker.lowercase()),
+            chainLogo = parsed.chain?.monoToneLogo,
+            awaitedTicker = if (isRunePending) assetTicker else runeTicker,
+            depositedAmount = depositedAmount,
+            pairedAddress = pairedAddress?.shortenForDisplay(),
+            refundsIn = blocksUntilRefund?.let { lpRefundsInUiText(it * THORCHAIN_BLOCK_SECONDS) },
+            // Completing means sending the missing side, which needs an account on its chain. When
+            // RUNE is the missing half the vault always has one.
+            canComplete = !isRunePending || assetAddress != null,
+        )
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -1235,6 +1323,29 @@ constructor(
         }
     }
 
+    /**
+     * Sends the user into the deposit flow for the half they still owe, on that half's own chain,
+     * with the pool pre-selected. The memo the flow builds is what THORChain matches against the
+     * pending record, so this completes the add rather than opening a second one.
+     */
+    fun onClickCompletePendingLp(poolId: String) {
+        val pending = state.value.lp.pendingDeposits.find { it.poolId == poolId } ?: return
+        val missingSideChain =
+            if (pending.awaitedTicker == Coins.ThorChain.RUNE.ticker) Chain.ThorChain
+            else parseThorChainPool(poolId).chain ?: return
+
+        viewModelScope.safeLaunch {
+            navigator.route(
+                Route.Deposit(
+                    vaultId = vaultId,
+                    chainId = missingSideChain.id,
+                    depositType = DeFiNavActions.ADD_LP.type,
+                    poolId = poolId,
+                )
+            )
+        }
+    }
+
     fun onClickRemoveLp(poolId: String) {
         viewModelScope.safeLaunch {
             navigator.route(
@@ -1451,6 +1562,7 @@ constructor(
         private const val RUJI_SYMBOL = "RUJI"
         private const val RUJI_REWARDS_SYMBOL = "USDC"
         private const val POSITION_DISPLAY_SCALE = 4
+        private const val THORCHAIN_BLOCK_SECONDS = 6L
 
         /**
          * The Manage-Positions key a placeholder is gated on. Both RUJI positions are toggled by

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -550,11 +550,27 @@ constructor(
     }
 
     /**
-     * Marks the scan as settled without touching [LpTabUiModel.pendingDeposits]. A failed reload
-     * must not erase a list an earlier one found — the refund timer is still running on it.
+     * Marks the scan as settled without erasing [LpTabUiModel.pendingDeposits]: a failed reload
+     * must still show a list an earlier one found, because the refund timer is running on it and
+     * the user needs to know. Completion is withdrawn instead — the whole point of re-scanning is
+     * that THORChain may already have refunded the deposit, and nothing downstream re-checks:
+     * onClickCompletePendingLp reads this list directly, and the add-liquidity preflight only asks
+     * about pool-wide pause and status, never about this record. A card the scan could not confirm
+     * therefore stays visible but cannot spend inbound gas on a dead deposit.
      */
     private fun markPendingLpDepositsSettled() {
-        state.update { it.copy(lp = it.lp.copy(pendingDepositsLoaded = true)) }
+        state.update {
+            it.copy(
+                lp =
+                    it.lp.copy(
+                        pendingDeposits =
+                            it.lp.pendingDeposits.map { deposit ->
+                                deposit.copy(canComplete = false)
+                            },
+                        pendingDepositsLoaded = true,
+                    )
+            )
+        }
     }
 
     /**
@@ -1362,6 +1378,9 @@ constructor(
      */
     fun onClickCompletePendingLp(poolId: String) {
         val pending = state.value.lp.pendingDeposits.find { it.poolId == poolId } ?: return
+        // Also enforced by the card's disabled button; held here too so a card the last scan
+        // could not confirm can never route into a deposit, whatever the UI does.
+        if (!pending.canComplete) return
         val missingSideChain =
             if (pending.awaitedTicker == Coins.ThorChain.RUNE.ticker) Chain.ThorChain
             else parseThorChainPool(poolId).chain ?: return

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -508,29 +508,24 @@ constructor(
     private fun loadPendingLpDeposits() {
         loadPendingLpJob?.cancel()
         loadPendingLpJob =
-            viewModelScope.launch {
-                try {
-                    val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
-                    val runeCoin =
-                        vault?.coins?.find { it.ticker == "RUNE" && it.chain == Chain.ThorChain }
-                            ?: return@launch
+            viewModelScope.safeLaunch(
+                onError = { Timber.e(it, "Failed to load pending THORChain LP deposits") }
+            ) {
+                val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
+                val runeCoin =
+                    vault?.coins?.find { it.ticker == "RUNE" && it.chain == Chain.ThorChain }
+                        ?: return@safeLaunch
 
-                    val pending =
-                        withContext(ioDispatcher) {
-                            getThorChainPendingLpDepositsUseCase(
-                                runeAddress = runeCoin.address,
-                                resolveAssetAddress = { poolId ->
-                                    vault.assetAddressForPool(poolId)
-                                },
-                            )
-                        }
+                val pending =
+                    withContext(ioDispatcher) {
+                        getThorChainPendingLpDepositsUseCase(
+                            runeAddress = runeCoin.address,
+                            resolveAssetAddress = { poolId -> vault.assetAddressForPool(poolId) },
+                        )
+                    }
 
-                    val models = pending.map { it.toUiModel(vault.assetAddressForPool(it.pool)) }
-                    state.update { it.copy(lp = it.lp.copy(pendingDeposits = models)) }
-                } catch (e: Throwable) {
-                    if (e is CancellationException) throw e
-                    Timber.e(e, "Failed to load pending THORChain LP deposits")
-                }
+                val models = pending.map { it.toUiModel(vault.assetAddressForPool(it.pool)) }
+                state.update { it.copy(lp = it.lp.copy(pendingDeposits = models)) }
             }
     }
 
@@ -1081,7 +1076,7 @@ constructor(
 
         if (selectedPools.isEmpty()) {
             loadLpJob?.cancel()
-            state.update { it.copy(lp = LpTabUiModel(isLoading = false, positions = emptyList())) }
+            state.update { it.copy(lp = it.lp.copy(isLoading = false, positions = emptyList())) }
             loadLpJob = viewModelScope.launch { reportLpFiat(BigDecimal.ZERO) }
             return
         }
@@ -1099,7 +1094,7 @@ constructor(
                 // has no liquidity yet should be visible so the Add button is reachable.
                 val placeholders = selectedPools.map { it.toPlaceholderUiModel(zero) }
                 state.update {
-                    it.copy(lp = LpTabUiModel(isLoading = true, positions = placeholders))
+                    it.copy(lp = it.lp.copy(isLoading = true, positions = placeholders))
                 }
 
                 try {
@@ -1114,7 +1109,7 @@ constructor(
                         Timber.e("Vault does not have RUNE coin for LP positions")
                         reportLpFiat(BigDecimal.ZERO)
                         state.update {
-                            it.copy(lp = LpTabUiModel(isLoading = false, positions = placeholders))
+                            it.copy(lp = it.lp.copy(isLoading = false, positions = placeholders))
                         }
                         return@launch
                     }
@@ -1186,15 +1181,13 @@ constructor(
                             // understate the header total rather than admit a value is missing.
                             LpLegTotal.Unavailable
                         }
-                    state.update {
-                        it.copy(lp = LpTabUiModel(isLoading = false, positions = merged))
-                    }
+                    state.update { it.copy(lp = it.lp.copy(isLoading = false, positions = merged)) }
                 } catch (e: Throwable) {
                     if (e is CancellationException) throw e
                     Timber.e(e, "Failed to load THORChain LP positions")
                     reportLpFiat(BigDecimal.ZERO)
                     state.update {
-                        it.copy(lp = LpTabUiModel(isLoading = false, positions = placeholders))
+                        it.copy(lp = it.lp.copy(isLoading = false, positions = placeholders))
                     }
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -104,9 +104,11 @@ internal data class ThorchainDefiPositionsUiModel(
     val bondPositionsDialog: List<PositionUiModelDialog> = defaultPositionsBondDialog(),
     val stakingPositionsDialog: List<PositionUiModelDialog> = defaultPositionsStakingDialog(),
     val lpPositionsDialog: List<PositionUiModelDialog> = emptyList(),
-    // Flips true once the available-pools fetch returns. Until then the LP tab should stay in
-    // loading state instead of flashing the empty/no-positions UI when the user has selected
-    // positions whose keys don't yet match the (empty) dialog list.
+    // Flips true once the available-pools fetch settles, success or failure. Until then the LP tab
+    // should stay in loading state instead of flashing the empty/no-positions UI when the user has
+    // selected positions whose keys don't yet match the (empty) dialog list. A failed fetch settles
+    // too: an unclearable spinner is worse than the no-positions container, which at least carries
+    // the Manage Positions retry.
     val lpDialogLoaded: Boolean = false,
     val selectedPositions: List<String> = defaultSelectedPositionsDialog(),
     val tempSelectedPositions: List<String> = defaultSelectedPositionsDialog(),
@@ -219,10 +221,14 @@ constructor(
                 Timber.e(e, "Failed to load THORChain LP pools for dialog")
                 // Leave availablePools null so the next user interaction (e.g. opening Manage
                 // Positions or saving a selection) retries instead of soft-locking.
-                // The tab deliberately stays in its loading state (see above), but the header total
-                // is a separate concern: reloadLpTab parks the LP leg unreported while it waits for
-                // this dataset, so report it as zero here or the total would never see all five
-                // legs and would spin forever.
+                // lpDialogLoaded means "settled", not "succeeded": leaving it false parks the tab
+                // in a spinner that nothing can ever clear, while any pending half-deposit still
+                // renders through it. Settling drops the tab to its no-positions container, whose
+                // Manage Positions button is the retry, and lets a pending card stand on its own.
+                state.update { it.copy(lpDialogLoaded = true) }
+                // The header total is a separate concern: reloadLpTab parks the LP leg unreported
+                // while it waits for this dataset, so report it as zero here or the total would
+                // never see all five legs and would spin forever.
                 reportLpFiat(BigDecimal.ZERO)
             }
         }
@@ -509,24 +515,48 @@ constructor(
         loadPendingLpJob?.cancel()
         loadPendingLpJob =
             viewModelScope.safeLaunch(
-                onError = { Timber.e(it, "Failed to load pending THORChain LP deposits") }
+                onError = {
+                    Timber.e(it, "Failed to load pending THORChain LP deposits")
+                    markPendingLpDepositsSettled()
+                }
             ) {
                 val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
                 val runeCoin =
                     vault?.coins?.find { it.ticker == "RUNE" && it.chain == Chain.ThorChain }
-                        ?: return@safeLaunch
+                if (runeCoin == null) {
+                    markPendingLpDepositsSettled()
+                    return@safeLaunch
+                }
 
                 val pending =
                     withContext(ioDispatcher) {
-                        getThorChainPendingLpDepositsUseCase(
-                            runeAddress = runeCoin.address,
-                            resolveAssetAddress = { poolId -> vault.assetAddressForPool(poolId) },
-                        )
+                        getThorChainPendingLpDepositsUseCase(runeAddress = runeCoin.address)
                     }
 
                 val models = pending.map { it.toUiModel(vault.assetAddressForPool(it.pool)) }
-                state.update { it.copy(lp = it.lp.copy(pendingDeposits = models)) }
+                state.update {
+                    it.copy(lp = it.lp.copy(pendingDeposits = models, pendingDepositsLoaded = true))
+                }
             }
+    }
+
+    /**
+     * Marks the scan as settled without touching [LpTabUiModel.pendingDeposits]. A failed reload
+     * must not erase a list an earlier one found — the refund timer is still running on it.
+     */
+    private fun markPendingLpDepositsSettled() {
+        state.update { it.copy(lp = it.lp.copy(pendingDepositsLoaded = true)) }
+    }
+
+    /**
+     * Re-scans for pending half-deposits when the screen comes back to the foreground. They sit on
+     * a refund timer that keeps running while the app is backgrounded, so a stale list can offer
+     * Complete Deposit on a deposit THORChain has already refunded. Positions are left to
+     * pull-to-refresh; only this leg goes stale on its own.
+     */
+    fun onScreenResumed() {
+        if (!::vaultId.isInitialized) return
+        loadPendingLpDeposits()
     }
 
     private fun String.shortenForDisplay(): String =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -614,13 +614,20 @@ constructor(
                     .formatTokenAmount(assetTicker)
             }
 
+        // The card is about the side that has not arrived — its title names that ticker — so the
+        // icon and chain badge have to follow it. Pinning them to the pool's asset put an ETH logo
+        // next to "Waiting for matching RUNE deposit".
+        val awaitedChain = if (isRunePending) parsed.chain else Chain.ThorChain
+        val awaitedTicker = if (isRunePending) assetTicker else runeTicker
+        val awaitedContractAddress = if (isRunePending) parsed.contractAddress else ""
+
         return PendingLpDepositUiModel(
             poolId = pool,
             icon =
-                lpAssetLogoRes(parsed.chain, assetTicker, parsed.contractAddress)
-                    ?: getCoinLogo(assetTicker.lowercase()),
-            chainLogo = parsed.chain?.monoToneLogo,
-            awaitedTicker = if (isRunePending) assetTicker else runeTicker,
+                lpAssetLogoRes(awaitedChain, awaitedTicker, awaitedContractAddress)
+                    ?: getCoinLogo(awaitedTicker.lowercase()),
+            chainLogo = awaitedChain?.monoToneLogo,
+            awaitedTicker = awaitedTicker,
             depositedAmount = depositedAmount,
             pairedAddress = pairedAddress?.shortenForDisplay(),
             refundsIn = blocksUntilRefund?.let { lpRefundsInUiText(it * THORCHAIN_BLOCK_SECONDS) },

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -513,6 +513,15 @@ constructor(
      */
     private fun loadPendingLpDeposits() {
         loadPendingLpJob?.cancel()
+        // Re-arm the gate only when there is a list that could now be wrong. A deposit found before
+        // the app was backgrounded may already have been refunded, and Complete Deposit on a
+        // refunded one just burns inbound gas — so hide it behind the spinner until this scan
+        // confirms it. With nothing pending there is nothing to invalidate, and re-arming would
+        // flash the whole tab to a spinner on every resume for the users who have no half-deposit
+        // at all.
+        if (state.value.lp.pendingDeposits.isNotEmpty()) {
+            state.update { it.copy(lp = it.lp.copy(pendingDepositsLoaded = false)) }
+        }
         loadPendingLpJob =
             viewModelScope.safeLaunch(
                 onError = {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -559,23 +559,30 @@ constructor(
     }
 
     /**
-     * For symmetric LP add the memo carries the user's address on the *paired* chain so THORChain
-     * can credit them when the asset half is later deposited from that chain. Returns null when the
-     * pool refers to the native chain (no pair) or when the asset chain can't be resolved.
+     * The vault's address on the *other* half of [poolId], as seen from the half being deposited
+     * from [chain]. A RUNE-side add names the asset address; the asset-side add that completes a
+     * pending half-deposit names the RUNE address. Either way THORChain needs both to match the two
+     * inbounds into one symmetric position instead of opening a second, asymmetric one.
+     *
+     * Returns `null` for a RUNE-only pool, which has no paired side, and for a [chain] belonging to
+     * neither half — callers treat that as "cannot build this memo".
      */
     private suspend fun resolvePairedAddress(
         chain: Chain,
         vaultId: String,
         poolId: String,
     ): String? {
-        if (chain != Chain.ThorChain) return null
-        val parsed =
-            parseThorChainPool(poolId).takeIf { it.chain != null && it.chain != Chain.ThorChain }
-                ?: return null
-        val assetChain = parsed.chain ?: return null
+        val assetChain =
+            parseThorChainPool(poolId).chain?.takeIf { it != Chain.ThorChain } ?: return null
+        val pairedChain =
+            when (chain) {
+                Chain.ThorChain -> assetChain
+                assetChain -> Chain.ThorChain
+                else -> return null
+            }
         return try {
             val vault = vaultRepository.get(vaultId) ?: return null
-            chainAccountAddressRepository.getAddress(chain = assetChain, vault = vault).first
+            chainAccountAddressRepository.getAddress(chain = pairedChain, vault = vault).first
         } catch (e: Throwable) {
             if (e is CancellationException) throw e
             Timber.e(e, "Failed to resolve paired address for $poolId")

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -134,6 +134,14 @@ internal data class DepositFormUiModel(
     // and the on-chain memo in sync at sub-percent granularity.
     val removeLpBasisPoints: Int = 0,
     val removeLpCacaoDisplay: String = "",
+    // THORChain remove-LP withdraws both sides of the pool, so the form shows the asset leg
+    // alongside the RUNE one. Maya's CACAO pools are single-sided here and leave these empty,
+    // which is what hides the second leg on that flow.
+    val removeLpAssetDisplay: String = "",
+    val removeLpAssetSymbol: String = "",
+    // The user's full asset-side redeem value (base units), scaled by the slider the same way
+    // removeLpPoolDepth is for the RUNE side.
+    val removeLpAssetRedeemBase: BigInteger = BigInteger.ZERO,
 )
 
 @HiltViewModel

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/RemoveLpCalculator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/RemoveLpCalculator.kt
@@ -10,9 +10,9 @@ internal object RemoveLpCalculator {
     const val RUNE_DECIMALS = 8
     const val DISPLAY_SCALE = 3
     // Precision kept on `userUnits * poolDepth / totalUnits` before we shift by
-    // 10^decimals and round to DISPLAY_SCALE. Must be >= max decimals + DISPLAY_SCALE
-    // (= 13) to avoid truncation; 18 matches the standard fixed-point scale and leaves
-    // headroom.
+    // 10^decimals and round to DISPLAY_SCALE. Must be >= decimals + scale of any call or the
+    // first DOWN division discards digits the second one still needs; 18 matches the standard
+    // fixed-point scale and leaves headroom over the largest current call (8 + 8).
     const val LP_UNITS_INTERMEDIATE_SCALE = 18
 
     /**
@@ -53,6 +53,13 @@ internal object RemoveLpCalculator {
         scale: Int = DISPLAY_SCALE,
     ): String? {
         if (totalPoolUnits.signum() <= 0) return null
+        // Both divisions round DOWN, so the intermediate must carry every digit the final scale
+        // will read. Below that the result is not merely coarser, it is wrong: at decimals=0 and
+        // scale=19 an exact 0.333… would print as 0.3333333333333333330.
+        require(decimals + scale <= LP_UNITS_INTERMEDIATE_SCALE) {
+            "decimals ($decimals) + scale ($scale) exceeds the intermediate precision " +
+                "($LP_UNITS_INTERMEDIATE_SCALE); the result would be silently wrong"
+        }
         return selectedUnits
             .toBigDecimal()
             .multiply(poolDepth.toBigDecimal())

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/RemoveLpCalculator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/RemoveLpCalculator.kt
@@ -40,19 +40,28 @@ internal object RemoveLpCalculator {
      * [BigInteger] overload of [computeAmountDisplay] for LP positions whose unit counts exceed
      * `Long.MAX_VALUE` (whale positions). Keeps the redeem-amount math in full-precision
      * fixed-point so no precision is lost converting through `Long`.
+     *
+     * [scale] is how many decimals the result keeps. It defaults to [DISPLAY_SCALE], which suits
+     * RUNE and CACAO; a high-unit-price pool asset needs more, or its whole redeem amount rounds
+     * away to `0.000`.
      */
     fun computeAmountDisplay(
         selectedUnits: BigInteger,
         poolDepth: BigInteger,
         totalPoolUnits: BigInteger,
         decimals: Int,
+        scale: Int = DISPLAY_SCALE,
     ): String? {
         if (totalPoolUnits.signum() <= 0) return null
         return selectedUnits
             .toBigDecimal()
             .multiply(poolDepth.toBigDecimal())
             .divide(totalPoolUnits.toBigDecimal(), LP_UNITS_INTERMEDIATE_SCALE, RoundingMode.DOWN)
-            .divide(BigDecimal.TEN.pow(decimals), DISPLAY_SCALE, RoundingMode.DOWN)
+            .divide(BigDecimal.TEN.pow(decimals), scale, RoundingMode.DOWN)
             .toPlainString()
     }
+
+    /** Drops the padding zeros a fixed [scale] leaves behind: `"1.840"` reads as `"1.84"`. */
+    fun trimTrailingZeros(display: String): String =
+        display.toBigDecimalOrNull()?.stripTrailingZeros()?.toPlainString() ?: display
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/DepositDataLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/DepositDataLoader.kt
@@ -104,18 +104,24 @@ constructor(
         val action = depositTypeActionProvider()?.takeIf { it.isNotEmpty() } ?: return
         clearDepositTypeAction()
 
-        val depositOption =
-            when (parseDepositType(action)) {
-                DeFiNavActions.BOND -> DepositOption.Bond
-                DeFiNavActions.UNBOND -> DepositOption.Unbond
-                DeFiNavActions.STAKE_CACAO -> DepositOption.AddCacaoPool
-                DeFiNavActions.UNSTAKE_CACAO -> DepositOption.RemoveCacaoPool
-                DeFiNavActions.ADD_LP -> DepositOption.AddLiquidity
-                DeFiNavActions.REMOVE_LP -> DepositOption.RemoveLiquidity
-                else -> DepositOption.Bond
-            }
-        selectDepositOption(depositOption)
+        selectDepositOption(depositOptionFor(action))
     }
+
+    /**
+     * Maps a `depositTypeAction` deep-link to the option the form should open on. Deep-linked
+     * options are deliberately absent from the per-chain [DepositOption] dropdown: the flow is
+     * entered from the DeFi tab, not picked here.
+     */
+    private fun depositOptionFor(action: String): DepositOption =
+        when (parseDepositType(action)) {
+            DeFiNavActions.BOND -> DepositOption.Bond
+            DeFiNavActions.UNBOND -> DepositOption.Unbond
+            DeFiNavActions.STAKE_CACAO -> DepositOption.AddCacaoPool
+            DeFiNavActions.UNSTAKE_CACAO -> DepositOption.RemoveCacaoPool
+            DeFiNavActions.ADD_LP -> DepositOption.AddLiquidity
+            DeFiNavActions.REMOVE_LP -> DepositOption.RemoveLiquidity
+            else -> DepositOption.Bond
+        }
 
     /**
      * Wires the init-time deposit flow at screen entry: builds the per-[chain] option list and
@@ -178,7 +184,15 @@ constructor(
                         if (chain.ticker() in SECURE_ASSETS_TICKERS) add(DepositOption.SecuredAsset)
                     }
             }
-        val depositOption = depositOptions.first()
+        // The dropdown list is empty for chains that expose no self-service deposit action (any
+        // chain outside the branches above whose ticker is not a secured asset). Those chains are
+        // still reachable by deep link — completing a pending THORChain LP half-deposit routes to
+        // the pool's own asset chain — so seed from the pending action first and never assume the
+        // list has a head.
+        val depositOption =
+            depositTypeActionProvider()?.takeIf { it.isNotEmpty() }?.let { depositOptionFor(it) }
+                ?: depositOptions.firstOrNull()
+                ?: DepositOption.Custom
         val defaultToken =
             when (chain) {
                 Chain.MayaChain -> Coins.MayaChain.CACAO

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
@@ -154,6 +154,11 @@ constructor(
                             availableLpUnits = null,
                             removeLpUnitsDivisor = BigInteger.ZERO,
                             removeLpPoolDepth = BigInteger.ZERO,
+                            // This branch returns before the reset below, so it has to clear the
+                            // asset leg itself or a previous pool's second amount stays on screen.
+                            removeLpAssetDisplay = "",
+                            removeLpAssetSymbol = "",
+                            removeLpAssetRedeemBase = BigInteger.ZERO,
                             balance = UiText.Empty,
                             errorText = UiText.StringResource(R.string.dialog_default_error_body),
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.repositories.LpBondablePool
 import com.vultisig.wallet.data.repositories.MayachainBondRepository
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.models.defi.parseThorChainPool
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.deposit.RemoveLpCalculator
 import com.vultisig.wallet.ui.utils.UiText
@@ -166,6 +167,11 @@ constructor(
                 removeLpPoolDepth = BigInteger.ZERO,
                 removeLpPercent = 0f,
                 removeLpCacaoDisplay = "",
+                // Maya pools withdraw CACAO only; clear any asset leg a previous THORChain
+                // selection left behind so the second amount does not linger on this form.
+                removeLpAssetDisplay = "",
+                removeLpAssetSymbol = "",
+                removeLpAssetRedeemBase = BigInteger.ZERO,
                 balance = R.string.share_balance_loading.asUiText(),
                 errorText = null,
             )
@@ -267,6 +273,9 @@ constructor(
                             removeLpPoolDepth = BigInteger.ZERO,
                             removeLpDecimals = RemoveLpCalculator.RUNE_DECIMALS,
                             removeLpTokenSymbol = Coins.ThorChain.RUNE.ticker,
+                            removeLpAssetDisplay = "",
+                            removeLpAssetSymbol = "",
+                            removeLpAssetRedeemBase = BigInteger.ZERO,
                             balance = UiText.Empty,
                             errorText = UiText.StringResource(R.string.dialog_default_error_body),
                         )
@@ -282,6 +291,9 @@ constructor(
                 removeLpTokenSymbol = Coins.ThorChain.RUNE.ticker,
                 removeLpPercent = 0f,
                 removeLpCacaoDisplay = "",
+                removeLpAssetDisplay = "",
+                removeLpAssetSymbol = "",
+                removeLpAssetRedeemBase = BigInteger.ZERO,
                 balance = R.string.share_balance_loading.asUiText(),
                 errorText = null,
             )
@@ -360,6 +372,8 @@ constructor(
                         removeLpPoolDepth = runeRedeemBase,
                         removeLpDecimals = RemoveLpCalculator.RUNE_DECIMALS,
                         removeLpTokenSymbol = symbol,
+                        removeLpAssetRedeemBase = position.assetRedeemValue,
+                        removeLpAssetSymbol = parseThorChainPool(poolId).ticker,
                         balance = balanceText,
                     )
                 }
@@ -386,17 +400,34 @@ constructor(
             availableUnits.multiply(basisPoints.toBigInteger()).divide(BigInteger.valueOf(10_000L))
         val cacaoDisplay =
             RemoveLpCalculator.computeAmountDisplay(
-                selectedUnits = selectedUnits,
-                poolDepth = s.removeLpPoolDepth,
-                totalPoolUnits = s.removeLpUnitsDivisor,
-                decimals = s.removeLpDecimals,
-            ) ?: return
+                    selectedUnits = selectedUnits,
+                    poolDepth = s.removeLpPoolDepth,
+                    totalPoolUnits = s.removeLpUnitsDivisor,
+                    decimals = s.removeLpDecimals,
+                )
+                ?.let(RemoveLpCalculator::trimTrailingZeros) ?: return
+        // The asset leg is priced per unit far above RUNE on some pools, so it keeps thornode's
+        // full 1e8 precision instead of the three decimals that suit RUNE and CACAO — at three it
+        // would round to 0.000 and read as nothing to withdraw.
+        val assetDisplay =
+            if (s.removeLpAssetSymbol.isEmpty()) ""
+            else
+                RemoveLpCalculator.computeAmountDisplay(
+                        selectedUnits = selectedUnits,
+                        poolDepth = s.removeLpAssetRedeemBase,
+                        totalPoolUnits = s.removeLpUnitsDivisor,
+                        decimals = RemoveLpCalculator.RUNE_DECIMALS,
+                        scale = RemoveLpCalculator.RUNE_DECIMALS,
+                    )
+                    ?.let(RemoveLpCalculator::trimTrailingZeros)
+                    .orEmpty()
         lpUnitsFieldState.setTextAndPlaceCursorAtEnd(selectedUnits.toString())
         state.update {
             it.copy(
                 removeLpPercent = percent,
                 removeLpBasisPoints = basisPoints,
                 removeLpCacaoDisplay = cacaoDisplay,
+                removeLpAssetDisplay = assetDisplay,
             )
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
@@ -167,8 +167,8 @@ constructor(
                 removeLpPoolDepth = BigInteger.ZERO,
                 removeLpPercent = 0f,
                 removeLpCacaoDisplay = "",
-                // Maya pools withdraw CACAO only; clear any asset leg a previous THORChain
-                // selection left behind so the second amount does not linger on this form.
+                // Clear the asset leg a previous selection left behind; the Maya pool's own asset
+                // depth fills it back in below, once loaded.
                 removeLpAssetDisplay = "",
                 removeLpAssetSymbol = "",
                 removeLpAssetRedeemBase = BigInteger.ZERO,
@@ -230,6 +230,12 @@ constructor(
                         }
                 val totalPoolUnits = pool.units.toBigIntegerOrNull() ?: BigInteger.ZERO
                 val cacaoDepth = pool.cacaoDepth.toBigIntegerOrNull() ?: BigInteger.ZERO
+                // A symmetric Maya withdrawal returns both halves, same as THORChain, so the form
+                // shows the paired asset leg too. It shares removeLpUnitsDivisor with the CACAO
+                // leg: selectedUnits * assetDepth / totalPoolUnits.
+                val assetDepth = pool.assetDepth.toBigIntegerOrNull() ?: BigInteger.ZERO
+                val assetSymbol =
+                    if (assetDepth.signum() > 0) parseThorChainPool(poolId).ticker else ""
                 val userAvailableUnits = userLpUnits.toBigIntegerOrNull()
                 val userCacao =
                     if (userAvailableUnits != null) {
@@ -254,6 +260,8 @@ constructor(
                         removeLpPoolDepth = cacaoDepth,
                         removeLpDecimals = RemoveLpCalculator.CACAO_DECIMALS,
                         removeLpTokenSymbol = "CACAO",
+                        removeLpAssetRedeemBase = assetDepth,
+                        removeLpAssetSymbol = assetSymbol,
                         balance = balanceText,
                     )
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/AddLiquidityStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/AddLiquidityStrategy.kt
@@ -88,11 +88,14 @@ internal class AddLiquidityStrategy(
         val srcAddress = selectedToken.address
         val gasFee = calculateGasFee(chain, selectedToken, srcAddress)
         val pairedAddress = resolvePairedAddress(chain, vaultId, poolId)
-        // Either half of a symmetric add MUST name the other half's address, or THORChain opens a
-        // separate asymmetric position rather than crediting the pair: a RUNE-side add carries the
-        // asset address, and the asset-side add that completes a pending half-deposit carries the
-        // RUNE address.
-        if (isSymmetricPool && pairedAddress == null) {
+        // Either half of a symmetric THORChain add MUST name the other half's address, or
+        // THORChain opens a separate asymmetric position rather than crediting the pair: a
+        // RUNE-side add carries the asset address, and the asset-side add that completes a pending
+        // half-deposit carries the RUNE address. Gated on the preflight's THORChain-only condition
+        // as well as the pool shape: resolvePairedAddress has no Maya branch and always returns
+        // null there, so isSymmetricPool alone would reject every real Maya pool add, while
+        // isThorChainLpAdd alone would reject a THOR.* pool that has no paired side at all.
+        if (isSymmetricPool && isThorChainLpAdd && pairedAddress == null) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.send_error_no_address)
             )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/AddLiquidityStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/AddLiquidityStrategy.kt
@@ -69,10 +69,15 @@ internal class AddLiquidityStrategy(
         }
         val tokenAmountInt = tokenAmount.movePointRight(selectedToken.decimal).toBigInteger()
 
+        val assetChain = parseThorChainPool(poolId).chain
+        val isSymmetricPool = assetChain != null && assetChain != Chain.ThorChain
+
         // Preflight against THORChain network state — pool status and the relevant mimir pause
         // keys. Refuses to build the keysign payload when the network would refund the inbound,
-        // sparing the user the inbound gas spend.
-        if (chain == Chain.ThorChain) {
+        // sparing the user the inbound gas spend. It asks about the pool, not about the inbound's
+        // source chain, so it must also cover the asset-side add that completes a pending
+        // half-deposit — that inbound is refundable on exactly the same terms.
+        if (chain == Chain.ThorChain || isSymmetricPool) {
             thorChainLpPreflight(poolId)?.let { block -> throw block.toError() }
         }
 
@@ -83,8 +88,6 @@ internal class AddLiquidityStrategy(
         // separate asymmetric position rather than crediting the pair: a RUNE-side add carries the
         // asset address, and the asset-side add that completes a pending half-deposit carries the
         // RUNE address.
-        val assetChain = parseThorChainPool(poolId).chain
-        val isSymmetricPool = assetChain != null && assetChain != Chain.ThorChain
         if (isSymmetricPool && pairedAddress == null) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.send_error_no_address)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/AddLiquidityStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/AddLiquidityStrategy.kt
@@ -79,15 +79,16 @@ internal class AddLiquidityStrategy(
         val srcAddress = selectedToken.address
         val gasFee = calculateGasFee(chain, selectedToken, srcAddress)
         val pairedAddress = resolvePairedAddress(chain, vaultId, poolId)
-        // For a RUNE-side add into a non-THOR pool the memo MUST carry the paired-chain address —
-        // otherwise THORChain can't credit the LP when the asset half is later deposited.
-        if (chain == Chain.ThorChain && pairedAddress == null) {
-            val assetChain = parseThorChainPool(poolId).chain
-            if (assetChain != null && assetChain != Chain.ThorChain) {
-                throw InvalidTransactionDataException(
-                    UiText.StringResource(R.string.send_error_no_address)
-                )
-            }
+        // Either half of a symmetric add MUST name the other half's address, or THORChain opens a
+        // separate asymmetric position rather than crediting the pair: a RUNE-side add carries the
+        // asset address, and the asset-side add that completes a pending half-deposit carries the
+        // RUNE address.
+        val assetChain = parseThorChainPool(poolId).chain
+        val isSymmetricPool = assetChain != null && assetChain != Chain.ThorChain
+        if (isSymmetricPool && pairedAddress == null) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_address)
+            )
         }
         val memo = DepositMemo.AddLiquidity(poolId, pairedAddress)
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/AddLiquidityStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/AddLiquidityStrategy.kt
@@ -76,8 +76,12 @@ internal class AddLiquidityStrategy(
         // keys. Refuses to build the keysign payload when the network would refund the inbound,
         // sparing the user the inbound gas spend. It asks about the pool, not about the inbound's
         // source chain, so it must also cover the asset-side add that completes a pending
-        // half-deposit — that inbound is refundable on exactly the same terms.
-        if (chain == Chain.ThorChain || isSymmetricPool) {
+        // half-deposit — that inbound is refundable on exactly the same terms, and it arrives on
+        // the pool's own asset chain. Maya reuses this strategy with chain == MayaChain and its
+        // own pool ids, which thornode knows nothing about: a THORChain-wide PAUSELP, or a
+        // same-named THOR pool sitting Staged, would reject a perfectly valid CACAO add.
+        val isThorChainLpAdd = chain == Chain.ThorChain || (isSymmetricPool && chain == assetChain)
+        if (isThorChainLpAdd) {
             thorChainLpPreflight(poolId)?.let { block -> throw block.toError() }
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.compose.SubcomposeAsyncImage
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.ui.components.UiHorizontalDivider
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
@@ -85,41 +86,11 @@ internal fun PendingLpWidget(state: PendingLpDepositUiModel, onClickComplete: ()
                 .padding(16.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(modifier = Modifier.size(48.dp)) {
-                SubcomposeAsyncImage(
-                    model = state.icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(48.dp).clip(CircleShape),
-                    error = {
-                        Box(
-                            modifier =
-                                Modifier.size(48.dp)
-                                    .clip(CircleShape)
-                                    .background(Theme.v2.colors.backgrounds.tertiary_2),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = state.awaitedTicker.firstOrNull()?.toString().orEmpty(),
-                                color = Theme.v2.colors.text.primary,
-                                style = Theme.brockmann.headings.title3,
-                            )
-                        }
-                    },
-                )
-
-                if (state.chainLogo != null) {
-                    AsyncImage(
-                        model = state.chainLogo,
-                        contentDescription = null,
-                        modifier =
-                            Modifier.align(Alignment.BottomEnd)
-                                .size(20.dp)
-                                .clip(CircleShape)
-                                .background(Theme.v2.colors.neutrals.n200, CircleShape)
-                                .border(1.dp, Theme.v2.colors.backgrounds.secondary, CircleShape),
-                    )
-                }
-            }
+            AssetIconWithChainBadge(
+                icon = state.icon,
+                chainLogo = state.chainLogo,
+                fallbackTicker = state.awaitedTicker,
+            )
 
             UiSpacer(12.dp)
 
@@ -181,6 +152,49 @@ internal fun PendingLpWidget(state: PendingLpDepositUiModel, onClickComplete: ()
     }
 }
 
+/**
+ * The pool asset's logo with its chain badge, falling back to the ticker's initial when the logo
+ * fails to load. Shared by the position and pending-deposit cards so the two stay in step.
+ */
+@Composable
+private fun AssetIconWithChainBadge(icon: ImageModel, chainLogo: Int?, fallbackTicker: String) {
+    Box(modifier = Modifier.size(48.dp)) {
+        SubcomposeAsyncImage(
+            model = icon,
+            contentDescription = null,
+            modifier = Modifier.size(48.dp).clip(CircleShape),
+            error = {
+                Box(
+                    modifier =
+                        Modifier.size(48.dp)
+                            .clip(CircleShape)
+                            .background(Theme.v2.colors.backgrounds.tertiary_2),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = fallbackTicker.firstOrNull()?.toString().orEmpty(),
+                        color = Theme.v2.colors.text.primary,
+                        style = Theme.brockmann.headings.title3,
+                    )
+                }
+            },
+        )
+
+        if (chainLogo != null) {
+            AsyncImage(
+                model = chainLogo,
+                contentDescription = null,
+                modifier =
+                    Modifier.align(Alignment.BottomEnd)
+                        .size(20.dp)
+                        .clip(CircleShape)
+                        .background(Theme.v2.colors.neutrals.n200, CircleShape)
+                        .border(1.dp, Theme.v2.colors.backgrounds.secondary, CircleShape),
+            )
+        }
+    }
+}
+
 @Composable
 private fun PendingLpRow(
     label: String,
@@ -220,41 +234,11 @@ internal fun LpWidget(
                 .padding(16.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Box(modifier = Modifier.size(48.dp)) {
-                SubcomposeAsyncImage(
-                    model = state.icon,
-                    contentDescription = null,
-                    modifier = Modifier.size(48.dp).clip(CircleShape),
-                    error = {
-                        Box(
-                            modifier =
-                                Modifier.size(48.dp)
-                                    .clip(CircleShape)
-                                    .background(Theme.v2.colors.backgrounds.tertiary_2),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            Text(
-                                text = state.assetTicker.firstOrNull()?.toString().orEmpty(),
-                                color = Theme.v2.colors.text.primary,
-                                style = Theme.brockmann.headings.title3,
-                            )
-                        }
-                    },
-                )
-
-                if (state.chainLogo != null) {
-                    AsyncImage(
-                        model = state.chainLogo,
-                        contentDescription = null,
-                        modifier =
-                            Modifier.align(Alignment.BottomEnd)
-                                .size(20.dp)
-                                .clip(CircleShape)
-                                .background(Theme.v2.colors.neutrals.n200, CircleShape)
-                                .border(1.dp, Theme.v2.colors.backgrounds.secondary, CircleShape),
-                    )
-                }
-            }
+            AssetIconWithChainBadge(
+                icon = state.icon,
+                chainLogo = state.chainLogo,
+                fallbackTicker = state.assetTicker,
+            )
 
             UiSpacer(12.dp)
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
@@ -27,10 +27,14 @@ import coil.compose.SubcomposeAsyncImage
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiHorizontalDivider
 import com.vultisig.wallet.ui.components.UiSpacer
+import com.vultisig.wallet.ui.components.buttons.VsButton
+import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.models.defi.LpPositionUiModel
 import com.vultisig.wallet.ui.models.defi.LpTabUiModel
+import com.vultisig.wallet.ui.models.defi.PendingLpDepositUiModel
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.asString
 
 /** Tab content listing LP positions, each with add and remove liquidity actions. */
 @Composable
@@ -38,8 +42,18 @@ internal fun LpTabContent(
     state: LpTabUiModel,
     onClickAdd: (String) -> Unit,
     onClickRemove: (String) -> Unit,
+    onClickCompletePending: (String) -> Unit = {},
 ) {
     Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        // Above the positions: a half-deposit is on a refund timer, so it is the one thing on this
+        // tab the user may need to act on before it expires.
+        state.pendingDeposits.forEach { pending ->
+            PendingLpWidget(
+                state = pending,
+                onClickComplete = { onClickCompletePending(pending.poolId) },
+            )
+        }
+
         state.positions.forEach { lpPosition ->
             LpWidget(
                 state = lpPosition,
@@ -48,6 +62,141 @@ internal fun LpTabContent(
                 onClickRemove = { onClickRemove(lpPosition.positionKey) },
             )
         }
+    }
+}
+
+/**
+ * A symmetric add that THORChain is still holding because only one side arrived. Shows what was
+ * deposited, the address the missing half has to come from, and how long is left before the deposit
+ * is refunded.
+ */
+@Composable
+internal fun PendingLpWidget(state: PendingLpDepositUiModel, onClickComplete: () -> Unit) {
+    Column(
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(Theme.v2.radius.xl)
+                .background(Theme.v2.colors.backgrounds.secondary)
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.alerts.warning,
+                    shape = Theme.v2.radius.xl,
+                )
+                .padding(16.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(modifier = Modifier.size(48.dp)) {
+                SubcomposeAsyncImage(
+                    model = state.icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp).clip(CircleShape),
+                    error = {
+                        Box(
+                            modifier =
+                                Modifier.size(48.dp)
+                                    .clip(CircleShape)
+                                    .background(Theme.v2.colors.backgrounds.tertiary_2),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Text(
+                                text = state.awaitedTicker.firstOrNull()?.toString().orEmpty(),
+                                color = Theme.v2.colors.text.primary,
+                                style = Theme.brockmann.headings.title3,
+                            )
+                        }
+                    },
+                )
+
+                if (state.chainLogo != null) {
+                    AsyncImage(
+                        model = state.chainLogo,
+                        contentDescription = null,
+                        modifier =
+                            Modifier.align(Alignment.BottomEnd)
+                                .size(20.dp)
+                                .clip(CircleShape)
+                                .background(Theme.v2.colors.neutrals.n200, CircleShape)
+                                .border(1.dp, Theme.v2.colors.backgrounds.secondary, CircleShape),
+                    )
+                }
+            }
+
+            UiSpacer(12.dp)
+
+            Column {
+                Text(
+                    text = stringResource(R.string.lp_pending_title, state.awaitedTicker),
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.alerts.warning,
+                )
+
+                UiSpacer(4.dp)
+
+                Text(
+                    text = stringResource(R.string.lp_pending_subtitle),
+                    style = Theme.brockmann.supplementary.caption,
+                    color = Theme.v2.colors.text.tertiary,
+                )
+            }
+        }
+
+        UiSpacer(16.dp)
+
+        UiHorizontalDivider()
+
+        UiSpacer(16.dp)
+
+        PendingLpRow(
+            label = stringResource(R.string.lp_pending_deposited),
+            value = state.depositedAmount,
+        )
+
+        if (state.pairedAddress != null) {
+            UiSpacer(8.dp)
+
+            PendingLpRow(
+                label = stringResource(R.string.lp_pending_from),
+                value = state.pairedAddress,
+            )
+        }
+
+        UiSpacer(8.dp)
+
+        PendingLpRow(
+            label = stringResource(R.string.lp_pending_refunds_in),
+            value =
+                state.refundsIn?.asString()
+                    ?: stringResource(R.string.lp_pending_refund_time_unknown),
+            valueColor = Theme.v2.colors.alerts.warning,
+        )
+
+        UiSpacer(16.dp)
+
+        VsButton(
+            label = stringResource(R.string.lp_pending_complete_deposit),
+            onClick = onClickComplete,
+            state = if (state.canComplete) VsButtonState.Enabled else VsButtonState.Disabled,
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}
+
+@Composable
+private fun PendingLpRow(
+    label: String,
+    value: String,
+    valueColor: Color = Theme.v2.colors.text.primary,
+) {
+    Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = label,
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.text.tertiary,
+        )
+
+        UiSpacer(1f)
+
+        Text(text = value, style = Theme.brockmann.body.s.medium, color = valueColor)
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/RemoveLpScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/RemoveLpScreen.kt
@@ -214,7 +214,7 @@ private fun RemoveLpLeg(amount: String, symbol: String, percentLabel: String) {
 
         Text(
             text = percentLabel,
-            style = Theme.brockmann.headings.subtitle,
+            style = Theme.brockmann.body.m.medium,
             color = Theme.v2.colors.text.tertiary,
             textAlign = TextAlign.Center,
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/RemoveLpScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/RemoveLpScreen.kt
@@ -112,42 +112,42 @@ internal fun RemoveLpScreenContent(
 
             UiGradientHorizontalDivider()
 
+            val percentLabel =
+                stringResource(
+                    R.string.remove_pool_percent_format,
+                    (state.removeLpPercent * 100).toInt(),
+                )
+
             Box(
                 modifier = Modifier.fillMaxWidth().weight(1f),
                 contentAlignment = Alignment.Center,
             ) {
                 Column(
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
-                    Text(
-                        text =
-                            if (state.removeLpCacaoDisplay.isEmpty())
-                                stringResource(
-                                    R.string.remove_pool_zero_amount,
-                                    state.removeLpTokenSymbol,
-                                )
-                            else
-                                stringResource(
-                                    R.string.remove_pool_amount_format,
-                                    state.removeLpCacaoDisplay,
-                                    state.removeLpTokenSymbol,
-                                ),
-                        style = Theme.brockmann.headings.largeTitle,
-                        color = Theme.v2.colors.text.primary,
-                        textAlign = TextAlign.Center,
+                    RemoveLpLeg(
+                        amount = state.removeLpCacaoDisplay,
+                        symbol = state.removeLpTokenSymbol,
+                        percentLabel = percentLabel,
                     )
 
-                    Text(
-                        text =
-                            stringResource(
-                                R.string.remove_pool_percent_format,
-                                (state.removeLpPercent * 100).toInt(),
-                            ),
-                        style = Theme.brockmann.body.m.medium,
-                        color = Theme.v2.colors.text.tertiary,
-                        textAlign = TextAlign.Center,
-                    )
+                    // A THORChain withdrawal returns both sides of the pool, so both are shown.
+                    // Maya's CACAO pools leave the asset symbol empty and stay single-leg.
+                    if (state.removeLpAssetSymbol.isNotEmpty()) {
+                        UiSpacer(20.dp)
+
+                        UiGradientHorizontalDivider()
+
+                        UiSpacer(20.dp)
+
+                        RemoveLpLeg(
+                            amount = state.removeLpAssetDisplay,
+                            symbol = state.removeLpAssetSymbol,
+                            percentLabel = percentLabel,
+                        )
+                    }
                 }
             }
 
@@ -191,6 +191,32 @@ internal fun RemoveLpScreenContent(
                 if (state.removeLpPercent > 0f && state.removeLpCacaoDisplay.isNotEmpty())
                     VsButtonState.Enabled
                 else VsButtonState.Disabled,
+        )
+    }
+}
+
+/** One side of the withdrawal: the amount coming back, and the share of the position it is. */
+@Composable
+private fun RemoveLpLeg(amount: String, symbol: String, percentLabel: String) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text =
+                if (amount.isEmpty()) stringResource(R.string.remove_pool_zero_amount, symbol)
+                else stringResource(R.string.remove_pool_amount_format, amount, symbol),
+            style = Theme.brockmann.headings.largeTitle,
+            color = Theme.v2.colors.text.primary,
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
+            text = percentLabel,
+            style = Theme.brockmann.headings.subtitle,
+            color = Theme.v2.colors.text.tertiary,
+            textAlign = TextAlign.Center,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.VaultId
@@ -69,6 +71,8 @@ internal fun ThorchainDefiPositionsScreen(
     }
 
     LaunchedEffect(vaultId) { model.setData(vaultId = vaultId) }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) { model.onScreenResumed() }
 
     ThorchainDefiPositionScreenContent(
         state = state,
@@ -208,16 +212,22 @@ internal fun ThorchainDefiPositionScreenContent(
                     }
 
                     DeFiTab.LP.displayNameRes -> {
-                        // Until the dialog dataset has loaded, treat the LP tab as still
-                        // loading
-                        // rather than flashing the no-positions container — the
-                        // lpPositionsDialog
-                        // list arrives asynchronously and "no match" is meaningless before
-                        // then.
+                        // Both feeds must settle before the tab can say anything definitive: the
+                        // dialog dataset decides which selected pools resolve to positions, and
+                        // the pending scan decides whether there is a half-deposit to act on.
+                        // "No match" and "nothing pending" are both meaningless until then, and
+                        // acting on either early flashes the no-positions container.
                         when {
-                            !state.lpDialogLoaded ->
+                            !state.lpDialogLoaded || !state.lp.pendingDepositsLoaded ->
                                 LpTabContent(
-                                    state = state.lp.copy(isLoading = true),
+                                    state =
+                                        state.lp.copy(
+                                            isLoading = true,
+                                            // Hide half-loaded pending cards behind the spinner
+                                            // rather than showing them inside a tab that is still
+                                            // declaring itself unloaded.
+                                            pendingDeposits = emptyList(),
+                                        ),
                                     onClickAdd = onClickAddLp,
                                     onClickRemove = onClickRemoveLp,
                                     onClickCompletePending = onClickCompletePendingLp,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
@@ -91,6 +91,7 @@ internal fun ThorchainDefiPositionsScreen(
         onClickTransfer = { model.onClickTransfer() },
         onClickAddLp = model::onClickAddLp,
         onClickRemoveLp = model::onClickRemoveLp,
+        onClickCompletePendingLp = model::onClickCompletePendingLp,
     )
 }
 
@@ -115,6 +116,7 @@ internal fun ThorchainDefiPositionScreenContent(
     onClickTransfer: () -> Unit = {},
     onClickAddLp: (String) -> Unit = {},
     onClickRemoveLp: (String) -> Unit = {},
+    onClickCompletePendingLp: (String) -> Unit = {},
 ) {
     val searchTextFieldState = remember { TextFieldState() }
 
@@ -218,14 +220,20 @@ internal fun ThorchainDefiPositionScreenContent(
                                     state = state.lp.copy(isLoading = true),
                                     onClickAdd = onClickAddLp,
                                     onClickRemove = onClickRemoveLp,
+                                    onClickCompletePending = onClickCompletePendingLp,
                                 )
-                            !state.selectedPositions.hasLpPositions(state.lpPositionsDialog) ->
+                            // A pending half-deposit is on a refund timer and belongs to no
+                            // selected pool, so it must survive the empty-selection branch —
+                            // otherwise the one user who has to act sees "no positions".
+                            !state.selectedPositions.hasLpPositions(state.lpPositionsDialog) &&
+                                state.lp.pendingDeposits.isEmpty() ->
                                 NoPositionsContainer(onManagePositionsClick = onEditPositionClick)
                             else ->
                                 LpTabContent(
                                     state = state.lp,
                                     onClickAdd = onClickAddLp,
                                     onClickRemove = onClickRemoveLp,
+                                    onClickCompletePending = onClickCompletePendingLp,
                                 )
                         }
                     }

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/LpPendingRefundFormatter.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/LpPendingRefundFormatter.kt
@@ -1,0 +1,34 @@
+package com.vultisig.wallet.ui.utils
+
+import com.vultisig.wallet.R
+
+private const val SECONDS_PER_MINUTE = 60L
+private const val MINUTES_PER_HOUR = 60L
+private const val HOURS_PER_DAY = 24L
+
+/**
+ * How long a half-finished symmetric add has before THORChain refunds it, as `"1d 4h"` or `"21h
+ * 14m"`.
+ *
+ * Days and hours are capped at two units the way the unstake hint is, but sub-hour values still
+ * read as `"0h 30m"`: someone half an hour from losing their deposit needs the minutes, not a
+ * rounded "soon".
+ */
+internal fun lpRefundsInUiText(remainingSeconds: Long): UiText {
+    val totalMinutes = remainingSeconds / SECONDS_PER_MINUTE
+    val totalHours = totalMinutes / MINUTES_PER_HOUR
+    val days = totalHours / HOURS_PER_DAY
+    val hours = totalHours % HOURS_PER_DAY
+    val minutes = totalMinutes % MINUTES_PER_HOUR
+    return if (days > 0L) {
+        UiText.FormattedText(
+            R.string.lp_pending_duration_days_hours_format,
+            listOf(days.toInt(), hours.toInt()),
+        )
+    } else {
+        UiText.FormattedText(
+            R.string.lp_pending_duration_hours_minutes_format,
+            listOf(hours.toInt(), minutes.toInt()),
+        )
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1205,6 +1205,15 @@
     <string name="onboarding_desc_page_1_part_2">Tresorfreigaben</string>
     <string name="verify_swap_youre_swapping_title">Sie tauschen</string>
     <string name="keysign_app_version_text">Version %1$s (%2$s)</string>
+    <string name="lp_pending_title">Warte auf passende %1$s-Einzahlung</string>
+    <string name="lp_pending_subtitle">THORChain hält diese Einzahlung, bis die passende Seite eintrifft, und erstattet sie andernfalls zurück.</string>
+    <string name="lp_pending_deposited">Eingezahlt</string>
+    <string name="lp_pending_from">Von</string>
+    <string name="lp_pending_refunds_in">Rückerstattung in</string>
+    <string name="lp_pending_duration_days_hours_format">%1$dT %2$dStd</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$dStd %2$dMin</string>
+    <string name="lp_pending_refund_time_unknown">Unbekannt</string>
+    <string name="lp_pending_complete_deposit">Einzahlung abschließen</string>
     <string name="lp_position">Position</string>
     <string name="add">Hinzufügen</string>
     <string name="remove">Entfernen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1203,6 +1203,15 @@
     <string name="onboarding_desc_page_1_part_2">Recursos compartidos de la bóveda</string>
     <string name="verify_swap_youre_swapping_title">Estás intercambiando</string>
     <string name="keysign_app_version_text">Versión %1$s (%2$s)</string>
+    <string name="lp_pending_title">Esperando el depósito correspondiente de %1$s</string>
+    <string name="lp_pending_subtitle">THORChain retiene este depósito hasta que llegue la parte correspondiente y lo reembolsa si no llega.</string>
+    <string name="lp_pending_deposited">Depositado</string>
+    <string name="lp_pending_from">Desde</string>
+    <string name="lp_pending_refunds_in">Se reembolsa en</string>
+    <string name="lp_pending_duration_days_hours_format">%1$dd %2$dh</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$dh %2$dm</string>
+    <string name="lp_pending_refund_time_unknown">Desconocido</string>
+    <string name="lp_pending_complete_deposit">Completar depósito</string>
     <string name="lp_position">Posición</string>
     <string name="add">Añadir</string>
     <string name="remove">Eliminar</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1208,6 +1208,15 @@
     <string name="onboarding_desc_page_1_part_2">dijeljenja trezora,</string>
     <string name="verify_swap_youre_swapping_title">Zamjenjujete</string>
     <string name="keysign_app_version_text">Verzija %1$s (%2$s)</string>
+    <string name="lp_pending_title">Čeka se odgovarajući %1$s polog</string>
+    <string name="lp_pending_subtitle">THORChain zadržava ovaj polog dok ne stigne odgovarajuća strana, a inače ga vraća.</string>
+    <string name="lp_pending_deposited">Položeno</string>
+    <string name="lp_pending_from">Od</string>
+    <string name="lp_pending_refunds_in">Povrat za</string>
+    <string name="lp_pending_duration_days_hours_format">%1$dd %2$dh</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$dh %2$dm</string>
+    <string name="lp_pending_refund_time_unknown">Nepoznato</string>
+    <string name="lp_pending_complete_deposit">Dovrši polog</string>
     <string name="lp_position">Pozicija</string>
     <string name="add">Dodaj</string>
     <string name="remove">Ukloni</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1203,6 +1203,15 @@
     <string name="onboarding_desc_page_1_part_2">Condivisioni del Vault,</string>
     <string name="verify_swap_youre_swapping_title">Stai effettuando uno scambio</string>
     <string name="keysign_app_version_text">Versione %1$s (%2$s)</string>
+    <string name="lp_pending_title">In attesa del deposito %1$s corrispondente</string>
+    <string name="lp_pending_subtitle">THORChain trattiene questo deposito finché non arriva la parte corrispondente, altrimenti lo rimborsa.</string>
+    <string name="lp_pending_deposited">Depositato</string>
+    <string name="lp_pending_from">Da</string>
+    <string name="lp_pending_refunds_in">Rimborso tra</string>
+    <string name="lp_pending_duration_days_hours_format">%1$dg %2$dh</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$dh %2$dmin</string>
+    <string name="lp_pending_refund_time_unknown">Sconosciuto</string>
+    <string name="lp_pending_complete_deposit">Completa il deposito</string>
     <string name="lp_position">Posizione</string>
     <string name="add">Aggiungi</string>
     <string name="remove">Rimuovi</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1235,6 +1235,15 @@
     <string name="bond_node_state_active">활성</string>
     <string name="bond_node_state_disabled">비활성</string>
     <string name="bond_node_state_unknown">알 수 없음</string>
+    <string name="lp_pending_title">%1$s 입금 대기 중</string>
+    <string name="lp_pending_subtitle">THORChain은 반대편 입금이 도착할 때까지 이 입금을 보관하며, 도착하지 않으면 환불합니다.</string>
+    <string name="lp_pending_deposited">입금됨</string>
+    <string name="lp_pending_from">보낼 주소</string>
+    <string name="lp_pending_refunds_in">환불까지</string>
+    <string name="lp_pending_duration_days_hours_format">%1$d일 %2$d시간</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$d시간 %2$d분</string>
+    <string name="lp_pending_refund_time_unknown">알 수 없음</string>
+    <string name="lp_pending_complete_deposit">입금 완료하기</string>
     <string name="lp_position">포지션</string>
     <string name="add">추가</string>
     <string name="remove">제거</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1200,6 +1200,15 @@
     <string name="onboarding_desc_page_1_part_2">Vault-shares,</string>
     <string name="verify_swap_youre_swapping_title">Je wisselt</string>
     <string name="keysign_app_version_text">Versie %1$s (%2$s)</string>
+    <string name="lp_pending_title">Wachten op bijbehorende %1$s-storting</string>
+    <string name="lp_pending_subtitle">THORChain houdt deze storting vast tot de bijbehorende kant binnenkomt en betaalt hem anders terug.</string>
+    <string name="lp_pending_deposited">Gestort</string>
+    <string name="lp_pending_from">Van</string>
+    <string name="lp_pending_refunds_in">Terugbetaling over</string>
+    <string name="lp_pending_duration_days_hours_format">%1$dd %2$du</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$du %2$dm</string>
+    <string name="lp_pending_refund_time_unknown">Onbekend</string>
+    <string name="lp_pending_complete_deposit">Storting voltooien</string>
     <string name="lp_position">Positie</string>
     <string name="add">Toevoegen</string>
     <string name="remove">Verwijderen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1202,6 +1202,15 @@
     <string name="onboarding_desc_page_1_part_2">Partilhas do cofre</string>
     <string name="verify_swap_youre_swapping_title">Está a trocar</string>
     <string name="keysign_app_version_text">Versão %1$s (%2$s)</string>
+    <string name="lp_pending_title">A aguardar o depósito %1$s correspondente</string>
+    <string name="lp_pending_subtitle">A THORChain retém este depósito até chegar a parte correspondente e reembolsa-o caso não chegue.</string>
+    <string name="lp_pending_deposited">Depositado</string>
+    <string name="lp_pending_from">De</string>
+    <string name="lp_pending_refunds_in">Reembolso em</string>
+    <string name="lp_pending_duration_days_hours_format">%1$dd %2$dh</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$dh %2$dm</string>
+    <string name="lp_pending_refund_time_unknown">Desconhecido</string>
+    <string name="lp_pending_complete_deposit">Concluir depósito</string>
     <string name="lp_position">Posição</string>
     <string name="add">Adicionar</string>
     <string name="remove">Remover</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1208,6 +1208,15 @@
     <string name="onboarding_desc_page_1_part_2">Общие ресурсы хранилища</string>
     <string name="verify_swap_youre_swapping_title">Вы выполняете обмен</string>
     <string name="keysign_app_version_text">Версия %1$s (%2$s)</string>
+    <string name="lp_pending_title">Ожидание парного депозита %1$s</string>
+    <string name="lp_pending_subtitle">THORChain удерживает этот депозит до поступления парной стороны, а иначе возвращает его.</string>
+    <string name="lp_pending_deposited">Внесено</string>
+    <string name="lp_pending_from">Откуда</string>
+    <string name="lp_pending_refunds_in">Возврат через</string>
+    <string name="lp_pending_duration_days_hours_format">%1$dд %2$dч</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$dч %2$dмин</string>
+    <string name="lp_pending_refund_time_unknown">Неизвестно</string>
+    <string name="lp_pending_complete_deposit">Завершить депозит</string>
     <string name="lp_position">Позиция</string>
     <string name="add">Добавить</string>
     <string name="remove">Удалить</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1534,6 +1534,15 @@
     <string name="onboarding_desc_page_1_part_2">保险库共享</string>
     <string name="verify_swap_youre_swapping_title">您正在交换</string>
     <string name="keysign_app_version_text">版本 %1$s (%2$s)</string>
+    <string name="lp_pending_title">等待配对的 %1$s 存入</string>
+    <string name="lp_pending_subtitle">THORChain 会保留此笔存入，直到配对的另一侧到达；否则将予以退款。</string>
+    <string name="lp_pending_deposited">已存入</string>
+    <string name="lp_pending_from">来自</string>
+    <string name="lp_pending_refunds_in">退款倒计时</string>
+    <string name="lp_pending_duration_days_hours_format">%1$d天 %2$d小时</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$d小时 %2$d分钟</string>
+    <string name="lp_pending_refund_time_unknown">未知</string>
+    <string name="lp_pending_complete_deposit">完成存入</string>
     <string name="lp_position">仓位</string>
     <string name="add">添加</string>
     <string name="remove">移除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1266,6 +1266,15 @@
     <string name="bond_node_state_active">Active</string>
     <string name="bond_node_state_disabled">Disabled</string>
     <string name="bond_node_state_unknown">Unknown</string>
+    <string name="lp_pending_title">Waiting for matching %1$s deposit</string>
+    <string name="lp_pending_subtitle">THORChain holds this deposit until the matching side arrives, then refunds it if it doesn\'t.</string>
+    <string name="lp_pending_deposited">Deposited</string>
+    <string name="lp_pending_from">From</string>
+    <string name="lp_pending_refunds_in">Refunds in</string>
+    <string name="lp_pending_duration_days_hours_format">%1$dd %2$dh</string>
+    <string name="lp_pending_duration_hours_minutes_format">%1$dh %2$dm</string>
+    <string name="lp_pending_refund_time_unknown">Unknown</string>
+    <string name="lp_pending_complete_deposit">Complete deposit</string>
     <string name="lp_position">Position</string>
     <string name="add">Add</string>
     <string name="remove">Remove</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -467,9 +467,9 @@ internal class ThorchainDefiPositionsViewModelTest {
         // lpDialogLoaded means settled, not succeeded: leaving it false parks the tab in a spinner
         // no retry can clear, while a pending half-deposit still renders through it. Settled, the
         // tab falls through to its no-positions container and its Manage Positions retry.
-        assertTrue(vm.state.value.lpDialogLoaded)
+        vm.state.value.lpDialogLoaded shouldBe true
         // availablePools stays null so the next interaction re-fetches instead of soft-locking.
-        assertTrue(vm.state.value.lpPositionsDialog.isEmpty())
+        vm.state.value.lpPositionsDialog.isEmpty() shouldBe true
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -126,7 +126,7 @@ internal class ThorchainDefiPositionsViewModelTest {
         coEvery { tcyStakingService.getStakingDetails(any(), any()) } returns flowOf()
         coEvery { defaultStakingPositionService.getStakingDetails(any(), any()) } returns flowOf()
         coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } returns emptyList()
-        coEvery { getThorChainPendingLpDepositsUseCase(any(), any()) } returns emptyList()
+        coEvery { getThorChainPendingLpDepositsUseCase(any()) } returns emptyList()
         coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } returns
             ThorChainLpPositions()
     }
@@ -457,16 +457,19 @@ internal class ThorchainDefiPositionsViewModelTest {
     }
 
     @Test
-    fun `the LP tab stays loading until the available-pool fetch resolves`() = runTest {
+    fun `a failed available-pool fetch still settles the LP tab`() = runTest {
         selectPositions("RUNE")
         coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } throws
             RuntimeException("midgard down")
 
         val vm = createViewModel().also { it.setData(VAULT_ID) }
 
-        // availablePools stays null so the tab must not flash an empty state.
-        assertTrue(vm.state.value.lp.isLoading)
-        assertFalse(vm.state.value.lpDialogLoaded)
+        // lpDialogLoaded means settled, not succeeded: leaving it false parks the tab in a spinner
+        // no retry can clear, while a pending half-deposit still renders through it. Settled, the
+        // tab falls through to its no-positions container and its Manage Positions retry.
+        assertTrue(vm.state.value.lpDialogLoaded)
+        // availablePools stays null so the next interaction re-fetches instead of soft-locking.
+        assertTrue(vm.state.value.lpPositionsDialog.isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.data.repositories.DefiPositionsRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionsUseCase
+import com.vultisig.wallet.data.usecases.GetThorChainPendingLpDepositsUseCase
 import com.vultisig.wallet.data.usecases.ThorChainLpPositions
 import com.vultisig.wallet.data.usecases.ThorchainBondUseCase
 import com.vultisig.wallet.data.utils.decimals
@@ -90,6 +91,7 @@ internal class ThorchainDefiPositionsViewModelTest {
     private lateinit var defaultStakingPositionService: DefaultStakingPositionService
     private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
     private lateinit var getThorChainLpPositionsUseCase: GetThorChainLpPositionsUseCase
+    private lateinit var getThorChainPendingLpDepositsUseCase: GetThorChainPendingLpDepositsUseCase
 
     @BeforeEach
     fun setUp() {
@@ -109,6 +111,7 @@ internal class ThorchainDefiPositionsViewModelTest {
         defaultStakingPositionService = mockk(relaxed = true)
         balanceVisibilityRepository = mockk(relaxed = true)
         getThorChainLpPositionsUseCase = mockk(relaxed = true)
+        getThorChainPendingLpDepositsUseCase = mockk(relaxed = true)
 
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
@@ -123,6 +126,7 @@ internal class ThorchainDefiPositionsViewModelTest {
         coEvery { tcyStakingService.getStakingDetails(any(), any()) } returns flowOf()
         coEvery { defaultStakingPositionService.getStakingDetails(any(), any()) } returns flowOf()
         coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } returns emptyList()
+        coEvery { getThorChainPendingLpDepositsUseCase(any(), any()) } returns emptyList()
         coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } returns
             ThorChainLpPositions()
     }
@@ -1269,6 +1273,7 @@ internal class ThorchainDefiPositionsViewModelTest {
             defaultStakingPositionService = defaultStakingPositionService,
             balanceVisibilityRepository = balanceVisibilityRepository,
             getThorChainLpPositionsUseCase = getThorChainLpPositionsUseCase,
+            getThorChainPendingLpDepositsUseCase = getThorChainPendingLpDepositsUseCase,
             ioDispatcher = testDispatcher,
         )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorChainLiquidityProviderJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorChainLiquidityProviderJson.kt
@@ -11,6 +11,13 @@ data class ThorChainLiquidityProviderJson(
     @SerialName("units") val units: String = "0",
     @SerialName("pending_rune") val pendingRune: String = "0",
     @SerialName("pending_asset") val pendingAsset: String = "0",
+    // Inbound hash of the side that arrived first. Only set while the deposit is still half-open,
+    // so it doubles as the marker that this record is a pending symmetric add rather than a
+    // position.
+    @SerialName("pending_tx_id") val pendingTxId: String? = null,
+    // Block the pending side was recorded at. Refund happens at
+    // `lastAddHeight + PendingLiquidityAgeLimit`, so the countdown cannot be derived without it.
+    @SerialName("last_add_height") val lastAddHeight: Long? = null,
     @SerialName("rune_deposit_value") val runeDepositValue: String = "0",
     @SerialName("asset_deposit_value") val assetDepositValue: String = "0",
     @SerialName("rune_redeem_value") val runeRedeemValue: String = "0",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorChainPoolJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorChainPoolJson.kt
@@ -14,4 +14,9 @@ data class ThorChainPoolJson(
     @Contextual @SerialName("asset_tor_price") val assetTorPrice: BigInteger,
     // pool status — typically Available / Staged / Suspended; absent on older endpoints
     @SerialName("status") val status: String? = null,
+    // Sum of every half-finished symmetric add on this pool, 1e8. Non-zero means at least one
+    // liquidity provider is waiting on a matching deposit — which pools are worth a per-user
+    // lookup, without asking thornode about all ~100 of them.
+    @SerialName("pending_inbound_rune") val pendingInboundRune: String = "0",
+    @SerialName("pending_inbound_asset") val pendingInboundAsset: String = "0",
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/ThorChainPendingLpDeposit.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/ThorChainPendingLpDeposit.kt
@@ -1,0 +1,37 @@
+package com.vultisig.wallet.data.models
+
+import java.math.BigInteger
+
+/**
+ * One half of a symmetric add-liquidity that THORChain is still holding.
+ *
+ * A symmetric add (`+:ASSET:<paired-address>`) only mints LP units once both sides arrive. Until
+ * then the deposited side sits as pending liquidity: no units, no outbound, and the LP record reads
+ * as an empty position — which is why it needs its own type rather than a [ThorChainLpPosition]
+ * with zero units. If the matching side never arrives, THORChain refunds the deposit at
+ * `lastAddHeight + PendingLiquidityAgeLimit`.
+ *
+ * Amounts are 1e8 fixed-point integers (thornode's native scale, not asset decimals).
+ */
+data class ThorChainPendingLpDeposit(
+    val pool: String,
+    val pendingRune: BigInteger,
+    val pendingAsset: BigInteger,
+    /** Inbound hash of the side that already arrived. */
+    val pendingTxId: String?,
+    /**
+     * The address THORChain expects the missing side to come from — the asset-side address when
+     * RUNE is pending, the RUNE address when the asset is pending.
+     */
+    val pairedAddress: String?,
+    /**
+     * Blocks left before the pending side is refunded, or `null` when the age limit or the chain
+     * height could not be read. Already clamped at zero: a deposit past its limit is awaiting the
+     * refund, not overdue by a negative amount.
+     */
+    val blocksUntilRefund: Long?,
+) {
+    /** True while THORChain still holds the RUNE half — the asset half is the one missing. */
+    val isRunePending: Boolean
+        get() = pendingRune.signum() > 0
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -511,7 +511,8 @@ constructor(
 
                         val updatedAccounts =
                             address.accounts.map { account ->
-                                val cachedBalance = balancesByTicker[account.token.ticker.lowercase()]
+                                val cachedBalance =
+                                    balancesByTicker[account.token.ticker.lowercase()]
                                 if (cachedBalance != null) {
                                     account.applyBalance(
                                         cachedBalance.tokenBalance,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -268,6 +268,12 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
+    fun bindGetThorChainPendingLpDepositsUseCase(
+        impl: GetThorChainPendingLpDepositsUseCaseImpl
+    ): GetThorChainPendingLpDepositsUseCase
+
+    @Binds
+    @Singleton
     fun bindThorChainLpPreflightUseCase(
         impl: ThorChainLpPreflightUseCaseImpl
     ): ThorChainLpPreflightUseCase

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainLpPositionsUseCase.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.usecases
 
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.thorchain.ThorChainLiquidityProviderJson
 import com.vultisig.wallet.data.api.models.thorchain.ThorChainPoolStatsJson
 import com.vultisig.wallet.data.models.ThorChainLpPosition
 import com.vultisig.wallet.data.utils.NetworkException
@@ -110,8 +111,13 @@ constructor(private val thorChainApi: ThorChainApi) : GetThorChainLpPositionsUse
     ): PoolFetch {
         val lp =
             try {
-                thorChainApi.getLiquidityProvider(pool.asset, runeAddress)
+                val runeSide = thorChainApi.getLiquidityProvider(pool.asset, runeAddress)
+                // An empty rune-side record must not shadow the asset side: symmetric adds are
+                // keyed by whichever address THORChain recorded them under, and a stale husk on
+                // the other side reads exactly like a live one until its amounts are inspected.
+                runeSide?.takeIf { it.hasLiquidity() }
                     ?: assetAddress?.let { thorChainApi.getLiquidityProvider(pool.asset, it) }
+                    ?: runeSide
             } catch (e: IOException) {
                 Timber.w(e, "Failed to fetch LP position for pool %s", pool.asset)
                 return PoolFetch.Failed
@@ -133,6 +139,12 @@ constructor(private val thorChainApi: ThorChainApi) : GetThorChainLpPositionsUse
             )
         )
     }
+
+    /** True when the record holds units or a pending half-deposit — i.e. it is worth reporting. */
+    private fun ThorChainLiquidityProviderJson.hasLiquidity(): Boolean =
+        (units.toBigIntegerOrNull()?.signum() ?: 0) > 0 ||
+            (pendingRune.toBigIntegerOrNull()?.signum() ?: 0) > 0 ||
+            (pendingAsset.toBigIntegerOrNull()?.signum() ?: 0) > 0
 
     // Midgard returns "NaN" for periods with insufficient history; treat as missing.
     private fun String.toFiniteDoubleOrNull(): Double? = toDoubleOrNull()?.takeIf { it.isFinite() }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainPendingLpDepositsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainPendingLpDepositsUseCase.kt
@@ -16,8 +16,11 @@ import timber.log.Timber
 /** Mimir key for the number of blocks THORChain holds a half-deposit before refunding it. */
 private const val PENDING_LIQUIDITY_AGE_LIMIT_MIMIR = "PENDINGLIQUIDITYAGELIMIT"
 
-/** `PendingLiquidityAgeLimit`'s constant value, used when mimir carries no override (~1 day). */
-private const val DEFAULT_PENDING_LIQUIDITY_AGE_LIMIT = 17_280L
+/**
+ * `PendingLiquidityAgeLimit`'s base constant, used when mimir carries no override. 100,800 blocks
+ * at THORChain's ~6s block time is roughly a week.
+ */
+private const val DEFAULT_PENDING_LIQUIDITY_AGE_LIMIT = 100_800L
 
 interface GetThorChainPendingLpDepositsUseCase {
     /**
@@ -30,26 +33,19 @@ interface GetThorChainPendingLpDepositsUseCase {
      *
      * The scan starts from `/thorchain/pools`, whose `pending_inbound_*` fields say which pools
      * hold *anyone's* pending liquidity. Only those pools are then checked against the user's
-     * addresses, so the usual cost is one request rather than one per pool.
+     * address, so the usual cost is one request rather than one per pool.
      *
-     * @param runeAddress the user's RUNE address — one side of every symmetric add.
-     * @param resolveAssetAddress the user's address on a pool's non-RUNE chain, or `null` when the
-     *   vault has no account there. Called only for pools that hold pending liquidity.
+     * @param runeAddress the user's RUNE address — one side of every symmetric add, and the side
+     *   thornode keys the record by.
      */
-    suspend operator fun invoke(
-        runeAddress: String,
-        resolveAssetAddress: suspend (poolId: String) -> String?,
-    ): List<ThorChainPendingLpDeposit>
+    suspend operator fun invoke(runeAddress: String): List<ThorChainPendingLpDeposit>
 }
 
 internal class GetThorChainPendingLpDepositsUseCaseImpl
 @Inject
 constructor(private val thorChainApi: ThorChainApi) : GetThorChainPendingLpDepositsUseCase {
 
-    override suspend fun invoke(
-        runeAddress: String,
-        resolveAssetAddress: suspend (poolId: String) -> String?,
-    ): List<ThorChainPendingLpDeposit> {
+    override suspend fun invoke(runeAddress: String): List<ThorChainPendingLpDeposit> {
         val candidates =
             try {
                 thorChainApi.getPools().filter { it.holdsPendingLiquidity() }
@@ -64,9 +60,7 @@ constructor(private val thorChainApi: ThorChainApi) : GetThorChainPendingLpDepos
 
         val found = coroutineScope {
             candidates
-                .map { pool ->
-                    async { fetchPending(pool.asset, runeAddress, resolveAssetAddress(pool.asset)) }
-                }
+                .map { pool -> async { fetchPending(pool.asset, runeAddress) } }
                 .awaitAll()
                 .filterNotNull()
         }
@@ -80,24 +74,13 @@ constructor(private val thorChainApi: ThorChainApi) : GetThorChainPendingLpDepos
             (pendingInboundAsset.toBigIntegerOrNull()?.signum() ?: 0) > 0
 
     /**
-     * Reads the user's LP record on [pool] from whichever side carries it. THORChain keys a
-     * symmetric add by the address that opened it, which may be either side, and the unused side
-     * can still answer with an empty husk — so a record without pending amounts does not end the
-     * search.
+     * Reads the user's LP record on [pool]. Looking it up by RUNE address alone is sufficient:
+     * thornode keys every record by the RUNE address whenever the add carries one, and a symmetric
+     * add always does — so an asset-address lookup can only ever return what this one already did.
      */
-    private suspend fun fetchPending(
-        pool: String,
-        runeAddress: String,
-        assetAddress: String?,
-    ): PendingFetch? =
+    private suspend fun fetchPending(pool: String, runeAddress: String): PendingFetch? =
         try {
-            val runeSide = thorChainApi.getLiquidityProvider(pool, runeAddress)
-            val record =
-                runeSide?.takeIf { it.hasPending() }
-                    ?: assetAddress
-                        ?.takeIf { it.isNotBlank() }
-                        ?.let { thorChainApi.getLiquidityProvider(pool, it) }
-            record?.toPendingFetch(pool)
+            thorChainApi.getLiquidityProvider(pool, runeAddress)?.toPendingFetch(pool)
         } catch (e: IOException) {
             Timber.w(e, "Failed to read pending liquidity for pool %s", pool)
             null
@@ -152,18 +135,15 @@ constructor(private val thorChainApi: ThorChainApi) : GetThorChainPendingLpDepos
             null
         }
 
-    private fun ThorChainLiquidityProviderJson.hasPending(): Boolean =
-        (pendingRune.toBigIntegerOrNull()?.signum() ?: 0) > 0 ||
-            (pendingAsset.toBigIntegerOrNull()?.signum() ?: 0) > 0
-
     /**
      * Reads an LP record as a half-finished symmetric add, or `null` when nothing is pending on it.
-     * Both sides are checked: the user may have sent either half first. A record that already holds
-     * units is a live position, not a pending deposit, even if a later add is still settling.
+     * Both sides are checked: the user may have sent either half first.
+     *
+     * A nonzero `units` does not rule a record out. Thornode stages a top-up's pending halves onto
+     * the same record that already holds a live position, so skipping those would hide exactly the
+     * half-deposit a returning LP needs to complete before it is refunded.
      */
     private fun ThorChainLiquidityProviderJson.toPendingFetch(pool: String): PendingFetch? {
-        if ((units.toBigIntegerOrNull()?.signum() ?: 0) > 0) return null
-
         val runePending = pendingRune.toBigIntegerOrNull() ?: BigInteger.ZERO
         val assetPending = pendingAsset.toBigIntegerOrNull() ?: BigInteger.ZERO
         if (runePending.signum() <= 0 && assetPending.signum() <= 0) return null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainPendingLpDepositsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainPendingLpDepositsUseCase.kt
@@ -1,0 +1,195 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.thorchain.ThorChainLiquidityProviderJson
+import com.vultisig.wallet.data.api.models.thorchain.ThorChainPoolJson
+import com.vultisig.wallet.data.models.ThorChainPendingLpDeposit
+import com.vultisig.wallet.data.utils.NetworkException
+import java.io.IOException
+import java.math.BigInteger
+import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import timber.log.Timber
+
+/** Mimir key for the number of blocks THORChain holds a half-deposit before refunding it. */
+private const val PENDING_LIQUIDITY_AGE_LIMIT_MIMIR = "PENDINGLIQUIDITYAGELIMIT"
+
+/** `PendingLiquidityAgeLimit`'s constant value, used when mimir carries no override (~1 day). */
+private const val DEFAULT_PENDING_LIQUIDITY_AGE_LIMIT = 17_280L
+
+interface GetThorChainPendingLpDepositsUseCase {
+    /**
+     * Finds the user's half-finished symmetric add-liquidity deposits.
+     *
+     * A symmetric add mints no LP units until both sides arrive, so these deposits are invisible to
+     * every position lookup — including this app's own, which reads a unit-less record as "no
+     * position". Unfound, they are simply refunded after `PendingLiquidityAgeLimit` with nothing
+     * ever shown to the user.
+     *
+     * The scan starts from `/thorchain/pools`, whose `pending_inbound_*` fields say which pools
+     * hold *anyone's* pending liquidity. Only those pools are then checked against the user's
+     * addresses, so the usual cost is one request rather than one per pool.
+     *
+     * @param runeAddress the user's RUNE address — one side of every symmetric add.
+     * @param resolveAssetAddress the user's address on a pool's non-RUNE chain, or `null` when the
+     *   vault has no account there. Called only for pools that hold pending liquidity.
+     */
+    suspend operator fun invoke(
+        runeAddress: String,
+        resolveAssetAddress: suspend (poolId: String) -> String?,
+    ): List<ThorChainPendingLpDeposit>
+}
+
+internal class GetThorChainPendingLpDepositsUseCaseImpl
+@Inject
+constructor(private val thorChainApi: ThorChainApi) : GetThorChainPendingLpDepositsUseCase {
+
+    override suspend fun invoke(
+        runeAddress: String,
+        resolveAssetAddress: suspend (poolId: String) -> String?,
+    ): List<ThorChainPendingLpDeposit> {
+        val candidates =
+            try {
+                thorChainApi.getPools().filter { it.holdsPendingLiquidity() }
+            } catch (e: IOException) {
+                Timber.w(e, "Failed to scan pools for pending liquidity")
+                return emptyList()
+            } catch (e: NetworkException) {
+                Timber.w(e, "Failed to scan pools for pending liquidity")
+                return emptyList()
+            }
+        if (candidates.isEmpty()) return emptyList()
+
+        val found = coroutineScope {
+            candidates
+                .map { pool ->
+                    async { fetchPending(pool.asset, runeAddress, resolveAssetAddress(pool.asset)) }
+                }
+                .awaitAll()
+                .filterNotNull()
+        }
+        if (found.isEmpty()) return emptyList()
+
+        return withRefundCountdown(found)
+    }
+
+    private fun ThorChainPoolJson.holdsPendingLiquidity(): Boolean =
+        (pendingInboundRune.toBigIntegerOrNull()?.signum() ?: 0) > 0 ||
+            (pendingInboundAsset.toBigIntegerOrNull()?.signum() ?: 0) > 0
+
+    /**
+     * Reads the user's LP record on [pool] from whichever side carries it. THORChain keys a
+     * symmetric add by the address that opened it, which may be either side, and the unused side
+     * can still answer with an empty husk — so a record without pending amounts does not end the
+     * search.
+     */
+    private suspend fun fetchPending(
+        pool: String,
+        runeAddress: String,
+        assetAddress: String?,
+    ): PendingFetch? =
+        try {
+            val runeSide = thorChainApi.getLiquidityProvider(pool, runeAddress)
+            val record =
+                runeSide?.takeIf { it.hasPending() }
+                    ?: assetAddress
+                        ?.takeIf { it.isNotBlank() }
+                        ?.let { thorChainApi.getLiquidityProvider(pool, it) }
+            record?.toPendingFetch(pool)
+        } catch (e: IOException) {
+            Timber.w(e, "Failed to read pending liquidity for pool %s", pool)
+            null
+        } catch (e: NetworkException) {
+            Timber.w(e, "Failed to read pending liquidity for pool %s", pool)
+            null
+        }
+
+    /**
+     * Resolves how long each half-deposit has before it is refunded. A failed read leaves the
+     * countdown null rather than inventing a deadline the user might plan around.
+     */
+    private suspend fun withRefundCountdown(
+        pending: List<PendingFetch>
+    ): List<ThorChainPendingLpDeposit> {
+        val (ageLimit, currentHeight) =
+            coroutineScope {
+                val ageLimitTask = async { fetchPendingLiquidityAgeLimit() }
+                val heightTask = async { fetchLastBlockOrNull() }
+                ageLimitTask.await() to heightTask.await()
+            }
+
+        return pending.map { (deposit, lastAddHeight) ->
+            if (ageLimit == null || currentHeight == null || lastAddHeight == null) deposit
+            else
+                deposit.copy(
+                    blocksUntilRefund = (lastAddHeight + ageLimit - currentHeight).coerceAtLeast(0L)
+                )
+        }
+    }
+
+    private suspend fun fetchPendingLiquidityAgeLimit(): Long? =
+        try {
+            thorChainApi.getMimir()[PENDING_LIQUIDITY_AGE_LIMIT_MIMIR]?.takeIf { it > 0 }
+                ?: DEFAULT_PENDING_LIQUIDITY_AGE_LIMIT
+        } catch (e: IOException) {
+            Timber.w(e, "Failed to read PendingLiquidityAgeLimit")
+            null
+        } catch (e: NetworkException) {
+            Timber.w(e, "Failed to read PendingLiquidityAgeLimit")
+            null
+        }
+
+    private suspend fun fetchLastBlockOrNull(): Long? =
+        try {
+            thorChainApi.getLastBlock().takeIf { it > 0 }
+        } catch (e: IOException) {
+            Timber.w(e, "Failed to read THORChain height")
+            null
+        } catch (e: NetworkException) {
+            Timber.w(e, "Failed to read THORChain height")
+            null
+        }
+
+    private fun ThorChainLiquidityProviderJson.hasPending(): Boolean =
+        (pendingRune.toBigIntegerOrNull()?.signum() ?: 0) > 0 ||
+            (pendingAsset.toBigIntegerOrNull()?.signum() ?: 0) > 0
+
+    /**
+     * Reads an LP record as a half-finished symmetric add, or `null` when nothing is pending on it.
+     * Both sides are checked: the user may have sent either half first. A record that already holds
+     * units is a live position, not a pending deposit, even if a later add is still settling.
+     */
+    private fun ThorChainLiquidityProviderJson.toPendingFetch(pool: String): PendingFetch? {
+        if ((units.toBigIntegerOrNull()?.signum() ?: 0) > 0) return null
+
+        val runePending = pendingRune.toBigIntegerOrNull() ?: BigInteger.ZERO
+        val assetPending = pendingAsset.toBigIntegerOrNull() ?: BigInteger.ZERO
+        if (runePending.signum() <= 0 && assetPending.signum() <= 0) return null
+
+        return PendingFetch(
+            deposit =
+                ThorChainPendingLpDeposit(
+                    pool = pool,
+                    pendingRune = runePending,
+                    pendingAsset = assetPending,
+                    pendingTxId = pendingTxId?.takeIf { it.isNotBlank() },
+                    pairedAddress =
+                        if (runePending.signum() > 0) assetAddress?.takeIf { it.isNotBlank() }
+                        else runeAddress?.takeIf { it.isNotBlank() },
+                    blocksUntilRefund = null,
+                ),
+            lastAddHeight = lastAddHeight?.takeIf { it > 0 },
+        )
+    }
+
+    /**
+     * A pending deposit plus the block it was recorded at. The height only exists to derive the
+     * refund countdown once, after the scan, so it stays out of the domain model.
+     */
+    private data class PendingFetch(
+        val deposit: ThorChainPendingLpDeposit,
+        val lastAddHeight: Long?,
+    )
+}


### PR DESCRIPTION
Closes #4331

## Summary

Two related gaps in the THORChain LP flows, both of which hide money the user has already committed.

**Pending half-deposits.** A symmetric add (`+:ASSET:<paired-address>`) mints no LP units until both sides arrive. In between, the LP record reads as an empty position, so every position lookup drops it — including ours, which treats a unit-less record as "no position". A user who sends the RUNE side and reopens the app sees nothing at all, and ~1 day later THORChain refunds the deposit with no indication anything happened.

The LP tab now shows a card for each half-deposit: what was deposited, the address the missing half has to come from, the time left before the refund, and a CTA into the deposit flow for the half still owed, on that half's own chain with the pool pre-selected.

**Remove LP second leg.** Withdrawing returns RUNE *and* the pool asset, but the form only rendered the RUNE leg, so the asset side stayed invisible until the confirmation screen. Both legs now render stacked with a divider, each with its own percentage, matching the design and iOS.

## Implementation notes

- Detection starts from `/thorchain/pools`, whose `pending_inbound_rune` / `pending_inbound_asset` say which pools hold anyone's pending liquidity. That collapses a ~100-pool fan-out into one request plus a per-user lookup for the handful of live candidates. Both sides of each candidate are tried, since a symmetric add is keyed by whichever address opened it.
- Refund deadline: `last_add_height + PendingLiquidityAgeLimit - currentHeight` at 6s/block. The limit comes from mimir (`PENDINGLIQUIDITYAGELIMIT`) and falls back to the 17,280 constant. A failed read renders "Unknown" rather than inventing a deadline.
- The pending cards intentionally bypass the Manage-Positions selection filter, including the `NoPositionsContainer` branch. A deposit stuck in a pool the user never selected is precisely the one that would otherwise expire unseen.
- Fixed a related shadowing bug: an empty rune-side LP record used to suppress the asset-side lookup entirely.
- The asset leg on Remove LP keeps thornode's full 1e8 precision — at the three decimals that suit RUNE and CACAO, a redeem of `0.07149251 VVV` rendered as `0.071`. Trailing zeros are trimmed on both legs so amounts read as `1.84`, not `1.840`.
- Maya's symmetric pools render both legs too: `loadRemoveLpData` reads `pool.assetDepth` alongside `cacaoDepth`, sharing `removeLpUnitsDivisor` with the CACAO leg.
- The THORChain LP preflight covers the RUNE side and the asset-side completion leg (which arrives on the pool's own asset chain). Maya's add-LP reuses the same strategy but is excluded — thornode's pause keys and pool status say nothing about a Maya pool.
- New strings are translated across all 10 locales.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest :data:testDebugUnitTest` — green
- [x] `./gradlew :app:lintDebug` — clean
- [x] Both screens rendered on an emulator via `PreviewActivity` (`remove_thor_lp`, `thor_lp_pending`): the two Remove LP legs match the design and iOS, and the pending card renders above the LP list with no pools selected
- [ ] Not verified against a live pending pool — see below

## Open question for review

Issue #4331 reports `pending_rune: 0` on the LP record queried at the paired asset address, which would defeat LP-record-based attribution. Per THORChain's add-liquidity handler the pending amount *should* live on the LP record, so I'd expect that record to sit under the RUNE address instead — but I couldn't reach thornode to confirm. Worth a check against a currently-pending pool before merge; if thornode really reports zero on both sides, only the pool-level aggregate carries the signal and per-user attribution has no source.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* View pending THORChain liquidity-pool deposits with amounts, paired addresses, token details, and refund countdowns.
* Complete eligible pending deposits directly from the liquidity positions screen.
* Improved liquidity removal screens to show both withdrawal assets and amounts.
* Refresh pending deposit information when returning to the liquidity positions screen.

## Bug Fixes
* Improved loading, retry, empty, and deposit validation states.

## Localization
* Added pending-deposit translations across supported languages.

## Testing
* Updated DeFi position coverage for pending deposits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
