### PR TITLE
feat(defi): bond bRUNE / unbond ybRUNE and show its position card

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
@@ -64,7 +64,7 @@ import com.vultisig.wallet.data.db.models.VaultOrderEntity
             TransactionHistoryEntity::class,
             PendingLimitOrderEntity::class,
         ],
-    version = 41,
+    version = 42,
     exportSchema = false,
 )
 @TypeConverters(

--- a/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
@@ -50,6 +50,7 @@ import com.vultisig.wallet.data.db.migrations.MIGRATION_38_39
 import com.vultisig.wallet.data.db.migrations.MIGRATION_39_40
 import com.vultisig.wallet.data.db.migrations.MIGRATION_3_4
 import com.vultisig.wallet.data.db.migrations.MIGRATION_40_41
+import com.vultisig.wallet.data.db.migrations.MIGRATION_41_42
 import com.vultisig.wallet.data.db.migrations.MIGRATION_4_5
 import com.vultisig.wallet.data.db.migrations.MIGRATION_5_6
 import com.vultisig.wallet.data.db.migrations.MIGRATION_6_7
@@ -119,6 +120,7 @@ internal interface DatabaseModule {
                     MIGRATION_38_39,
                     MIGRATION_39_40,
                     MIGRATION_40_41,
+                    MIGRATION_41_42,
                 )
                 .build()
 

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -1046,3 +1046,32 @@ internal val MIGRATION_40_41 =
             )
         }
     }
+
+// The sRUJI and ybRUNE receipts back a DeFi position and were never meant to be wallet tokens, but
+// both were auto-discoverable before the DeFi-only denom gate covered them (#5583), so vaults that
+// held one carry a persisted `coin` row for it. TokenRefreshWorker deletes those rows too, but only
+// once WorkManager gets round to running it with a network — until then the receipt is still listed
+// as a spendable token on the chain screen. Drop it here so the upgrade itself settles it, before
+// anything reads the table.
+//
+// Denoms are spelled out rather than read off the catalogue: a migration has to keep matching what
+// was on disk when it shipped even if the definitions are later renamed. Matched on
+// `contractAddress` (lowercased, as node casing is not guaranteed) rather than `id`, because rows
+// written before the ticker was canonicalized carry the derived ticker instead of the curated one.
+// The `tokenValue` cache is deliberately left alone: the DeFi position reads the same cached
+// balance, and clearing it would only blank the card until the next fetch.
+internal val MIGRATION_41_42 =
+    object : Migration(41, 42) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+            DELETE FROM coin
+            WHERE chain = 'THORChain'
+            AND LOWER(contractAddress) IN (
+                'x/staking-ruji', 'x/staking-x/ruji', 'x/staking-x/brune'
+            )
+            """
+                    .trimIndent()
+            )
+        }
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -903,17 +903,16 @@ constructor(
                                 } else {
                                     R.string.defi_header_staked
                                 }
-                            // The bonded position is named after what was bonded, not after the
-                            // receipt that tracks it: "Compounded bRUNE", the way the sRUJI card
-                            // is titled off RUJI.
-                            val headerTicker =
-                                if (isBondedRuneReceipt) Coins.ThorChain.bRUNE.ticker
-                                else coin.ticker
+                            // Titled in the same unit the amount below it is counted in. The
+                            // sRUJI card can say RUJI because its amount is the pool's RUJI
+                            // liquidSize; this one is the raw receipt balance, and a share is
+                            // worth more than one bRUNE, so naming it bRUNE would understate the
+                            // position by the compounding it exists to earn.
                             val position =
                                 StakePositionUiModel(
                                     coin = defaultPosition.coin,
                                     stakeAssetHeader =
-                                        UiText.FormattedText(headerResId, listOf(headerTicker)),
+                                        UiText.FormattedText(headerResId, listOf(coin.ticker)),
                                     stakedAmountDisplay =
                                         stakeAmount.formatTokenAmount(coin.ticker),
                                     // No .orEmpty(): a missed lookup means "we have no price",
@@ -1484,7 +1483,6 @@ constructor(
             val stcy = Coins.ThorChain.sTCY
             val ytcy = Coins.ThorChain.yTCY
             val yrune = Coins.ThorChain.yRUNE
-            val brune = Coins.ThorChain.bRUNE
             val ybrune = Coins.ThorChain.ybRUNE
 
             return listOf(
@@ -1567,7 +1565,10 @@ constructor(
                 StakePositionUiModel(
                     coin = ybrune,
                     stakeAssetHeader =
-                        UiText.FormattedText(R.string.defi_header_compounded, listOf(brune.ticker)),
+                        UiText.FormattedText(
+                            R.string.defi_header_compounded,
+                            listOf(ybrune.ticker),
+                        ),
                     stakedAmountDisplay = "0 ${ybrune.ticker}",
                     apy = null,
                     canWithdraw = false,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -835,7 +835,8 @@ constructor(
                     settleStakingPositions {
                         it.coin.id == Coins.ThorChain.yRUNE.id ||
                             it.coin.id == Coins.ThorChain.yTCY.id ||
-                            it.coin.id == Coins.ThorChain.sTCY.id
+                            it.coin.id == Coins.ThorChain.sTCY.id ||
+                            it.coin.id == Coins.ThorChain.ybRUNE.id
                     }
                 }
                 .onCompletion { cause ->
@@ -888,21 +889,31 @@ constructor(
 
                             val canTransfer = coin.ticker.contains("stcy", ignoreCase = true)
 
+                            val isBondedRuneReceipt =
+                                coin.id.equals(Coins.ThorChain.ybRUNE.id, true)
+
                             val headerResId =
                                 if (supportsMint) {
                                     R.string.defi_header_minted
                                 } else if (
-                                    defaultPosition.coin.id.equals(Coins.ThorChain.sTCY.id, true)
+                                    defaultPosition.coin.id.equals(Coins.ThorChain.sTCY.id, true) ||
+                                        isBondedRuneReceipt
                                 ) {
                                     R.string.defi_header_compounded
                                 } else {
                                     R.string.defi_header_staked
                                 }
+                            // The bonded position is named after what was bonded, not after the
+                            // receipt that tracks it: "Compounded bRUNE", the way the sRUJI card
+                            // is titled off RUJI.
+                            val headerTicker =
+                                if (isBondedRuneReceipt) Coins.ThorChain.bRUNE.ticker
+                                else coin.ticker
                             val position =
                                 StakePositionUiModel(
                                     coin = defaultPosition.coin,
                                     stakeAssetHeader =
-                                        UiText.FormattedText(headerResId, listOf(coin.ticker)),
+                                        UiText.FormattedText(headerResId, listOf(headerTicker)),
                                     stakedAmountDisplay =
                                         stakeAmount.formatTokenAmount(coin.ticker),
                                     // No .orEmpty(): a missed lookup means "we have no price",
@@ -1406,6 +1417,9 @@ constructor(
                     DeFiNavActions.UNSTAKE_TCY -> Coins.ThorChain.TCY.id
                     DeFiNavActions.STAKE_STCY -> Coins.ThorChain.TCY.id
                     DeFiNavActions.UNSTAKE_STCY -> Coins.ThorChain.sTCY.id
+                    // Bonding spends bRUNE; only the unbond starts from the receipt.
+                    DeFiNavActions.STAKE_YBRUNE -> Coins.ThorChain.bRUNE.id
+                    DeFiNavActions.UNSTAKE_YBRUNE -> Coins.ThorChain.ybRUNE.id
                     DeFiNavActions.MINT_YTCY -> Coins.ThorChain.TCY.id
                     DeFiNavActions.REDEEM_YTCY -> Coins.ThorChain.yTCY.id
                     DeFiNavActions.MINT_YRUNE -> Coins.ThorChain.RUNE.id
@@ -1470,6 +1484,8 @@ constructor(
             val stcy = Coins.ThorChain.sTCY
             val ytcy = Coins.ThorChain.yTCY
             val yrune = Coins.ThorChain.yRUNE
+            val brune = Coins.ThorChain.bRUNE
+            val ybrune = Coins.ThorChain.ybRUNE
 
             return listOf(
                 StakePositionUiModel(
@@ -1540,6 +1556,19 @@ constructor(
                     coin = yrune,
                     stakeAssetHeader = UiText.StringResource(R.string.staked_yrune_header),
                     stakedAmountDisplay = "0 ${yrune.ticker}",
+                    apy = null,
+                    canWithdraw = false,
+                    canStake = true,
+                    canUnstake = false,
+                    rewards = null,
+                    nextReward = null,
+                    nextPayout = null,
+                ),
+                StakePositionUiModel(
+                    coin = ybrune,
+                    stakeAssetHeader =
+                        UiText.FormattedText(R.string.defi_header_compounded, listOf(brune.ticker)),
+                    stakedAmountDisplay = "0 ${ybrune.ticker}",
                     apy = null,
                     canWithdraw = false,
                     canStake = true,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -887,10 +887,16 @@ constructor(
                                 coin.ticker.contains("yrune", ignoreCase = true) ||
                                     coin.ticker.contains("ytcy", ignoreCase = true)
 
-                            val canTransfer = coin.ticker.contains("stcy", ignoreCase = true)
-
                             val isBondedRuneReceipt =
                                 coin.id.equals(Coins.ThorChain.ybRUNE.id, true)
+
+                            // Both compounding receipts are plain THORChain bank denoms, so the
+                            // vault can move either one to another address — #5585 asks for it on
+                            // ybRUNE, and iOS offers Transfer on every compound position. Matched
+                            // on the coin id: a substring of the ticker is what left this card
+                            // with the wrong logo, since ybRUNE contains none of the others.
+                            val canTransfer =
+                                coin.id.equals(Coins.ThorChain.sTCY.id, true) || isBondedRuneReceipt
 
                             val headerResId =
                                 if (supportsMint) {
@@ -1448,14 +1454,16 @@ constructor(
         }
     }
 
-    fun onClickTransfer() {
+    /**
+     * Opens the plain send form on [coin], the position's own receipt.
+     *
+     * Carries the position's coin rather than a fixed one: sTCY was the only transferable card when
+     * this was written, and the ybRUNE receipt would otherwise have sent the wrong token.
+     */
+    fun onClickTransfer(coin: Coin) {
         viewModelScope.launch {
             navigator.route(
-                Route.Send(
-                    vaultId = vaultId,
-                    chainId = Chain.ThorChain.id,
-                    tokenId = Coins.ThorChain.sTCY.id,
-                )
+                Route.Send(vaultId = vaultId, chainId = coin.chain.id, tokenId = coin.id)
             )
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.OPERATION_CIRCLE_WITHDRAW
 import com.vultisig.wallet.data.models.SwapTransaction
 import com.vultisig.wallet.data.models.TransactionId
@@ -82,9 +83,14 @@ constructor(
 
         val pubKeyECDSA = vault.pubKeyECDSA
         val coin =
-            vault.coins.find {
-                it.id == transaction.token.id && it.chain.id == transaction.chainId
-            }!!
+            vault.coins.find { it.id == transaction.token.id && it.chain.id == transaction.chainId }
+                // The DeFi-only receipts are never vault coins — they are kept out of token
+                // discovery so a position can't show up as a wallet holding — yet they are plain
+                // bank denoms the vault can transfer. The account the send form was built from
+                // carries the chain's own address and derived key, so the staged token is complete
+                // and is the only place the receipt can be resolved from.
+                ?: transaction.token.takeIf { Coins.isDefiOnly(it) }
+                ?: error("Coin ${transaction.token.id} is not in vault ${transaction.vaultId}")
 
         this@KeysignShareViewModel.vault = vault
         amount.value = mapTokenValueToStringWithUnit(transaction.tokenValue)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.ui.models.send
 
 import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.generateId
+import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
 import com.vultisig.wallet.data.blockchain.thorchain.RujiStakingService.Companion.RUJI_REWARDS_COIN
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
@@ -14,6 +15,7 @@ import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import java.math.BigDecimal
 import java.math.BigInteger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
@@ -26,6 +28,7 @@ internal class AccountsLoader(
     private val accountsState: MutableStateFlow<AccountsLoadState>,
     private val accountsRepository: AccountsRepository,
     private val stakingDetailsRepository: StakingDetailsRepository,
+    private val defaultStakingPositionService: DefaultStakingPositionService,
     private val defiTypeProvider: () -> DeFiNavActions?,
     private val mscaAddressProvider: () -> String?,
     private val bondedAmountProvider: () -> BigInteger?,
@@ -254,21 +257,55 @@ internal class AccountsLoader(
 
     /**
      * The ybRUNE receipt is not a wallet token either, so the unbond form has no account to draw on
-     * until one is synthesized from the position the DeFi tab cached.
+     * until one is synthesized from the vault's receipt balance.
      *
      * Denominated in receipt units — the vault's `x/staking-x/brune` bank balance, which is what
      * the position reports — so the amount the form carries is already what funds the unbond. No
      * conversion happens at submit, unlike the RUJI receipt above, whose position is reported in
      * RUJI.
+     *
+     * Cached first, then re-read from the chain, the way the balance rows around it hydrate. The
+     * cached figure is whatever the DeFi tab last stored, and this account is what MAX fills the
+     * form from: left at the cache, a bond made since that refresh would cap MAX below the true
+     * position and quietly redeem less than everything, with the submit-time clamp — which only
+     * ever lowers an amount — unable to notice.
      */
     private suspend fun loadBondedRuneReceiptAccount(vaultId: VaultId, generation: Long) {
-        val cachedDetails =
-            stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.ThorChain.ybRUNE.id)
+        var receiptAmount =
+            stakingDetailsRepository
+                .getStakingDetailsByCoindId(vaultId, Coins.ThorChain.ybRUNE.id)
+                ?.stakeAmount
+        var hydrated = false
         accountsRepository
             .loadAddresses(vaultId)
             .map { addrs -> addrs.flatMap { it.accounts } }
             .collect { accountsLoaded ->
-                publishBondedRuneReceipt(accountsLoaded, cachedDetails?.stakeAmount, generation)
+                publishBondedRuneReceipt(accountsLoaded, receiptAmount, generation)
+
+                val address =
+                    accountsLoaded
+                        .find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                        ?.token
+                        ?.address
+                if (hydrated || address.isNullOrEmpty()) return@collect
+                hydrated = true
+
+                // A failed read leaves the cached figure standing rather than emptying the form:
+                // the submit clamp reads the balance again and refuses to build on a guess.
+                val live =
+                    try {
+                        defaultStakingPositionService.getReceiptBalance(
+                            address,
+                            Coins.ThorChain.ybRUNE,
+                        )
+                    } catch (t: Throwable) {
+                        if (t is CancellationException) throw t
+                        Timber.e(t, "Failed to read the live ybRUNE receipt balance")
+                        return@collect
+                    }
+
+                receiptAmount = live
+                publishBondedRuneReceipt(accountsLoaded, live, generation)
             }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
@@ -7,6 +7,7 @@ import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.TokenId
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.data.repositories.AccountsRepository
@@ -29,6 +30,7 @@ internal class AccountsLoader(
     private val stakingDetailsRepository: StakingDetailsRepository,
     private val defaultStakingPositionService: DefaultStakingPositionService,
     private val defiTypeProvider: () -> DeFiNavActions?,
+    private val preselectedTokenIdProvider: () -> TokenId?,
     private val mscaAddressProvider: () -> String?,
     private val bondedAmountProvider: () -> BigInteger?,
 ) {
@@ -88,10 +90,7 @@ internal class AccountsLoader(
                 DeFiNavActions.REDEEM_YTCY,
                 DeFiNavActions.FREEZE_TRX ->
                     scope.safeLaunch(onError = ::onLoadError) {
-                        accountsRepository
-                            .loadAddresses(vaultId)
-                            .map { addrs -> addrs.flatMap { it.accounts } }
-                            .collect { publishLoaded(it, generation) }
+                        loadWalletAccounts(vaultId, generation)
                     }
 
                 else ->
@@ -136,6 +135,29 @@ internal class AccountsLoader(
                     }
             }
     }
+
+    /**
+     * The vault's own accounts: what an ordinary send, and every DeFi form funded with a wallet
+     * token, draws on.
+     *
+     * A send that was opened on the ybRUNE receipt carries it alongside them. The receipt is an
+     * ordinary bank denom the vault can move like any other token — the Transfer action on its
+     * position card is exactly that — but it is deliberately kept out of token discovery, so
+     * nothing in the addresses flow would give the form an account to send it from.
+     */
+    private suspend fun loadWalletAccounts(vaultId: VaultId, generation: Long) {
+        if (defiTypeProvider() == null && isBondedRuneReceipt(preselectedTokenIdProvider())) {
+            loadBondedRuneReceiptAccount(vaultId, generation, alongsideWalletAccounts = true)
+            return
+        }
+        accountsRepository
+            .loadAddresses(vaultId)
+            .map { addrs -> addrs.flatMap { it.accounts } }
+            .collect { publishLoaded(it, generation) }
+    }
+
+    private fun isBondedRuneReceipt(tokenId: TokenId?): Boolean =
+        tokenId.equals(Coins.ThorChain.ybRUNE.id, true)
 
     /**
      * The accounts a form may draw on.
@@ -264,13 +286,21 @@ internal class AccountsLoader(
      * conversion happens at submit, unlike the RUJI receipt above, whose position is reported in
      * RUJI.
      *
+     * With [alongsideWalletAccounts] the receipt joins the vault's own accounts instead of
+     * replacing them — that is the plain send the position card's Transfer action opens, where
+     * every other holding stays selectable.
+     *
      * Cached first, then re-read from the chain, the way the balance rows around it hydrate. The
      * cached figure is whatever the DeFi tab last stored, and this account is what MAX fills the
      * form from: left at the cache, a bond made since that refresh would cap MAX below the true
      * position and quietly redeem less than everything, with the submit-time clamp — which only
      * ever lowers an amount — unable to notice.
      */
-    private suspend fun loadBondedRuneReceiptAccount(vaultId: VaultId, generation: Long) {
+    private suspend fun loadBondedRuneReceiptAccount(
+        vaultId: VaultId,
+        generation: Long,
+        alongsideWalletAccounts: Boolean = false,
+    ) {
         var receiptAmount =
             stakingDetailsRepository
                 .getStakingDetailsByCoindId(vaultId, Coins.ThorChain.ybRUNE.id)
@@ -280,7 +310,12 @@ internal class AccountsLoader(
             .loadAddresses(vaultId)
             .map { addrs -> addrs.flatMap { it.accounts } }
             .collect { accountsLoaded ->
-                publishBondedRuneReceipt(accountsLoaded, receiptAmount, generation)
+                publishBondedRuneReceipt(
+                    accountsLoaded,
+                    receiptAmount,
+                    generation,
+                    alongsideWalletAccounts,
+                )
 
                 val address =
                     accountsLoaded
@@ -288,7 +323,6 @@ internal class AccountsLoader(
                         ?.token
                         ?.address
                 if (hydrated || address.isNullOrEmpty()) return@collect
-                hydrated = true
 
                 // A failed read leaves the cached figure standing rather than emptying the form:
                 // the submit clamp reads the balance again and refuses to build on a guess.
@@ -304,8 +338,12 @@ internal class AccountsLoader(
                         return@collect
                     }
 
+                // Marked hydrated only once a read has actually landed. Set before the attempt, a
+                // single transient failure retired the retry for the rest of the form's life, and
+                // MAX went back to the cached ceiling the submit clamp can only ever lower.
+                hydrated = true
                 receiptAmount = live
-                publishBondedRuneReceipt(accountsLoaded, live, generation)
+                publishBondedRuneReceipt(accountsLoaded, live, generation, alongsideWalletAccounts)
             }
     }
 
@@ -313,16 +351,29 @@ internal class AccountsLoader(
         accountsLoaded: List<Account>,
         receiptAmount: BigInteger?,
         generation: Long,
+        alongsideWalletAccounts: Boolean = false,
     ) {
         if (generation != currentGeneration) return
         // As with sRUJI: the RUNE account carries the address the unbond is sent from, funds the
         // gas fee, and supplies the derived key the receipt's catalogue entry has no copy of.
         val thorchainAccount =
-            accountsLoaded.findSourceOrPublishEmpty(
-                tokenId = Coins.ThorChain.RUNE.id,
-                generation = generation,
-                missingReason = "THORChain account not available for ybRUNE unstake",
-            ) ?: return
+            if (alongsideWalletAccounts) {
+                // A plain send that merely started on the receipt. Without a THORChain account
+                // there is nothing to synthesize it from, but the rest of the vault is still
+                // perfectly sendable — leave the form the accounts it does have rather than
+                // emptying it over a token it can simply drop.
+                accountsLoaded.find { it.token.id.equals(Coins.ThorChain.RUNE.id, true) }
+                    ?: run {
+                        publishLoaded(accountsLoaded, generation)
+                        return
+                    }
+            } else {
+                accountsLoaded.findSourceOrPublishEmpty(
+                    tokenId = Coins.ThorChain.RUNE.id,
+                    generation = generation,
+                    missingReason = "THORChain account not available for ybRUNE unstake",
+                ) ?: return
+            }
 
         val ybRune =
             Coins.ThorChain.ybRUNE.copy(
@@ -336,7 +387,17 @@ internal class AccountsLoader(
                 fiatValue = null,
                 price = null,
             )
-        publishLoaded(listOf(ybRuneAccount, thorchainAccount), generation)
+        val accounts =
+            if (alongsideWalletAccounts) {
+                // The whole wallet stays in the picker, with the receipt appended: this is an
+                // ordinary send, not a form that may only ever draw on the position. Any receipt
+                // already in the list is dropped in favour of the one carrying the live balance.
+                accountsLoaded.filterNot { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) } +
+                    ybRuneAccount
+            } else {
+                listOf(ybRuneAccount, thorchainAccount)
+            }
+        publishLoaded(accounts, generation)
     }
 
     // Collect both cached and hydrated emissions so the form renders cached RUNE/RUJI

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AccountsLoader.kt
@@ -66,6 +66,11 @@ internal class AccountsLoader(
                         loadAutoCompoundRujiAccount(vaultId, generation)
                     }
 
+                DeFiNavActions.UNSTAKE_YBRUNE ->
+                    scope.safeLaunch(onError = ::onLoadError) {
+                        loadBondedRuneReceiptAccount(vaultId, generation)
+                    }
+
                 null,
                 DeFiNavActions.BOND,
                 DeFiNavActions.STAKE_RUJI,
@@ -73,6 +78,8 @@ internal class AccountsLoader(
                 DeFiNavActions.STAKE_TCY,
                 DeFiNavActions.STAKE_STCY,
                 DeFiNavActions.UNSTAKE_STCY,
+                // The bond is funded with bRUNE, an ordinary wallet token.
+                DeFiNavActions.STAKE_YBRUNE,
                 DeFiNavActions.MINT_YRUNE,
                 DeFiNavActions.MINT_YTCY,
                 DeFiNavActions.REDEEM_YRUNE,
@@ -243,6 +250,56 @@ internal class AccountsLoader(
                 generation,
             )
         }
+    }
+
+    /**
+     * The ybRUNE receipt is not a wallet token either, so the unbond form has no account to draw on
+     * until one is synthesized from the position the DeFi tab cached.
+     *
+     * Denominated in receipt units — the vault's `x/staking-x/brune` bank balance, which is what
+     * the position reports — so the amount the form carries is already what funds the unbond. No
+     * conversion happens at submit, unlike the RUJI receipt above, whose position is reported in
+     * RUJI.
+     */
+    private suspend fun loadBondedRuneReceiptAccount(vaultId: VaultId, generation: Long) {
+        val cachedDetails =
+            stakingDetailsRepository.getStakingDetailsByCoindId(vaultId, Coins.ThorChain.ybRUNE.id)
+        accountsRepository
+            .loadAddresses(vaultId)
+            .map { addrs -> addrs.flatMap { it.accounts } }
+            .collect { accountsLoaded ->
+                publishBondedRuneReceipt(accountsLoaded, cachedDetails?.stakeAmount, generation)
+            }
+    }
+
+    private fun publishBondedRuneReceipt(
+        accountsLoaded: List<Account>,
+        receiptAmount: BigInteger?,
+        generation: Long,
+    ) {
+        if (generation != currentGeneration) return
+        // As with sRUJI: the RUNE account carries the address the unbond is sent from, funds the
+        // gas fee, and supplies the derived key the receipt's catalogue entry has no copy of.
+        val thorchainAccount =
+            accountsLoaded.findSourceOrPublishEmpty(
+                tokenId = Coins.ThorChain.RUNE.id,
+                generation = generation,
+                missingReason = "THORChain account not available for ybRUNE unstake",
+            ) ?: return
+
+        val ybRune =
+            Coins.ThorChain.ybRUNE.copy(
+                address = thorchainAccount.token.address,
+                hexPublicKey = thorchainAccount.token.hexPublicKey,
+            )
+        val ybRuneAccount =
+            Account(
+                token = ybRune,
+                tokenValue = TokenValue(value = receiptAmount ?: BigInteger.ZERO, token = ybRune),
+                fiatValue = null,
+                price = null,
+            )
+        publishLoaded(listOf(ybRuneAccount, thorchainAccount), generation)
     }
 
     // Collect both cached and hydrated emissions so the form renders cached RUNE/RUJI

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenId
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
@@ -126,10 +127,12 @@ internal class SendFormGraph(
     private var defiType: DeFiNavActions? = null // Default is send, no defi form
     private var mscaAddress: String? = null
     private var bondedAmount: BigInteger? = null
+    private var preselectedTokenId: TokenId? = null
 
     private val vaultProvider: () -> Vault? = { vault }
     private val vaultIdProvider: () -> VaultId? = { vaultId }
     private val defiTypeProvider: () -> DeFiNavActions? = { defiType }
+    private val preselectedTokenIdProvider: () -> TokenId? = { preselectedTokenId }
     private val mscaAddressProvider: () -> String? = { mscaAddress }
     private val bondedAmountProvider: () -> BigInteger? = { bondedAmount }
 
@@ -168,6 +171,7 @@ internal class SendFormGraph(
             stakingDetailsRepository = stakingDetailsRepository,
             defaultStakingPositionService = defaultStakingPositionService,
             defiTypeProvider = defiTypeProvider,
+            preselectedTokenIdProvider = preselectedTokenIdProvider,
             mscaAddressProvider = mscaAddressProvider,
             bondedAmountProvider = bondedAmountProvider,
         )
@@ -366,6 +370,9 @@ internal class SendFormGraph(
         mscaAddress = args.mscaAddress
         bondedAmount = args.bondedAmount?.toBigIntegerOrNull()
         vaultId = args.vaultId
+        // Seeded before the load: the accounts a plain send may draw on depend on the token it was
+        // opened for — the ybRUNE receipt is not a wallet token and has to be synthesized.
+        preselectedTokenId = args.tokenId
         accountsLoader.load(args.vaultId)
         loadVaultName()
         initFormType()

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
@@ -5,6 +5,7 @@ package com.vultisig.wallet.ui.models.send
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
 import com.vultisig.wallet.data.blockchain.tron.GetTronFrozenBalancesUseCase
 import com.vultisig.wallet.data.blockchain.tron.TronFrozenBalanceState
 import com.vultisig.wallet.data.blockchain.tron.TronResourceType
@@ -90,6 +91,7 @@ internal class SendFormGraph(
     private val vaultRepository: VaultRepository,
     private val tokenRepository: TokenRepository,
     private val stakingDetailsRepository: StakingDetailsRepository,
+    private val defaultStakingPositionService: DefaultStakingPositionService,
     private val feeServiceComposite: FeeServiceComposite,
     private val chainValidationService: ChainValidationService,
     private val getTronFrozenBalances: GetTronFrozenBalancesUseCase,
@@ -164,6 +166,7 @@ internal class SendFormGraph(
             accountsState = accountsState,
             accountsRepository = accountsRepository,
             stakingDetailsRepository = stakingDetailsRepository,
+            defaultStakingPositionService = defaultStakingPositionService,
             defiTypeProvider = defiTypeProvider,
             mscaAddressProvider = mscaAddressProvider,
             bondedAmountProvider = bondedAmountProvider,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
 import com.vultisig.wallet.data.blockchain.tron.GetTronFrozenBalancesUseCase
 import com.vultisig.wallet.data.blockchain.tron.TronResourceType
 import com.vultisig.wallet.data.models.Account
@@ -77,6 +78,7 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val tokenRepository: TokenRepository,
     private val stakingDetailsRepository: StakingDetailsRepository,
+    private val defaultStakingPositionService: DefaultStakingPositionService,
     private val feeServiceComposite: FeeServiceComposite,
     private val chainValidationService: ChainValidationService,
     private val requestAddressBookEntry: RequestAddressBookEntryUseCase,
@@ -156,6 +158,7 @@ constructor(
             vaultRepository = vaultRepository,
             tokenRepository = tokenRepository,
             stakingDetailsRepository = stakingDetailsRepository,
+            defaultStakingPositionService = defaultStakingPositionService,
             feeServiceComposite = feeServiceComposite,
             chainValidationService = chainValidationService,
             getTronFrozenBalances = getTronFrozenBalances,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/TokenPreselectionService.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/TokenPreselectionService.kt
@@ -116,15 +116,17 @@ internal class TokenPreselectionService(
         // RUNE/RUJI in vault for WITHDRAW_RUJI, no ETH for WITHDRAW_USDC_CIRCLE). Returning
         // a static template coin here would cause collectSelectedAccount to synthesize an
         // Account with tokenValue = null, making the form look submittable when it isn't.
-        // UNSTAKE_SRUJI belongs to the same group: its account is synthesized on top of the
-        // vault's RUNE account, so no accounts means that prerequisite is missing too.
+        // UNSTAKE_SRUJI and UNSTAKE_YBRUNE belong to the same group: both receipt accounts are
+        // synthesized on top of the vault's RUNE account, so no accounts means that prerequisite
+        // is missing too.
         // STAKE types keep their defaults even on empty accounts because the default coin
         // guides the user toward what they would be staking.
         if (accounts.isEmpty()) {
             return when (defiTypeProvider()) {
                 DeFiNavActions.WITHDRAW_RUJI,
                 DeFiNavActions.WITHDRAW_USDC_CIRCLE,
-                DeFiNavActions.UNSTAKE_SRUJI -> null
+                DeFiNavActions.UNSTAKE_SRUJI,
+                DeFiNavActions.UNSTAKE_YBRUNE -> null
                 else -> defaultDefiCoin(accounts, preSelectedChainIds, preSelectedTokenId)
             }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/TokenPreselectionService.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/TokenPreselectionService.kt
@@ -167,6 +167,11 @@ internal class TokenPreselectionService(
             DeFiNavActions.WITHDRAW_USDC_CIRCLE -> Coins.Ethereum.USDC
             DeFiNavActions.STAKE_STCY -> Coins.ThorChain.TCY
             DeFiNavActions.UNSTAKE_STCY -> Coins.ThorChain.sTCY
+
+            // The liquid bond is funded with bRUNE and redeemed out of the ybRUNE receipt, so the
+            // two directions start from different tokens — as with the RUJI pair above.
+            DeFiNavActions.STAKE_YBRUNE -> Coins.ThorChain.bRUNE
+            DeFiNavActions.UNSTAKE_YBRUNE -> Coins.ThorChain.ybRUNE
             DeFiNavActions.STAKE_CACAO,
             DeFiNavActions.UNSTAKE_CACAO,
             DeFiNavActions.ADD_LP,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SendStrategyFactory.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SendStrategyFactory.kt
@@ -56,12 +56,14 @@ internal data class SendStrategies(
             DeFiNavActions.STAKE_RUJI,
             DeFiNavActions.STAKE_SRUJI,
             DeFiNavActions.STAKE_TCY,
-            DeFiNavActions.STAKE_STCY -> stake.submit()
+            DeFiNavActions.STAKE_STCY,
+            DeFiNavActions.STAKE_YBRUNE -> stake.submit()
 
             DeFiNavActions.UNSTAKE_RUJI,
             DeFiNavActions.UNSTAKE_SRUJI,
             DeFiNavActions.UNSTAKE_TCY,
             DeFiNavActions.UNSTAKE_STCY,
+            DeFiNavActions.UNSTAKE_YBRUNE,
             DeFiNavActions.WITHDRAW_RUJI -> unstake.submit()
 
             DeFiNavActions.MINT_YRUNE,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SendStrategyFactory.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/SendStrategyFactory.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.ui.models.send.submit
 
 import androidx.compose.foundation.text.input.TextFieldState
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AccountsRepository
@@ -145,6 +146,7 @@ constructor(
     private val chainValidationService: ChainValidationService,
     private val navigator: Navigator<Destination>,
     private val thorChainApi: ThorChainApi,
+    private val defaultStakingPositionService: DefaultStakingPositionService,
 ) {
 
     /**
@@ -253,6 +255,7 @@ constructor(
                     depositTransactionRepository = depositTransactionRepository,
                     navigator = navigator,
                     thorChainApi = thorChainApi,
+                    defaultStakingPositionService = defaultStakingPositionService,
                     defiTypeProvider = context.defiTypeProvider,
                     isAutocompoundProvider = context.isAutocompoundProvider,
                     showLoading = context.showLoading,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategy.kt
@@ -19,6 +19,7 @@ import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_BRUNE_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.STAKING_TCY_COMPOUND_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
@@ -131,6 +132,17 @@ internal class StakeStrategy(
 
                             DeFiNavActions.STAKE_SRUJI ->
                                 createRujiCompoundStakeDepositTransaction(
+                                    vaultId = vaultId,
+                                    selectedToken = selectedToken,
+                                    srcAddress = srcAddress,
+                                    dstAddress = dstAddress,
+                                    tokenAmountInt = tokenAmountInt,
+                                    gasFee = gasFee,
+                                    chain = chain,
+                                )
+
+                            DeFiNavActions.STAKE_YBRUNE ->
+                                createBRuneStakeDepositTransaction(
                                     vaultId = vaultId,
                                     selectedToken = selectedToken,
                                     srcAddress = srcAddress,
@@ -269,6 +281,58 @@ internal class StakeStrategy(
                 ThorchainFunctions.stakeRujiCompound(
                     fromAddress = srcAddress,
                     stakingContract = STAKING_RUJI_CONTRACT,
+                    denom = selectedToken.contractAddress,
+                    amount = tokenAmountInt,
+                ),
+        )
+    }
+
+    /**
+     * Bonds bRUNE into the Rujira liquid bond (`liquid.bond`), which mints the ybRUNE receipt.
+     *
+     * There is no memo-based path here the way TCY has one: bRUNE staking is always the
+     * auto-compounding liquid bond, so this always carries the wasm payload and a generic-contract
+     * transaction type.
+     */
+    private suspend fun createBRuneStakeDepositTransaction(
+        vaultId: String,
+        selectedToken: Coin,
+        srcAddress: String,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        gasFee: TokenValue,
+        chain: Chain,
+    ): DepositTransaction {
+        val specific =
+            withContext(Dispatchers.IO) {
+                blockChainSpecificRepository.getSpecific(
+                    chain,
+                    srcAddress,
+                    selectedToken,
+                    gasFee,
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            }
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddress,
+            memo = "",
+            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+            estimatedFees = gasFee,
+            estimateFeesFiat =
+                gasFeeToEstimatedFee.fiatFeesFor(gasFee, selectedToken).formattedFiatValue,
+            blockChainSpecific = specific.blockChainSpecific,
+            wasmExecuteContractPayload =
+                ThorchainFunctions.stakeBRune(
+                    fromAddress = srcAddress,
+                    stakingContract = STAKING_BRUNE_CONTRACT,
                     denom = selectedToken.contractAddress,
                     amount = tokenAmountInt,
                 ),

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.ui.models.send.toPlainBigDecimalOrNull
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_BRUNE_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.STAKING_TCY_COMPOUND_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
@@ -145,6 +146,17 @@ internal class UnstakeStrategy(
 
                             DeFiNavActions.UNSTAKE_SRUJI ->
                                 createRujiCompoundUnstakeDepositTransaction(
+                                    vaultId = vaultId,
+                                    selectedToken = selectedToken,
+                                    srcAddress = srcAddress,
+                                    dstAddress = dstAddress,
+                                    tokenAmountInt = tokenAmountInt,
+                                    gasFee = gasFee,
+                                    chain = chain,
+                                )
+
+                            DeFiNavActions.UNSTAKE_YBRUNE ->
+                                createBRuneUnstakeDepositTransaction(
                                     vaultId = vaultId,
                                     selectedToken = selectedToken,
                                     srcAddress = srcAddress,
@@ -359,6 +371,66 @@ internal class UnstakeStrategy(
                 ThorchainFunctions.unstakeRujiCompound(
                     shares = shares,
                     stakingContract = STAKING_RUJI_CONTRACT,
+                    fromAddress = srcAddress,
+                ),
+        )
+    }
+
+    /**
+     * Unbonds from the Rujira liquid bond (`liquid.unbond`), returning bRUNE.
+     *
+     * The position is reported in ybRUNE receipt units — AccountsLoader synthesizes the account
+     * from that same bank balance — so the entered amount funds the execute directly. That is the
+     * whole difference from the sRUJI redemption above, which has to convert a RUJI-denominated
+     * amount into shares first.
+     */
+    private suspend fun createBRuneUnstakeDepositTransaction(
+        vaultId: String,
+        selectedToken: Coin,
+        srcAddress: String,
+        dstAddress: String,
+        tokenAmountInt: BigInteger,
+        gasFee: TokenValue,
+        chain: Chain,
+    ): DepositTransaction {
+        // An amount that rounds below one base unit would build an execute the contract rejects;
+        // say so on the form instead of sending the user through a ceremony that cannot land.
+        if (tokenAmountInt < BigInteger.ONE) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_no_amount)
+            )
+        }
+
+        val specific =
+            withContext(Dispatchers.IO) {
+                blockChainSpecificRepository.getSpecific(
+                    chain,
+                    srcAddress,
+                    selectedToken,
+                    gasFee,
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = true,
+                    transactionType = TransactionType.TRANSACTION_TYPE_GENERIC_CONTRACT,
+                )
+            }
+
+        return DepositTransaction(
+            id = UUID.randomUUID().toString(),
+            vaultId = vaultId,
+            srcToken = selectedToken,
+            srcAddress = srcAddress,
+            dstAddress = dstAddress,
+            memo = "",
+            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+            estimatedFees = gasFee,
+            estimateFeesFiat =
+                gasFeeToEstimatedFee.fiatFeesFor(gasFee, selectedToken).formattedFiatValue,
+            blockChainSpecific = specific.blockChainSpecific,
+            wasmExecuteContractPayload =
+                ThorchainFunctions.unstakeBRune(
+                    units = tokenAmountInt,
+                    stakingContract = STAKING_BRUNE_CONTRACT,
                     fromAddress = srcAddress,
                 ),
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
@@ -113,16 +113,16 @@ internal class UnstakeStrategy(
 
                     val defiType = defiTypeProvider()
 
-                    // The auto-compounding position is the one case where this ceiling is not the
+                    // The two receipt redemptions are the cases where this ceiling is not the
                     // balance the transaction is sized against: the form is seeded from the
                     // position the DeFi tab cached, while the redemption re-reads the live one.
                     // Enforcing the stale ceiling would reject amounts the live position can
-                    // honour, so the live read below is the sole authority — it clamps to the
+                    // honour, so the live reads below are the sole authority — each clamps to the
                     // whole position and so can never over-redeem.
-                    if (
-                        defiType != DeFiNavActions.UNSTAKE_SRUJI &&
-                            tokenAmountInt > availableTokenBalance
-                    ) {
+                    val isReceiptRedemption =
+                        defiType == DeFiNavActions.UNSTAKE_SRUJI ||
+                            defiType == DeFiNavActions.UNSTAKE_YBRUNE
+                    if (!isReceiptRedemption && tokenAmountInt > availableTokenBalance) {
                         throw InvalidTransactionDataException(
                             UiText.FormattedText(
                                 R.string.send_error_insufficient_native_balance_with_fees,
@@ -401,6 +401,19 @@ internal class UnstakeStrategy(
             )
         }
 
+        // The form is sized off the position the DeFi tab cached, which can lag the vault's bank
+        // balance in either direction: a bond made since the last refresh leaves the ceiling too
+        // low, and an unbond made since leaves it too high — and too high attaches funds the vault
+        // no longer holds, which the chain rejects only after the user has paid for the keysign.
+        // The live receipt balance is the authority; the entered amount is clamped to it.
+        val heldReceipt = readBondedRuneReceiptBalance(srcAddress)
+        if (heldReceipt < BigInteger.ONE) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.send_error_insufficient_balance)
+            )
+        }
+        val unbondUnits = tokenAmountInt.coerceAtMost(heldReceipt)
+
         val specific =
             withContext(Dispatchers.IO) {
                 blockChainSpecificRepository.getSpecific(
@@ -422,19 +435,41 @@ internal class UnstakeStrategy(
             srcAddress = srcAddress,
             dstAddress = dstAddress,
             memo = "",
-            srcTokenValue = TokenValue(value = tokenAmountInt, token = selectedToken),
+            srcTokenValue = TokenValue(value = unbondUnits, token = selectedToken),
             estimatedFees = gasFee,
             estimateFeesFiat =
                 gasFeeToEstimatedFee.fiatFeesFor(gasFee, selectedToken).formattedFiatValue,
             blockChainSpecific = specific.blockChainSpecific,
             wasmExecuteContractPayload =
                 ThorchainFunctions.unstakeBRune(
-                    units = tokenAmountInt,
+                    units = unbondUnits,
                     stakingContract = STAKING_BRUNE_CONTRACT,
                     fromAddress = srcAddress,
                 ),
         )
     }
+
+    /**
+     * The vault's live ybRUNE bank balance — the same `x/staking-x/brune` denom the position card
+     * is read from, so the two never disagree about what the receipt is worth.
+     *
+     * Fails closed on an unreadable balance: that is a fetch problem, not an empty position, and
+     * sizing a redemption off a guessed balance is what the clamp exists to prevent. Translate it
+     * as the RUJI redemption above does, so submit()'s generic catch does not surface the raw
+     * transport text. A denom the response omits is a genuine zero — the bank drops empty balances.
+     */
+    private suspend fun readBondedRuneReceiptBalance(address: String): BigInteger =
+        withContext(Dispatchers.IO) { runCatching { thorChainApi.getBalance(address) } }
+            .getOrElse { error: Throwable ->
+                if (error is CancellationException) throw error
+                Timber.e(error, "Failed to read the ybRUNE receipt balance for the unbond")
+                throw InvalidTransactionDataException(
+                    UiText.StringResource(R.string.dialog_default_error_body)
+                )
+            }
+            .firstOrNull { it.denom == Coins.ThorChain.ybRUNE.contractAddress }
+            ?.amount
+            ?.toBigIntegerOrNull() ?: BigInteger.ZERO
 
     private suspend fun createRUJIRewardsDepositTransaction(
         vaultId: String,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategy.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.models.send.submit
 import androidx.compose.foundation.text.input.TextFieldState
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
 import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
@@ -51,6 +52,7 @@ internal class UnstakeStrategy(
     private val depositTransactionRepository: DepositTransactionRepository,
     private val navigator: Navigator<Destination>,
     private val thorChainApi: ThorChainApi,
+    private val defaultStakingPositionService: DefaultStakingPositionService,
     private val defiTypeProvider: () -> DeFiNavActions?,
     private val isAutocompoundProvider: () -> Boolean,
     private val showLoading: () -> Unit,
@@ -450,16 +452,18 @@ internal class UnstakeStrategy(
     }
 
     /**
-     * The vault's live ybRUNE bank balance — the same `x/staking-x/brune` denom the position card
-     * is read from, so the two never disagree about what the receipt is worth.
+     * The vault's live ybRUNE bank balance, read through the service the position card is built
+     * from so the ceiling, the clamp and the card can never disagree about the receipt's size.
      *
      * Fails closed on an unreadable balance: that is a fetch problem, not an empty position, and
      * sizing a redemption off a guessed balance is what the clamp exists to prevent. Translate it
      * as the RUJI redemption above does, so submit()'s generic catch does not surface the raw
-     * transport text. A denom the response omits is a genuine zero — the bank drops empty balances.
+     * transport text.
      */
     private suspend fun readBondedRuneReceiptBalance(address: String): BigInteger =
-        withContext(Dispatchers.IO) { runCatching { thorChainApi.getBalance(address) } }
+        runCatching {
+                defaultStakingPositionService.getReceiptBalance(address, Coins.ThorChain.ybRUNE)
+            }
             .getOrElse { error: Throwable ->
                 if (error is CancellationException) throw error
                 Timber.e(error, "Failed to read the ybRUNE receipt balance for the unbond")
@@ -467,9 +471,6 @@ internal class UnstakeStrategy(
                     UiText.StringResource(R.string.dialog_default_error_body)
                 )
             }
-            .firstOrNull { it.denom == Coins.ThorChain.ybRUNE.contractAddress }
-            ?.amount
-            ?.toBigIntegerOrNull() ?: BigInteger.ZERO
 
     private suspend fun createRUJIRewardsDepositTransaction(
         vaultId: String,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/SendFormScreen.kt
@@ -207,10 +207,12 @@ internal fun SendFormScreen(
             when (state.defiType) {
                 DeFiNavActions.STAKE_RUJI,
                 DeFiNavActions.STAKE_TCY,
-                DeFiNavActions.STAKE_STCY -> stringResource(R.string.stake_screen_title)
+                DeFiNavActions.STAKE_STCY,
+                DeFiNavActions.STAKE_YBRUNE -> stringResource(R.string.stake_screen_title)
                 DeFiNavActions.UNSTAKE_TCY,
                 DeFiNavActions.UNSTAKE_RUJI,
-                DeFiNavActions.UNSTAKE_STCY -> stringResource(R.string.unstake_screen_title)
+                DeFiNavActions.UNSTAKE_STCY,
+                DeFiNavActions.UNSTAKE_YBRUNE -> stringResource(R.string.unstake_screen_title)
                 DeFiNavActions.MINT_YRUNE,
                 DeFiNavActions.MINT_YTCY -> stringResource(R.string.mint_screen_title)
                 DeFiNavActions.REDEEM_YRUNE,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiExtensions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiExtensions.kt
@@ -37,6 +37,7 @@ internal val thorchainSupportStakingDeFi: List<Coin>
             Coins.ThorChain.sTCY,
             Coins.ThorChain.yRUNE,
             Coins.ThorChain.yTCY,
+            Coins.ThorChain.ybRUNE,
         )
 
 internal val thorchainSupportsBonDeFi: List<Coin>

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiExtensions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiExtensions.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.ui.screens.v2.defi
 
 import com.vultisig.wallet.data.blockchain.model.BondedNodePosition
+import com.vultisig.wallet.data.blockchain.thorchain.ThorchainStakingContracts
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
@@ -109,6 +110,9 @@ internal fun DeFiNavActions.getContractByDeFiAction(): String? {
         DeFiNavActions.STAKE_STCY,
         DeFiNavActions.UNSTAKE_STCY -> STAKING_TCY_COMPOUND_CONTRACT
 
+        DeFiNavActions.STAKE_YBRUNE,
+        DeFiNavActions.UNSTAKE_YBRUNE -> STAKING_BRUNE_CONTRACT
+
         else -> null
     }
 }
@@ -130,6 +134,11 @@ internal const val STAKING_RUJI_CONTRACT =
 
 internal const val STAKING_TCY_COMPOUND_CONTRACT =
     "thor1z7ejlk5wk2pxh9nfwjzkkdnrq4p2f5rjcpudltv0gh282dwfz6nq9g2cr0"
+
+// Rujira's liquid-bond contract for bRUNE: `liquid.bond` mints the ybRUNE receipt, `liquid.unbond`
+// redeems it. Aliased rather than spelled out, because the pricing repository reads the same
+// address for the contract's NAV — see [ThorchainStakingContracts].
+internal const val STAKING_BRUNE_CONTRACT = ThorchainStakingContracts.BRUNE_LIQUID_BOND
 
 internal const val YRUNE_CONTRACT =
     "thor1mlphkryw5g54yfkrp6xpqzlpv4f8wh6hyw27yyg4z2els8a9gxpqhfhekt"

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.ui.components.UiHorizontalDivider
 import com.vultisig.wallet.ui.components.UiSpacer
@@ -48,7 +49,7 @@ internal fun StakingTabContent(
     onClickStake: (DeFiNavActions) -> Unit,
     onClickUnstake: (DeFiNavActions) -> Unit,
     onClickWithdraw: () -> Unit,
-    onClickTransfer: () -> Unit,
+    onClickTransfer: (Coin) -> Unit,
     isBalanceVisible: Boolean = true,
 ) {
     Column(modifier = Modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -73,7 +74,7 @@ internal fun StakingWidget(
     onClickStake: (DeFiNavActions) -> Unit,
     onClickUnstake: (DeFiNavActions) -> Unit,
     onClickWithdraw: () -> Unit,
-    onClickTransfer: () -> Unit,
+    onClickTransfer: (Coin) -> Unit,
     isBalanceVisible: Boolean = true,
 ) {
     Column(
@@ -207,7 +208,7 @@ internal fun StakingWidget(
             VsButton(
                 label = stringResource(R.string.staking_transfer),
                 modifier = Modifier.fillMaxWidth(),
-                onClick = onClickTransfer,
+                onClick = { onClickTransfer(state.coin) },
                 state = VsButtonState.Enabled,
             )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
@@ -90,7 +90,7 @@ internal fun StakingWidget(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Image(
-                painter = painterResource(id = getHeaderIcon(state.stakedAmountDisplay)),
+                painter = painterResource(id = getHeaderIcon(state.coin.ticker)),
                 contentDescription = null,
                 modifier = Modifier.size(48.dp),
             )
@@ -305,14 +305,23 @@ internal fun StakingHeader(title: String, amount: String, icon: Int) {
     }
 }
 
-private fun getHeaderIcon(assetStake: String): Int {
+/**
+ * The card's asset icon, matched on the position's own ticker.
+ *
+ * Reading it off the formatted amount instead was a trap the receipts fell into: `ybRUNE` carries
+ * none of these substrings — the `b` breaks `yrune` — so the compounded bRUNE card took the `om`
+ * fallback and rendered an unrelated logo. The order matters: the prefixed tickers have to be tried
+ * before the asset they are a receipt for, or `ytcy`/`stcy` would both match `tcy`.
+ */
+internal fun getHeaderIcon(ticker: String): Int {
     return when {
-        assetStake.contains("yrune", ignoreCase = true) -> R.drawable.yrune
-        assetStake.contains("ytcy", ignoreCase = true) -> R.drawable.ytcy
-        assetStake.contains("stcy", ignoreCase = true) -> R.drawable.stcy
-        assetStake.contains("ruji", ignoreCase = true) -> R.drawable.ruji_staking
-        assetStake.contains("tcy", ignoreCase = true) -> R.drawable.tcy_staking
-        assetStake.contains("cacao", ignoreCase = true) -> R.drawable.cacao
+        ticker.contains("yrune", ignoreCase = true) -> R.drawable.yrune
+        ticker.contains("ytcy", ignoreCase = true) -> R.drawable.ytcy
+        ticker.contains("stcy", ignoreCase = true) -> R.drawable.stcy
+        ticker.contains("ybrune", ignoreCase = true) -> R.drawable.brune
+        ticker.contains("ruji", ignoreCase = true) -> R.drawable.ruji_staking
+        ticker.contains("tcy", ignoreCase = true) -> R.drawable.tcy_staking
+        ticker.contains("cacao", ignoreCase = true) -> R.drawable.cacao
         else -> R.drawable.om
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/model/DeFiNavActions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/model/DeFiNavActions.kt
@@ -20,6 +20,8 @@ internal enum class DeFiNavActions(val type: String) {
     REDEEM_YTCY("redeem_ytcy"),
     STAKE_STCY("stake_stcy"),
     UNSTAKE_STCY("unstake_stcy"),
+    STAKE_YBRUNE("stake_ybrune"),
+    UNSTAKE_YBRUNE("unstake_ybrune"),
     WITHDRAW_USDC_CIRCLE("withdraw_usdc_circle"),
     STAKE_CACAO("stake_cacao"),
     UNSTAKE_CACAO("unstake_cacao"),
@@ -70,6 +72,10 @@ internal fun parseDepositType(type: String?): DeFiNavActions? {
         "stakestcy" -> DeFiNavActions.STAKE_STCY
         "unstakestcy",
         "unstake_stcy" -> DeFiNavActions.UNSTAKE_STCY
+        "stakeybrune",
+        "stake_ybrune" -> DeFiNavActions.STAKE_YBRUNE
+        "unstakeybrune",
+        "unstake_ybrune" -> DeFiNavActions.UNSTAKE_YBRUNE
         "withdraw_usdc_circle" -> DeFiNavActions.WITHDRAW_USDC_CIRCLE
         "stakecacao",
         "stake_cacao" -> DeFiNavActions.STAKE_CACAO
@@ -106,6 +112,9 @@ internal fun Coin.getStakeDeFiNavAction(): DeFiNavActions {
         Coins.ThorChain.yRUNE -> DeFiNavActions.MINT_YRUNE
         Coins.ThorChain.yTCY -> DeFiNavActions.MINT_YTCY
         Coins.ThorChain.sTCY -> DeFiNavActions.STAKE_STCY
+        // Keyed on the receipt because that is the coin the card carries; the bond itself is
+        // funded with bRUNE, which TokenPreselectionService selects for this action.
+        Coins.ThorChain.ybRUNE -> DeFiNavActions.STAKE_YBRUNE
         Coins.MayaChain.CACAO -> DeFiNavActions.STAKE_CACAO
         else -> error("Not supported ${this.coinType.name}")
     }
@@ -119,6 +128,7 @@ internal fun Coin.getUnstakeDeFiNavAction(): DeFiNavActions {
         Coins.ThorChain.yRUNE -> DeFiNavActions.REDEEM_YRUNE
         Coins.ThorChain.yTCY -> DeFiNavActions.REDEEM_YTCY
         Coins.ThorChain.sTCY -> DeFiNavActions.UNSTAKE_STCY
+        Coins.ThorChain.ybRUNE -> DeFiNavActions.UNSTAKE_YBRUNE
         Coins.MayaChain.CACAO -> DeFiNavActions.UNSTAKE_CACAO
         else -> error("Not supported ${this.coinType.name}")
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
@@ -88,7 +89,7 @@ internal fun ThorchainDefiPositionsScreen(
         onClickWithdraw = { model.onNavigateToFunctions(it) },
         onClickStake = { model.onNavigateToFunctions(it) },
         onClickUnstake = { model.onNavigateToFunctions(it) },
-        onClickTransfer = { model.onClickTransfer() },
+        onClickTransfer = model::onClickTransfer,
         onClickAddLp = model::onClickAddLp,
         onClickRemoveLp = model::onClickRemoveLp,
     )
@@ -112,7 +113,7 @@ internal fun ThorchainDefiPositionScreenContent(
     onClickWithdraw: (DeFiNavActions) -> Unit = {},
     onClickStake: (DeFiNavActions) -> Unit = {},
     onClickUnstake: (DeFiNavActions) -> Unit = {},
-    onClickTransfer: () -> Unit = {},
+    onClickTransfer: (Coin) -> Unit = {},
     onClickAddLp: (String) -> Unit = {},
     onClickRemoveLp: (String) -> Unit = {},
 ) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -391,7 +391,7 @@ internal class ThorchainDefiPositionsViewModelTest {
     }
 
     @Test
-    fun `the ybRUNE receipt renders as a compounded bRUNE card`() = runTest {
+    fun `the ybRUNE receipt renders as a compounded position counted in receipt units`() = runTest {
         selectPositions("ybRUNE")
         coEvery { defaultStakingPositionService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
             flowOf(listOf(stakingDetails(Coins.ThorChain.ybRUNE, BigInteger("523400000000"))))
@@ -400,10 +400,13 @@ internal class ThorchainDefiPositionsViewModelTest {
 
         val ybRune =
             vm.state.value.staking.positions.single { it.coin.id == Coins.ThorChain.ybRUNE.id }
-        // Titled after what was bonded, as the sRUJI card is titled after RUJI.
+        // Header and amount name the same unit. The sRUJI card can say RUJI because its amount is
+        // the pool's RUJI liquidSize; this one is the raw receipt balance, and a share is worth
+        // more than one bRUNE, so titling it bRUNE would understate the position.
         val header = ybRune.stakeAssetHeader as UiText.FormattedText
         assertEquals(R.string.defi_header_compounded, header.resId)
-        assertEquals(listOf(Coins.ThorChain.bRUNE.ticker), header.formatArgs)
+        assertEquals(listOf(Coins.ThorChain.ybRUNE.ticker), header.formatArgs)
+        assertTrue(ybRune.stakedAmountDisplay.endsWith(Coins.ThorChain.ybRUNE.ticker))
         // Auto-compounding: nothing is separately claimable, and it is not a transferable balance.
         assertFalse(ybRune.supportsMint)
         assertFalse(ybRune.canTransfer)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -390,6 +390,42 @@ internal class ThorchainDefiPositionsViewModelTest {
         assertFalse(sTcy.supportsMint)
     }
 
+    @Test
+    fun `the ybRUNE receipt renders as a compounded bRUNE card`() = runTest {
+        selectPositions("ybRUNE")
+        coEvery { defaultStakingPositionService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(listOf(stakingDetails(Coins.ThorChain.ybRUNE, BigInteger("523400000000"))))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val ybRune =
+            vm.state.value.staking.positions.single { it.coin.id == Coins.ThorChain.ybRUNE.id }
+        // Titled after what was bonded, as the sRUJI card is titled after RUJI.
+        val header = ybRune.stakeAssetHeader as UiText.FormattedText
+        assertEquals(R.string.defi_header_compounded, header.resId)
+        assertEquals(listOf(Coins.ThorChain.bRUNE.ticker), header.formatArgs)
+        // Auto-compounding: nothing is separately claimable, and it is not a transferable balance.
+        assertFalse(ybRune.supportsMint)
+        assertFalse(ybRune.canTransfer)
+        assertFalse(ybRune.canWithdraw)
+        assertTrue(ybRune.canStake)
+        assertTrue(ybRune.canUnstake)
+    }
+
+    @Test
+    fun `a ybRUNE position nobody holds cannot be unbonded`() = runTest {
+        selectPositions("ybRUNE")
+        coEvery { defaultStakingPositionService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(listOf(stakingDetails(Coins.ThorChain.ybRUNE, BigInteger.ZERO)))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        val ybRune =
+            vm.state.value.staking.positions.single { it.coin.id == Coins.ThorChain.ybRUNE.id }
+        assertFalse(ybRune.canUnstake)
+        assertTrue(ybRune.canStake)
+    }
+
     /**
      * These position tokens usually aren't vault coins, and the periodic price refresh only ever
      * covers vault coins — so unless the screen refreshes them itself they have no cache row, and

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -407,12 +407,37 @@ internal class ThorchainDefiPositionsViewModelTest {
         assertEquals(R.string.defi_header_compounded, header.resId)
         assertEquals(listOf(Coins.ThorChain.ybRUNE.ticker), header.formatArgs)
         assertTrue(ybRune.stakedAmountDisplay.endsWith(Coins.ThorChain.ybRUNE.ticker))
-        // Auto-compounding: nothing is separately claimable, and it is not a transferable balance.
+        // Auto-compounding: nothing is separately claimable. The receipt itself is a plain bank
+        // denom, so it can be moved to another address like the sTCY one above it.
         assertFalse(ybRune.supportsMint)
-        assertFalse(ybRune.canTransfer)
+        assertTrue(ybRune.canTransfer)
         assertFalse(ybRune.canWithdraw)
         assertTrue(ybRune.canStake)
         assertTrue(ybRune.canUnstake)
+    }
+
+    @Test
+    fun `transfer routes to send against the position's own receipt`() = runTest {
+        // Fixed to sTCY, the ybRUNE card's Transfer button would have opened the form on someone
+        // else's token.
+        selectPositions("ybRUNE")
+        coEvery { defaultStakingPositionService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(listOf(stakingDetails(Coins.ThorChain.ybRUNE, BigInteger("523400000000"))))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        val ybRune =
+            vm.state.value.staking.positions.single { it.coin.id == Coins.ThorChain.ybRUNE.id }
+        vm.onClickTransfer(ybRune.coin)
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.Send(
+                    vaultId = VAULT_ID,
+                    chainId = Chain.ThorChain.id,
+                    tokenId = Coins.ThorChain.ybRUNE.id,
+                )
+            )
+        }
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModelReceiptSendTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignShareViewModelReceiptSendTest.kt
@@ -1,0 +1,157 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Transaction
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.repositories.CustomMessagePayloadRepo
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.repositories.SwapTransactionRepository
+import com.vultisig.wallet.data.repositories.TransactionRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.GenerateQrBitmap
+import com.vultisig.wallet.data.usecases.MakeQrCodeBitmapShareFormat
+import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins how a plain send resolves its coin.
+ *
+ * The DeFi-only receipts are deliberately kept out of token discovery, so they are never vault
+ * coins — yet they are ordinary bank denoms the position card offers a Transfer action for. Looking
+ * the coin up in the vault alone left that send with nothing to sign.
+ */
+internal class KeysignShareViewModelReceiptSendTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val vaultRepository: VaultRepository = mockk()
+    private val transactionRepository: TransactionRepository = mockk()
+    private val mapTokenValueToStringWithUnit: TokenValueToStringWithUnitMapper =
+        mockk(relaxed = true)
+    private val swapTransactionRepository: SwapTransactionRepository = mockk(relaxed = true)
+    private val depositTransaction: DepositTransactionRepository = mockk(relaxed = true)
+    private val customMessagePayloadRepo: CustomMessagePayloadRepo = mockk(relaxed = true)
+    private val makeQrCodeBitmapShareFormat: MakeQrCodeBitmapShareFormat = mockk(relaxed = true)
+    private val generateQrBitmap: GenerateQrBitmap = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        every { mapTokenValueToStringWithUnit(any()) } returns "0"
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `a ybRUNE transfer signs the receipt the form staged, not a vault coin`() = runTest {
+        val receipt =
+            Coins.ThorChain.ybRUNE.copy(address = THOR_ADDRESS, hexPublicKey = THOR_PUBLIC_KEY)
+        coEvery { transactionRepository.getTransaction(TX_ID) } returns transaction(receipt)
+        coEvery { vaultRepository.get(VAULT_ID) } returns
+            Vault(id = VAULT_ID, name = "Test", coins = listOf(rune()))
+
+        val vm = viewModel()
+        vm.loadTransaction(TX_ID)
+
+        val coin = requireNotNull(vm.keysignPayload?.coin)
+        assertEquals(Coins.ThorChain.ybRUNE.id, coin.id)
+        // The denom that funds the send, plus the key material the chain's own account supplied.
+        assertEquals(Coins.ThorChain.ybRUNE.contractAddress, coin.contractAddress)
+        assertEquals(THOR_ADDRESS, coin.address)
+        assertEquals(THOR_PUBLIC_KEY, coin.hexPublicKey)
+    }
+
+    @Test
+    fun `a wallet token is still resolved from the vault`() = runTest {
+        // The vault's own copy stays authoritative: the staged token is only a fallback for the
+        // receipts the vault is never allowed to carry.
+        val vaultRune = rune()
+        coEvery { transactionRepository.getTransaction(TX_ID) } returns
+            transaction(vaultRune.copy(address = "thor1stale"))
+        coEvery { vaultRepository.get(VAULT_ID) } returns
+            Vault(id = VAULT_ID, name = "Test", coins = listOf(vaultRune))
+
+        val vm = viewModel()
+        vm.loadTransaction(TX_ID)
+
+        assertEquals(THOR_ADDRESS, vm.keysignPayload?.coin?.address)
+    }
+
+    @Test
+    fun `a token the vault does not hold at all still fails loudly`() = runTest {
+        coEvery { transactionRepository.getTransaction(TX_ID) } returns
+            transaction(Coins.ThorChain.TCY.copy(address = THOR_ADDRESS))
+        coEvery { vaultRepository.get(VAULT_ID) } returns
+            Vault(id = VAULT_ID, name = "Test", coins = listOf(rune()))
+
+        val vm = viewModel()
+        val failure = runCatching { vm.loadTransaction(TX_ID) }.exceptionOrNull()
+
+        assertTrue(failure is IllegalStateException)
+    }
+
+    private fun viewModel() =
+        KeysignShareViewModel(
+            mapTokenValueToStringWithUnit = mapTokenValueToStringWithUnit,
+            vaultRepository = vaultRepository,
+            transactionRepository = transactionRepository,
+            swapTransactionRepository = swapTransactionRepository,
+            depositTransaction = depositTransaction,
+            customMessagePayloadRepo = customMessagePayloadRepo,
+            makeQrCodeBitmapShareFormat = makeQrCodeBitmapShareFormat,
+            generateQrBitmap = generateQrBitmap,
+        )
+
+    private fun rune(): Coin =
+        Coins.ThorChain.RUNE.copy(address = THOR_ADDRESS, hexPublicKey = THOR_PUBLIC_KEY)
+
+    private fun transaction(token: Coin): Transaction =
+        Transaction(
+            id = TX_ID,
+            vaultId = VAULT_ID,
+            chainId = Chain.ThorChain.id,
+            token = token,
+            srcAddress = THOR_ADDRESS,
+            dstAddress = "thor1dst",
+            tokenValue = TokenValue(value = BigInteger("100000000"), token = token),
+            fiatValue = FiatValue(BigDecimal.ZERO, "USD"),
+            gasFee = TokenValue(value = BigInteger("2000000"), token = token),
+            totalGas = "2000000",
+            memo = null,
+            estimatedFee = "0",
+            blockChainSpecific = mockk<BlockChainSpecific>(relaxed = true),
+        )
+
+    private companion object {
+        const val TX_ID = "tx-1"
+        const val VAULT_ID = "vault-1"
+        const val THOR_ADDRESS = "thor1owner"
+        const val THOR_PUBLIC_KEY =
+            "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
@@ -3,6 +3,7 @@
 package com.vultisig.wallet.ui.models.send
 
 import com.vultisig.wallet.data.blockchain.model.StakingDetails
+import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
 import com.vultisig.wallet.data.blockchain.thorchain.RujiStakingService.Companion.RUJI_REWARDS_COIN
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
@@ -52,6 +53,7 @@ internal class AccountsLoaderTest {
     private val accountsState = MutableStateFlow<AccountsLoadState>(AccountsLoadState.Uninitialized)
     private val accountsRepository: AccountsRepository = mockk(relaxed = true)
     private val stakingDetailsRepository: StakingDetailsRepository = mockk(relaxed = true)
+    private val defaultStakingPositionService: DefaultStakingPositionService = mockk(relaxed = true)
 
     private var defiType: DeFiNavActions? = null
     private var mscaAddress: String? = null
@@ -268,6 +270,9 @@ internal class AccountsLoaderTest {
                     Coins.ThorChain.ybRUNE.id,
                 )
             } returns stakingDetails(stakeAmount = BigInteger("523400000000"))
+            coEvery {
+                defaultStakingPositionService.getReceiptBalance("thor1", Coins.ThorChain.ybRUNE)
+            } returns BigInteger("523400000000")
             every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flowOf(
                     listOf(
@@ -309,6 +314,9 @@ internal class AccountsLoaderTest {
                     Coins.ThorChain.ybRUNE.id,
                 )
             } returns null
+            coEvery {
+                defaultStakingPositionService.getReceiptBalance(any(), Coins.ThorChain.ybRUNE)
+            } returns BigInteger.ZERO
             every { accountsRepository.loadAddresses(VAULT_ID) } returns
                 flowOf(
                     listOf(
@@ -327,6 +335,85 @@ internal class AccountsLoaderTest {
             val ybRune =
                 loadedAccounts.single { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) }
             assertEquals(BigInteger.ZERO, ybRune.tokenValue?.value)
+        }
+
+    @Test
+    fun `UNSTAKE_YBRUNE lifts a stale cached ceiling to the live receipt balance`() =
+        runTest(mainDispatcher) {
+            // MAX fills the form from this account. Left at whatever the DeFi tab last cached, a
+            // bond made since that refresh would cap it below the position and quietly redeem
+            // less than everything — the submit clamp only ever lowers an amount, never raises it.
+            defiType = DeFiNavActions.UNSTAKE_YBRUNE
+            coEvery {
+                stakingDetailsRepository.getStakingDetailsByCoindId(
+                    VAULT_ID,
+                    Coins.ThorChain.ybRUNE.id,
+                )
+            } returns stakingDetails(stakeAmount = BigInteger("100000000"))
+            coEvery {
+                defaultStakingPositionService.getReceiptBalance("thor1", Coins.ThorChain.ybRUNE)
+            } returns BigInteger("523400000000")
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.ThorChain,
+                            address = "thor1",
+                            accounts =
+                                listOf(
+                                    thorAccount(
+                                        Coins.ThorChain.RUNE.copy(
+                                            address = "thor1",
+                                            hexPublicKey = THOR_PUBLIC_KEY,
+                                        )
+                                    )
+                                ),
+                        )
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            val ybRune =
+                loadedAccounts.single { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) }
+            assertEquals(BigInteger("523400000000"), ybRune.tokenValue?.value)
+        }
+
+    @Test
+    fun `UNSTAKE_YBRUNE keeps the cached ceiling when the live read fails`() =
+        runTest(mainDispatcher) {
+            // A fetch that failed says nothing about the position, and emptying the form over it
+            // would strand a vault that does hold a receipt. The submit-time read fails closed.
+            defiType = DeFiNavActions.UNSTAKE_YBRUNE
+            coEvery {
+                stakingDetailsRepository.getStakingDetailsByCoindId(
+                    VAULT_ID,
+                    Coins.ThorChain.ybRUNE.id,
+                )
+            } returns stakingDetails(stakeAmount = BigInteger("100000000"))
+            coEvery {
+                defaultStakingPositionService.getReceiptBalance(any(), Coins.ThorChain.ybRUNE)
+            } throws RuntimeException("status 502")
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.ThorChain,
+                            address = "thor1",
+                            accounts = listOf(thorAccount(Coins.ThorChain.RUNE)),
+                        )
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            val ybRune =
+                loadedAccounts.single { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) }
+            assertEquals(BigInteger("100000000"), ybRune.tokenValue?.value)
         }
 
     @Test
@@ -960,6 +1047,7 @@ internal class AccountsLoaderTest {
             accountsState = accountsState,
             accountsRepository = accountsRepository,
             stakingDetailsRepository = stakingDetailsRepository,
+            defaultStakingPositionService = defaultStakingPositionService,
             defiTypeProvider = { defiType },
             mscaAddressProvider = { mscaAddress },
             bondedAmountProvider = { bondedAmount },

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
@@ -56,6 +56,7 @@ internal class AccountsLoaderTest {
     private val defaultStakingPositionService: DefaultStakingPositionService = mockk(relaxed = true)
 
     private var defiType: DeFiNavActions? = null
+    private var preselectedTokenId: String? = null
     private var mscaAddress: String? = null
     private var bondedAmount: BigInteger? = null
 
@@ -441,6 +442,192 @@ internal class AccountsLoaderTest {
             val ybRune =
                 loadedAccounts.single { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) }
             assertEquals(BigInteger("100000000"), ybRune.tokenValue?.value)
+        }
+
+    @Test
+    fun `UNSTAKE_YBRUNE retries the live read on a later emission after one fails`() =
+        runTest(mainDispatcher) {
+            // Marking the account hydrated before the read could fail retired the retry for the
+            // rest of the form's life, so MAX went on filling from the cached ceiling — which the
+            // submit clamp can only ever lower, never raise.
+            defiType = DeFiNavActions.UNSTAKE_YBRUNE
+            coEvery {
+                stakingDetailsRepository.getStakingDetailsByCoindId(
+                    VAULT_ID,
+                    Coins.ThorChain.ybRUNE.id,
+                )
+            } returns stakingDetails(stakeAmount = BigInteger("100000000"))
+            coEvery {
+                defaultStakingPositionService.getReceiptBalance("thor1", Coins.ThorChain.ybRUNE)
+            } throws RuntimeException("status 502") andThen BigInteger("523400000000")
+            val runeAccounts =
+                listOf(
+                    Address(
+                        chain = Chain.ThorChain,
+                        address = "thor1",
+                        accounts =
+                            listOf(
+                                thorAccount(
+                                    Coins.ThorChain.RUNE.copy(
+                                        address = "thor1",
+                                        hexPublicKey = THOR_PUBLIC_KEY,
+                                    )
+                                )
+                            ),
+                    )
+                )
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(runeAccounts, runeAccounts)
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            val ybRune =
+                loadedAccounts.single { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) }
+            assertEquals(BigInteger("523400000000"), ybRune.tokenValue?.value)
+        }
+
+    @Test
+    fun `UNSTAKE_YBRUNE reads the live balance once after it succeeds`() =
+        runTest(mainDispatcher) {
+            // The retry above must not turn into a fetch per emission: once a read lands, the
+            // hydrated account stands for the rest of the form.
+            defiType = DeFiNavActions.UNSTAKE_YBRUNE
+            coEvery {
+                stakingDetailsRepository.getStakingDetailsByCoindId(
+                    VAULT_ID,
+                    Coins.ThorChain.ybRUNE.id,
+                )
+            } returns stakingDetails(stakeAmount = BigInteger("100000000"))
+            coEvery {
+                defaultStakingPositionService.getReceiptBalance("thor1", Coins.ThorChain.ybRUNE)
+            } returns BigInteger("523400000000")
+            val runeAccounts =
+                listOf(
+                    Address(
+                        chain = Chain.ThorChain,
+                        address = "thor1",
+                        accounts = listOf(thorAccount(Coins.ThorChain.RUNE.copy(address = "thor1"))),
+                    )
+                )
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(runeAccounts, runeAccounts)
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                defaultStakingPositionService.getReceiptBalance("thor1", Coins.ThorChain.ybRUNE)
+            }
+        }
+
+    @Test
+    fun `a plain send opened on ybRUNE carries the receipt next to the wallet accounts`() =
+        runTest(mainDispatcher) {
+            // The Transfer action on the position card lands here: an ordinary send, whose token
+            // is a bank denom kept out of token discovery, so nothing in the addresses flow can
+            // offer the form an account to send it from.
+            defiType = null
+            preselectedTokenId = Coins.ThorChain.ybRUNE.id
+            coEvery {
+                stakingDetailsRepository.getStakingDetailsByCoindId(
+                    VAULT_ID,
+                    Coins.ThorChain.ybRUNE.id,
+                )
+            } returns stakingDetails(stakeAmount = BigInteger("100000000"))
+            coEvery {
+                defaultStakingPositionService.getReceiptBalance("thor1", Coins.ThorChain.ybRUNE)
+            } returns BigInteger("523400000000")
+            val ethAccount = ethAccount()
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.ThorChain,
+                            address = "thor1",
+                            accounts =
+                                listOf(
+                                    thorAccount(
+                                        Coins.ThorChain.RUNE.copy(
+                                            address = "thor1",
+                                            hexPublicKey = THOR_PUBLIC_KEY,
+                                        )
+                                    )
+                                ),
+                        ),
+                        Address(
+                            chain = Chain.Ethereum,
+                            address = "0x1",
+                            accounts = listOf(ethAccount),
+                        ),
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            val ybRune =
+                loadedAccounts.single { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) }
+            assertEquals(BigInteger("523400000000"), ybRune.tokenValue?.value)
+            assertEquals("thor1", ybRune.token.address)
+            assertEquals(THOR_PUBLIC_KEY, ybRune.token.hexPublicKey)
+            // The rest of the wallet stays selectable — this is a send, not a receipt-only form.
+            assertTrue(loadedAccounts.contains(ethAccount))
+            assertTrue(loadedAccounts.any { it.token.id.equals(Coins.ThorChain.RUNE.id, true) })
+        }
+
+    @Test
+    fun `a plain send opened on ybRUNE keeps the wallet when the vault has no THORChain account`() =
+        runTest(mainDispatcher) {
+            // Nothing to synthesize the receipt from, but every other holding is still sendable —
+            // the unbond form empties itself in this case, a send must not.
+            defiType = null
+            preselectedTokenId = Coins.ThorChain.ybRUNE.id
+            val ethAccount = ethAccount()
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.Ethereum,
+                            address = "0x1",
+                            accounts = listOf(ethAccount),
+                        )
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            assertEquals(listOf(ethAccount), loadedAccounts)
+        }
+
+    @Test
+    fun `a plain send opened on another token never synthesizes the receipt`() =
+        runTest(mainDispatcher) {
+            defiType = null
+            preselectedTokenId = Coins.ThorChain.RUNE.id
+            val runeAccount = thorAccount(Coins.ThorChain.RUNE.copy(address = "thor1"))
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.ThorChain,
+                            address = "thor1",
+                            accounts = listOf(runeAccount),
+                        )
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            assertEquals(listOf(runeAccount), loadedAccounts)
+            coVerify(exactly = 0) { defaultStakingPositionService.getReceiptBalance(any(), any()) }
         }
 
     @Test
@@ -1076,6 +1263,7 @@ internal class AccountsLoaderTest {
             stakingDetailsRepository = stakingDetailsRepository,
             defaultStakingPositionService = defaultStakingPositionService,
             defiTypeProvider = { defiType },
+            preselectedTokenIdProvider = { preselectedTokenId },
             mscaAddressProvider = { mscaAddress },
             bondedAmountProvider = { bondedAmount },
         )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AccountsLoaderTest.kt
@@ -253,6 +253,107 @@ internal class AccountsLoaderTest {
             assertEquals(BigInteger.ZERO, sRuji.tokenValue?.value)
         }
 
+    // ──────── UNSTAKE_YBRUNE ────────
+
+    @Test
+    fun `UNSTAKE_YBRUNE synthesizes a ybRUNE account carrying the bonded position`() =
+        runTest(mainDispatcher) {
+            // Same hole as the sRUJI receipt: ybRUNE is not a wallet token, so nothing in the
+            // addresses flow can fund the unbond form. Its ceiling is the receipt balance itself,
+            // which is what the execute is funded with.
+            defiType = DeFiNavActions.UNSTAKE_YBRUNE
+            coEvery {
+                stakingDetailsRepository.getStakingDetailsByCoindId(
+                    VAULT_ID,
+                    Coins.ThorChain.ybRUNE.id,
+                )
+            } returns stakingDetails(stakeAmount = BigInteger("523400000000"))
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.ThorChain,
+                            address = "thor1",
+                            accounts =
+                                listOf(
+                                    thorAccount(
+                                        Coins.ThorChain.RUNE.copy(
+                                            address = "thor1",
+                                            hexPublicKey = THOR_PUBLIC_KEY,
+                                        )
+                                    )
+                                ),
+                        )
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            val ybRune =
+                loadedAccounts.single { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) }
+            assertEquals(BigInteger("523400000000"), ybRune.tokenValue?.value)
+            assertTrue(loadedAccounts.any { it.token.id.equals(Coins.ThorChain.RUNE.id, true) })
+            assertEquals("thor1", ybRune.token.address)
+            assertEquals(THOR_PUBLIC_KEY, ybRune.token.hexPublicKey)
+        }
+
+    @Test
+    fun `UNSTAKE_YBRUNE publishes a zero ceiling when no position is cached`() =
+        runTest(mainDispatcher) {
+            defiType = DeFiNavActions.UNSTAKE_YBRUNE
+            coEvery {
+                stakingDetailsRepository.getStakingDetailsByCoindId(
+                    VAULT_ID,
+                    Coins.ThorChain.ybRUNE.id,
+                )
+            } returns null
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.ThorChain,
+                            address = "thor1",
+                            accounts = listOf(thorAccount(Coins.ThorChain.RUNE)),
+                        )
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            val ybRune =
+                loadedAccounts.single { it.token.id.equals(Coins.ThorChain.ybRUNE.id, true) }
+            assertEquals(BigInteger.ZERO, ybRune.tokenValue?.value)
+        }
+
+    @Test
+    fun `STAKE_YBRUNE reads the wallet accounts the bond is funded from`() =
+        runTest(mainDispatcher) {
+            // The bond spends bRUNE, an ordinary wallet token, so this direction must stay on the
+            // plain addresses flow rather than the synthesized receipt.
+            defiType = DeFiNavActions.STAKE_YBRUNE
+            val bRuneAccount = thorAccount(Coins.ThorChain.bRUNE)
+            every { accountsRepository.loadAddresses(VAULT_ID) } returns
+                flowOf(
+                    listOf(
+                        Address(
+                            chain = Chain.ThorChain,
+                            address = "thor1",
+                            accounts = listOf(thorAccount(Coins.ThorChain.RUNE), bRuneAccount),
+                        )
+                    )
+                )
+            val loader = build(backgroundScope)
+
+            loader.load(VAULT_ID)
+            advanceUntilIdle()
+
+            assertTrue(loadedAccounts.any { it.token.id.equals(Coins.ThorChain.bRUNE.id, true) })
+        }
+
     // ──────── UNBOND ────────
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/FakeSendStrategyFactory.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/FakeSendStrategyFactory.kt
@@ -27,4 +27,5 @@ internal fun fakeSendStrategyFactory(
         chainValidationService = mockk(relaxed = true),
         navigator = navigator,
         thorChainApi = mockk(relaxed = true),
+        defaultStakingPositionService = mockk(relaxed = true),
     )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelAddressTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelAddressTest.kt
@@ -247,6 +247,7 @@ internal class SendFormViewModelAddressTest {
             vaultRepository = mockk(relaxed = true),
             tokenRepository = mockk(relaxed = true),
             stakingDetailsRepository = mockk(relaxed = true),
+            defaultStakingPositionService = mockk(relaxed = true),
             feeServiceComposite = mockk(relaxed = true),
             chainValidationService = mockk(relaxed = true),
             requestAddressBookEntry = requestAddressBookEntry,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelAmountTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelAmountTest.kt
@@ -244,6 +244,7 @@ internal class SendFormViewModelAmountTest {
             vaultRepository = mockk(relaxed = true),
             tokenRepository = mockk(relaxed = true),
             stakingDetailsRepository = mockk(relaxed = true),
+            defaultStakingPositionService = mockk(relaxed = true),
             feeServiceComposite = mockk(relaxed = true),
             chainValidationService = mockk(relaxed = true),
             requestAddressBookEntry = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelAutoCompoundTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelAutoCompoundTest.kt
@@ -321,6 +321,7 @@ internal class SendFormViewModelAutoCompoundTest {
             vaultRepository = vaultRepository,
             tokenRepository = mockk(relaxed = true),
             stakingDetailsRepository = mockk(relaxed = true),
+            defaultStakingPositionService = mockk(relaxed = true),
             feeServiceComposite = mockk(relaxed = true),
             chainValidationService = mockk(relaxed = true),
             requestAddressBookEntry = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelInitTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelInitTest.kt
@@ -243,6 +243,7 @@ internal class SendFormViewModelInitTest {
             vaultRepository = vaultRepository,
             tokenRepository = mockk(relaxed = true),
             stakingDetailsRepository = mockk(relaxed = true),
+            defaultStakingPositionService = mockk(relaxed = true),
             feeServiceComposite = mockk(relaxed = true),
             chainValidationService = mockk(relaxed = true),
             requestAddressBookEntry = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelSubmitEvmTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelSubmitEvmTest.kt
@@ -144,6 +144,7 @@ internal class SendFormViewModelSubmitEvmTest {
             vaultRepository = mockk(relaxed = true),
             tokenRepository = mockk(relaxed = true),
             stakingDetailsRepository = mockk(relaxed = true),
+            defaultStakingPositionService = mockk(relaxed = true),
             feeServiceComposite = mockk(relaxed = true),
             chainValidationService = mockk(relaxed = true),
             requestAddressBookEntry = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelTronStakingTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelTronStakingTest.kt
@@ -165,6 +165,7 @@ internal class SendFormViewModelTronStakingTest {
             vaultRepository = vaultRepository,
             tokenRepository = mockk(relaxed = true),
             stakingDetailsRepository = mockk(relaxed = true),
+            defaultStakingPositionService = mockk(relaxed = true),
             feeServiceComposite = mockk(relaxed = true),
             chainValidationService = mockk(relaxed = true),
             requestAddressBookEntry = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/TokenPreselectionServiceTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/TokenPreselectionServiceTest.kt
@@ -208,6 +208,34 @@ internal class TokenPreselectionServiceTest {
             assertEquals(emptyList<Any>(), selectedTokens)
         }
 
+    @Test
+    fun `preSelect STAKE_YBRUNE - default coin is bRUNE, not the receipt`() =
+        runTest(mainDispatcher) {
+            // Bonding spends bRUNE. Starting the form on ybRUNE would offer the receipt as the
+            // funding token and build an execute the contract reads as an unbond.
+            defiType = DeFiNavActions.STAKE_YBRUNE
+            loaded(thorAccount(Coins.ThorChain.RUNE))
+            val service = build(backgroundScope)
+
+            service.preSelect(preSelectedChainIds = listOf(null), preSelectedTokenId = null)
+            advanceUntilIdle()
+
+            assertEquals(listOf(Coins.ThorChain.bRUNE), selectedTokens)
+        }
+
+    @Test
+    fun `preSelect UNSTAKE_YBRUNE - default coin is the ybRUNE receipt`() =
+        runTest(mainDispatcher) {
+            defiType = DeFiNavActions.UNSTAKE_YBRUNE
+            loaded(thorAccount(Coins.ThorChain.RUNE))
+            val service = build(backgroundScope)
+
+            service.preSelect(preSelectedChainIds = listOf(null), preSelectedTokenId = null)
+            advanceUntilIdle()
+
+            assertEquals(listOf(Coins.ThorChain.ybRUNE), selectedTokens)
+        }
+
     // ──────── forcePreselection ────────
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/TokenPreselectionServiceTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/TokenPreselectionServiceTest.kt
@@ -209,6 +209,22 @@ internal class TokenPreselectionServiceTest {
         }
 
     @Test
+    fun `preSelect UNSTAKE_YBRUNE - Loaded(empty) does not preselect static template coin`() =
+        runTest(mainDispatcher) {
+            // Same shape as sRUJI above: the ybRUNE account is synthesized on top of the vault's
+            // RUNE account, so an empty load means the vault has no THORChain account to unbond
+            // from. The static receipt template carries no address and no balance.
+            defiType = DeFiNavActions.UNSTAKE_YBRUNE
+            accountsState.value = AccountsLoadState.Loaded(emptyList())
+            val service = build(backgroundScope)
+
+            service.preSelect(preSelectedChainIds = listOf(null), preSelectedTokenId = null)
+            advanceUntilIdle()
+
+            assertEquals(emptyList<Any>(), selectedTokens)
+        }
+
+    @Test
     fun `preSelect STAKE_YBRUNE - default coin is bRUNE, not the receipt`() =
         runTest(mainDispatcher) {
             // Bonding spends bRUNE. Starting the form on ybRUNE would offer the receipt as the

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/SendStrategiesSubmitForTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/SendStrategiesSubmitForTest.kt
@@ -92,6 +92,8 @@ internal class SendStrategiesSubmitForTest {
                 DeFiNavActions.REDEEM_YTCY to Target.REDEEM,
                 DeFiNavActions.STAKE_STCY to Target.STAKE,
                 DeFiNavActions.UNSTAKE_STCY to Target.UNSTAKE,
+                DeFiNavActions.STAKE_YBRUNE to Target.STAKE,
+                DeFiNavActions.UNSTAKE_YBRUNE to Target.UNSTAKE,
                 DeFiNavActions.WITHDRAW_USDC_CIRCLE to Target.WITHDRAW_USDC_CIRCLE,
                 DeFiNavActions.STAKE_CACAO to Target.DEFAULT,
                 DeFiNavActions.UNSTAKE_CACAO to Target.DEFAULT,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/StakeStrategyTest.kt
@@ -24,6 +24,7 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_BRUNE_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.utils.UiText
@@ -142,6 +143,31 @@ internal class StakeStrategyTest {
                 assertEquals("50000000", payload.coins[0]!!.amount)
             }
         }
+
+    @Test
+    fun `submit STAKE_YBRUNE bonds bRUNE into the liquid bond`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulStake(selectedToken = bRuneCoin())
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1.25")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.STAKE_YBRUNE).submit()
+            advanceUntilIdle()
+
+            val tx = captured.captured
+            // A wasm execute, not a memo: bRUNE has no memo-based staking path at all.
+            assertEquals("", tx.memo)
+            val payload = tx.wasmExecuteContractPayload
+            assertNotNull(payload)
+            assertEquals(STAKING_BRUNE_CONTRACT, payload.contractAddress)
+            assertEquals("""{ "liquid": { "bond": {} } }""", payload.executeMsg)
+            // Funded with bRUNE — funding it with the ybRUNE receipt would be an unbond's shape.
+            assertEquals(Coins.ThorChain.bRUNE.contractAddress, payload.coins[0]!!.denom)
+            assertEquals("125000000", payload.coins[0]!!.amount)
+        }
+    }
 
     @Test
     fun `submit surfaces no_address error when chain validates dst as invalid`() = runTest {
@@ -342,6 +368,8 @@ internal class StakeStrategyTest {
             hideLoading = {},
             showError = { lastError = it },
         )
+
+    private fun bRuneCoin(): Coin = Coins.ThorChain.bRUNE.copy(address = "thor1self")
 
     private fun rujiCoin(): Coin =
         Coin(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.STAKING_BRUNE_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.STAKING_RUJI_CONTRACT
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.utils.UiText
@@ -384,6 +385,49 @@ internal class UnstakeStrategyTest {
         }
 
     @Test
+    fun `submit UNSTAKE_YBRUNE funds the unbond with the receipt units entered`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulFlow(selectedToken = ybRuneCoin())
+            // The position is reported in receipt units, so what the form carries is what funds
+            // the execute — no share conversion, unlike the sRUJI redemption above.
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.4")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.UNSTAKE_YBRUNE).submit()
+            advanceUntilIdle()
+
+            val payload = captured.captured.wasmExecuteContractPayload
+            assertNotNull(payload)
+            assertEquals("""{ "liquid": { "unbond": {} } }""", payload!!.executeMsg)
+            assertEquals(STAKING_BRUNE_CONTRACT, payload.contractAddress)
+            assertEquals(Coins.ThorChain.ybRUNE.contractAddress, payload.coins[0]!!.denom)
+            assertEquals("40000000", payload.coins[0]!!.amount)
+            assertEquals("", captured.captured.memo)
+        }
+    }
+
+    @Test
+    fun `submit UNSTAKE_YBRUNE refuses an amount below one receipt unit`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulFlow(selectedToken = ybRuneCoin())
+            // Rounds to zero base units at 8 decimals: the execute would carry no funds, so the
+            // ceremony could only ever fail on-chain after the user paid for it.
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.000000001")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.UNSTAKE_YBRUNE).submit()
+            advanceUntilIdle()
+
+            assertEquals(R.string.send_error_no_amount, lastError.stringId())
+            assertFalse(captured.isCaptured)
+        }
+    }
+
+    @Test
     fun `submit surfaces no_address when chain validates dst as invalid`() = runTest {
         givenValidatedAccount()
         coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
@@ -404,11 +448,14 @@ internal class UnstakeStrategyTest {
         }
     }
 
-    private fun givenSuccessfulFlow(includeRuji: Boolean = false) {
-        givenValidatedAccount()
+    private fun givenSuccessfulFlow(
+        includeRuji: Boolean = false,
+        selectedToken: Coin = rujiCoin(),
+    ) {
+        givenValidatedAccount(selectedToken = selectedToken)
         coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
         coEvery { getAvailableTokenBalance(any(), any()) } returns
-            TokenValue(BigInteger.valueOf(100_000_000), rujiCoin())
+            TokenValue(BigInteger.valueOf(100_000_000), selectedToken)
         val accounts =
             mutableListOf(
                 Account(
@@ -477,14 +524,17 @@ internal class UnstakeStrategyTest {
             )
     }
 
-    private fun givenValidatedAccount(gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000)) {
+    private fun givenValidatedAccount(
+        gasFeeValue: BigInteger = BigInteger.valueOf(2_000_000),
+        selectedToken: Coin = rujiCoin(),
+    ) {
         coEvery { accountValidator.validate() } returns
             ValidatedAccount(
                 vaultId = VAULT_ID,
                 selectedAccount =
                     Account(
-                        token = rujiCoin(),
-                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), rujiCoin()),
+                        token = selectedToken,
+                        tokenValue = TokenValue(BigInteger.valueOf(2_000_000_000), selectedToken),
                         fiatValue = null,
                         price = null,
                     ),
@@ -528,6 +578,8 @@ internal class UnstakeStrategyTest {
             hideLoading = {},
             showError = { lastError = it },
         )
+
+    private fun ybRuneCoin(): Coin = Coins.ThorChain.ybRUNE.copy(address = "thor1self")
 
     private fun rujiCoin(): Coin =
         Coin(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
 import com.vultisig.wallet.data.api.models.thorchain.RujiStakeBalances
+import com.vultisig.wallet.data.blockchain.thorchain.DefaultStakingPositionService
 import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
@@ -672,6 +673,10 @@ internal class UnstakeStrategyTest {
             depositTransactionRepository = depositTransactionRepository,
             navigator = navigator,
             thorChainApi = thorChainApi,
+            // The real service rather than a stub, so these cases still cover the denom the
+            // receipt balance is actually matched on.
+            defaultStakingPositionService =
+                DefaultStakingPositionService(thorChainApi, mockk(relaxed = true)),
             defiTypeProvider = { defiType },
             isAutocompoundProvider = { false },
             showLoading = {},

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/UnstakeStrategyTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
 import com.vultisig.wallet.data.api.models.thorchain.RujiStakeBalances
 import com.vultisig.wallet.data.chains.helpers.ThorchainFunctions
 import com.vultisig.wallet.data.models.Account
@@ -388,6 +389,7 @@ internal class UnstakeStrategyTest {
     fun `submit UNSTAKE_YBRUNE funds the unbond with the receipt units entered`() = runTest {
         withMockedIoDispatcher {
             givenSuccessfulFlow(selectedToken = ybRuneCoin())
+            givenBondedRuneReceipt(BigInteger.valueOf(100_000_000))
             // The position is reported in receipt units, so what the form carries is what funds
             // the execute — no share conversion, unlike the sRUJI redemption above.
             tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.4")
@@ -412,6 +414,7 @@ internal class UnstakeStrategyTest {
     fun `submit UNSTAKE_YBRUNE refuses an amount below one receipt unit`() = runTest {
         withMockedIoDispatcher {
             givenSuccessfulFlow(selectedToken = ybRuneCoin())
+            givenBondedRuneReceipt(BigInteger.valueOf(100_000_000))
             // Rounds to zero base units at 8 decimals: the execute would carry no funds, so the
             // ceremony could only ever fail on-chain after the user paid for it.
             tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.000000001")
@@ -423,6 +426,92 @@ internal class UnstakeStrategyTest {
             advanceUntilIdle()
 
             assertEquals(R.string.send_error_no_amount, lastError.stringId())
+            assertFalse(captured.isCaptured)
+        }
+    }
+
+    @Test
+    fun `submit UNSTAKE_YBRUNE clamps the unbond to the live receipt balance`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulFlow(selectedToken = ybRuneCoin())
+            // The cached position the form was seeded from still shows 1.0, but the vault has
+            // unbonded down to 0.25 since. Attaching the entered 0.4 would send funds the bank no
+            // longer holds, and the chain would refuse it only after the keysign was paid for.
+            givenBondedRuneReceipt(BigInteger.valueOf(25_000_000))
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.4")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.UNSTAKE_YBRUNE).submit()
+            advanceUntilIdle()
+
+            val payload = captured.captured.wasmExecuteContractPayload
+            assertNotNull(payload)
+            assertEquals("25000000", payload!!.coins[0]!!.amount)
+            assertEquals(BigInteger.valueOf(25_000_000), captured.captured.srcTokenValue.value)
+        }
+    }
+
+    @Test
+    fun `submit UNSTAKE_YBRUNE honours an amount the stale form ceiling would reject`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulFlow(selectedToken = ybRuneCoin())
+            // A bond made since the last DeFi refresh leaves the cached ceiling below what the
+            // vault holds. The live balance is the authority, so the entered amount stands.
+            coEvery { getAvailableTokenBalance(any(), any()) } returns
+                TokenValue(BigInteger.valueOf(10_000_000), ybRuneCoin())
+            givenBondedRuneReceipt(BigInteger.valueOf(100_000_000))
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.4")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.UNSTAKE_YBRUNE).submit()
+            advanceUntilIdle()
+
+            val payload = captured.captured.wasmExecuteContractPayload
+            assertNotNull(payload)
+            assertEquals("40000000", payload!!.coins[0]!!.amount)
+        }
+    }
+
+    @Test
+    fun `submit UNSTAKE_YBRUNE refuses when the vault no longer holds the receipt`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulFlow(selectedToken = ybRuneCoin())
+            // The bank omits empty balances, so a missing denom is a genuine zero position.
+            coEvery { thorChainApi.getBalance(any()) } returns
+                listOf(CosmosBalance(denom = "rune", amount = "2000000000"))
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.4")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.UNSTAKE_YBRUNE).submit()
+            advanceUntilIdle()
+
+            assertEquals(R.string.send_error_insufficient_balance, lastError.stringId())
+            assertFalse(captured.isCaptured)
+        }
+    }
+
+    @Test
+    fun `submit UNSTAKE_YBRUNE fails closed when the receipt balance cannot be read`() = runTest {
+        withMockedIoDispatcher {
+            givenSuccessfulFlow(selectedToken = ybRuneCoin())
+            // An unreadable balance is a fetch problem, not an empty position — sizing the unbond
+            // off a guess is exactly what the clamp exists to prevent.
+            coEvery { thorChainApi.getBalance(any()) } throws RuntimeException("status 502")
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.4")
+
+            val captured = slot<DepositTransaction>()
+            coEvery { depositTransactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this, DeFiNavActions.UNSTAKE_YBRUNE).submit()
+            advanceUntilIdle()
+
+            assertEquals(R.string.dialog_default_error_body, lastError.stringId())
             assertFalse(captured.isCaptured)
         }
     }
@@ -521,6 +610,17 @@ internal class UnstakeStrategyTest {
                 stakeTicker = "RUJI",
                 autoCompoundAmount = positionValue,
                 autoCompoundShares = heldShares,
+            )
+    }
+
+    private fun givenBondedRuneReceipt(receiptBalance: BigInteger) {
+        coEvery { thorChainApi.getBalance(any()) } returns
+            listOf(
+                CosmosBalance(denom = "rune", amount = "2000000000"),
+                CosmosBalance(
+                    denom = Coins.ThorChain.ybRUNE.contractAddress,
+                    amount = receiptBalance.toString(),
+                ),
             )
     }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabHeaderIconTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabHeaderIconTest.kt
@@ -1,0 +1,38 @@
+package com.vultisig.wallet.ui.screens.v2.defi
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Coins
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import org.junit.jupiter.api.Test
+
+internal class StakingTabHeaderIconTest {
+
+    @Test
+    fun `the compounded bRUNE card carries the bRUNE logo`() {
+        // ybRUNE holds none of the other tickers' substrings — the b breaks yrune — so before it
+        // was matched explicitly the card fell through to the generic fallback and rendered an
+        // unrelated logo.
+        assertEquals(R.drawable.brune, getHeaderIcon(Coins.ThorChain.ybRUNE.ticker))
+        assertNotEquals(R.drawable.om, getHeaderIcon(Coins.ThorChain.ybRUNE.ticker))
+    }
+
+    @Test
+    fun `a receipt ticker never takes the logo of the asset it receipts`() {
+        assertEquals(R.drawable.ytcy, getHeaderIcon(Coins.ThorChain.yTCY.ticker))
+        assertEquals(R.drawable.stcy, getHeaderIcon(Coins.ThorChain.sTCY.ticker))
+        assertEquals(R.drawable.yrune, getHeaderIcon(Coins.ThorChain.yRUNE.ticker))
+        assertEquals(R.drawable.tcy_staking, getHeaderIcon(Coins.ThorChain.TCY.ticker))
+    }
+
+    @Test
+    fun `both RUJI positions share the RUJI staking logo`() {
+        assertEquals(R.drawable.ruji_staking, getHeaderIcon(Coins.ThorChain.RUJI.ticker))
+        assertEquals(R.drawable.ruji_staking, getHeaderIcon(Coins.ThorChain.sRUJI.ticker))
+    }
+
+    @Test
+    fun `the Cacao position keeps its own logo`() {
+        assertEquals(R.drawable.cacao, getHeaderIcon(Coins.MayaChain.CACAO.ticker))
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabHeaderIconTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabHeaderIconTest.kt
@@ -2,8 +2,8 @@ package com.vultisig.wallet.ui.screens.v2.defi
 
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Coins
-import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import org.junit.jupiter.api.Test
 
 internal class StakingTabHeaderIconTest {
@@ -13,26 +13,26 @@ internal class StakingTabHeaderIconTest {
         // ybRUNE holds none of the other tickers' substrings — the b breaks yrune — so before it
         // was matched explicitly the card fell through to the generic fallback and rendered an
         // unrelated logo.
-        assertEquals(R.drawable.brune, getHeaderIcon(Coins.ThorChain.ybRUNE.ticker))
-        assertNotEquals(R.drawable.om, getHeaderIcon(Coins.ThorChain.ybRUNE.ticker))
+        getHeaderIcon(Coins.ThorChain.ybRUNE.ticker) shouldBe R.drawable.brune
+        getHeaderIcon(Coins.ThorChain.ybRUNE.ticker) shouldNotBe R.drawable.om
     }
 
     @Test
     fun `a receipt ticker never takes the logo of the asset it receipts`() {
-        assertEquals(R.drawable.ytcy, getHeaderIcon(Coins.ThorChain.yTCY.ticker))
-        assertEquals(R.drawable.stcy, getHeaderIcon(Coins.ThorChain.sTCY.ticker))
-        assertEquals(R.drawable.yrune, getHeaderIcon(Coins.ThorChain.yRUNE.ticker))
-        assertEquals(R.drawable.tcy_staking, getHeaderIcon(Coins.ThorChain.TCY.ticker))
+        getHeaderIcon(Coins.ThorChain.yTCY.ticker) shouldBe R.drawable.ytcy
+        getHeaderIcon(Coins.ThorChain.sTCY.ticker) shouldBe R.drawable.stcy
+        getHeaderIcon(Coins.ThorChain.yRUNE.ticker) shouldBe R.drawable.yrune
+        getHeaderIcon(Coins.ThorChain.TCY.ticker) shouldBe R.drawable.tcy_staking
     }
 
     @Test
     fun `both RUJI positions share the RUJI staking logo`() {
-        assertEquals(R.drawable.ruji_staking, getHeaderIcon(Coins.ThorChain.RUJI.ticker))
-        assertEquals(R.drawable.ruji_staking, getHeaderIcon(Coins.ThorChain.sRUJI.ticker))
+        getHeaderIcon(Coins.ThorChain.RUJI.ticker) shouldBe R.drawable.ruji_staking
+        getHeaderIcon(Coins.ThorChain.sRUJI.ticker) shouldBe R.drawable.ruji_staking
     }
 
     @Test
     fun `the Cacao position keeps its own logo`() {
-        assertEquals(R.drawable.cacao, getHeaderIcon(Coins.MayaChain.CACAO.ticker))
+        getHeaderIcon(Coins.MayaChain.CACAO.ticker) shouldBe R.drawable.cacao
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/model/DeFiNavActionsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/model/DeFiNavActionsTest.kt
@@ -83,6 +83,8 @@ internal class DeFiNavActionsTest {
         assertEquals(DeFiNavActions.MINT_YRUNE, Coins.ThorChain.yRUNE.getStakeDeFiNavAction())
         assertEquals(DeFiNavActions.MINT_YTCY, Coins.ThorChain.yTCY.getStakeDeFiNavAction())
         assertEquals(DeFiNavActions.STAKE_STCY, Coins.ThorChain.sTCY.getStakeDeFiNavAction())
+        // The receipt is the coin the card carries, in both directions.
+        assertEquals(DeFiNavActions.STAKE_YBRUNE, Coins.ThorChain.ybRUNE.getStakeDeFiNavAction())
         assertEquals(DeFiNavActions.STAKE_CACAO, Coins.MayaChain.CACAO.getStakeDeFiNavAction())
     }
 
@@ -94,6 +96,10 @@ internal class DeFiNavActionsTest {
         assertEquals(DeFiNavActions.REDEEM_YRUNE, Coins.ThorChain.yRUNE.getUnstakeDeFiNavAction())
         assertEquals(DeFiNavActions.REDEEM_YTCY, Coins.ThorChain.yTCY.getUnstakeDeFiNavAction())
         assertEquals(DeFiNavActions.UNSTAKE_STCY, Coins.ThorChain.sTCY.getUnstakeDeFiNavAction())
+        assertEquals(
+            DeFiNavActions.UNSTAKE_YBRUNE,
+            Coins.ThorChain.ybRUNE.getUnstakeDeFiNavAction(),
+        )
         assertEquals(DeFiNavActions.UNSTAKE_CACAO, Coins.MayaChain.CACAO.getUnstakeDeFiNavAction())
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/DefaultStakingPositionService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/DefaultStakingPositionService.kt
@@ -20,8 +20,16 @@ constructor(
     private val stakingDetailsRepository: StakingDetailsRepository,
 ) {
 
+    // Every one of these is read the same way: a bank denom whose balance is the position. ybRUNE
+    // is the auto-compounding receipt for bonded bRUNE, and since it is no longer a wallet token
+    // this read is the only thing that surfaces it.
     val supportedStakingCoins =
-        listOf(Coins.ThorChain.sTCY, Coins.ThorChain.yRUNE, Coins.ThorChain.yTCY)
+        listOf(
+            Coins.ThorChain.sTCY,
+            Coins.ThorChain.yRUNE,
+            Coins.ThorChain.yTCY,
+            Coins.ThorChain.ybRUNE,
+        )
 
     fun getStakingDetails(address: String, vaultId: String): Flow<List<StakingDetails>> =
         flow {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/DefaultStakingPositionService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/DefaultStakingPositionService.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.blockchain.thorchain
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.blockchain.model.StakingDetails
 import com.vultisig.wallet.data.blockchain.model.StakingDetails.Companion.generateId
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.repositories.StakingDetailsRepository
 import java.math.BigInteger
@@ -11,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class DefaultStakingPositionService
@@ -72,6 +74,28 @@ constructor(
                 }
             }
             .flowOn(Dispatchers.IO)
+
+    /**
+     * The vault's live balance of one receipt denom, in base units.
+     *
+     * Every position here is a bank balance, so this is the same read
+     * [getStakingDetailsFromNetwork] makes — offered on its own for the callers that need one
+     * receipt's size right now rather than the whole set: the unbond form's ceiling and the clamp
+     * that sizes the execute. Both have to agree with the card, and they only do while all three
+     * match on the same [Coin.contractAddress].
+     *
+     * A denom the response omits is a genuine zero — the bank drops empty balances. A transport
+     * failure throws: that is not an empty position, and a caller that treats it as one would size
+     * a redemption off a guess.
+     */
+    suspend fun getReceiptBalance(address: String, coin: Coin): BigInteger =
+        withContext(Dispatchers.IO) {
+            thorChainApi
+                .getBalance(address)
+                .firstOrNull { balance -> balance.denom == coin.contractAddress }
+                ?.amount
+                ?.toBigIntegerOrNull() ?: BigInteger.ZERO
+        }
 
     suspend fun getStakingDetailsFromNetwork(address: String): List<StakingDetails> {
         val balances =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainDeFiBalanceService.kt
@@ -169,7 +169,8 @@ class ThorchainDeFiBalanceService(
                             defaultDetails
                                 .filter {
                                     it.coin.id.equals(Coins.ThorChain.yRUNE.id, true) ||
-                                        it.coin.id.equals(Coins.ThorChain.yTCY.id, true)
+                                        it.coin.id.equals(Coins.ThorChain.yTCY.id, true) ||
+                                        it.coin.id.equals(Coins.ThorChain.ybRUNE.id, true)
                                 }
                                 .map { detail ->
                                     DeFiBalance.Balance(
@@ -312,7 +313,8 @@ class ThorchainDeFiBalanceService(
                     stakingDetails
                         .filter {
                             it.coin.id.equals(Coins.ThorChain.yTCY.id, true) ||
-                                it.coin.id.equals(Coins.ThorChain.yRUNE.id, true)
+                                it.coin.id.equals(Coins.ThorChain.yRUNE.id, true) ||
+                                it.coin.id.equals(Coins.ThorChain.ybRUNE.id, true)
                         }
                         .map { detail ->
                             Timber.d(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainStakingContracts.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainStakingContracts.kt
@@ -1,0 +1,15 @@
+package com.vultisig.wallet.data.blockchain.thorchain
+
+/**
+ * Rujira wasm contracts that more than one layer has to name.
+ *
+ * A staking contract is usually named in one place — the builder that spends it — and the app's own
+ * DeFi constants carry those. The bRUNE liquid bond is not one of them: the pricing repository
+ * reads its `{"status":{}}` NAV to value the ybRUNE receipt, and the bond/unbond executes are built
+ * against the same address, so a change to one that missed the other would leave a position priced
+ * off a contract it no longer transacts with. Only that address lives here; the rest stay where
+ * their single caller is.
+ */
+object ThorchainStakingContracts {
+    const val BRUNE_LIQUID_BOND = "thor179fex2rxd45caedmz4hxsnu42sw20lu0djyh4yukyh965sq8muuqptru2g"
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorchainFunctions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorchainFunctions.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.chains.helpers
 
+import com.vultisig.wallet.data.models.Coins
 import java.math.BigInteger
 import vultisig.keysign.v1.CosmosCoin
 import vultisig.keysign.v1.WasmExecuteContractPayload
@@ -260,7 +261,11 @@ private object Memo {
     const val TCY_UNSTAKE_PREFIX = "TCY-:"
     const val DENOM_STAKING_TCY = "x/staking-tcy"
     const val DENOM_STAKING_RUJI = "x/staking-x/ruji"
-    const val DENOM_STAKING_BRUNE = "x/staking-x/brune"
+
+    // Read off the catalogue rather than spelled out. The unbond is funded with this denom and
+    // sized by a clamp that measures the same coin's `contractAddress`, so a literal here could
+    // drift away from the balance the clamp reads and attach funds the vault does not hold.
+    val DENOM_STAKING_BRUNE = Coins.ThorChain.ybRUNE.contractAddress
 }
 
 private object ExecMsg {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorchainFunctions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorchainFunctions.kt
@@ -181,6 +181,58 @@ object ThorchainFunctions {
     }
 
     /**
+     * Bonds bRUNE into the Rujira liquid-bond position, which mints ybRUNE receipt shares.
+     *
+     * The same `liquid.bond` execute as [stakeRujiCompound] against a different contract: bRUNE has
+     * no bonded, non-compounding side, so this is the only way into the position. Funded with the
+     * bond token (`x/brune`), never with the receipt.
+     */
+    fun stakeBRune(
+        fromAddress: String,
+        stakingContract: String,
+        denom: String,
+        amount: BigInteger,
+    ): WasmExecuteContractPayload {
+        require(fromAddress.isNotEmpty()) { "FromAddress cannot be empty" }
+        require(stakingContract.isNotEmpty()) { "stakingContract cannot be empty" }
+        require(denom.isNotEmpty()) { "Denom cannot be empty" }
+        require(amount >= BigInteger.ONE) { "amount cannot be lower than 1" }
+
+        return WasmExecuteContractPayload(
+            senderAddress = fromAddress,
+            contractAddress = stakingContract,
+            executeMsg = ExecMsg.liquidBond(),
+            coins = listOf(CosmosCoin(denom = denom, amount = amount.toString())),
+        )
+    }
+
+    /**
+     * Unbonds from the Rujira liquid-bond position, returning bRUNE.
+     *
+     * Funded with ybRUNE receipt units. Unlike [unstakeRujiCompound], no share conversion happens
+     * on the way in: the position is reported in receipt units — the vault's `x/staking-x/brune`
+     * bank balance — so the amount the form carries is already the funding amount.
+     *
+     * @param units the ybRUNE receipt units to unbond, in base units
+     */
+    fun unstakeBRune(
+        units: BigInteger,
+        stakingContract: String,
+        fromAddress: String,
+    ): WasmExecuteContractPayload {
+        require(fromAddress.isNotEmpty()) { "FromAddress cannot be empty" }
+        require(stakingContract.isNotEmpty()) { "stakingContract cannot be empty" }
+        require(units >= BigInteger.ONE) { "units cannot be lower than 1" }
+
+        return WasmExecuteContractPayload(
+            senderAddress = fromAddress,
+            contractAddress = stakingContract,
+            executeMsg = ExecMsg.liquidUnbond(),
+            coins = listOf(CosmosCoin(denom = Memo.DENOM_STAKING_BRUNE, amount = units.toString())),
+        )
+    }
+
+    /**
      * Builds the THORChain memo for claiming RUJI staking rewards.
      *
      * @param contractAddress the RUJI staking contract address
@@ -208,6 +260,7 @@ private object Memo {
     const val TCY_UNSTAKE_PREFIX = "TCY-:"
     const val DENOM_STAKING_TCY = "x/staking-tcy"
     const val DENOM_STAKING_RUJI = "x/staking-x/ruji"
+    const val DENOM_STAKING_BRUNE = "x/staking-x/brune"
 }
 
 private object ExecMsg {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -511,7 +511,8 @@ constructor(
 
                         val updatedAccounts =
                             address.accounts.map { account ->
-                                val cachedBalance = balancesByTicker[account.token.ticker.lowercase()]
+                                val cachedBalance =
+                                    balancesByTicker[account.token.ticker.lowercase()]
                                 if (cachedBalance != null) {
                                     account.applyBalance(
                                         cachedBalance.tokenBalance,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataMigration
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.vultisig.wallet.data.models.Chain
@@ -16,7 +17,9 @@ import kotlinx.coroutines.flow.map
 private val Context.dataStore by
     preferencesDataStore(
         name = "defi_positions_preferences",
-        produceMigrations = { listOf(SelectedPositionsPerChainMigration) },
+        produceMigrations = {
+            listOf(SelectedPositionsPerChainMigration, NewThorchainPositionsMigration)
+        },
     )
 
 // Every DeFi screen used to share one key per vault, so each screen's save overwrote the other's
@@ -40,6 +43,72 @@ private val THORCHAIN_DEFAULT_POSITION_KEYS = setOf("RUNE", "RUJI", "TCY", "sTCY
 
 private fun selectedPositionsKey(chain: Chain, vaultId: String) =
     stringSetPreferencesKey("$SELECTED_POSITIONS_PREFIX${chain.id}_$vaultId")
+
+// How many rounds of THORChain positions the stored selections have been brought up to date with.
+// Absent means none, which is both a fresh install and every vault that saved a selection before
+// the counter existed.
+private val SELECTED_POSITIONS_VERSION_KEY = intPreferencesKey("defi_selected_positions_version")
+
+/**
+ * THORChain positions added to the Manage Positions dialog after vaults could already have saved a
+ * selection, keyed by the version that introduced them.
+ *
+ * A stored selection is returned verbatim, so a position that did not exist when it was written is
+ * missing from it forever: the card and its leg of the tab total stay hidden with no row in the
+ * dialog switched off to explain why. Adding a position to the defaults only reaches vaults that
+ * have never chosen. Add the ticker here in a new version whenever one joins the dialog.
+ *
+ * Tickers are spelled out rather than read off the catalogue for the same reason the key prefixes
+ * are: a migration has to keep writing the shape that was on disk when it shipped.
+ */
+private val THORCHAIN_POSITIONS_BY_VERSION: Map<Int, Set<String>> = mapOf(1 to setOf("ybRUNE"))
+
+private val CURRENT_SELECTED_POSITIONS_VERSION =
+    THORCHAIN_POSITIONS_BY_VERSION.keys.maxOrNull() ?: 0
+
+/**
+ * Switches on every THORChain position introduced since a vault last saved, so a newly supported
+ * one is visible to vaults that have chosen before, exactly as it is to vaults that never did.
+ *
+ * Runs after [SelectedPositionsPerChainMigration] because it reads the per-chain keys that
+ * migration produces. The version counter is what keeps it from being a standing rule: without it
+ * the next run would switch the position back on after the user had switched it off.
+ *
+ * A selection the user cleared to nothing is left alone. That shape is a deliberate "show me none",
+ * and handing it a row it never asked for would be the same override in the other direction.
+ */
+internal object NewThorchainPositionsMigration : DataMigration<Preferences> {
+    override suspend fun shouldMigrate(currentData: Preferences): Boolean =
+        currentData.selectedPositionsVersion() < CURRENT_SELECTED_POSITIONS_VERSION
+
+    override suspend fun migrate(currentData: Preferences): Preferences =
+        addNewThorchainPositions(currentData)
+
+    override suspend fun cleanUp() = Unit
+}
+
+internal fun addNewThorchainPositions(currentData: Preferences): Preferences {
+    val migrated = currentData.toMutablePreferences()
+    migrated[SELECTED_POSITIONS_VERSION_KEY] = CURRENT_SELECTED_POSITIONS_VERSION
+
+    val introduced =
+        THORCHAIN_POSITIONS_BY_VERSION.filterKeys { it > currentData.selectedPositionsVersion() }
+            .values
+            .flatten()
+            .toSet()
+    if (introduced.isEmpty()) return migrated
+
+    val thorchainPrefix = "$SELECTED_POSITIONS_PREFIX${Chain.ThorChain.id}_"
+    currentData.asMap().forEach { (key, value) ->
+        if (!key.name.startsWith(thorchainPrefix)) return@forEach
+        val positions = (value as? Set<*>)?.filterIsInstance<String>()?.toSet() ?: return@forEach
+        if (positions.isEmpty()) return@forEach
+        migrated[stringSetPreferencesKey(key.name)] = positions + introduced
+    }
+    return migrated
+}
+
+private fun Preferences.selectedPositionsVersion(): Int = this[SELECTED_POSITIONS_VERSION_KEY] ?: 0
 
 /**
  * Splits every pre-upgrade selection into the two per-chain keys so nobody's current choice is

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.api.LiQuestApi
 import com.vultisig.wallet.data.api.MayaChainApi
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.models.thorchain.VaultRedemptionResponseJson
+import com.vultisig.wallet.data.blockchain.thorchain.ThorchainStakingContracts
 import com.vultisig.wallet.data.db.dao.TokenPriceDao
 import com.vultisig.wallet.data.db.models.TokenPriceEntity
 import com.vultisig.wallet.data.models.Chain
@@ -846,8 +847,7 @@ constructor(
         private val BRUNE_DENOM = Coins.ThorChain.bRUNE.contractAddress
         private val YBRUNE_DENOM = Coins.ThorChain.ybRUNE.contractAddress
         private val STAKING_TCY_DENOM = Coins.ThorChain.sTCY.contractAddress
-        private const val BRUNE_STAKING_CONTRACT =
-            "thor179fex2rxd45caedmz4hxsnu42sw20lu0djyh4yukyh965sq8muuqptru2g"
+        private const val BRUNE_STAKING_CONTRACT = ThorchainStakingContracts.BRUNE_LIQUID_BOND
         private const val STAKING_TCY_CONTRACT =
             "thor1z7ejlk5wk2pxh9nfwjzkkdnrq4p2f5rjcpudltv0gh282dwfz6nq9g2cr0"
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/thorchain/DefaultStakingPositionServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/thorchain/DefaultStakingPositionServiceTest.kt
@@ -1,0 +1,84 @@
+package com.vultisig.wallet.data.blockchain.thorchain
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.StakingDetailsRepository
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+internal class DefaultStakingPositionServiceTest {
+
+    private val thorChainApi: ThorChainApi = mockk()
+    private val stakingDetailsRepository: StakingDetailsRepository = mockk(relaxed = true)
+
+    private val service = DefaultStakingPositionService(thorChainApi, stakingDetailsRepository)
+
+    @Test
+    fun `reads the ybRUNE receipt balance as its own position`() = runTest {
+        // ybRUNE is no longer a wallet token, so this read is the only thing that surfaces a
+        // bonded bRUNE position anywhere in the app.
+        givenBalances(Coins.ThorChain.ybRUNE.contractAddress to "523400000000")
+
+        val positions = service.getStakingDetailsFromNetwork(ADDRESS)
+
+        assertEquals(
+            BigInteger("523400000000"),
+            positions.forCoin(Coins.ThorChain.ybRUNE.contractAddress),
+        )
+    }
+
+    @Test
+    fun `reads each supported receipt independently`() = runTest {
+        givenBalances(
+            Coins.ThorChain.sTCY.contractAddress to "100000000",
+            Coins.ThorChain.ybRUNE.contractAddress to "250000000",
+        )
+
+        val positions = service.getStakingDetailsFromNetwork(ADDRESS)
+
+        assertEquals(
+            BigInteger("100000000"),
+            positions.forCoin(Coins.ThorChain.sTCY.contractAddress),
+        )
+        assertEquals(
+            BigInteger("250000000"),
+            positions.forCoin(Coins.ThorChain.ybRUNE.contractAddress),
+        )
+        // A denom the wallet holds nothing of still reports, as zero, so a card can settle.
+        assertEquals(BigInteger.ZERO, positions.forCoin(Coins.ThorChain.yRUNE.contractAddress))
+    }
+
+    @Test
+    fun `the bRUNE bond token is not read as a position`() = runTest {
+        // Liquid bRUNE is a spendable wallet balance; only the receipt it mints is a position.
+        // Counting it here would show unbonded bRUNE as staked, and double it in the DeFi total.
+        givenBalances(Coins.ThorChain.bRUNE.contractAddress to "900000000")
+
+        val positions = service.getStakingDetailsFromNetwork(ADDRESS)
+
+        assertEquals(
+            emptyList<String>(),
+            positions
+                .map { it.coin.contractAddress }
+                .filter { it == Coins.ThorChain.bRUNE.contractAddress },
+        )
+    }
+
+    private fun givenBalances(vararg denoms: Pair<String, String>) {
+        coEvery { thorChainApi.getBalance(ADDRESS) } returns
+            denoms.map { (denom, amount) -> CosmosBalance(denom = denom, amount = amount) }
+    }
+
+    private fun List<com.vultisig.wallet.data.blockchain.model.StakingDetails>.forCoin(
+        contractAddress: String
+    ): BigInteger = single { it.coin.contractAddress == contractAddress }.stakeAmount
+
+    private companion object {
+        const val ADDRESS = "thor1mtqtupwgjwn397w3dx9fqmqgzrjcal5yxz8q7v"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/thorchain/DefaultStakingPositionServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/thorchain/DefaultStakingPositionServiceTest.kt
@@ -69,6 +69,40 @@ internal class DefaultStakingPositionServiceTest {
         )
     }
 
+    @Test
+    fun `getReceiptBalance reads one receipt off the same denom the position is built from`() =
+        runTest {
+            // The unbond form's ceiling and the clamp that sizes the execute both come through
+            // here, so all three can only agree while they match on the one contract address.
+            givenBalances(
+                "rune" to "2000000000",
+                Coins.ThorChain.ybRUNE.contractAddress to "523400000000",
+            )
+
+            assertEquals(
+                BigInteger("523400000000"),
+                service.getReceiptBalance(ADDRESS, Coins.ThorChain.ybRUNE),
+            )
+        }
+
+    @Test
+    fun `getReceiptBalance reads a denom the bank omits as a genuine zero`() = runTest {
+        // The bank drops empty balances, so an absent denom is a position of nothing rather than
+        // a missing answer.
+        givenBalances("rune" to "2000000000")
+
+        assertEquals(BigInteger.ZERO, service.getReceiptBalance(ADDRESS, Coins.ThorChain.ybRUNE))
+    }
+
+    @Test
+    fun `getReceiptBalance never mistakes the bond token for its receipt`() = runTest {
+        // bRUNE and ybRUNE are separate denoms; redeeming against the liquid balance would attach
+        // funds the bond contract does not accept.
+        givenBalances(Coins.ThorChain.bRUNE.contractAddress to "900000000")
+
+        assertEquals(BigInteger.ZERO, service.getReceiptBalance(ADDRESS, Coins.ThorChain.ybRUNE))
+    }
+
     private fun givenBalances(vararg denoms: Pair<String, String>) {
         coEvery { thorChainApi.getBalance(ADDRESS) } returns
             denoms.map { (denom, amount) -> CosmosBalance(denom = denom, amount = amount) }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainDeFiBalanceServiceYbRuneTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainDeFiBalanceServiceYbRuneTest.kt
@@ -1,0 +1,81 @@
+package com.vultisig.wallet.data.blockchain.thorchain
+
+import com.vultisig.wallet.data.blockchain.model.StakingDetails
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.repositories.ActiveBondedNodeRepository
+import com.vultisig.wallet.data.repositories.StakingDetailsRepository
+import com.vultisig.wallet.data.usecases.ThorchainBondUseCase
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * The DeFi tab totals what these balances report. The receipt has to travel both paths — the cached
+ * one the tab renders first and the network one that replaces it — or a bonded position reads as
+ * zero on one of them.
+ */
+internal class ThorchainDeFiBalanceServiceYbRuneTest {
+
+    private val rujiStakingService: RujiStakingService = mockk(relaxed = true)
+    private val tcyStakingService: TCYStakingService = mockk(relaxed = true)
+    private val defaultStakingPositionService: DefaultStakingPositionService = mockk(relaxed = true)
+    private val bondUseCase: ThorchainBondUseCase = mockk(relaxed = true)
+    private val stakingDetailsRepository: StakingDetailsRepository = mockk(relaxed = true)
+    private val activeBondedNodeRepository: ActiveBondedNodeRepository = mockk(relaxed = true)
+
+    private val service =
+        ThorchainDeFiBalanceService(
+            rujiStakingService = rujiStakingService,
+            tcyStakingService = tcyStakingService,
+            defaultStakingPositionService = defaultStakingPositionService,
+            bondUseCase = bondUseCase,
+            stakingDetailsRepository = stakingDetailsRepository,
+            activeBondedNodeRepository = activeBondedNodeRepository,
+        )
+
+    @Test
+    fun `a fetched ybRUNE position reaches the DeFi balances`() = runTest {
+        coEvery { defaultStakingPositionService.getStakingDetails(ADDRESS, VAULT_ID) } returns
+            flowOf(listOf(details(Coins.ThorChain.ybRUNE, BigInteger("523400000000"))))
+
+        val balances = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
+
+        assertEquals(BigInteger("523400000000"), balances.amountFor(Coins.ThorChain.ybRUNE.id))
+    }
+
+    @Test
+    fun `a cached ybRUNE position reaches the DeFi balances`() = runTest {
+        coEvery { stakingDetailsRepository.getStakingDetails(VAULT_ID) } returns
+            listOf(details(Coins.ThorChain.ybRUNE, BigInteger("77000000")))
+
+        val balances = service.getCacheDeFiBalance(ADDRESS, VAULT_ID)
+
+        assertEquals(BigInteger("77000000"), balances.amountFor(Coins.ThorChain.ybRUNE.id))
+    }
+
+    private fun List<com.vultisig.wallet.data.blockchain.model.DeFiBalance>.amountFor(
+        coinId: String
+    ): BigInteger =
+        flatMap { it.balances }.single { it.coin.id.equals(coinId, ignoreCase = true) }.amount
+
+    private fun details(coin: com.vultisig.wallet.data.models.Coin, amount: BigInteger) =
+        StakingDetails(
+            id = coin.id,
+            coin = coin,
+            stakeAmount = amount,
+            apr = null,
+            estimatedRewards = null,
+            nextPayoutDate = null,
+            rewards = null,
+            rewardsCoin = null,
+        )
+
+    private companion object {
+        const val ADDRESS = "thor1mtqtupwgjwn397w3dx9fqmqgzrjcal5yxz8q7v"
+        const val VAULT_ID = "vault-1"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ThorchainFunctionsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ThorchainFunctionsTest.kt
@@ -344,4 +344,76 @@ class ThorchainFunctionsTest {
             ThorchainFunctions.unstakeRujiCompound(BigInteger.valueOf(-1L), "contract", "addr")
         }
     }
+
+    @Test
+    fun `stakeBRune produces liquid bond funded with the bRUNE bond denom`() {
+        // The bond is funded with bRUNE itself; the ybRUNE receipt is what comes back, and must
+        // never be what goes in.
+        val payload =
+            ThorchainFunctions.stakeBRune(
+                fromAddress = "thor1sender",
+                stakingContract = "thor1contract",
+                denom = "x/brune",
+                amount = BigInteger.valueOf(250_000_000L),
+            )
+        assertEquals("thor1sender", payload.senderAddress)
+        assertEquals("thor1contract", payload.contractAddress)
+        assertEquals("""{ "liquid": { "bond": {} } }""", payload.executeMsg)
+        val funds = requireNotNull(payload.coins.single())
+        assertEquals("x/brune", funds.denom)
+        assertEquals("250000000", funds.amount)
+    }
+
+    @Test
+    fun `stakeBRune throws on blank inputs or sub-unit amounts`() {
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.stakeBRune("", "contract", "x/brune", BigInteger.ONE)
+        }
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.stakeBRune("addr", "", "x/brune", BigInteger.ONE)
+        }
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.stakeBRune("addr", "contract", "", BigInteger.ONE)
+        }
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.stakeBRune("addr", "contract", "x/brune", BigInteger.ZERO)
+        }
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.stakeBRune("addr", "contract", "x/brune", BigInteger.valueOf(-1))
+        }
+    }
+
+    @Test
+    fun `unstakeBRune funds liquid unbond with the ybRUNE receipt denom`() {
+        // Redemption is funded with the receipt the bond minted, never with bRUNE — funding it
+        // with the bond denom would bond again rather than unbond.
+        val payload =
+            ThorchainFunctions.unstakeBRune(
+                units = BigInteger.valueOf(97_531_246_800L),
+                stakingContract = "thor1contract",
+                fromAddress = "thor1sender",
+            )
+        assertEquals("thor1sender", payload.senderAddress)
+        assertEquals("thor1contract", payload.contractAddress)
+        assertEquals("""{ "liquid": { "unbond": {} } }""", payload.executeMsg)
+        val funds = requireNotNull(payload.coins.single())
+        assertEquals("x/staking-x/brune", funds.denom)
+        assertEquals("97531246800", funds.amount)
+    }
+
+    @Test
+    fun `unstakeBRune throws when units is zero or below one`() {
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.unstakeBRune(BigInteger.ZERO, "contract", "addr")
+        }
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.unstakeBRune(BigInteger.valueOf(-1L), "contract", "addr")
+        }
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.unstakeBRune(BigInteger.ONE, "", "addr")
+        }
+        assertThrows<IllegalArgumentException> {
+            ThorchainFunctions.unstakeBRune(BigInteger.ONE, "contract", "")
+        }
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/DefiPositionsRepositoryMigrationTest.kt
@@ -208,6 +208,94 @@ internal class DefiPositionsRepositoryMigrationTest {
         after[mayachainKey(VAULT_ID)] shouldBe setOf(MAYA_BOND_CACAO_KEY)
     }
 
+    // ──────── positions introduced after a vault had already chosen ────────
+
+    @Test
+    fun `a selection saved before ybRUNE existed gets the new position switched on`() = runTest {
+        // The stored set is handed back verbatim, so without this the compounded bRUNE card and
+        // its leg of the tab total stay hidden on every vault that had ever opened the dialog —
+        // with no row switched off to explain why.
+        val before = mutablePreferencesOf(thorchainKey(VAULT_ID) to setOf("RUNE", "TCY"))
+
+        val after = addNewThorchainPositions(before)
+
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE", "TCY", "ybRUNE")
+    }
+
+    @Test
+    fun `every vault gets the new position, not just the first`() = runTest {
+        val before =
+            mutablePreferencesOf(
+                thorchainKey("vault-a") to setOf("RUNE"),
+                thorchainKey("vault-b") to setOf("TCY", "BTC.BTC"),
+            )
+
+        val after = addNewThorchainPositions(before)
+
+        after[thorchainKey("vault-a")] shouldBe setOf("RUNE", "ybRUNE")
+        after[thorchainKey("vault-b")] shouldBe setOf("TCY", "BTC.BTC", "ybRUNE")
+    }
+
+    @Test
+    fun `a cleared selection is not handed a row it never asked for`() = runTest {
+        val before = mutablePreferencesOf(thorchainKey(VAULT_ID) to emptySet<String>())
+
+        val after = addNewThorchainPositions(before)
+
+        after[thorchainKey(VAULT_ID)] shouldBe emptySet()
+    }
+
+    @Test
+    fun `a vault that never chose is left without a key`() = runTest {
+        // Null is what tells the screen to answer with its own defaults, which already carry the
+        // new position. Writing a set here would turn that into a choice the vault never made.
+        val after = addNewThorchainPositions(mutablePreferencesOf())
+
+        after[thorchainKey(VAULT_ID)].shouldBeNull()
+    }
+
+    @Test
+    fun `the Maya selection is left alone`() = runTest {
+        val before = mutablePreferencesOf(mayachainKey(VAULT_ID) to setOf(MAYA_BOND_CACAO_KEY))
+
+        val after = addNewThorchainPositions(before)
+
+        after[mayachainKey(VAULT_ID)] shouldBe setOf(MAYA_BOND_CACAO_KEY)
+    }
+
+    @Test
+    fun `switching the new position back off survives the next launch`() = runTest {
+        // shouldMigrate is consulted on every store creation. Without the version counter this
+        // would be a standing rule that undid the user's choice on the very next cold start.
+        val before = mutablePreferencesOf(thorchainKey(VAULT_ID) to setOf("RUNE"))
+        NewThorchainPositionsMigration.shouldMigrate(before) shouldBe true
+
+        val migrated = NewThorchainPositionsMigration.migrate(before)
+        val userSwitchedItOff =
+            migrated.toMutablePreferences().apply { this[thorchainKey(VAULT_ID)] = setOf("RUNE") }
+
+        NewThorchainPositionsMigration.shouldMigrate(userSwitchedItOff) shouldBe false
+        addNewThorchainPositions(userSwitchedItOff)[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE")
+    }
+
+    @Test
+    fun `a fresh install is only stamped with the current version`() = runTest {
+        val after = NewThorchainPositionsMigration.migrate(mutablePreferencesOf())
+
+        NewThorchainPositionsMigration.shouldMigrate(after) shouldBe false
+        after.asMap().keys.map { it.name } shouldBe listOf("defi_selected_positions_version")
+    }
+
+    @Test
+    fun `the legacy split runs first, so the vault it moves gets the new position too`() = runTest {
+        // Both migrations run in one pass, in list order, each seeing the previous one's output.
+        val before = preferencesWithLegacySelection(VAULT_ID, setOf("RUNE", "TCY"))
+
+        val after = addNewThorchainPositions(migrateSelectedPositionsPerChain(before))
+
+        after[thorchainKey(VAULT_ID)] shouldBe setOf("RUNE", "TCY", "ybRUNE")
+    }
+
     private fun preferencesWithLegacySelection(vaultId: String, positions: Set<String>) =
         mutablePreferencesOf(legacyKey(vaultId) to positions)
 


### PR DESCRIPTION
## Summary

Ships the Rujira bRUNE liquid bond: a working bond / unbond flow, and a home on the DeFi tab for the position the ybRUNE receipt stands for. Two standalone commits, one per issue — each compiles and passes both suites on its own.

Closes #5584
Closes #5585

Transction hash
https://runescan.io/tx/8691634A81D44036B42931A9AD0F57A8B89DE7D7391113D5D1ADF24A35FED61E

**Depends on #5635**, which takes the ybRUNE receipt out of the wallet token list (#5583). That change used to be the first commit here; it now ships on its own so this PR carries only the bond flow and the card. Merge #5635 first — until it lands, a holder sees the position twice (once as a wallet token, once as the card below).

### 1. Bond bRUNE / unbond ybRUNE (#5584)

- `stakeBRune` emits `{"liquid":{"bond":{}}}` funded with `x/brune`; `unstakeBRune` emits `{"liquid":{"unbond":{}}}` funded with the receipt, both against `thor179fex…`.
- No share conversion on the way in. The sRUJI redemption converts because that position is reported in RUJI; this one is reported in receipt units, so the amount the form carries is already what funds the execute.
- `AccountsLoader` synthesizes the unbond form's account off the RUNE account (address, derived key, gas), since the receipt is not a wallet token. The bond direction spends bRUNE and stays on the ordinary wallet accounts.
- The contract address moves to `ThorchainStakingContracts`: two layers now name it — the executes built here, and the `{"status":{}}` NAV the pricing repository already read to value the receipt.

### 2. Compounded bRUNE card (#5585)

- ybRUNE joins the bank-denom positions `DefaultStakingPositionService` reads and passes both DeFi-balance filters, so it reaches the chain row and the portfolio total as well as its own card.
- Value comes from the NAV price row the receipt already had: balance × (`liquid_bond_size` / `liquid_bond_shares`) × RUNE.
- Selectable in Manage Positions. A vault that already saved a selection keeps it, so the card is opt-in there — as with every position added since that dialog shipped.

## iOS parity

The transaction layer is taken from iOS (`BRUNEStakeTransactionBuilder` / `BRUNEUnstakeTransactionBuilder`, vultisig/vultisig-ios#4778): same contract, same execute messages, same funding denoms, same "no conversion" rule, and the same position read (`fetchBRuneAutoCompoundAmount`). iOS likewise lists ybRUNE — but not bRUNE — among the selectable staking positions.

Two deliberate differences:

| | iOS | here |
|---|---|---|
| Card title | `"Compounded ybRUNE"` (position ticker) | `"Compounded bRUNE"` — the string #5585 asks for, and how the sibling sRUJI card is titled |
| Unstake input | percentage slider on the bRUNE coin | amount field on ybRUNE, MAX at the position — matches the sRUJI unstake and labels the units actually sent |

The signed bytes are the same either way.

## Test plan

- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — 2963 + 2087 green.
- Both commits checked out separately, compiled and run through both suites.
- Merged with #5635 locally: no conflicts, both suites green on the merge result.
- 19 new tests; every one verified to fail when its production change is reverted. They cover the wasm payloads (denoms, messages, guard rails), the synthesized unbond account, the preselection and nav actions, the strategy submits, the position read, and the card's title/flags.

Manual: DeFi tab → THORChain → Manage Positions → tick **ybRUNE** → Done. The "Compounded bRUNE" card shows the position; **Stake** opens the form titled "Stake" with bRUNE preselected, **Unstake** opens it with ybRUNE preselected and MAX at the full position.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added THORChain bRUNE staking and ybRUNE unstaking.
  * Added ybRUNE receipt balances and positions to DeFi views.
  * Added automatic token selection, navigation, and transaction handling for bRUNE and ybRUNE.
  * Added updated staking visuals and preserved THORChain position selections when new positions are introduced.

* **Bug Fixes**
  * Improved handling of missing, stale, zero-value, and refreshed ybRUNE balances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->