### PR TITLE
fix(home): give the edit pill its pen and a Chains/Tokens label

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/buttons/VsEditPill.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/buttons/VsEditPill.kt
@@ -1,0 +1,59 @@
+package com.vultisig.wallet.ui.components.v2.buttons
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.clickOnce
+import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
+import com.vultisig.wallet.ui.components.v2.containers.ContainerType
+import com.vultisig.wallet.ui.components.v2.containers.V2Container
+import com.vultisig.wallet.ui.theme.Theme
+
+/**
+ * Pill that opens the edit sheet for whatever the tab next to it lists: the chains of a vault on
+ * the home screen, the tokens of a chain on its detail screen.
+ *
+ * Both surfaces show the same pen and the same chrome, so [label] is the only thing that says which
+ * list is about to be edited — it is required rather than defaulted for that reason.
+ */
+@Composable
+internal fun VsEditPill(label: String, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    V2Container(
+        modifier = modifier.clickOnce(onClick = onClick),
+        type = ContainerType.SECONDARY,
+        radius = Theme.v2.radius.pill,
+        borderType = ContainerBorderType.Borderless,
+    ) {
+        Row(
+            modifier = Modifier.padding(all = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(space = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            UiIcon(
+                drawableResId = R.drawable.ic_edit_pencil,
+                size = 16.dp,
+                tint = Theme.v2.colors.text.primary,
+            )
+
+            Text(
+                text = label,
+                style = Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.text.secondary,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewVsEditPill() {
+    VsEditPill(label = "Chains", onClick = {})
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainTokensTabMenuAndSearchBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainTokensTabMenuAndSearchBar.kt
@@ -19,6 +19,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
+import com.vultisig.wallet.ui.components.v2.buttons.VsEditPill
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
 import com.vultisig.wallet.ui.components.v2.tab.TabMenuAndSearchBar
@@ -77,18 +78,7 @@ fun ChainTokensTabMenuAndSearchBar(
 
                 UiSpacer(size = 8.dp)
 
-                V2Container(
-                    type = ContainerType.SECONDARY,
-                    radius = Theme.v2.radius.pill,
-                    modifier = Modifier.clickOnce(onClick = onEditClick),
-                ) {
-                    UiIcon(
-                        drawableResId = R.drawable.edit_chain,
-                        size = 16.dp,
-                        modifier = Modifier.padding(all = 12.dp),
-                        tint = Theme.v2.colors.primary.accent4,
-                    )
-                }
+                VsEditPill(label = stringResource(R.string.edit_tokens), onClick = onEditClick)
             }
         },
         onCancelSearchClick = onCancelSearchClick,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/HomePageTabMenu.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/HomePageTabMenu.kt
@@ -21,6 +21,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
+import com.vultisig.wallet.ui.components.v2.buttons.VsEditPill
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
@@ -78,19 +79,7 @@ internal fun HomePageTabMenu(
 
             // Hidden for KeyImport vaults where chains are fixed at import time
             if (isEditVisible) {
-                V2Container(
-                    modifier = Modifier.clickOnce(onClick = onEditClick),
-                    radius = Theme.v2.radius.pill,
-                    type = ContainerType.SECONDARY,
-                    borderType = ContainerBorderType.Borderless,
-                ) {
-                    UiIcon(
-                        drawableResId = R.drawable.edit_chain,
-                        size = 16.dp,
-                        tint = Theme.v2.colors.primary.accent4,
-                        modifier = Modifier.padding(12.dp),
-                    )
-                }
+                VsEditPill(label = stringResource(R.string.edit_chains), onClick = onEditClick)
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -150,6 +150,8 @@
     <string name="swap_error_no_amount">Die Menge muss eine positive Zahl sein</string>
     <string name="app_name">Vultisig</string>
     <string name="tokens">Tokens</string>
+    <string name="edit_chains">Blockchains</string>
+    <string name="edit_tokens">Tokens</string>
     <string name="vault_list_vaults_list">Tresore</string>
     <string name="tx_done_address_copied">%1$s in die Zwischenablage kopiert</string>
     <string name="token_logo">Token-Logo</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -228,6 +228,8 @@
     <string name="app_name">Vultisig</string>
     <string name="token_logo">Logotipo de token</string>
     <string name="tokens">Tokens</string>
+    <string name="edit_chains">Cadenas</string>
+    <string name="edit_tokens">Tokens</string>
     <string name="swap_screen_invalid_vault">La transacción probablemente fallará, la bóveda no pudo cargarse.</string>
     <string name="vault_settings_error_backup_file">ocurrió un error</string>
     <string name="vault_settings_error_backup_failed">La copia de seguridad falló. No se guardó ningún archivo. Inténtalo de nuevo.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -143,6 +143,8 @@
     <string name="swap_error_no_amount">Iznos mora biti pozitivan broj. Pokušajte ponovno.</string>
     <string name="app_name">Vultisig</string>
     <string name="tokens">Tokeni</string>
+    <string name="edit_chains">Lanci</string>
+    <string name="edit_tokens">Tokeni</string>
     <string name="transaction_type_button_swap">Zamijeni</string>
     <string name="chain_account_view_swap">ZAMIJENI</string>
     <string name="signing_error_please_try_again_s">Greška pri prijavi. Molimo pokušajte ponovno. %s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -143,6 +143,8 @@
     <string name="swap_error_no_amount">La quantità deve essere un numero positivo.</string>
     <string name="app_name">Vultisig</string>
     <string name="tokens">Tokens</string>
+    <string name="edit_chains">Catene</string>
+    <string name="edit_tokens">Tokens</string>
     <string name="transaction_type_button_swap">Scambia</string>
     <string name="swap_form_vault">Cassaforte</string>
     <string name="swap_form_min_pay">pagamento min.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -116,6 +116,8 @@
     <string name="app_name">Vultisig</string>
     <string name="token_logo">토큰 로고</string>
     <string name="tokens">토큰</string>
+    <string name="edit_chains">체인</string>
+    <string name="edit_tokens">토큰</string>
     <string name="keysign">서명</string>
     <string name="signing_error_please_try_again_s">서명 오류. 다시 시도해 주세요. %s</string>
     <string name="try_again">다시 시도</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -2,6 +2,8 @@
     <string name="app_name">Vultisig</string>
     <string name="token_logo">Token logo</string>
     <string name="tokens">Tokens</string>
+    <string name="edit_chains">Ketens</string>
+    <string name="edit_tokens">Tokens</string>
     <string name="keysign">Sleutel tekenen</string>
     <string name="signing_error_please_try_again_s">Ondertekeningsfout. Probeer het opnieuw. %s</string>
     <string name="try_again">Probeer opnieuw</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -2,6 +2,8 @@
 <resources>
     <string name="app_name">Vultisig</string>
     <string name="tokens">Tokens</string>
+    <string name="edit_chains">Cadeias</string>
+    <string name="edit_tokens">Tokens</string>
     <string name="signing_error_please_try_again_s">Erro ao Assinar. Por favor, tente novamente. %s</string>
     <string name="try_again">Tentar Novamente</string>
     <string name="vault_settings_title">Configurações do Cofre</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2,6 +2,8 @@
     <string name="app_name">Vultisig</string>
     <string name="token_logo">Логотип токена</string>
     <string name="tokens">Токены</string>
+    <string name="edit_chains">Сети</string>
+    <string name="edit_tokens">Токены</string>
     <string name="keysign">Ключевая подпись</string>
     <string name="signing_error_please_try_again_s">Ошибка подписи. Пожалуйста, попробуйте еще раз. %s</string>
     <string name="try_again">Попробуйте еще раз</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -111,6 +111,8 @@
     <string name="app_name">Vultisig</string>
     <string name="token_logo">代币标志</string>
     <string name="tokens">代币</string>
+    <string name="edit_chains">区块链</string>
+    <string name="edit_tokens">代币</string>
     <string name="keysign">密钥签名</string>
     <string name="signing_error_please_try_again_s">签名错误。请重试。%s</string>
     <string name="try_again">重试</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,7 +118,9 @@
     <string name="open_account_button">Open Account</string>
     <string name="app_name">Vultisig</string>
     <string name="token_logo">Token logo</string>
-    <string name="tokens">Assets</string>
+    <string name="tokens">Tokens</string>
+    <string name="edit_chains">Chains</string>
+    <string name="edit_tokens">Tokens</string>
     <string name="keysign">Keysign</string>
     <string name="signing_error_please_try_again_s">Signing Error. Please try again. %s</string>
     <string name="try_again">Try again</string>


### PR DESCRIPTION
Closes #5641

## Summary

The pill that opens chain selection on the vault home, and token management on a chain's detail screen, was an icon-only circle: `edit_chain` (a card-and-pen glyph) tinted accent blue. Figma's tab-menu component is a labelled pill — a plain pen next to **Chains** on the portfolio, **Tokens** on a chain.

Both surfaces now render one shared `VsEditPill`, so the two copies of the same control can't drift apart again.

Figma: [Portfolio](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=48948-113411) · [Tokens](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=48948-111456)

## What changed

| | Before | After (Figma) |
|---|---|---|
| Shape | icon-only circle, 12dp padding | pill: 12dp padding, 8dp gap, icon + label |
| Icon | `edit_chain` (card + pen), 16dp | `ic_edit_pencil` (pen), 16dp |
| Icon tint | `primary.accent4` #4879FD | `text.primary` #F0F4FC |
| Label | — | Footnote 13/18 (+0.06), `text.secondary` #C9D6E8 |
| Fill / radius | `backgrounds.secondary` #061B3A, pill | unchanged — already matches |
| Height | 40dp | 42dp (the 18sp line box, not the 16dp icon, sets the row) |

## On device

| Home — "Chains" | Chain detail — "Tokens" |
|---|---|
| ![home](https://i.imgur.com/Bvn02VK.png) | ![chain detail](https://i.imgur.com/4JLcYWq.png) |

Captured on this branch. There is no matching before capture; the previous state is the icon-only circle in the table above.

## Notes for review

- **The issue says "chain-link icon"; the design says pen.** The icon layer in both Figma nodes is named `pen` and its path is a pencil, so that's what shipped. Happy to swap if the issue text was the intent.
- **No new drawable.** `ic_edit_pencil`'s path *is* the design's vector: Figma coords × 1.5 + 2.0996 maps onto it exactly. A dedicated 16dp copy would only have differed in stroke weight, and Figma's 2px there would render heavier than the `ic_search` sitting beside it — that icon is the same design's 2px stroke drawn at 1.33dp. `edit_chain` stays in the tree; the DeFi Manage Positions button still uses it.
- **One string change beyond the pill.** `R.string.tokens` read "Assets" in English only — all nine other locales already translate it as Tokens, and the Figma node labels that tab Tokens. Left as-is the screen would read "Assets" tab next to a "Tokens" pill. Single call site (that tab); easy to drop if you'd rather keep it out.
- `edit_chains` / `edit_tokens` added to all 10 locales, each using the chain term that locale already uses (de Blockchains, es Cadenas, hr Lanci, it Catene, ko 체인, nl Ketens, pt Cadeias, ru Сети, zh 区块链).
- The KeyImport `isEditVisible` gate and both click handlers are untouched.

## Test plan

- `./gradlew :app:compileDebugKotlin --offline` — green.
- `./gradlew :app:lintDebug --offline` — BUILD SUCCESSFUL, no new issues (covers `MissingTranslation` for the two new keys).
- ktfmt applied to the touched files.

Every changed value above was read off the two Figma nodes. Still worth a look at the pill's fit next to the tab on narrow screens in German, which renders the longest label ("Blockchains").

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent edit pills for managing chains and tokens.
  - Edit controls now display clear labels alongside the edit icon.
- **Localization**
  - Added translated chain and token editing labels across multiple languages.
  - Updated the English “Assets” label to “Tokens” for clearer terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->