### PR TITLE
fix(defi): describe a Kamino transaction the same way on both devices

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
@@ -76,6 +76,17 @@ internal data class DepositTransactionUiModel(
      * `MsgDeposit` carries no coins and whose whole cost really is one network fee.
      */
     val limitCancelDonatesDust: Boolean = false,
+    /**
+     * The share count a Kamino withdraw's own instruction carries, formatted, on a device that
+     * cannot check the amount above it. Null everywhere else.
+     *
+     * A withdraw is requested in vault shares and displayed in the tokens those shares are worth,
+     * at a rate that never crosses the wire — so a joining co-signer holds a headline figure it has
+     * no way to confirm and no Blockaid badge to qualify it. Rather than leaving the number looking
+     * as checked as the vault name beside it, the screen says which figure did come from the bytes
+     * (issue #5644). iOS surfaces the same case as `.amountUnverifiable`.
+     */
+    val unverifiedWithdrawShares: String? = null,
 )
 
 internal data class VerifyDepositUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinDepositUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinDepositUiModelBuilder.kt
@@ -2,8 +2,15 @@ package com.vultisig.wallet.ui.models.keysign
 
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDepositRentReserve
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRelayedIntent
+import com.vultisig.wallet.data.blockchain.solana.kamino.kaminoNetworkFeeLamports
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.GasFeeParams
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_DEPOSIT
+import com.vultisig.wallet.data.models.OPERATION_KAMINO_WITHDRAW
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.getPubKeyByChain
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
@@ -40,13 +47,23 @@ constructor(
     private val addressBookRepository: AddressBookRepository,
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val feeResolver: JoinKeysignFeeResolver,
+    private val depositRentReserve: KaminoDepositRentReserve,
 ) {
 
     /**
      * Builds the deposit [JoinKeysignVerifyResult] from [payload] for the vault identified by
      * [vaultId], resolving fees and parsing the THOR memo.
+     *
+     * @param kamino what the relayed Solana bytes turned out to be, when they were recognised as a
+     *   Kamino Earn deposit or withdraw. It carries everything a THOR memo carries for the chains
+     *   above — which vault, which direction — none of which a Kamino payload states in a field
+     *   (issue #5644).
      */
-    suspend fun build(payload: KeysignPayload, vaultId: String): JoinKeysignVerifyResult {
+    suspend fun build(
+        payload: KeysignPayload,
+        vaultId: String,
+        kamino: KaminoRelayedIntent? = null,
+    ): JoinKeysignVerifyResult {
         when (payload.blockChainSpecific) {
             is BlockChainSpecific.MayaChain,
             is BlockChainSpecific.THORChain,
@@ -56,6 +73,14 @@ constructor(
             // to render its verify screen so multi-device staking ceremonies aren't blocked.
             is BlockChainSpecific.Ton,
             is BlockChainSpecific.UTXO -> Unit
+
+            // Solana arrives here only as a recognised Kamino transaction. A raw Solana payload
+            // nobody could read is still a send, and rendering it as a deposit would put a
+            // deposit's framing around bytes this device cannot describe.
+            is BlockChainSpecific.Solana ->
+                requireNotNull(kamino) {
+                    "a Solana deposit must be a recognised Kamino transaction"
+                }
 
             else -> error("BlockChainSpecific ${payload.blockChainSpecific} is not supported")
         }
@@ -89,12 +114,13 @@ constructor(
 
         val nativeCoin = withContext(Dispatchers.IO) { tokenRepository.getNativeToken(chain.id) }
         val estimatedTokenFees =
-            feeResolver.resolveJoinKeysignNetworkFee(
-                payload = payload,
-                chain = chain,
-                nativeCoin = nativeCoin,
-                blockchainTransaction = blockchainTransaction,
-            )
+            kamino?.let { kaminoNetworkFee(it, payload, nativeCoin) }
+                ?: feeResolver.resolveJoinKeysignNetworkFee(
+                    payload = payload,
+                    chain = chain,
+                    nativeCoin = nativeCoin,
+                    blockchainTransaction = blockchainTransaction,
+                )
 
         val totalGasAndFee =
             gasFeeToEstimatedFee(
@@ -119,11 +145,17 @@ constructor(
                 estimatedFees = estimatedTokenFees,
                 estimateFeesFiat = totalGasAndFee.formattedFiatValue,
                 blockChainSpecific = payload.blockChainSpecific,
-                operation = parsedThorMemo?.operation.orEmpty(),
+                operation = kamino?.let(::kaminoOperation) ?: parsedThorMemo?.operation.orEmpty(),
                 nodeAddress = parsedThorMemo?.nodeAddress.orEmpty(),
                 pairedAddress = parsedThorMemo?.pairedAddress.orEmpty(),
                 thorAddress = parsedThorMemo?.thorAddress.orEmpty(),
                 pool = parsedThorMemo?.pool.orEmpty(),
+                // The verify screen labels this row as the vault for a Kamino operation, so the
+                // co-signer reads the destination by name rather than as a bare program address.
+                validatorName = kamino?.vault?.fallbackName,
+                // Renders the instruction breakdown the initiating device shows, which for a
+                // pre-built transaction is the only place its real work is visible.
+                signSolana = payload.signSolana,
             )
         // Resolve the same From/To labels the initiator renders (issue #5301), so the joining
         // co-signer sees "VaultName (address)" instead of raw thor1… addresses. Mirrors
@@ -157,6 +189,48 @@ constructor(
             verifyUiModel = VerifyUiModel.Deposit(VerifyDepositUiModel(depositTransactionUiModel)),
             transactionTypeUiModel = TransactionTypeUiModel.Deposit(depositTransactionUiModel),
             transactionHistoryData = mapDepositTransactionHistoryData(depositTransactionUiModel),
+        )
+    }
+
+    private fun kaminoOperation(kamino: KaminoRelayedIntent): String =
+        when (kamino.action) {
+            KaminoAction.DEPOSIT -> OPERATION_KAMINO_DEPOSIT
+            KaminoAction.WITHDRAW -> OPERATION_KAMINO_WITHDRAW
+        }
+
+    /**
+     * The fee the initiating device quotes for these bytes, derived here from the relayed compute
+     * budget rather than re-estimated.
+     *
+     * A fee service can only price the transfer it is handed, and this is not one: it is a
+     * pre-built transaction carrying its own compute-unit limit — 320,000 to 400,000 against a
+     * transfer's 100,000 — plus, on a first native-SOL deposit, the rent for the accounts it
+     * creates. Estimating it as a transfer is how the two devices came to quote fees a hundredfold
+     * apart for one transaction (issue #5644).
+     */
+    private suspend fun kaminoNetworkFee(
+        kamino: KaminoRelayedIntent,
+        payload: KeysignPayload,
+        nativeCoin: Coin,
+    ): TokenValue {
+        val specific = payload.blockChainSpecific as BlockChainSpecific.Solana
+        val rentReserve =
+            if (kamino.action == KaminoAction.DEPOSIT) {
+                withContext(Dispatchers.IO) {
+                    depositRentReserve(kamino.vault, payload.coin.address)
+                }
+            } else {
+                BigInteger.ZERO
+            }
+        return TokenValue(
+            value =
+                kaminoNetworkFeeLamports(
+                    vault = kamino.vault,
+                    action = kamino.action,
+                    relayedUnitPrice = specific.priorityFee,
+                    rentReserve = rentReserve,
+                ),
+            token = nativeCoin,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinDepositUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinDepositUiModelBuilder.kt
@@ -24,6 +24,7 @@ import com.vultisig.wallet.data.usecases.ThorchainMemoParser
 import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionHistoryDataMapper
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionToUiModelMapper
+import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
 import com.vultisig.wallet.ui.utils.resolveDstVaultName
 import java.math.BigInteger
 import java.util.UUID
@@ -48,6 +49,7 @@ constructor(
     private val chainAccountAddressRepository: ChainAccountAddressRepository,
     private val feeResolver: JoinKeysignFeeResolver,
     private val depositRentReserve: KaminoDepositRentReserve,
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper,
 ) {
 
     /**
@@ -184,6 +186,7 @@ constructor(
                     srcVaultName = srcVaultName,
                     dstVaultName = dstVaultName,
                     dstAddressBookTitle = dstAddressBookTitle,
+                    unverifiedWithdrawShares = kamino?.let(::withdrawShares),
                 )
         return JoinKeysignVerifyResult(
             verifyUiModel = VerifyUiModel.Deposit(VerifyDepositUiModel(depositTransactionUiModel)),
@@ -191,6 +194,22 @@ constructor(
             transactionHistoryData = mapDepositTransactionHistoryData(depositTransactionUiModel),
         )
     }
+
+    /**
+     * The share figure a withdraw's kVault instruction carries, formatted, or null for a deposit —
+     * whose headline amount this device already checked against the same instruction.
+     *
+     * Sized by the vault's own share scale, which is not the token's: Allez SOL's shares carry six
+     * decimals against the token's nine.
+     */
+    private fun withdrawShares(kamino: KaminoRelayedIntent): String? =
+        kamino
+            .takeIf { it.action == KaminoAction.WITHDRAW }
+            ?.let {
+                mapTokenValueToDecimalUiString(
+                    TokenValue(value = it.amount, unit = "", decimals = it.vault.sharesDecimals)
+                )
+            }
 
     private fun kaminoOperation(kamino: KaminoRelayedIntent): String =
         when (kamino.action) {
@@ -213,7 +232,6 @@ constructor(
         payload: KeysignPayload,
         nativeCoin: Coin,
     ): TokenValue {
-        val specific = payload.blockChainSpecific as BlockChainSpecific.Solana
         val rentReserve =
             if (kamino.action == KaminoAction.DEPOSIT) {
                 withContext(Dispatchers.IO) {
@@ -227,7 +245,10 @@ constructor(
                 kaminoNetworkFeeLamports(
                     vault = kamino.vault,
                     action = kamino.action,
-                    relayedUnitPrice = specific.priorityFee,
+                    // From the instructions, not from the field relayed beside them. The two are
+                    // pinned equal by KaminoRelayedIntent.takeIfDescribedBy before this runs, and
+                    // the one inside the bytes is the one the runtime charges.
+                    relayedUnitPrice = kamino.priorityFee?.price,
                     rentReserve = rentReserve,
                 ),
             token = nativeCoin,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -613,7 +613,10 @@ constructor(
     private suspend fun loadTransaction(payload: KeysignPayload) {
         val currency = appCurrencyRepository.currency.first()
         val swapPayload = payload.swapPayload
-        val kamino = resolveKaminoIntent(payload)
+        // Resolved after the swap branch, not before it: recognition decodes the relayed bytes and
+        // derives an associated token account per allow-listed vault, none of which a swap payload
+        // has any use for.
+        val kamino = if (swapPayload == null) resolveKaminoIntent(payload) else null
         when {
             swapPayload != null ->
                 applyVerifyResult(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -13,6 +13,8 @@ import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.api.ZcashApi
 import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.api.utils.HttpException
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRelayedIntent
+import com.vultisig.wallet.data.blockchain.solana.kamino.ResolveKaminoRelayedIntentUseCase
 import com.vultisig.wallet.data.chains.helpers.SigningHelper
 import com.vultisig.wallet.data.common.DeepLinkHelper
 import com.vultisig.wallet.data.common.Endpoints
@@ -281,6 +283,7 @@ constructor(
     private val joinDepositUiModelBuilder: JoinDepositUiModelBuilder,
     private val joinSendUiModelBuilder: JoinSendUiModelBuilder,
     private val parseCosmosMessage: ParseCosmosMessageUseCase,
+    private val resolveKaminoRelayedIntent: ResolveKaminoRelayedIntentUseCase,
 ) : ViewModel() {
     companion object {
         private const val VAULT_PARAMETER = "vault"
@@ -610,6 +613,7 @@ constructor(
     private suspend fun loadTransaction(payload: KeysignPayload) {
         val currency = appCurrencyRepository.currency.first()
         val swapPayload = payload.swapPayload
+        val kamino = resolveKaminoIntent(payload)
         when {
             swapPayload != null ->
                 applyVerifyResult(
@@ -619,6 +623,13 @@ constructor(
                         vault = _currentVault,
                         currency = currency,
                     )
+                )
+
+            // A Kamino payload states none of what it is in a field — no memo, no deposit flag —
+            // so it reaches the deposit screen on the strength of its own bytes or not at all.
+            kamino != null ->
+                applyVerifyResult(
+                    joinDepositUiModelBuilder.build(payload, _currentVault.id, kamino)
                 )
 
             isDepositPayload(payload) ->
@@ -649,6 +660,23 @@ constructor(
                 scanTransaction(sendResult.transaction)
             }
         }
+    }
+
+    /**
+     * The Kamino Earn deposit or withdraw this payload describes, read from the transaction it
+     * carries, or null when the bytes are not one of this app's Kamino transactions.
+     *
+     * Read from the bytes rather than from the fields beside them, then held against those fields
+     * by [takeIfDescribedBy] before the payload is treated as a Kamino transaction.
+     */
+    private suspend fun resolveKaminoIntent(payload: KeysignPayload): KaminoRelayedIntent? {
+        if (payload.coin.chain != Chain.Solana) return null
+        val rawTransactions = payload.signSolana?.rawTransactions ?: return null
+
+        return withContext(Dispatchers.IO) {
+                resolveKaminoRelayedIntent(rawTransactions, payload.coin.address)
+            }
+            ?.takeIfDescribedBy(payload)
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KaminoJoinIntent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KaminoJoinIntent.kt
@@ -1,0 +1,34 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRelayedIntent
+import com.vultisig.wallet.data.blockchain.solana.kamino.kaminoDestinationAddress
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import timber.log.Timber
+
+/**
+ * This intent when [payload]'s display fields describe the transaction it was read from, null when
+ * they do not.
+ *
+ * A co-signing device is told an amount and a destination, and handed the bytes that will actually
+ * be signed. Only the bytes say what the transaction does, so the two are compared before the
+ * payload is given a Kamino deposit's framing: a payload naming a destination the transaction does
+ * not pay, or a deposit amount the kVault instruction does not carry, keeps the generic screen
+ * rather than being dressed up as something this device could not confirm (issue #5644).
+ *
+ * Withdraw amounts are deliberately not compared — the instruction carries the share count where
+ * the payload carries the tokens those shares are worth, and the rate between them is not something
+ * a joining device can pin down.
+ */
+internal fun KaminoRelayedIntent.takeIfDescribedBy(payload: KeysignPayload): KaminoRelayedIntent? {
+    val expectedDestination = kaminoDestinationAddress(vault, action, payload.coin.address)
+    if (payload.toAddress != expectedDestination) {
+        Timber.w("Kamino payload names a destination its own transaction does not pay")
+        return null
+    }
+    if (action == KaminoAction.DEPOSIT && amount != payload.toAmount) {
+        Timber.w("Kamino payload states an amount its own transaction does not carry")
+        return null
+    }
+    return this
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KaminoJoinIntent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KaminoJoinIntent.kt
@@ -1,8 +1,13 @@
 package com.vultisig.wallet.ui.models.keysign
 
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoPriorityFee
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRelayedIntent
+import com.vultisig.wallet.data.blockchain.solana.kamino.coin
 import com.vultisig.wallet.data.blockchain.solana.kamino.kaminoDestinationAddress
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import timber.log.Timber
 
@@ -10,20 +15,41 @@ import timber.log.Timber
  * This intent when [payload]'s display fields describe the transaction it was read from, null when
  * they do not.
  *
- * A co-signing device is told an amount and a destination, and handed the bytes that will actually
- * be signed. Only the bytes say what the transaction does, so the two are compared before the
- * payload is given a Kamino deposit's framing: a payload naming a destination the transaction does
- * not pay, or a deposit amount the kVault instruction does not carry, keeps the generic screen
- * rather than being dressed up as something this device could not confirm (issue #5644).
+ * A co-signing device is told an amount, a destination, an asset and a fee, and handed the bytes
+ * that will actually be signed. Only the bytes say what the transaction does, so the two are
+ * compared before the payload is given a Kamino deposit's framing: a payload naming a destination
+ * the transaction does not pay, an asset it does not move, a fee it does not charge, or a deposit
+ * amount the kVault instruction does not carry, keeps the generic screen rather than being dressed
+ * up as something this device could not confirm (issue #5644).
  *
  * Withdraw amounts are deliberately not compared — the instruction carries the share count where
  * the payload carries the tokens those shares are worth, and the rate between them is not something
- * a joining device can pin down.
+ * a joining device can pin down. That one is disclosed instead of checked, by
+ * [JoinDepositUiModelBuilder], which names the share figure the bytes do carry. iOS answers the
+ * same case with `.amountUnverifiable` rather than with a refusal, for the same reason: refusing
+ * would break every legitimate peer withdraw.
  */
 internal fun KaminoRelayedIntent.takeIfDescribedBy(payload: KeysignPayload): KaminoRelayedIntent? {
+    // Not merely a cast guard. The fee row below is priced off this payload's compute budget, and
+    // the deposit screen scales its amount with this payload's coin — neither of which a payload
+    // for some other chain carries at all.
+    val specific = payload.blockChainSpecific as? BlockChainSpecific.Solana
+    if (specific == null || payload.coin.chain != Chain.Solana) {
+        Timber.w("Kamino bytes arrived under a payload that is not a Solana one")
+        return null
+    }
+
     val expectedDestination = kaminoDestinationAddress(vault, action, payload.coin.address)
     if (payload.toAddress != expectedDestination) {
         Timber.w("Kamino payload names a destination its own transaction does not pay")
+        return null
+    }
+    if (!describesAsset(payload.coin)) {
+        Timber.w("Kamino payload names an asset that is not the vault's underlying token")
+        return null
+    }
+    if (!describesPriorityFee(specific)) {
+        Timber.w("Kamino payload states a network fee its own transaction does not charge")
         return null
     }
     if (action == KaminoAction.DEPOSIT && amount != payload.toAmount) {
@@ -31,4 +57,47 @@ internal fun KaminoRelayedIntent.takeIfDescribedBy(payload: KeysignPayload): Kam
         return null
     }
     return this
+}
+
+/**
+ * Whether [coin] is the vault's underlying token.
+ *
+ * The verify screen scales `toAmount` by this coin's decimals and labels it with its ticker, so a
+ * coin that is not the vault's asset renders the headline figure at the wrong precision or under
+ * the wrong name — a nine-decimal SOL deposit relayed as a six-decimal coin reads a thousandfold
+ * out. The base-unit amount check above does not catch it: base units are the same number either
+ * way, and it is the scale applied to them that moves.
+ *
+ * Skipped when no wallet coin maps to the vault's mint, matching iOS: an unestablished fact is not
+ * a contradiction.
+ */
+private fun KaminoRelayedIntent.describesAsset(coin: Coin): Boolean {
+    val underlying = vault.coin ?: return true
+    return coin.decimal == underlying.decimal &&
+        coin.contractAddress == underlying.contractAddress &&
+        coin.ticker.equals(underlying.ticker, ignoreCase = true)
+}
+
+/**
+ * Whether the compute budget recorded beside the bytes is the one inside them.
+ *
+ * The two are genuinely independent claims: [specific] is what the initiating device says it
+ * injected and is what the joining device's fee row is priced from, while
+ * [KaminoRelayedIntent.priorityFee] is what the runtime will actually charge against. A relay that
+ * lowered the recorded price, or stripped the budget from the bytes, would otherwise leave a screen
+ * quoting one fee for a transaction that pays another — and the displayed figure is clamped into
+ * [com.vultisig.wallet.data.blockchain.solana.kamino.KaminoComputeBudget.MAX_UNIT_PRICE] where the
+ * charged one is a bare `u64`.
+ *
+ * "Neither has one" would agree, but cannot arise: the validator refuses bytes carrying no budget
+ * before this runs.
+ */
+private fun KaminoRelayedIntent.describesPriorityFee(specific: BlockChainSpecific.Solana): Boolean {
+    val recorded =
+        if (specific.priorityFee.signum() > 0 && specific.priorityLimit.signum() > 0) {
+            KaminoPriorityFee(limit = specific.priorityLimit, price = specific.priorityFee)
+        } else {
+            null
+        }
+    return recorded == priorityFee
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -483,7 +483,10 @@ constructor(
             // Through [kaminoNetworkFeeLamports] rather than inline, because a co-signing device
             // quotes this same fee for this same transaction off the relayed payload, and one
             // shared derivation is what keeps the two screens from disagreeing.
-            val recordedBudget = keysignPayload.blockChainSpecific as BlockChainSpecific.Solana
+            val recordedBudget =
+                checkNotNull(keysignPayload.blockChainSpecific as? BlockChainSpecific.Solana) {
+                    "a Kamino payload must carry a Solana compute budget"
+                }
             // A first native-SOL deposit also spends the rent [spendableBalance] reserved against
             // the same balance, on the wSOL ATA, share ATA and farm UserState it creates. Folded in
             // here too, or the amount plus this fee would undercount the wallet's starting balance

--- a/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModel.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.blockchain.solana.kamino.BuildKaminoKeysignPayloadUseCase
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoComputeBudget
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDepositRentReserve
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoPositionMath
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRate
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoShareAmount
@@ -25,6 +26,7 @@ import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawLiquidity
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawMath
 import com.vultisig.wallet.data.blockchain.solana.kamino.coin
 import com.vultisig.wallet.data.blockchain.solana.kamino.kaminoDestinationAddress
+import com.vultisig.wallet.data.blockchain.solana.kamino.kaminoNetworkFeeLamports
 import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
@@ -127,6 +129,7 @@ constructor(
     private val balanceRepository: BalanceRepository,
     private val blockChainSpecificRepository: BlockChainSpecificRepository,
     private val buildKeysignPayload: BuildKaminoKeysignPayloadUseCase,
+    private val depositRentReserve: KaminoDepositRentReserve,
     private val depositTransactionRepository: DepositTransactionRepository,
     private val navigator: Navigator<Destination>,
 ) : ViewModel() {
@@ -235,7 +238,7 @@ constructor(
         if (!coin.isNativeToken) return BigDecimal(balance).movePointLeft(coin.decimal)
 
         val priorityFee = kaminoDepositPriorityFee(vault, coin)
-        val rentReserve = kaminoNativeDepositRentReserve(vault, coin)
+        val rentReserve = depositRentReserve(vault, coin.address)
 
         val headroom = SolanaHelper.DefaultFeeInLamports + priorityFee + rentReserve
         return BigDecimal((balance - headroom).coerceAtLeast(BigInteger.ZERO))
@@ -260,54 +263,6 @@ constructor(
             networkPrice = networkPrice,
         )
     }
-
-    private suspend fun kaminoNativeDepositRentReserve(vault: KaminoVault, coin: Coin): BigInteger {
-        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) return BigInteger.ZERO
-
-        val tokenAccountRent = tokenAccountRentReserve()
-        val wrappedSolRent =
-            tokenAccountRent.takeUnless { tokenAccountExists(coin.address, vault.tokenMint) }
-                ?: BigInteger.ZERO
-        val shareAccountRent =
-            tokenAccountRent.takeUnless { tokenAccountExists(coin.address, vault.sharesMint) }
-                ?: BigInteger.ZERO
-        val farmUserStateRent =
-            FARM_USER_STATE_RENT_LAMPORTS.takeUnless { hasKaminoVaultPosition(coin.address, vault) }
-                ?: BigInteger.ZERO
-
-        return wrappedSolRent + shareAccountRent + farmUserStateRent
-    }
-
-    private suspend fun tokenAccountRentReserve(): BigInteger =
-        runCatchingCancellable { solanaApi.getMinimumBalanceForRentExemption() }
-            .getOrNull()
-            ?.takeIf { it.signum() > 0 } ?: SPL_TOKEN_ACCOUNT_RENT_LAMPORTS
-
-    private suspend fun tokenAccountExists(walletAddress: String, mint: String): Boolean =
-        runCatchingCancellable {
-                solanaApi.getTokenAssociatedAccountByOwner(walletAddress, mint).first != null
-            }
-            .getOrDefault(false)
-
-    /**
-     * Whether the wallet already has a farm UserState account for this vault, so a redeposit does
-     * not need to pay its rent again.
-     *
-     * Goes through [KaminoWithdrawEligibility.resolve] rather than checking for a bare entry in the
-     * response: the same endpoint keeps a zero-share row for a wallet that has fully exited, and
-     * the withdraw flow already treats that row as no position. Checking entry presence alone would
-     * disagree with that and waive the rent on an account that may no longer exist.
-     */
-    private suspend fun hasKaminoVaultPosition(walletAddress: String, vault: KaminoVault): Boolean =
-        runCatchingCancellable {
-                val entry =
-                    kaminoApi.getUserPositions(walletAddress).firstOrNull {
-                        it.vaultAddress == vault.address
-                    }
-                KaminoWithdrawEligibility.resolve(entry, vault.sharesDecimals) is
-                    KaminoWithdrawEligibility.Withdrawable
-            }
-            .getOrDefault(false)
 
     /**
      * Resolves what the withdraw form may offer, in shares first and tokens only as a projection.
@@ -525,9 +480,9 @@ constructor(
             // records rather than from a flat constant, so the number on this screen is the number
             // inside the bytes.
             //
-            // Deliberately the same arithmetic iOS applies to the relayed payload — its base term
-            // is `SolanaHelper.defaultFeeInLamports`, the same 1,000,000, plus price × limit — so
-            // the two devices quote one figure for one transaction instead of two.
+            // Through [kaminoNetworkFeeLamports] rather than inline, because a co-signing device
+            // quotes this same fee for this same transaction off the relayed payload, and one
+            // shared derivation is what keeps the two screens from disagreeing.
             val recordedBudget = keysignPayload.blockChainSpecific as BlockChainSpecific.Solana
             // A first native-SOL deposit also spends the rent [spendableBalance] reserved against
             // the same balance, on the wSOL ATA, share ATA and farm UserState it creates. Folded in
@@ -535,20 +490,19 @@ constructor(
             // by exactly that rent on the verify screen.
             val rentReserve =
                 if (!route.isWithdraw && coin.isNativeToken) {
-                    kaminoNativeDepositRentReserve(vault, coin)
+                    depositRentReserve(vault, coin.address)
                 } else {
                     BigInteger.ZERO
                 }
             val gasFee =
                 TokenValue(
                     value =
-                        SolanaHelper.DefaultFeeInLamports +
-                            KaminoComputeBudget.priorityFeeLamports(
-                                vault = vault,
-                                action = action,
-                                networkPrice = recordedBudget.priorityFee,
-                            ) +
-                            rentReserve,
+                        kaminoNetworkFeeLamports(
+                            vault = vault,
+                            action = action,
+                            relayedUnitPrice = recordedBudget.priorityFee,
+                            rentReserve = rentReserve,
+                        ),
                     token = solCoin,
                 )
 
@@ -667,19 +621,6 @@ constructor(
     }
 
     private companion object {
-        /**
-         * Rent-exempt minimum for a 165-byte SPL token account. Used only when the live read fails
-         * — reserving nothing would be worse than reserving a value that has not moved in practice.
-         */
-        val SPL_TOKEN_ACCOUNT_RENT_LAMPORTS: BigInteger = BigInteger.valueOf(2_039_280)
-
-        /**
-         * Rent-exempt minimum Kamino charges when a first deposit creates the farms `UserState`.
-         * The account size is Kamino-owned, so keep the observed mainnet lamport value here rather
-         * than pretending the app can derive it from SPL token-account rent.
-         */
-        val FARM_USER_STATE_RENT_LAMPORTS: BigInteger = BigInteger.valueOf(6_299_080)
-
         val ONE_HUNDRED = BigDecimal(100)
         const val DEFAULT_SCALE = 6
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -165,6 +165,20 @@ internal fun VerifyDepositScreen(
 
                     SwapToken(valuedToken = tx.token, isLoading = state.isLoading)
 
+                    // A joining co-signer's Kamino withdraw: the amount above is a token
+                    // projection of a share figure, at a rate that never crossed the wire. Naming
+                    // the share count the instruction does carry is the difference between a
+                    // number this device checked and one it only relayed.
+                    tx.unverifiedWithdrawShares?.let { shares ->
+                        UiSpacer(12.dp)
+                        Text(
+                            text =
+                                stringResource(R.string.kamino_verify_withdraw_unverified, shares),
+                            style = Theme.brockmann.supplementary.caption,
+                            color = Theme.v2.colors.text.tertiary,
+                        )
+                    }
+
                     // Stated before signing, not after: cancelling refunds only what has not
                     // filled, and on the L1 route the amount above is dust that is DONATED — it has
                     // no refund path — so that route gets a sentence that names it rather than the

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -544,6 +544,7 @@
     <string name="verify_deposit_depositing">Du zahlst ein</string>
     <string name="verify_deposit_withdrawing">Du hebst ab</string>
     <string name="kamino_verify_vault">Vault</string>
+    <string name="kamino_verify_withdraw_unverified">Dieses Gerät kann diesen Betrag nicht bestätigen. Die Transaktion zieht %1$s Vault-Anteile ab.</string>
     <string name="kamino_error_build_failed">Diese Transaktion konnte nicht vorbereitet werden</string>
     <string name="kamino_withdraw_nothing">Aus diesem Vault gibt es nichts abzuheben</string>
     <string name="kamino_withdraw_unreadable">Diese Position konnte nicht gelesen werden, daher ist keine Abhebung möglich</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -544,6 +544,7 @@
     <string name="verify_deposit_depositing">Estás depositando</string>
     <string name="verify_deposit_withdrawing">Estás retirando</string>
     <string name="kamino_verify_vault">Vault</string>
+    <string name="kamino_verify_withdraw_unverified">Este dispositivo no puede confirmar este importe. La transacción retira %1$s participaciones del vault.</string>
     <string name="kamino_error_build_failed">No se pudo preparar esta transacción</string>
     <string name="kamino_withdraw_nothing">No hay nada que retirar de este vault</string>
     <string name="kamino_withdraw_unreadable">No se pudo leer esta posición, así que no se puede preparar el retiro</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -545,6 +545,7 @@
     <string name="verify_deposit_depositing">Deponirate</string>
     <string name="verify_deposit_withdrawing">Povlačite</string>
     <string name="kamino_verify_vault">Vault</string>
+    <string name="kamino_verify_withdraw_unverified">Ovaj uređaj ne može potvrditi ovaj iznos. Transakcija povlači %1$s udjela vaulta.</string>
     <string name="kamino_error_build_failed">Ovu transakciju nije bilo moguće pripremiti</string>
     <string name="kamino_withdraw_nothing">Iz ovog vaulta nema se što povući</string>
     <string name="kamino_withdraw_unreadable">Ovu poziciju nije bilo moguće pročitati, pa se povlačenje ne može pripremiti</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -544,6 +544,7 @@
     <string name="verify_deposit_depositing">Stai depositando</string>
     <string name="verify_deposit_withdrawing">Stai prelevando</string>
     <string name="kamino_verify_vault">Vault</string>
+    <string name="kamino_verify_withdraw_unverified">Questo dispositivo non può confermare questo importo. La transazione preleva %1$s quote del vault.</string>
     <string name="kamino_error_build_failed">Impossibile preparare questa transazione</string>
     <string name="kamino_withdraw_nothing">Non c\'è nulla da prelevare da questo vault</string>
     <string name="kamino_withdraw_unreadable">Impossibile leggere questa posizione, quindi il prelievo non può essere preparato</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -90,6 +90,7 @@
     <string name="verify_deposit_depositing">예치 중</string>
     <string name="verify_deposit_withdrawing">출금 중</string>
     <string name="kamino_verify_vault">볼트</string>
+    <string name="kamino_verify_withdraw_unverified">이 기기에서는 이 금액을 확인할 수 없습니다. 이 트랜잭션은 볼트 지분 %1$s개를 출금합니다.</string>
     <string name="kamino_error_build_failed">이 거래를 준비할 수 없습니다</string>
     <string name="kamino_withdraw_nothing">이 볼트에서 출금할 것이 없습니다</string>
     <string name="kamino_withdraw_unreadable">이 포지션을 읽을 수 없어 출금을 준비할 수 없습니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -541,6 +541,7 @@
     <string name="verify_deposit_depositing">Je stort</string>
     <string name="verify_deposit_withdrawing">Je neemt op</string>
     <string name="kamino_verify_vault">Vault</string>
+    <string name="kamino_verify_withdraw_unverified">Dit apparaat kan dit bedrag niet bevestigen. De transactie neemt %1$s vault-aandelen op.</string>
     <string name="kamino_error_build_failed">Kan deze transactie niet voorbereiden</string>
     <string name="kamino_withdraw_nothing">Er is niets op te nemen uit deze vault</string>
     <string name="kamino_withdraw_unreadable">Deze positie kon niet worden gelezen, dus er kan geen opname worden voorbereid</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -542,6 +542,7 @@
     <string name="verify_deposit_depositing">Você está depositando</string>
     <string name="verify_deposit_withdrawing">Você está retirando</string>
     <string name="kamino_verify_vault">Vault</string>
+    <string name="kamino_verify_withdraw_unverified">Este dispositivo não consegue confirmar este valor. A transação retira %1$s cotas do vault.</string>
     <string name="kamino_error_build_failed">Não foi possível preparar esta transação</string>
     <string name="kamino_withdraw_nothing">Não há nada a retirar deste vault</string>
     <string name="kamino_withdraw_unreadable">Não foi possível ler esta posição, então a retirada não pode ser preparada</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -543,6 +543,7 @@
     <string name="verify_deposit_depositing">Вы вносите</string>
     <string name="verify_deposit_withdrawing">Вы выводите</string>
     <string name="kamino_verify_vault">Vault Kamino</string>
+    <string name="kamino_verify_withdraw_unverified">Это устройство не может подтвердить сумму. Транзакция выводит долей vault‑а: %1$s.</string>
     <string name="kamino_error_build_failed">Не удалось подготовить эту транзакцию</string>
     <string name="kamino_withdraw_nothing">Из этого vault‑а нечего выводить</string>
     <string name="kamino_withdraw_unreadable">Не удалось прочитать эту позицию, поэтому вывод невозможно подготовить</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -543,7 +543,7 @@
     <string name="verify_deposit_depositing">Вы вносите</string>
     <string name="verify_deposit_withdrawing">Вы выводите</string>
     <string name="kamino_verify_vault">Vault Kamino</string>
-    <string name="kamino_verify_withdraw_unverified">Это устройство не может подтвердить сумму. Транзакция выводит долей vault‑а: %1$s.</string>
+    <string name="kamino_verify_withdraw_unverified">Это устройство не может подтвердить сумму. Количество выводимых долей vault‑а: %1$s.</string>
     <string name="kamino_error_build_failed">Не удалось подготовить эту транзакцию</string>
     <string name="kamino_withdraw_nothing">Из этого vault‑а нечего выводить</string>
     <string name="kamino_withdraw_unreadable">Не удалось прочитать эту позицию, поэтому вывод невозможно подготовить</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -85,6 +85,7 @@
     <string name="verify_deposit_depositing">正在存入</string>
     <string name="verify_deposit_withdrawing">正在提取</string>
     <string name="kamino_verify_vault">金库</string>
+    <string name="kamino_verify_withdraw_unverified">此设备无法确认该金额。该交易将提取 %1$s 份金库份额。</string>
     <string name="kamino_error_build_failed">无法准备此交易</string>
     <string name="kamino_withdraw_nothing">该金库没有可提取的资产</string>
     <string name="kamino_withdraw_unreadable">无法读取该仓位，因此无法准备提取</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,6 +93,7 @@
     <string name="verify_deposit_depositing">You\'re depositing</string>
     <string name="verify_deposit_withdrawing">You\'re withdrawing</string>
     <string name="kamino_verify_vault">Vault</string>
+    <string name="kamino_verify_withdraw_unverified">This device can\'t confirm this amount. The transaction withdraws %1$s vault shares.</string>
     <string name="kamino_error_build_failed">Couldn\'t prepare this transaction</string>
     <string name="kamino_withdraw_nothing">Nothing to withdraw from this vault</string>
     <string name="kamino_withdraw_unreadable">This position couldn\'t be read, so no withdrawal can be prepared</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinDepositKaminoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinDepositKaminoTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.ui.models.keysign
 
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDepositRentReserve
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoPriorityFee
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRelayedIntent
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.models.Chain
@@ -21,6 +22,7 @@ import com.vultisig.wallet.data.usecases.ThorchainMemoParser
 import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionHistoryDataMapper
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionToUiModelMapper
+import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapperImpl
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -29,6 +31,7 @@ import io.mockk.slot
 import java.math.BigInteger
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import vultisig.keysign.v1.SignSolana
 
 /**
@@ -74,9 +77,18 @@ internal class JoinDepositKaminoTest {
             chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
             feeResolver = feeResolver,
             depositRentReserve = depositRentReserve,
+            mapTokenValueToDecimalUiString = TokenValueToDecimalUiStringMapperImpl(),
         )
 
     private suspend fun build(intent: KaminoRelayedIntent, toAddress: String): DepositTransaction {
+        buildResult(intent, toAddress)
+        return captured.captured
+    }
+
+    private suspend fun buildResult(
+        intent: KaminoRelayedIntent?,
+        toAddress: String,
+    ): JoinKeysignVerifyResult {
         val storedVault = mockk<Vault>(relaxed = true)
         coEvery { vaultRepository.get(VAULT_ID) } returns storedVault
         coEvery { vaultRepository.getAll() } returns emptyList()
@@ -92,8 +104,7 @@ internal class JoinDepositKaminoTest {
             DepositTransactionUiModel()
         coEvery { mapDepositTransactionHistoryData(any()) } returns mockk(relaxed = true)
 
-        builder.build(payload(toAddress), VAULT_ID, intent)
-        return captured.captured
+        return builder.build(payload(toAddress), VAULT_ID, intent)
     }
 
     @Test
@@ -136,11 +147,52 @@ internal class JoinDepositKaminoTest {
         coVerify(exactly = 0) { depositRentReserve(any(), any()) }
     }
 
+    @Test
+    fun `a withdraw names the share count its instruction carries`() = runTest {
+        // The amount above it is a token projection at a rate that never crossed the wire, and no
+        // Blockaid badge qualifies it — so the screen says which figure did come from the bytes.
+        val result = buildResult(intent(KaminoAction.WITHDRAW), toAddress = SIGNER)
+
+        // 500,000 at the vault's six share decimals, which are not the token's nine.
+        result.transactionTypeUiModel
+            .let { it as TransactionTypeUiModel.Deposit }
+            .depositTransactionUiModel
+            .unverifiedWithdrawShares shouldBe "0.5"
+    }
+
+    @Test
+    fun `a deposit's amount was checked against the bytes, so nothing is disclaimed`() = runTest {
+        coEvery { depositRentReserve(vault, SIGNER) } returns RENT
+
+        val result = buildResult(intent(KaminoAction.DEPOSIT), toAddress = vault.address)
+
+        result.transactionTypeUiModel
+            .let { it as TransactionTypeUiModel.Deposit }
+            .depositTransactionUiModel
+            .unverifiedWithdrawShares shouldBe null
+    }
+
+    @Test
+    fun `a Solana payload that is not a recognised Kamino transaction is refused`() = runTest {
+        // Bytes nobody could read are still a send. Rendering them as a deposit would put a
+        // deposit's framing — an operation, a vault name — around a transaction this device cannot
+        // describe, which is the shape issue #5644 reported in the first place.
+        assertThrows<IllegalArgumentException> { buildResult(intent = null, toAddress = SIGNER) }
+    }
+
     private fun intent(action: KaminoAction) =
         KaminoRelayedIntent(
             vault = vault,
             action = action,
             amount = if (action == KaminoAction.DEPOSIT) AMOUNT else BigInteger.valueOf(500_000),
+            priorityFee =
+                KaminoPriorityFee(
+                    limit =
+                        BigInteger.valueOf(
+                            if (action == KaminoAction.DEPOSIT) 350_000 else 400_000
+                        ),
+                    price = BigInteger.valueOf(250_000),
+                ),
         )
 
     private fun payload(toAddress: String) =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinDepositKaminoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinDepositKaminoTest.kt
@@ -1,0 +1,172 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDepositRentReserve
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRelayedIntent
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.EstimatedGasFee
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.repositories.AddressBookRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.ThorchainMemoParser
+import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
+import com.vultisig.wallet.ui.models.mappers.DepositTransactionHistoryDataMapper
+import com.vultisig.wallet.ui.models.mappers.DepositTransactionToUiModelMapper
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import java.math.BigInteger
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.SignSolana
+
+/**
+ * What a co-signing device shows for a Kamino Earn transaction (issue #5644): the same operation,
+ * vault and network fee the initiating device shows, rather than a plain send priced as a transfer.
+ */
+internal class JoinDepositKaminoTest {
+
+    private val vault = KaminoVaultRegistry.ALLEZ_SOL
+
+    private val solCoin =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "SOL",
+            logo = "sol",
+            address = SIGNER,
+            decimal = 9,
+            hexPublicKey = "hex",
+            priceProviderID = "solana",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val gasFeeToEstimatedFee = mockk<GasFeeToEstimatedFeeUseCase>()
+    private val tokenRepository = mockk<TokenRepository>()
+    private val vaultRepository = mockk<VaultRepository>()
+    private val depositRentReserve = mockk<KaminoDepositRentReserve>()
+    private val feeResolver = mockk<JoinKeysignFeeResolver>()
+    private val mapDepositTransactionToUiModel = mockk<DepositTransactionToUiModelMapper>()
+    private val mapDepositTransactionHistoryData = mockk<DepositTransactionHistoryDataMapper>()
+
+    private val captured = slot<DepositTransaction>()
+
+    private val builder =
+        JoinDepositUiModelBuilder(
+            tokenRepository = tokenRepository,
+            vaultRepository = vaultRepository,
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            mapDepositTransactionToUiModel = mapDepositTransactionToUiModel,
+            mapDepositTransactionHistoryData = mapDepositTransactionHistoryData,
+            thorchainMemoParser = mockk<ThorchainMemoParser>(relaxed = true),
+            addressBookRepository = mockk<AddressBookRepository>(relaxed = true),
+            chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
+            feeResolver = feeResolver,
+            depositRentReserve = depositRentReserve,
+        )
+
+    private suspend fun build(intent: KaminoRelayedIntent, toAddress: String): DepositTransaction {
+        val storedVault = mockk<Vault>(relaxed = true)
+        coEvery { vaultRepository.get(VAULT_ID) } returns storedVault
+        coEvery { vaultRepository.getAll() } returns emptyList()
+        coEvery { tokenRepository.getNativeToken(any()) } returns solCoin
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.90",
+                formattedTokenValue = "0.0117 SOL",
+                tokenValue = TokenValue(BigInteger.ONE, solCoin),
+                fiatValue = mockk(relaxed = true),
+            )
+        coEvery { mapDepositTransactionToUiModel(capture(captured)) } returns
+            DepositTransactionUiModel()
+        coEvery { mapDepositTransactionHistoryData(any()) } returns mockk(relaxed = true)
+
+        builder.build(payload(toAddress), VAULT_ID, intent)
+        return captured.captured
+    }
+
+    @Test
+    fun `a deposit is labelled as one, names its vault and carries its bytes`() = runTest {
+        coEvery { depositRentReserve(vault, SIGNER) } returns RENT
+
+        val deposit = build(intent(KaminoAction.DEPOSIT), toAddress = vault.address)
+
+        deposit.operation shouldBe "KaminoDeposit"
+        deposit.validatorName shouldBe "Allez SOL"
+        deposit.dstAddress shouldBe vault.address
+        // The amount the initiating device shows: the deposit principal, not the whole native-SOL
+        // debit a simulation of these bytes reports.
+        deposit.srcTokenValue.value shouldBe AMOUNT
+        deposit.signSolana?.rawTransactions shouldBe listOf(RAW)
+    }
+
+    @Test
+    fun `a deposit is priced off the relayed compute budget and its account rent`() = runTest {
+        coEvery { depositRentReserve(vault, SIGNER) } returns RENT
+
+        val deposit = build(intent(KaminoAction.DEPOSIT), toAddress = vault.address)
+
+        // 1,000,000 base + (250,000 µlamports × 350,000 units / 1e6) + rent — the initiating
+        // device's own figure, not a transfer-shaped re-estimate.
+        deposit.estimatedFees.value shouldBe BigInteger.valueOf(1_087_500) + RENT
+        deposit.estimatedFees.unit shouldBe "SOL"
+        coVerify(exactly = 0) {
+            feeResolver.resolveJoinKeysignNetworkFee(any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `a withdraw is labelled as one and spends no rent`() = runTest {
+        val deposit = build(intent(KaminoAction.WITHDRAW), toAddress = SIGNER)
+
+        deposit.operation shouldBe "KaminoWithdraw"
+        // 1,000,000 base + (250,000 × 400,000 / 1e6). A withdraw creates no account of its own.
+        deposit.estimatedFees.value shouldBe BigInteger.valueOf(1_100_000)
+        coVerify(exactly = 0) { depositRentReserve(any(), any()) }
+    }
+
+    private fun intent(action: KaminoAction) =
+        KaminoRelayedIntent(
+            vault = vault,
+            action = action,
+            amount = if (action == KaminoAction.DEPOSIT) AMOUNT else BigInteger.valueOf(500_000),
+        )
+
+    private fun payload(toAddress: String) =
+        KeysignPayload(
+            coin = solCoin,
+            toAddress = toAddress,
+            toAmount = AMOUNT,
+            blockChainSpecific =
+                BlockChainSpecific.Solana(
+                    recentBlockHash = "hash",
+                    priorityFee = BigInteger.valueOf(250_000),
+                    priorityLimit = BigInteger.valueOf(350_000),
+                ),
+            vaultPublicKeyECDSA = "pubkey",
+            vaultLocalPartyID = "party",
+            libType = null,
+            wasmExecuteContractPayload = null,
+            signSolana = SignSolana(rawTransactions = listOf(RAW)),
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+        const val SIGNER = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+        const val RAW = "relayed-transaction"
+
+        val AMOUNT: BigInteger = BigInteger.valueOf(429_219_030)
+        val RENT: BigInteger = BigInteger.valueOf(10_377_640)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KaminoJoinIntentTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KaminoJoinIntentTest.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.ui.models.keysign
 
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoPriorityFee
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRelayedIntent
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.models.Chain
@@ -77,19 +78,118 @@ internal class KaminoJoinIntentTest {
             null
     }
 
-    private fun intent(action: KaminoAction, amount: BigInteger) =
-        KaminoRelayedIntent(vault = vault, action = action, amount = amount)
+    @Test
+    fun `an asset that is not the vault's underlying token is refused`() {
+        // Base units are the same number whatever scale is claimed for them, so the amount check
+        // above passes — and the screen then divides that number by the wrong power of ten. A
+        // nine-decimal SOL deposit relayed as six decimals reads a thousand times larger.
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT)
 
-    private fun payload(toAddress: String, toAmount: BigInteger) =
+        intent.takeIfDescribedBy(
+            payload(toAddress = vault.address, toAmount = AMOUNT, coin = solCoin.copy(decimal = 6))
+        ) shouldBe null
+    }
+
+    @Test
+    fun `an asset under a false ticker is refused`() {
+        // The hero reads "You're depositing <amount> <ticker>": a true figure beside the wrong
+        // asset name is still a false claim about what is leaving the wallet.
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT)
+
+        intent.takeIfDescribedBy(
+            payload(
+                toAddress = vault.address,
+                toAmount = AMOUNT,
+                coin = solCoin.copy(ticker = "USDC"),
+            )
+        ) shouldBe null
+    }
+
+    @Test
+    fun `a payload quoting a fee its own bytes do not charge is refused`() {
+        // The fee row is priced from the recorded budget while the runtime charges the one in the
+        // instructions, and the display clamps where the charge does not — so a low recorded price
+        // beside a high instruction price is an unbounded fee under a capped figure.
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT)
+
+        intent.takeIfDescribedBy(
+            payload(
+                toAddress = vault.address,
+                toAmount = AMOUNT,
+                recordedPrice = BigInteger.valueOf(20_000),
+            )
+        ) shouldBe null
+    }
+
+    @Test
+    fun `a payload recording a limit the bytes do not reserve is refused`() {
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT)
+
+        intent.takeIfDescribedBy(
+            payload(
+                toAddress = vault.address,
+                toAmount = AMOUNT,
+                recordedLimit = BigInteger.valueOf(100_000),
+            )
+        ) shouldBe null
+    }
+
+    @Test
+    fun `bytes carrying no readable budget are refused whatever the payload records`() {
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT, priorityFee = null)
+
+        intent.takeIfDescribedBy(payload(toAddress = vault.address, toAmount = AMOUNT)) shouldBe
+            null
+    }
+
+    @Test
+    fun `a payload for another chain is refused rather than cast`() {
+        // Recognition keys off the coin's chain, which does not settle what shape the specific is —
+        // and the fee row and the amount scale both read fields only a Solana one carries.
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT)
+
+        val ethereumSpecific =
+            BlockChainSpecific.Ethereum(
+                maxFeePerGasWei = BigInteger.ONE,
+                priorityFeeWei = BigInteger.ONE,
+                nonce = BigInteger.ZERO,
+                gasLimit = BigInteger.ONE,
+            )
+
+        intent.takeIfDescribedBy(
+            payload(toAddress = vault.address, toAmount = AMOUNT)
+                .copy(blockChainSpecific = ethereumSpecific)
+        ) shouldBe null
+    }
+
+    private fun intent(
+        action: KaminoAction,
+        amount: BigInteger,
+        priorityFee: KaminoPriorityFee? = RELAYED_BUDGET,
+    ) =
+        KaminoRelayedIntent(
+            vault = vault,
+            action = action,
+            amount = amount,
+            priorityFee = priorityFee,
+        )
+
+    private fun payload(
+        toAddress: String,
+        toAmount: BigInteger,
+        coin: Coin = solCoin,
+        recordedPrice: BigInteger = RELAYED_BUDGET.price,
+        recordedLimit: BigInteger = RELAYED_BUDGET.limit,
+    ) =
         KeysignPayload(
-            coin = solCoin,
+            coin = coin,
             toAddress = toAddress,
             toAmount = toAmount,
             blockChainSpecific =
                 BlockChainSpecific.Solana(
                     recentBlockHash = "hash",
-                    priorityFee = BigInteger.valueOf(250_000),
-                    priorityLimit = BigInteger.valueOf(350_000),
+                    priorityFee = recordedPrice,
+                    priorityLimit = recordedLimit,
                 ),
             vaultPublicKeyECDSA = "pubkey",
             vaultLocalPartyID = "party",
@@ -101,5 +201,12 @@ internal class KaminoJoinIntentTest {
         const val SIGNER = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
 
         val AMOUNT: BigInteger = BigInteger.valueOf(429_219_030)
+
+        /** What the instructions carry, and what the payload has to record to be believed. */
+        val RELAYED_BUDGET =
+            KaminoPriorityFee(
+                limit = BigInteger.valueOf(350_000),
+                price = BigInteger.valueOf(250_000),
+            )
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KaminoJoinIntentTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KaminoJoinIntentTest.kt
@@ -1,0 +1,105 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoAction
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRelayedIntent
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import io.kotest.matchers.shouldBe
+import java.math.BigInteger
+import org.junit.jupiter.api.Test
+
+/**
+ * The gate between what a relayed Kamino transaction says and what the payload around it claims
+ * (issue #5644).
+ */
+internal class KaminoJoinIntentTest {
+
+    private val vault = KaminoVaultRegistry.ALLEZ_SOL
+
+    private val solCoin =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "SOL",
+            logo = "sol",
+            address = SIGNER,
+            decimal = 9,
+            hexPublicKey = "hex",
+            priceProviderID = "solana",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    @Test
+    fun `a deposit whose amount and destination agree is kept`() {
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT)
+
+        intent.takeIfDescribedBy(payload(toAddress = vault.address, toAmount = AMOUNT)) shouldBe
+            intent
+    }
+
+    @Test
+    fun `a deposit stating an amount the transaction does not carry is refused`() {
+        // The reported symptom in reverse: the two devices must not describe one transaction with
+        // two amounts, so a payload that disagrees with its own bytes loses the deposit framing.
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT)
+
+        intent.takeIfDescribedBy(
+            payload(toAddress = vault.address, toAmount = AMOUNT + BigInteger.ONE)
+        ) shouldBe null
+    }
+
+    @Test
+    fun `a deposit pointed somewhere other than the vault is refused`() {
+        val intent = intent(KaminoAction.DEPOSIT, AMOUNT)
+
+        intent.takeIfDescribedBy(payload(toAddress = SIGNER, toAmount = AMOUNT)) shouldBe null
+    }
+
+    @Test
+    fun `a withdraw paying the signer is kept, its share count never compared with tokens`() {
+        // The instruction carries shares and the payload carries the tokens they are worth, so the
+        // two figures legitimately differ.
+        val intent = intent(KaminoAction.WITHDRAW, BigInteger.valueOf(500_000))
+
+        intent.takeIfDescribedBy(payload(toAddress = SIGNER, toAmount = AMOUNT)) shouldBe intent
+    }
+
+    @Test
+    fun `a withdraw pointed at the vault is refused`() {
+        // A withdraw pays the signer; naming the vault as the destination tells the approving user
+        // the opposite of what the transaction does.
+        val intent = intent(KaminoAction.WITHDRAW, BigInteger.valueOf(500_000))
+
+        intent.takeIfDescribedBy(payload(toAddress = vault.address, toAmount = AMOUNT)) shouldBe
+            null
+    }
+
+    private fun intent(action: KaminoAction, amount: BigInteger) =
+        KaminoRelayedIntent(vault = vault, action = action, amount = amount)
+
+    private fun payload(toAddress: String, toAmount: BigInteger) =
+        KeysignPayload(
+            coin = solCoin,
+            toAddress = toAddress,
+            toAmount = toAmount,
+            blockChainSpecific =
+                BlockChainSpecific.Solana(
+                    recentBlockHash = "hash",
+                    priorityFee = BigInteger.valueOf(250_000),
+                    priorityLimit = BigInteger.valueOf(350_000),
+                ),
+            vaultPublicKeyECDSA = "pubkey",
+            vaultLocalPartyID = "party",
+            libType = null,
+            wasmExecuteContractPayload = null,
+        )
+
+    private companion object {
+        const val SIGNER = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+        val AMOUNT: BigInteger = BigInteger.valueOf(429_219_030)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/solanastaking/KaminoAmountViewModelTest.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.api.KaminoVaultMetricsJson
 import com.vultisig.wallet.data.api.KaminoVaultStateJson
 import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.blockchain.solana.kamino.BuildKaminoKeysignPayloadUseCase
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDepositRentReserve
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoWithdrawEligibility
 import com.vultisig.wallet.data.models.Chain
@@ -153,6 +154,9 @@ internal class KaminoAmountViewModelTest {
             balanceRepository = balanceRepository,
             blockChainSpecificRepository = blockChainSpecificRepository,
             buildKeysignPayload = buildKeysignPayload,
+            // The real reserve over the same stubbed APIs: it is the rent arithmetic these tests
+            // assert on, and it now runs on the co-signing device too.
+            depositRentReserve = KaminoDepositRentReserve(solanaApi, kaminoApi),
             depositTransactionRepository = depositTransactionRepository,
             navigator = navigator,
         )

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransactionAndroidTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransactionAndroidTest.kt
@@ -62,14 +62,36 @@ class KaminoRelayedTransactionAndroidTest {
         assertEquals(KaminoAction.WITHDRAW, intent?.action)
     }
 
+    @Test
+    fun a_recognised_deposit_carries_the_budget_wallet_core_encoded_into_it() {
+        // The limit instruction is encoded inside WalletCore's `setComputeUnitLimit`, so this is
+        // where the reader meets the real encoding rather than one the tests wrote themselves. The
+        // joining device prices its fee row off this pair, and refuses the payload when the fields
+        // relayed beside the bytes disagree with it.
+        val intent =
+            ResolveKaminoRelayedIntentUseCase()(
+                listOf(preparedDeposit(price = BigInteger.valueOf(250_000))),
+                KaminoFixtures.WALLET,
+            )
+
+        assertEquals(
+            KaminoPriorityFee(
+                limit = KaminoComputeBudget.unitLimitFor(vault, KaminoAction.DEPOSIT),
+                price = BigInteger.valueOf(250_000),
+            ),
+            intent?.priorityFee,
+        )
+    }
+
     /** The bytes the initiating device would relay: the live response, budgeted and memo'd. */
-    private fun preparedDeposit(): String = runBlocking {
+    private fun preparedDeposit(price: BigInteger? = null): String = runBlocking {
         KaminoTransactionPreparer(KaminoFixtureApi(KaminoFixtures.DEPOSIT))
             .prepare(
                 vault = vault,
                 action = KaminoAction.DEPOSIT,
                 walletAddress = KaminoFixtures.WALLET,
                 amount = "1",
+                networkUnitPrice = price,
             )
     }
 

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransactionAndroidTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransactionAndroidTest.kt
@@ -1,0 +1,80 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.WalletCoreNative
+import java.math.BigInteger
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import wallet.core.jni.SolanaAddress
+
+/**
+ * The co-signing device's half of the prepare pipeline, on the same live transactions: what the
+ * initiating device builds is what a joining device recognises (issue #5644).
+ *
+ * The unit coverage next door pins the rules against hand-built instruction lists; this pins them
+ * against real Kamino bytes, which is what proves the kVault discriminators and the share-account
+ * derivation are the ones those transactions actually carry.
+ */
+class KaminoRelayedTransactionAndroidTest {
+
+    private val vault = KaminoVaultRegistry.STEAKHOUSE_USDC
+
+    @Before
+    fun loadWalletCore() {
+        WalletCoreNative.ensureLoaded()
+    }
+
+    @Test
+    fun a_prepared_deposit_is_recognised_as_a_deposit_into_its_vault() {
+        val intent =
+            ResolveKaminoRelayedIntentUseCase()(listOf(preparedDeposit()), KaminoFixtures.WALLET)
+
+        assertEquals(vault, intent?.vault)
+        assertEquals(KaminoAction.DEPOSIT, intent?.action)
+        // The fixture was built for 1 USDC, and the instruction carries it in base units — the same
+        // figure the payload's toAmount states, which is what lets the two devices be compared.
+        assertEquals(BigInteger.valueOf(1_000_000), intent?.amount)
+    }
+
+    @Test
+    fun another_wallets_transaction_cannot_be_named_by_this_signer() {
+        // The vault is named by the signer's own share account, so the same bytes read against a
+        // different wallet resolve to nothing rather than to somebody else's position.
+        val intent = ResolveKaminoRelayedIntentUseCase()(listOf(preparedDeposit()), OTHER_WALLET)
+
+        assertNull(intent)
+    }
+
+    @Test
+    fun a_live_withdraw_reads_as_a_withdraw_of_shares() {
+        // Decoded straight from the captured response rather than prepared: this withdraw carries
+        // the withdraw-everything sentinel, so preparing it is refused before it can be relayed.
+        // The reader is what is under test here, and it needs no budget or memo to do its job.
+        val decoded = KaminoTransactionDecoder.decode(KaminoFixtures.WITHDRAW)
+        val shareAccount =
+            SolanaAddress(KaminoFixtures.WALLET).defaultTokenAddress(vault.sharesMint)
+
+        val intent = KaminoRelayedTransactionReader.read(decoded, mapOf(shareAccount to vault))
+
+        assertEquals(vault, intent?.vault)
+        assertEquals(KaminoAction.WITHDRAW, intent?.action)
+    }
+
+    /** The bytes the initiating device would relay: the live response, budgeted and memo'd. */
+    private fun preparedDeposit(): String = runBlocking {
+        KaminoTransactionPreparer(KaminoFixtureApi(KaminoFixtures.DEPOSIT))
+            .prepare(
+                vault = vault,
+                action = KaminoAction.DEPOSIT,
+                walletAddress = KaminoFixtures.WALLET,
+                amount = "1",
+            )
+    }
+
+    private companion object {
+        /** A valid Solana address that is not the one these fixtures were built for. */
+        const val OTHER_WALLET = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaSignatureEnvelope.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaSignatureEnvelope.kt
@@ -1,0 +1,103 @@
+package com.vultisig.wallet.data.blockchain.solana
+
+/**
+ * The wire envelope of a Solana transaction: `[compact-u16 signature count][count × 64-byte
+ * signature slot][message]`.
+ *
+ * Shared by the raw-signing path and by the checks that run before it, deliberately. The signing
+ * path splices signer 0's signature into [firstSignatureOffset] and leaves every other slot as it
+ * received it, so a check that a transaction is safe to sign that way has to read the same envelope
+ * the splice writes into — a second, parallel parse could agree with itself and still describe
+ * different bytes.
+ *
+ * @property message the pre-image ed25519 signs verbatim.
+ * @property requiredSignatures the number of declared signature slots, which is the message
+ *   header's `numRequiredSignatures`.
+ */
+data class SolanaSignatureEnvelope(
+    val bytes: ByteArray,
+    val firstSignatureOffset: Int,
+    val requiredSignatures: Int,
+    val message: ByteArray,
+) {
+
+    /**
+     * Whether every declared signature slot is still an all-zero placeholder.
+     *
+     * What makes the splice at slot 0 safe: a slot already carrying bytes is somebody's signature
+     * over some message, and this transaction would be broadcast carrying it.
+     */
+    val isUnsigned: Boolean
+        get() =
+            (firstSignatureOffset until
+                    firstSignatureOffset + requiredSignatures * SIGNATURE_LENGTH)
+                .all { bytes[it] == ZERO_BYTE }
+
+    // ByteArray identity would make two structurally equal envelopes compare unequal.
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (other is SolanaSignatureEnvelope &&
+                bytes.contentEquals(other.bytes) &&
+                firstSignatureOffset == other.firstSignatureOffset &&
+                requiredSignatures == other.requiredSignatures &&
+                message.contentEquals(other.message))
+
+    override fun hashCode(): Int =
+        31 * (31 * (31 * bytes.contentHashCode() + firstSignatureOffset) + requiredSignatures) +
+            message.contentHashCode()
+
+    companion object {
+
+        const val SIGNATURE_LENGTH = 64
+
+        private const val ZERO_BYTE: Byte = 0
+
+        /**
+         * Splits [bytes] into its envelope.
+         *
+         * Reading the message out of the original bytes — rather than decoding into WalletCore's
+         * representation and re-serializing it — keeps the pre-image hash independent of
+         * WalletCore's encoder. That re-encode is not guaranteed to reproduce the original bytes
+         * for a v0 message referencing an Address Lookup Table (the standard shape for
+         * DEX/aggregator swaps), which would make co-signing devices compute mismatching hashes and
+         * stall the ceremony.
+         *
+         * @throws IllegalStateException if [bytes] is not a well-formed envelope.
+         */
+        fun parse(bytes: ByteArray): SolanaSignatureEnvelope {
+            val (signatureCount, firstSignatureOffset) = readCompactU16(bytes)
+            check(signatureCount >= 1) { "Solana transaction declares no signatures" }
+
+            val messageOffset = firstSignatureOffset + signatureCount * SIGNATURE_LENGTH
+            check(messageOffset < bytes.size) {
+                "Solana transaction too short for its $signatureCount declared signature(s)"
+            }
+            return SolanaSignatureEnvelope(
+                bytes = bytes,
+                firstSignatureOffset = firstSignatureOffset,
+                requiredSignatures = signatureCount,
+                message = bytes.copyOfRange(messageOffset, bytes.size),
+            )
+        }
+
+        /**
+         * Decodes the Solana compact-u16 (shortvec) at the start of [bytes] — up to three bytes, 7
+         * payload bits each with the high bit signalling "more bytes follow" — and returns the
+         * decoded value together with the offset just past it (where the signature slots begin).
+         */
+        private fun readCompactU16(bytes: ByteArray): Pair<Int, Int> {
+            var value = 0
+            var offset = 0
+            var shift = 0
+            while (offset < bytes.size) {
+                val byte = bytes[offset].toInt() and 0xFF
+                value = value or ((byte and 0x7F) shl shift)
+                offset++
+                if (byte and 0x80 == 0) return value to offset
+                shift += 7
+                if (shift > 14) error("Malformed compact-u16 in Solana transaction")
+            }
+            error("Truncated compact-u16 in Solana transaction")
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
@@ -16,6 +16,16 @@ enum class KaminoAction {
 }
 
 /**
+ * The ComputeBudget a transaction carries: the unit limit it reserves and the micro-lamport price
+ * it pays per unit.
+ *
+ * The two together are the priority fee — one without the other prices nothing — so they are
+ * compared as a pair. A co-signing device holds a second, independent claim about them in
+ * `BlockChainSpecific.Solana`, and the two have to agree before either is put on a screen.
+ */
+data class KaminoPriorityFee(val limit: BigInteger, val price: BigInteger)
+
+/**
  * Compute-unit budget for Kamino transactions.
  *
  * Kamino builds its transactions with no ComputeBudget instruction at all and ignores priority-fee
@@ -28,6 +38,14 @@ object KaminoComputeBudget {
 
     /** The ComputeBudget program both injected instructions invoke. */
     const val PROGRAM_ID = "ComputeBudget111111111111111111111111111111"
+
+    /**
+     * Stands for a ComputeBudget that is present but unreadable — a duplicate, a truncated
+     * argument, an instruction that is neither of the two. Negative on purpose: it can equal no
+     * budget a payload could legitimately record, so a comparison against it always disagrees.
+     */
+    val MALFORMED =
+        KaminoPriorityFee(limit = BigInteger.ONE.negate(), price = BigInteger.ONE.negate())
 
     /** `ComputeBudgetInstruction::SetComputeUnitLimit`, borsh discriminator 2, then a `u32`. */
     const val SET_UNIT_LIMIT_DISCRIMINATOR = 2
@@ -90,6 +108,56 @@ object KaminoComputeBudget {
      * 100,000,000, so every congested-network sample would land above the ceiling unclamped.
      */
     val MAX_UNIT_PRICE: BigInteger = BigInteger.valueOf(1_000_000)
+
+    /**
+     * The compute budget carried by [instructions], or null when they carry none.
+     *
+     * Reads what the bytes say rather than what anything alongside them claims: this is the figure
+     * the runtime will charge against, and on a co-signing device it is the only side of the fee
+     * row that is not a display field somebody else filled in.
+     *
+     * Malformed is not the same as absent, so a ComputeBudget instruction this cannot parse — or a
+     * second one of either kind — answers [MALFORMED] rather than null. A caller comparing against
+     * a payload must refuse it: "cannot be read" agreeing with "there is none" is how a stripped
+     * budget would pass for a matching one.
+     */
+    fun readFrom(instructions: List<KaminoTxInstruction>): KaminoPriorityFee? {
+        val budget = instructions.filter { it.programId == PROGRAM_ID }
+        if (budget.isEmpty()) return null
+
+        val limits = budget.mapNotNull { unitLimitArgument(it.data) }
+        val prices = budget.mapNotNull { unitPriceArgument(it.data) }
+        if (budget.size != 2 || limits.size != 1 || prices.size != 1) return MALFORMED
+
+        return KaminoPriorityFee(limit = limits.single(), price = prices.single())
+    }
+
+    /** `SetComputeUnitLimit`'s `u32` argument, or null when [data] is not that instruction. */
+    fun unitLimitArgument(data: ByteArray): BigInteger? =
+        littleEndianArgument(data, SET_UNIT_LIMIT_DISCRIMINATOR, UNSIGNED_INT_BYTES)
+
+    /** `SetComputeUnitPrice`'s `u64` argument, or null when [data] is not that instruction. */
+    fun unitPriceArgument(data: ByteArray): BigInteger? =
+        littleEndianArgument(data, SET_UNIT_PRICE_DISCRIMINATOR, UNSIGNED_LONG_BYTES)
+
+    /**
+     * The little-endian argument of a ComputeBudget instruction, when [data] is exactly the
+     * discriminator followed by [width] bytes. A longer instruction is refused rather than read
+     * from its prefix: trailing bytes mean this is not the instruction it appears to be.
+     */
+    private fun littleEndianArgument(data: ByteArray, discriminator: Int, width: Int): BigInteger? {
+        if (data.size != width + 1) return null
+        if ((data[0].toInt() and 0xFF) != discriminator) return null
+        var value = BigInteger.ZERO
+        for (offset in width - 1 downTo 0) {
+            value = value.shiftLeft(8).or(BigInteger.valueOf(data[1 + offset].toLong() and 0xFF))
+        }
+        return value
+    }
+
+    private const val UNSIGNED_INT_BYTES = 4
+
+    private const val UNSIGNED_LONG_BYTES = 8
 
     fun unitLimitFor(vault: KaminoVault, action: KaminoAction): BigInteger =
         when (action) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudget.kt
@@ -47,6 +47,20 @@ object KaminoComputeBudget {
     val MALFORMED =
         KaminoPriorityFee(limit = BigInteger.ONE.negate(), price = BigInteger.ONE.negate())
 
+    /**
+     * Where the two injected instructions sit, and the order they sit in.
+     *
+     * A cross-platform contract rather than a preference: iOS emits the limit at 0 and the price at
+     * 1 and matches the remaining instructions positionally, so a transaction laid out any other
+     * way is one an iPhone co-signer reads as unsigned-for and will not join. Defined here because
+     * both the device that builds the layout ([KaminoTransactionPreparer]) and the one that refuses
+     * anything else ([KaminoTransactionValidator]) have to mean the same thing by it.
+     */
+    const val UNIT_LIMIT_INDEX = 0
+
+    /** Right after the limit, which is where iOS puts it. */
+    const val UNIT_PRICE_INDEX = UNIT_LIMIT_INDEX + 1
+
     /** `ComputeBudgetInstruction::SetComputeUnitLimit`, borsh discriminator 2, then a `u32`. */
     const val SET_UNIT_LIMIT_DISCRIMINATOR = 2
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransaction.kt
@@ -15,11 +15,16 @@ import wallet.core.jni.SolanaAddress
  * @property amount the kVault instruction's own `u64` argument — token base units for a deposit,
  *   vault shares for a withdraw. The two are not interchangeable, and only the deposit figure is
  *   comparable with the payload's `toAmount`.
+ * @property priorityFee the compute budget the bytes carry, which is what the runtime charges
+ *   against. Never null in practice — [KaminoTransactionValidator] refuses a transaction without
+ *   one — but read from the instructions rather than from the fields relayed beside them, because
+ *   the fee row on the verify screen is priced off it.
  */
 data class KaminoRelayedIntent(
     val vault: KaminoVault,
     val action: KaminoAction,
     val amount: BigInteger,
+    val priorityFee: KaminoPriorityFee?,
 )
 
 /**
@@ -67,7 +72,12 @@ object KaminoRelayedTransactionReader {
         val vault = kvault.accounts.firstNotNullOfOrNull(vaultsByShareAccount::get) ?: return null
         val amount = kvaultAmountArgument(kvault.data) ?: return null
 
-        return KaminoRelayedIntent(vault = vault, action = action, amount = amount)
+        return KaminoRelayedIntent(
+            vault = vault,
+            action = action,
+            amount = amount,
+            priorityFee = KaminoComputeBudget.readFrom(decoded.instructions),
+        )
     }
 
     private fun ByteArray.startsWith(prefix: ByteArray): Boolean =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransaction.kt
@@ -1,0 +1,169 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import java.math.BigInteger
+import javax.inject.Inject
+import timber.log.Timber
+import wallet.core.jni.SolanaAddress
+
+/**
+ * A Kamino deposit or withdraw recovered from the bytes of a relayed transaction.
+ *
+ * A co-signing device receives the transaction and a handful of display fields beside it, and only
+ * the bytes are the thing it will sign. Everything here is read out of them: which vault, which
+ * direction, and the amount the kVault instruction itself carries.
+ *
+ * @property amount the kVault instruction's own `u64` argument — token base units for a deposit,
+ *   vault shares for a withdraw. The two are not interchangeable, and only the deposit figure is
+ *   comparable with the payload's `toAmount`.
+ */
+data class KaminoRelayedIntent(
+    val vault: KaminoVault,
+    val action: KaminoAction,
+    val amount: BigInteger,
+)
+
+/**
+ * Reads a decoded transaction as a Kamino deposit or withdraw, or refuses to call it one.
+ *
+ * Kept free of JNI so the rules are unit-testable; decoding and address derivation are the caller's
+ * job — see [ResolveKaminoRelayedIntentUseCase].
+ */
+object KaminoRelayedTransactionReader {
+
+    /**
+     * Anchor's instruction discriminators for the two kVault entry points, the first eight bytes of
+     * `sha256("global:<name>")`. Pinned as bytes rather than derived, because deriving them means
+     * hard-coding the names instead, and these are what the fixtures actually carry:
+     * `global:deposit` and `global:withdraw_from_available`.
+     */
+    private val DEPOSIT_DISCRIMINATOR = hex("f223c68952e1f2b6")
+
+    private val WITHDRAW_DISCRIMINATOR = hex("1383709baadc2239")
+
+    /**
+     * @param vaultsByShareAccount the caller's derived share-token account for each vault it knows,
+     *   keyed by address. The vault's own address is not in a transaction's static account keys —
+     *   Kamino loads it from an address lookup table — so this account is what names the vault.
+     * @return the intent, or null when these bytes are not a single-instruction Kamino deposit or
+     *   withdraw for a vault the caller named.
+     */
+    fun read(
+        decoded: KaminoDecodedTransaction,
+        vaultsByShareAccount: Map<String, KaminoVault>,
+    ): KaminoRelayedIntent? {
+        // Exactly one, not the first of several: two kVault instructions in one transaction is a
+        // shape this app never builds, and picking either would describe half of what gets signed.
+        val kvault =
+            decoded.instructions.singleOrNull { it.programId == KaminoVaultRegistry.PROGRAM_ID }
+                ?: return null
+
+        val action =
+            when {
+                kvault.data.startsWith(DEPOSIT_DISCRIMINATOR) -> KaminoAction.DEPOSIT
+                kvault.data.startsWith(WITHDRAW_DISCRIMINATOR) -> KaminoAction.WITHDRAW
+                else -> return null
+            }
+
+        val vault = kvault.accounts.firstNotNullOfOrNull(vaultsByShareAccount::get) ?: return null
+        val amount = kvaultAmountArgument(kvault.data) ?: return null
+
+        return KaminoRelayedIntent(vault = vault, action = action, amount = amount)
+    }
+
+    private fun ByteArray.startsWith(prefix: ByteArray): Boolean =
+        size >= prefix.size && prefix.indices.all { this[it] == prefix[it] }
+
+    private fun hex(value: String): ByteArray =
+        ByteArray(value.length / 2) { value.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
+}
+
+/**
+ * The `u64` amount argument of a kVault instruction: an 8-byte Anchor discriminator followed by the
+ * amount, little-endian. Null when the instruction is too short to carry one.
+ */
+fun kvaultAmountArgument(data: ByteArray): BigInteger? {
+    if (data.size < 16) return null
+    var value = BigInteger.ZERO
+    for (offset in 7 downTo 0) {
+        value = value.shiftLeft(8).or(BigInteger.valueOf((data[8 + offset].toLong() and 0xFF)))
+    }
+    return value
+}
+
+/**
+ * The wallet's associated token account for [mint], or null when WalletCore cannot derive one.
+ *
+ * A free function rather than a lambda in the constructor below: the delegation runs before the
+ * instance exists, which is not somewhere a lambda can be built.
+ */
+private fun deriveAssociatedTokenAccount(owner: String, mint: String): String? =
+    try {
+        SolanaAddress(owner).defaultTokenAddress(mint)
+    } catch (_: Exception) {
+        null
+    }
+
+/**
+ * Recognises a relayed transaction as one of this app's own Kamino transactions.
+ *
+ * A joining device is handed bytes and a `toAddress`/`toAmount` pair the initiating device filled
+ * in. Those fields are display material — they are not what gets signed — so the recognition runs
+ * on the bytes and then holds them to the same [KaminoTransactionValidator] rules the initiating
+ * device applied before relaying them. Anything that fails is simply not claimed as a Kamino
+ * transaction: the co-signer keeps the generic screen it gets today rather than being blocked
+ * mid-ceremony over a shape this reader does not know.
+ */
+class ResolveKaminoRelayedIntentUseCase
+internal constructor(
+    private val decode: (base64Transaction: String) -> KaminoDecodedTransaction,
+    // Derives an associated token account. Backed by WalletCore JNI in production; overridable so
+    // the recognition rules can be unit-tested without the native library.
+    private val tokenAccount: (owner: String, mint: String) -> String?,
+) {
+
+    @Inject constructor() : this(KaminoTransactionDecoder::decode, ::deriveAssociatedTokenAccount)
+
+    /**
+     * @param rawTransactions the relayed `signSolana` batch. Kamino relays exactly one transaction;
+     *   a batch of any other size is somebody else's payload.
+     * @param signerAddress the vault's own Solana address — the same address on both devices, which
+     *   is what makes the initiating device's derivations reproducible here.
+     */
+    operator fun invoke(
+        rawTransactions: List<String>,
+        signerAddress: String,
+    ): KaminoRelayedIntent? {
+        val rawTransaction = rawTransactions.singleOrNull() ?: return null
+        val decoded = runCatching { decode(rawTransaction) }.getOrNull() ?: return null
+
+        val vaultsByShareAccount =
+            KaminoVaultRegistry.ALLOW_LIST.mapNotNull { vault ->
+                    tokenAccount(signerAddress, vault.sharesMint)?.let { it to vault }
+                }
+                .toMap()
+
+        val intent =
+            KaminoRelayedTransactionReader.read(decoded, vaultsByShareAccount) ?: return null
+
+        val wrappedSolAccount =
+            if (intent.vault.tokenMint == KaminoVaultRegistry.WRAPPED_SOL_MINT) {
+                tokenAccount(signerAddress, KaminoVaultRegistry.WRAPPED_SOL_MINT)
+            } else {
+                null
+            }
+
+        return try {
+            KaminoTransactionValidator.validate(
+                decoded = decoded,
+                vault = intent.vault,
+                action = intent.action,
+                signerAddress = signerAddress,
+                wrappedSolAccount = wrappedSolAccount,
+            )
+            intent
+        } catch (e: KaminoTransactionRejected) {
+            Timber.w(e, "Relayed transaction looks like Kamino but is not one this app would build")
+            null
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionCost.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionCost.kt
@@ -1,0 +1,116 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.chains.helpers.SolanaHelper
+import com.vultisig.wallet.data.utils.runCatchingCancellable
+import java.math.BigInteger
+import javax.inject.Inject
+
+/**
+ * Rent-exempt minimum for a 165-byte SPL token account. Used only when the live read fails —
+ * reserving nothing would be worse than reserving a value that has not moved in practice.
+ */
+val SPL_TOKEN_ACCOUNT_RENT_LAMPORTS: BigInteger = BigInteger.valueOf(2_039_280)
+
+/**
+ * Rent-exempt minimum Kamino charges when a first deposit creates the farms `UserState`. The
+ * account size is Kamino-owned, so keep the observed mainnet lamport value here rather than
+ * pretending the app can derive it from SPL token-account rent.
+ */
+val FARM_USER_STATE_RENT_LAMPORTS: BigInteger = BigInteger.valueOf(6_299_080)
+
+/**
+ * What a Kamino transaction costs its signer in SOL, beyond the amount itself.
+ *
+ * Shared by the initiating and the co-signing device on purpose. Both quote this figure on their
+ * verify screens for the same transaction, and the only way two devices agree on a number is to
+ * derive it the same way from the same inputs — the vault, the action, the relayed unit price and
+ * the rent below, all of which are identical on both sides (issue #5644).
+ *
+ * The base term is deliberately the arithmetic iOS applies to a relayed payload —
+ * `SolanaHelper.defaultFeeInLamports`, the same 1,000,000, plus price × limit — so an iPhone
+ * co-signer quotes one figure for one transaction rather than a second one of its own.
+ *
+ * @param relayedUnitPrice the micro-lamports-per-compute-unit price recorded in the payload, which
+ *   is the one the bytes were priced with. [KaminoComputeBudget.unitPriceFor] is idempotent, so
+ *   passing it back through yields the same price rather than a second clamp.
+ * @param rentReserve what the transaction spends creating accounts, from [KaminoDepositRentReserve]
+ *   — zero for everything but a first native-SOL deposit.
+ */
+fun kaminoNetworkFeeLamports(
+    vault: KaminoVault,
+    action: KaminoAction,
+    relayedUnitPrice: BigInteger?,
+    rentReserve: BigInteger = BigInteger.ZERO,
+): BigInteger =
+    SolanaHelper.DefaultFeeInLamports +
+        KaminoComputeBudget.priorityFeeLamports(
+            vault = vault,
+            action = action,
+            networkPrice = relayedUnitPrice,
+        ) +
+        rentReserve
+
+/**
+ * The rent a Kamino deposit spends on accounts it has to create, in lamports.
+ *
+ * Only the wrapped-SOL vault pays this out of the same balance the deposit comes from, which is why
+ * a token vault always answers zero: a token deposit pays its rent in SOL, not in the token being
+ * deposited, and the token form has no reason to reserve against it.
+ *
+ * Every read here is about the signer's own accounts, so a co-signing device asking the same
+ * questions about the same wallet gets the same answers as the device that built the transaction.
+ */
+class KaminoDepositRentReserve
+@Inject
+constructor(private val solanaApi: SolanaApi, private val kaminoApi: KaminoApi) {
+
+    suspend operator fun invoke(vault: KaminoVault, walletAddress: String): BigInteger {
+        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) return BigInteger.ZERO
+
+        val tokenAccountRent = tokenAccountRentReserve()
+        val wrappedSolRent =
+            tokenAccountRent.takeUnless { tokenAccountExists(walletAddress, vault.tokenMint) }
+                ?: BigInteger.ZERO
+        val shareAccountRent =
+            tokenAccountRent.takeUnless { tokenAccountExists(walletAddress, vault.sharesMint) }
+                ?: BigInteger.ZERO
+        val farmUserStateRent =
+            FARM_USER_STATE_RENT_LAMPORTS.takeUnless { hasVaultPosition(walletAddress, vault) }
+                ?: BigInteger.ZERO
+
+        return wrappedSolRent + shareAccountRent + farmUserStateRent
+    }
+
+    private suspend fun tokenAccountRentReserve(): BigInteger =
+        runCatchingCancellable { solanaApi.getMinimumBalanceForRentExemption() }
+            .getOrNull()
+            ?.takeIf { it.signum() > 0 } ?: SPL_TOKEN_ACCOUNT_RENT_LAMPORTS
+
+    private suspend fun tokenAccountExists(walletAddress: String, mint: String): Boolean =
+        runCatchingCancellable {
+                solanaApi.getTokenAssociatedAccountByOwner(walletAddress, mint).first != null
+            }
+            .getOrDefault(false)
+
+    /**
+     * Whether the wallet already has a farm UserState account for this vault, so a redeposit does
+     * not need to pay its rent again.
+     *
+     * Goes through [KaminoWithdrawEligibility.resolve] rather than checking for a bare entry in the
+     * response: the same endpoint keeps a zero-share row for a wallet that has fully exited, and
+     * the withdraw flow already treats that row as no position. Checking entry presence alone would
+     * disagree with that and waive the rent on an account that may no longer exist.
+     */
+    private suspend fun hasVaultPosition(walletAddress: String, vault: KaminoVault): Boolean =
+        runCatchingCancellable {
+                val entry =
+                    kaminoApi.getUserPositions(walletAddress).firstOrNull {
+                        it.vaultAddress == vault.address
+                    }
+                KaminoWithdrawEligibility.resolve(entry, vault.sharesDecimals) is
+                    KaminoWithdrawEligibility.Withdrawable
+            }
+            .getOrDefault(false)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionCost.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionCost.kt
@@ -6,6 +6,9 @@ import com.vultisig.wallet.data.chains.helpers.SolanaHelper
 import com.vultisig.wallet.data.utils.runCatchingCancellable
 import java.math.BigInteger
 import javax.inject.Inject
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import timber.log.Timber
 
 /**
  * Rent-exempt minimum for a 165-byte SPL token account. Used only when the live read fails —
@@ -66,25 +69,35 @@ class KaminoDepositRentReserve
 @Inject
 constructor(private val solanaApi: SolanaApi, private val kaminoApi: KaminoApi) {
 
-    suspend operator fun invoke(vault: KaminoVault, walletAddress: String): BigInteger {
-        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) return BigInteger.ZERO
+    /**
+     * The four reads are independent of one another, so they run together: this sits in front of a
+     * verify screen that cannot quote a fee until it answers, on both the initiating and the
+     * co-signing device.
+     */
+    suspend operator fun invoke(vault: KaminoVault, walletAddress: String): BigInteger =
+        coroutineScope {
+            if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT)
+                return@coroutineScope BigInteger.ZERO
 
-        val tokenAccountRent = tokenAccountRentReserve()
-        val wrappedSolRent =
-            tokenAccountRent.takeUnless { tokenAccountExists(walletAddress, vault.tokenMint) }
-                ?: BigInteger.ZERO
-        val shareAccountRent =
-            tokenAccountRent.takeUnless { tokenAccountExists(walletAddress, vault.sharesMint) }
-                ?: BigInteger.ZERO
-        val farmUserStateRent =
-            FARM_USER_STATE_RENT_LAMPORTS.takeUnless { hasVaultPosition(walletAddress, vault) }
-                ?: BigInteger.ZERO
+            val tokenAccountRent = async { tokenAccountRentReserve() }
+            val hasWrappedSolAccount = async { tokenAccountExists(walletAddress, vault.tokenMint) }
+            val hasShareAccount = async { tokenAccountExists(walletAddress, vault.sharesMint) }
+            val hasPosition = async { hasVaultPosition(walletAddress, vault) }
 
-        return wrappedSolRent + shareAccountRent + farmUserStateRent
-    }
+            val rent = tokenAccountRent.await()
+            val wrappedSolRent = if (hasWrappedSolAccount.await()) BigInteger.ZERO else rent
+            val shareAccountRent = if (hasShareAccount.await()) BigInteger.ZERO else rent
+            val farmUserStateRent =
+                if (hasPosition.await()) BigInteger.ZERO else FARM_USER_STATE_RENT_LAMPORTS
+
+            wrappedSolRent + shareAccountRent + farmUserStateRent
+        }
 
     private suspend fun tokenAccountRentReserve(): BigInteger =
         runCatchingCancellable { solanaApi.getMinimumBalanceForRentExemption() }
+            .onFailure {
+                Timber.w(it, "Kamino rent-exemption read failed, reserving the pinned minimum")
+            }
             .getOrNull()
             ?.takeIf { it.signum() > 0 } ?: SPL_TOKEN_ACCOUNT_RENT_LAMPORTS
 
@@ -92,6 +105,10 @@ constructor(private val solanaApi: SolanaApi, private val kaminoApi: KaminoApi) 
         runCatchingCancellable {
                 solanaApi.getTokenAssociatedAccountByOwner(walletAddress, mint).first != null
             }
+            // A failed read reserves the rent for an account that may already exist, which
+            // overstates the fee rather than understating it — but it is a guess either way, and a
+            // silent one is a fee nobody can account for afterwards.
+            .onFailure { Timber.w(it, "Kamino token-account read failed for mint %s", mint) }
             .getOrDefault(false)
 
     /**
@@ -112,5 +129,6 @@ constructor(private val solanaApi: SolanaApi, private val kaminoApi: KaminoApi) 
                 KaminoWithdrawEligibility.resolve(entry, vault.sharesDecimals) is
                     KaminoWithdrawEligibility.Withdrawable
             }
+            .onFailure { Timber.w(it, "Kamino positions read failed for vault %s", vault.address) }
             .getOrDefault(false)
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.blockchain.solana.kamino
 
 import com.vultisig.wallet.data.api.KaminoApi
+import com.vultisig.wallet.data.blockchain.solana.SolanaSignatureEnvelope
 import io.ktor.util.decodeBase64Bytes
 import java.math.BigInteger
 import javax.inject.Inject
@@ -16,18 +17,31 @@ import wallet.core.jni.proto.Solana
  * [feePayer] is the message's own account key 0 — the fee payer and first required signer. It has
  * to come from the message header rather than from any instruction's account list: an instruction
  * that happens to name the wallet first says nothing about who is authorising the transaction.
+ *
+ * @property requiredSignatures how many signatures the message declares. Carried because the
+ *   raw-signing path fills slot 0 and leaves every other slot as it received it, so a second
+ *   required signer is a transaction this app would sign and then broadcast incomplete — or
+ *   alongside somebody else's signature.
+ * @property isUnsigned whether every declared slot is still an all-zero placeholder, which is what
+ *   makes that splice safe.
+ *
+ * Neither carries a default. A default would have to be the permissive value, and the whole point
+ * of both is that nothing was checking them.
  */
 data class KaminoDecodedTransaction(
     val feePayer: String?,
     val instructions: List<KaminoTxInstruction>,
+    val requiredSignatures: Int,
+    val isUnsigned: Boolean,
 )
 
 /** Decodes a base64 Solana transaction into the instructions validation reasons about. */
 object KaminoTransactionDecoder {
 
     fun decode(base64Transaction: String): KaminoDecodedTransaction {
-        val decoded =
-            TransactionDecoder.decode(CoinType.SOLANA, base64Transaction.decodeBase64Bytes())
+        val wireBytes = base64Transaction.decodeBase64Bytes()
+        val envelope = SolanaSignatureEnvelope.parse(wireBytes)
+        val decoded = TransactionDecoder.decode(CoinType.SOLANA, wireBytes)
         val output = Solana.DecodingTransactionOutput.parseFrom(decoded)
         check(output.hasTransaction()) { "transaction could not be decoded" }
 
@@ -66,6 +80,8 @@ object KaminoTransactionDecoder {
         return KaminoDecodedTransaction(
             feePayer = accountKeys.firstOrNull(),
             instructions = decodedInstructions,
+            requiredSignatures = envelope.requiredSignatures,
+            isUnsigned = envelope.isUnsigned,
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -202,8 +202,9 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
             instructions.indices.filter {
                 instructions[it].programId == KaminoComputeBudget.PROGRAM_ID
             }
-        check(budgetIndices == listOf(UNIT_LIMIT_INDEX)) {
-            "expected the app's compute-unit limit alone at index $UNIT_LIMIT_INDEX, " +
+        check(budgetIndices == listOf(KaminoComputeBudget.UNIT_LIMIT_INDEX)) {
+            "expected the app's compute-unit limit alone at index " +
+                "${KaminoComputeBudget.UNIT_LIMIT_INDEX}, " +
                 "found ComputeBudget instructions at $budgetIndices"
         }
 
@@ -217,18 +218,11 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
         return checkNotNull(
             SolanaTransaction.insertInstruction(
                 withLimit,
-                UNIT_PRICE_INDEX,
+                KaminoComputeBudget.UNIT_PRICE_INDEX,
                 KaminoComputeBudget.setUnitPriceInstructionJson(price),
             )
         ) {
             "WalletCore could not set the Kamino compute-unit price"
         }
-    }
-
-    private companion object {
-        private const val UNIT_LIMIT_INDEX = 0
-
-        /** Right after the limit, which is where iOS puts it. */
-        private const val UNIT_PRICE_INDEX = UNIT_LIMIT_INDEX + 1
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -70,6 +70,11 @@ object KaminoTransactionValidator {
     /** What the kVault program reads as "withdraw everything". */
     private val U64_MAX = BigInteger("18446744073709551615")
 
+    /** Where [KaminoTransactionPreparer] puts the compute budget, and where iOS expects it. */
+    private const val UNIT_LIMIT_INDEX = 0
+
+    private const val UNIT_PRICE_INDEX = UNIT_LIMIT_INDEX + 1
+
     /**
      * @throws KaminoTransactionRejected if [instructions] is not a transaction the app is willing
      *   to sign for [vault].
@@ -131,6 +136,96 @@ object KaminoTransactionValidator {
         rejectValueMovementAwayFromTheSigner(instructions, vault, wrappedSolAccount)
         rejectAnotherAccountsAuthority(decoded.feePayer, signerAddress)
         rejectTheWithdrawEverythingSentinel(instructions)
+        rejectAForeignComputeBudget(instructions, vault, action)
+        rejectAnythingButOneEmptySignatureSlot(decoded)
+    }
+
+    /**
+     * Refuses a compute budget that is not the one this app injects.
+     *
+     * The budget is what the transaction will be charged: price × limit, in lamports, on top of the
+     * base fee. Both devices quote it on their verify screens — the initiating one from the values
+     * it recorded, a co-signing one from the values relayed beside the bytes — and neither of those
+     * is the budget the runtime reads. That one is here, in the instructions.
+     *
+     * So the shape is pinned rather than merely allow-listed. The program alone being permitted is
+     * what let a deposit legitimately carry a ComputeBudget instruction while its argument said
+     * anything at all: a price is an unbounded `u64` multiplied by a six-figure limit, so an
+     * unchecked one is an unbounded fee sitting under a fee row that clamps its own display into
+     * [KaminoComputeBudget.MAX_UNIT_PRICE]. iOS refuses the same disagreement
+     * (`KaminoVerifyPresentation.priorityFeeAgrees`).
+     *
+     * Position is pinned too, not for the fee's sake but because the layout is a cross-platform
+     * contract: iOS emits the limit at 0 and the price at 1 and reads the remaining instructions
+     * positionally, so anything else is a transaction an iPhone co-signer will not join.
+     */
+    private fun rejectAForeignComputeBudget(
+        instructions: List<KaminoTxInstruction>,
+        vault: KaminoVault,
+        action: KaminoAction,
+    ) {
+        val budget =
+            KaminoComputeBudget.readFrom(instructions)
+                ?: reject(
+                    "transaction carries no compute budget, so it would run against the runtime " +
+                        "default and abort"
+                )
+        if (budget == KaminoComputeBudget.MALFORMED) {
+            reject("transaction carries a compute budget this app cannot read")
+        }
+
+        val budgetIndices =
+            instructions.indices.filter {
+                instructions[it].programId == KaminoComputeBudget.PROGRAM_ID
+            }
+        if (budgetIndices != listOf(UNIT_LIMIT_INDEX, UNIT_PRICE_INDEX)) {
+            reject(
+                "compute budget must be the leading two instructions, found it at $budgetIndices"
+            )
+        }
+        if (KaminoComputeBudget.unitLimitArgument(instructions[UNIT_LIMIT_INDEX].data) == null) {
+            reject("instruction $UNIT_LIMIT_INDEX must be the compute-unit limit")
+        }
+
+        val expectedLimit = KaminoComputeBudget.unitLimitFor(vault, action)
+        if (budget.limit != expectedLimit) {
+            reject(
+                "compute-unit limit is ${budget.limit} rather than the $expectedLimit this app " +
+                    "reserves for a $action"
+            )
+        }
+        // `unitPriceFor` is the clamp itself, so a price it does not move is a price already inside
+        // the range — the same range iOS clamps into and the only one its decoder accepts.
+        if (budget.price != KaminoComputeBudget.unitPriceFor(budget.price)) {
+            reject(
+                "compute-unit price ${budget.price} is outside " +
+                    "[${KaminoComputeBudget.FALLBACK_UNIT_PRICE}, " +
+                    "${KaminoComputeBudget.MAX_UNIT_PRICE}]"
+            )
+        }
+    }
+
+    /**
+     * Refuses anything but a transaction with one still-empty signature slot.
+     *
+     * The raw-signing path splices this vault's signature into slot 0 and leaves the message and
+     * every further slot exactly as received — which is right for a dApp co-sign and wrong here. A
+     * second required signer means the app signs and broadcasts something incomplete, or something
+     * completed by whoever supplied the bytes; a slot that already holds bytes means a signature
+     * over some message this device never saw riding along with its own.
+     *
+     * Fail-closed on both devices. iOS gates the same decode with `validateUnsignedSingleSigner`.
+     */
+    private fun rejectAnythingButOneEmptySignatureSlot(decoded: KaminoDecodedTransaction) {
+        if (decoded.requiredSignatures != 1) {
+            reject(
+                "transaction declares ${decoded.requiredSignatures} required signatures; only " +
+                    "signer 0's slot is ever filled"
+            )
+        }
+        if (!decoded.isUnsigned) {
+            reject("transaction already carries a signature in a slot this app does not write")
+        }
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -150,7 +150,7 @@ object KaminoTransactionValidator {
     private fun rejectTheWithdrawEverythingSentinel(instructions: List<KaminoTxInstruction>) {
         instructions.forEachIndexed { index, instruction ->
             if (instruction.programId != KaminoVaultRegistry.PROGRAM_ID) return@forEachIndexed
-            val amount = kvaultAmount(instruction.data) ?: return@forEachIndexed
+            val amount = kvaultAmountArgument(instruction.data) ?: return@forEachIndexed
             if (amount == U64_MAX) {
                 reject(
                     "instruction $index carries the withdraw-everything sentinel, which this app " +
@@ -158,19 +158,6 @@ object KaminoTransactionValidator {
                 )
             }
         }
-    }
-
-    /**
-     * The `u64` amount argument of a kVault instruction: an 8-byte Anchor discriminator followed by
-     * the amount, little-endian. Null when the instruction is too short to carry one.
-     */
-    private fun kvaultAmount(data: ByteArray): BigInteger? {
-        if (data.size < 16) return null
-        var value = BigInteger.ZERO
-        for (offset in 7 downTo 0) {
-            value = value.shiftLeft(8).or(BigInteger.valueOf((data[8 + offset].toLong() and 0xFF)))
-        }
-        return value
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -70,11 +70,6 @@ object KaminoTransactionValidator {
     /** What the kVault program reads as "withdraw everything". */
     private val U64_MAX = BigInteger("18446744073709551615")
 
-    /** Where [KaminoTransactionPreparer] puts the compute budget, and where iOS expects it. */
-    private const val UNIT_LIMIT_INDEX = 0
-
-    private const val UNIT_PRICE_INDEX = UNIT_LIMIT_INDEX + 1
-
     /**
      * @throws KaminoTransactionRejected if [instructions] is not a transaction the app is willing
      *   to sign for [vault].
@@ -178,13 +173,22 @@ object KaminoTransactionValidator {
             instructions.indices.filter {
                 instructions[it].programId == KaminoComputeBudget.PROGRAM_ID
             }
-        if (budgetIndices != listOf(UNIT_LIMIT_INDEX, UNIT_PRICE_INDEX)) {
+        if (
+            budgetIndices !=
+                listOf(KaminoComputeBudget.UNIT_LIMIT_INDEX, KaminoComputeBudget.UNIT_PRICE_INDEX)
+        ) {
             reject(
                 "compute budget must be the leading two instructions, found it at $budgetIndices"
             )
         }
-        if (KaminoComputeBudget.unitLimitArgument(instructions[UNIT_LIMIT_INDEX].data) == null) {
-            reject("instruction $UNIT_LIMIT_INDEX must be the compute-unit limit")
+        if (
+            KaminoComputeBudget.unitLimitArgument(
+                instructions[KaminoComputeBudget.UNIT_LIMIT_INDEX].data
+            ) == null
+        ) {
+            reject(
+                "instruction ${KaminoComputeBudget.UNIT_LIMIT_INDEX} must be the compute-unit limit"
+            )
         }
 
         val expectedLimit = KaminoComputeBudget.unitLimitFor(vault, action)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.chains.helpers
 
+import com.vultisig.wallet.data.blockchain.solana.SolanaSignatureEnvelope
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingOpType
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingPayload
 import com.vultisig.wallet.data.common.toHexByteArray
@@ -44,7 +45,7 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
         val DefaultFeeInLamports: BigInteger = 1000000.toBigInteger()
 
         /** Byte length of an ed25519 signature, and of each slot in a Solana signature array. */
-        private const val SIGNATURE_LENGTH = 64
+        private const val SIGNATURE_LENGTH = SolanaSignatureEnvelope.SIGNATURE_LENGTH
 
         /**
          * The Solana transaction id is the first signature in the signed transaction. WalletCore
@@ -469,64 +470,13 @@ class SolanaHelper(private val vaultHexPublicKey: String) {
     }
 
     /**
-     * A dApp-supplied raw Solana transaction split into its wire envelope `[compact-u16 signature
-     * count][count × 64-byte signature slot][message]`.
-     *
-     * [message] is the pre-image ed25519 signs verbatim; [firstSignatureOffset] is where signer 0's
-     * slot begins, so the produced signature can be spliced back into [bytes] without disturbing
-     * anything else.
-     */
-    private class RawSolanaTransaction(
-        val bytes: ByteArray,
-        val firstSignatureOffset: Int,
-        val message: ByteArray,
-    )
-
-    /**
      * Parses the `[shortvec(numSignatures)][numSignatures × 64-byte slot][message]` envelope of a
-     * dApp-supplied raw transaction and returns its message bytes verbatim.
+     * dApp-supplied raw transaction.
      *
-     * Signing over these original bytes — rather than decoding into WalletCore's representation and
-     * re-serializing it (the `TransactionDecoder` → `SigningInput.rawMessage` →
-     * `TransactionCompiler` round trip) — keeps the pre-image hash independent of WalletCore's
-     * encoder. That re-encode is not guaranteed to reproduce the original bytes for a v0 message
-     * referencing an Address Lookup Table (the standard shape for DEX/aggregator swaps), which
-     * would make co-signing devices compute mismatching hashes and stall the ceremony.
+     * Shared with the checks that decide whether a transaction may be signed this way at all — see
+     * [SolanaSignatureEnvelope], which is also where the reasons for parsing the original bytes
+     * rather than round-tripping them through WalletCore live.
      */
-    private fun parseRawTransaction(base64Transaction: String): RawSolanaTransaction {
-        val bytes = base64Transaction.decodeBase64Bytes()
-
-        val (signatureCount, firstSignatureOffset) = readCompactU16(bytes)
-        check(signatureCount >= 1) { "Solana transaction declares no signatures" }
-
-        val messageOffset = firstSignatureOffset + signatureCount * SIGNATURE_LENGTH
-        check(messageOffset < bytes.size) {
-            "Solana transaction too short for its $signatureCount declared signature(s)"
-        }
-        return RawSolanaTransaction(
-            bytes = bytes,
-            firstSignatureOffset = firstSignatureOffset,
-            message = bytes.copyOfRange(messageOffset, bytes.size),
-        )
-    }
-
-    /**
-     * Decodes the Solana compact-u16 (shortvec) at the start of [bytes] — up to three bytes, 7
-     * payload bits each with the high bit signalling "more bytes follow" — and returns the decoded
-     * value together with the offset just past it (where the signature slots begin).
-     */
-    private fun readCompactU16(bytes: ByteArray): Pair<Int, Int> {
-        var value = 0
-        var offset = 0
-        var shift = 0
-        while (offset < bytes.size) {
-            val byte = bytes[offset].toInt() and 0xFF
-            value = value or ((byte and 0x7F) shl shift)
-            offset++
-            if (byte and 0x80 == 0) return value to offset
-            shift += 7
-            if (shift > 14) error("Malformed compact-u16 in Solana transaction")
-        }
-        error("Truncated compact-u16 in Solana transaction")
-    }
+    private fun parseRawTransaction(base64Transaction: String): SolanaSignatureEnvelope =
+        SolanaSignatureEnvelope.parse(base64Transaction.decodeBase64Bytes())
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaSignatureEnvelopeTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaSignatureEnvelopeTest.kt
@@ -1,0 +1,83 @@
+package com.vultisig.wallet.data.blockchain.solana
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * The envelope the raw-signing path splices into, and the checks that decide whether it may.
+ *
+ * Read from the original wire bytes rather than re-serialized, so these fixtures are hand-built
+ * `[compact-u16 count][count × 64-byte slot][message]` rather than anything WalletCore produced.
+ */
+class SolanaSignatureEnvelopeTest {
+
+    @Test
+    fun `a single-signature transaction splits into its slot and its message`() {
+        val envelope = SolanaSignatureEnvelope.parse(transaction(signatures = 1))
+
+        assertEquals(1, envelope.requiredSignatures)
+        assertEquals(1, envelope.firstSignatureOffset)
+        assertEquals(MESSAGE.toList(), envelope.message.toList())
+        assertTrue(envelope.isUnsigned)
+    }
+
+    @Test
+    fun `a slot that already carries bytes is not unsigned`() {
+        // What makes the splice at slot 0 safe is that nothing is being overwritten. A filled slot
+        // is somebody's signature over some message, and it would be broadcast along with ours.
+        val bytes = transaction(signatures = 1).also { it[1] = 7 }
+
+        assertFalse(SolanaSignatureEnvelope.parse(bytes).isUnsigned)
+    }
+
+    @Test
+    fun `a second empty slot still counts as a second required signature`() {
+        // Emptiness is not the question here — the splice fills slot 0 and leaves slot 1 as it
+        // found it, so this transaction would go out one signature short.
+        val envelope = SolanaSignatureEnvelope.parse(transaction(signatures = 2))
+
+        assertEquals(2, envelope.requiredSignatures)
+        assertTrue(envelope.isUnsigned)
+    }
+
+    @Test
+    fun `a transaction declaring no signatures is refused`() {
+        assertThrows<IllegalStateException> {
+            SolanaSignatureEnvelope.parse(byteArrayOf(0) + MESSAGE)
+        }
+    }
+
+    @Test
+    fun `a transaction too short for the slots it declares is refused`() {
+        assertThrows<IllegalStateException> {
+            SolanaSignatureEnvelope.parse(byteArrayOf(2) + ByteArray(64))
+        }
+    }
+
+    @Test
+    fun `a multi-byte compact-u16 count is decoded from all its payload bits`() {
+        // 0x80 0x01 is 128 with the continuation bit set on the first byte. Well past anything a
+        // real transaction carries, but the shortvec is what the count is read through and a
+        // single-byte-only reader would call this 0.
+        val bytes = byteArrayOf(0x80.toByte(), 0x01) + ByteArray(128 * 64) + MESSAGE
+
+        val envelope = SolanaSignatureEnvelope.parse(bytes)
+
+        assertEquals(128, envelope.requiredSignatures)
+        assertEquals(2, envelope.firstSignatureOffset)
+        assertEquals(MESSAGE.toList(), envelope.message.toList())
+    }
+
+    private fun transaction(signatures: Int): ByteArray =
+        byteArrayOf(signatures.toByte()) +
+            ByteArray(signatures * SolanaSignatureEnvelope.SIGNATURE_LENGTH) +
+            MESSAGE
+
+    private companion object {
+        /** Stands in for the message; the envelope never looks inside it. */
+        val MESSAGE = byteArrayOf(0x01, 0x02, 0x03, 0x04)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoBudgetInstructions.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoBudgetInstructions.kt
@@ -1,0 +1,36 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import java.math.BigInteger
+
+/**
+ * The two ComputeBudget instructions [KaminoTransactionPreparer] injects, at the positions it puts
+ * them: the unit limit first, the unit price second.
+ *
+ * Every valid Kamino transaction carries this pair, so the fixtures in these tests do too — the
+ * validator refuses a transaction whose budget is missing, misplaced or not the one this app builds
+ * for the vault and action in hand.
+ */
+internal fun computeBudgetInstructions(
+    vault: KaminoVault,
+    action: KaminoAction,
+    price: BigInteger = KaminoComputeBudget.FALLBACK_UNIT_PRICE,
+    limit: BigInteger = KaminoComputeBudget.unitLimitFor(vault, action),
+): List<KaminoTxInstruction> =
+    listOf(
+        KaminoTxInstruction(KaminoComputeBudget.PROGRAM_ID, setUnitLimitData(limit)),
+        KaminoTxInstruction(
+            KaminoComputeBudget.PROGRAM_ID,
+            KaminoComputeBudget.setUnitPriceData(price),
+        ),
+    )
+
+/**
+ * Borsh-encoded `SetComputeUnitLimit`: the discriminator byte followed by the limit as a
+ * little-endian `u32`.
+ *
+ * Written here rather than in production code because nothing there encodes one — WalletCore's
+ * `SolanaTransaction.setComputeUnitLimit` does it inside the JNI layer.
+ */
+internal fun setUnitLimitData(limit: BigInteger): ByteArray =
+    byteArrayOf(KaminoComputeBudget.SET_UNIT_LIMIT_DISCRIMINATOR.toByte()) +
+        ByteArray(Int.SIZE_BYTES) { byte -> limit.shiftRight(8 * byte).toInt().toByte() }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudgetTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoComputeBudgetTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.blockchain.solana.kamino
 
 import java.math.BigInteger
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -190,4 +191,68 @@ class KaminoComputeBudgetTest {
             KaminoComputeBudget.setUnitPriceData(BigInteger.valueOf(-1))
         }
     }
+
+    @Test
+    fun `the budget is read back out of the instructions it was encoded into`() {
+        val budget =
+            KaminoComputeBudget.readFrom(
+                computeBudgetInstructions(solVault, KaminoAction.DEPOSIT, price = MILLION)
+            )
+
+        assertEquals(
+            KaminoPriorityFee(limit = BigInteger.valueOf(350_000), price = MILLION),
+            budget,
+        )
+    }
+
+    @Test
+    fun `instructions carrying no compute budget read as none`() {
+        // Distinct from unreadable: the caller has to be able to tell "there is no budget" from
+        // "there is one and it does not parse", because only the second contradicts a payload.
+        assertNull(
+            KaminoComputeBudget.readFrom(
+                listOf(KaminoTxInstruction(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1)))
+            )
+        )
+    }
+
+    @Test
+    fun `a truncated argument is unreadable rather than read from its prefix`() {
+        // A shorter or longer instruction is not the one it claims to be, and reading a partial
+        // little-endian argument would answer some smaller number with full confidence.
+        assertEquals(
+            KaminoComputeBudget.MALFORMED,
+            KaminoComputeBudget.readFrom(
+                listOf(
+                    KaminoTxInstruction(KaminoComputeBudget.PROGRAM_ID, byteArrayOf(2, 0x20, 0x4E)),
+                    KaminoTxInstruction(
+                        KaminoComputeBudget.PROGRAM_ID,
+                        KaminoComputeBudget.setUnitPriceData(MILLION),
+                    ),
+                )
+            ),
+        )
+    }
+
+    @Test
+    fun `a second price instruction is unreadable rather than resolved to one of them`() {
+        val duplicated =
+            computeBudgetInstructions(solVault, KaminoAction.DEPOSIT) +
+                KaminoTxInstruction(
+                    KaminoComputeBudget.PROGRAM_ID,
+                    KaminoComputeBudget.setUnitPriceData(MILLION),
+                )
+
+        assertEquals(KaminoComputeBudget.MALFORMED, KaminoComputeBudget.readFrom(duplicated))
+    }
+
+    @Test
+    fun `the unreadable marker matches no budget a payload could record`() {
+        // It is compared for equality against what the payload claims, so it has to be a value no
+        // legitimate claim can take — the payload's fields are unsigned.
+        assertTrue(KaminoComputeBudget.MALFORMED.limit.signum() < 0)
+        assertTrue(KaminoComputeBudget.MALFORMED.price.signum() < 0)
+    }
+
+    private val MILLION: BigInteger = BigInteger.valueOf(1_000_000)
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransactionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransactionTest.kt
@@ -1,0 +1,249 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import java.math.BigInteger
+import java.security.MessageDigest
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * What a co-signing device can work out about a relayed Kamino transaction from its bytes alone
+ * (issue #5644).
+ *
+ * The instruction shapes here are the ones the live fixtures in `KaminoFixtureApi` decode to — an
+ * associated-account creation, the kVault instruction, the farms pair, the compute budget and the
+ * attribution memo last — with the discriminators and account lists copied from that decode.
+ */
+class KaminoRelayedTransactionTest {
+
+    private val vault = KaminoVaultRegistry.STEAKHOUSE_USDC
+    private val solVault = KaminoVaultRegistry.ALLEZ_SOL
+
+    private val signer = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+    /** The signer's share account for [vault] — what names the vault inside the bytes. */
+    private val shareAccount = "GSayQpRaoh1LFdBbja4vensNKDfihcixzCcQShKMCdMJ"
+
+    private val vaultsByShareAccount = mapOf(shareAccount to vault)
+
+    private val depositDiscriminator = hex("f223c68952e1f2b6")
+    private val withdrawDiscriminator = hex("1383709baadc2239")
+
+    private val memo =
+        KaminoTxInstruction(
+            programId = KaminoAttributionMemo.MEMO_PROGRAM_ID,
+            data = KaminoAttributionMemo.TAG.toByteArray(),
+        )
+
+    @Test
+    fun `the kVault discriminators are the Anchor names they claim to be`() {
+        // Pinned as bytes in the reader, so this is where the derivation is written down: get one
+        // wrong and every Kamino transaction silently stops being recognised.
+        assertEquals(anchorDiscriminator("deposit").toList(), depositDiscriminator.toList())
+        assertEquals(
+            anchorDiscriminator("withdraw_from_available").toList(),
+            withdrawDiscriminator.toList(),
+        )
+    }
+
+    @Test
+    fun `a deposit is read as its vault, direction and token amount`() {
+        val intent = read(depositInstructions(amount = ONE_USDC))
+
+        assertEquals(vault, intent?.vault)
+        assertEquals(KaminoAction.DEPOSIT, intent?.action)
+        assertEquals(ONE_USDC, intent?.amount)
+    }
+
+    @Test
+    fun `a withdraw is read as a withdraw, carrying shares rather than tokens`() {
+        val shares = BigInteger.valueOf(500_000)
+        val intent = read(withdrawInstructions(amount = shares))
+
+        assertEquals(KaminoAction.WITHDRAW, intent?.action)
+        assertEquals(shares, intent?.amount)
+    }
+
+    @Test
+    fun `a transaction that never invokes kVault is not a Kamino transaction`() {
+        val instructions = depositInstructions().filterNot { it.programId == KVAULT }
+
+        assertNull(read(instructions))
+    }
+
+    @Test
+    fun `two kVault instructions are refused rather than half-described`() {
+        val instructions = depositInstructions() + kvault(depositDiscriminator, ONE_USDC)
+
+        assertNull(read(instructions))
+    }
+
+    @Test
+    fun `a kVault instruction the app has no name for is not guessed at`() {
+        // A third entry point would move value in a way neither screen describes; better the
+        // co-signer keeps the generic screen than is shown a deposit that is not one.
+        val instructions =
+            depositInstructions().map { instruction ->
+                if (instruction.programId == KVAULT) {
+                    kvault(hex("0102030405060708"), ONE_USDC)
+                } else {
+                    instruction
+                }
+            }
+
+        assertNull(read(instructions))
+    }
+
+    @Test
+    fun `a vault whose share account is not named cannot be identified`() {
+        // The vault's own address travels in an address lookup table, so an unresolved share
+        // account leaves nothing to name it with.
+        assertNull(
+            KaminoRelayedTransactionReader.read(
+                decoded(depositInstructions()),
+                vaultsByShareAccount = emptyMap(),
+            )
+        )
+    }
+
+    @Test
+    fun `an instruction too short to carry an amount is refused`() {
+        val instructions =
+            depositInstructions().map { instruction ->
+                if (instruction.programId == KVAULT) {
+                    KaminoTxInstruction(KVAULT, depositDiscriminator, listOf(signer, shareAccount))
+                } else {
+                    instruction
+                }
+            }
+
+        assertNull(read(instructions))
+    }
+
+    @Test
+    fun `recognition runs the same validator the initiating device ran`() {
+        // The memo is what the initiating device appends last; a transaction missing it is not one
+        // this app built, whatever its instructions say.
+        assertNull(resolve(depositInstructions(memoInstruction = null)))
+    }
+
+    @Test
+    fun `a payload carrying more than one transaction is not a Kamino payload`() {
+        val useCase = useCase(depositInstructions())
+
+        assertNull(useCase(listOf(RAW, RAW), signer))
+    }
+
+    @Test
+    fun `bytes that cannot be decoded are not a Kamino payload`() {
+        val useCase =
+            ResolveKaminoRelayedIntentUseCase(
+                decode = { error("not a Solana transaction") },
+                tokenAccount = ::fakeTokenAccount,
+            )
+
+        assertNull(useCase(listOf(RAW), signer))
+    }
+
+    @Test
+    fun `a recognised deposit reaches the caller`() {
+        assertEquals(vault, resolve(depositInstructions())?.vault)
+    }
+
+    @Test
+    fun `the network fee is the relayed budget plus the rent the deposit spends`() {
+        val rent = BigInteger.valueOf(10_377_640)
+
+        val fee =
+            kaminoNetworkFeeLamports(
+                vault = solVault,
+                action = KaminoAction.DEPOSIT,
+                relayedUnitPrice = BigInteger.valueOf(250_000),
+                rentReserve = rent,
+            )
+
+        // 1,000,000 base + (250,000 µlamports × 350,000 units / 1e6) + rent.
+        assertEquals(BigInteger.valueOf(1_000_000 + 87_500) + rent, fee)
+    }
+
+    @Test
+    fun `a withdraw quotes the budget alone, with no rent to spend`() {
+        val fee =
+            kaminoNetworkFeeLamports(
+                vault = solVault,
+                action = KaminoAction.WITHDRAW,
+                relayedUnitPrice = BigInteger.valueOf(250_000),
+            )
+
+        // 1,000,000 base + (250,000 × 400,000 / 1e6).
+        assertEquals(BigInteger.valueOf(1_000_000 + 100_000), fee)
+    }
+
+    private fun read(instructions: List<KaminoTxInstruction>): KaminoRelayedIntent? =
+        KaminoRelayedTransactionReader.read(decoded(instructions), vaultsByShareAccount)
+
+    private fun resolve(instructions: List<KaminoTxInstruction>): KaminoRelayedIntent? =
+        useCase(instructions)(listOf(RAW), signer)
+
+    private fun useCase(instructions: List<KaminoTxInstruction>) =
+        ResolveKaminoRelayedIntentUseCase(
+            decode = { decoded(instructions) },
+            tokenAccount = ::fakeTokenAccount,
+        )
+
+    /** Stands in for WalletCore's derivation, answering the share account the bytes name. */
+    private fun fakeTokenAccount(owner: String, mint: String): String? =
+        if (owner == signer && mint == vault.sharesMint) shareAccount else "other-$mint"
+
+    private fun decoded(instructions: List<KaminoTxInstruction>) =
+        KaminoDecodedTransaction(feePayer = signer, instructions = instructions)
+
+    private fun depositInstructions(
+        amount: BigInteger = ONE_USDC,
+        memoInstruction: KaminoTxInstruction? = memo,
+    ) =
+        listOfNotNull(
+            KaminoTxInstruction(COMPUTE_BUDGET, byteArrayOf(2)),
+            KaminoTxInstruction(COMPUTE_BUDGET, byteArrayOf(3)),
+            KaminoTxInstruction(ASSOCIATED_TOKEN, byteArrayOf(1)),
+            kvault(depositDiscriminator, amount),
+            KaminoTxInstruction(KaminoVaultRegistry.FARMS_PROGRAM_ID, hex("6f11b9fa3c7a26fe")),
+            KaminoTxInstruction(KaminoVaultRegistry.FARMS_PROGRAM_ID, hex("ceb0ca12c8d1b36c")),
+            memoInstruction,
+        )
+
+    private fun withdrawInstructions(amount: BigInteger) =
+        listOf(
+            KaminoTxInstruction(COMPUTE_BUDGET, byteArrayOf(2)),
+            KaminoTxInstruction(ASSOCIATED_TOKEN, byteArrayOf(1)),
+            kvault(withdrawDiscriminator, amount),
+            memo,
+        )
+
+    private fun kvault(discriminator: ByteArray, amount: BigInteger) =
+        KaminoTxInstruction(
+            programId = KVAULT,
+            data = discriminator + amount.toLittleEndianU64(),
+            accounts = listOf(signer, KaminoTransactionDecoder.UNKNOWN_ACCOUNT, shareAccount),
+        )
+
+    private fun BigInteger.toLittleEndianU64(): ByteArray =
+        ByteArray(8) { index -> shiftRight(index * 8).and(BigInteger.valueOf(0xFF)).toByte() }
+
+    private fun anchorDiscriminator(name: String): ByteArray =
+        MessageDigest.getInstance("SHA-256").digest("global:$name".toByteArray()).copyOfRange(0, 8)
+
+    private fun hex(value: String): ByteArray =
+        ByteArray(value.length / 2) { value.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
+
+    private companion object {
+        const val KVAULT = KaminoVaultRegistry.PROGRAM_ID
+        const val COMPUTE_BUDGET = KaminoComputeBudget.PROGRAM_ID
+        const val ASSOCIATED_TOKEN = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+
+        /** Any string: the decode is faked, so the bytes themselves are never read. */
+        const val RAW = "relayed-transaction"
+
+        val ONE_USDC: BigInteger = BigInteger.valueOf(1_000_000)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransactionTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransactionTest.kt
@@ -151,6 +151,60 @@ class KaminoRelayedTransactionTest {
     }
 
     @Test
+    fun `the intent carries the budget from the instructions, not from beside them`() {
+        // What the fee row is priced from on the joining device. Read here rather than taken from
+        // the payload's own field, which is a display value the initiating device filled in.
+        val intent =
+            read(
+                depositInstructions(
+                    budget =
+                        computeBudgetInstructions(
+                            vault,
+                            KaminoAction.DEPOSIT,
+                            price = BigInteger.valueOf(250_000),
+                        )
+                )
+            )
+
+        assertEquals(
+            KaminoPriorityFee(
+                limit = KaminoComputeBudget.unitLimitFor(vault, KaminoAction.DEPOSIT),
+                price = BigInteger.valueOf(250_000),
+            ),
+            intent?.priorityFee,
+        )
+    }
+
+    @Test
+    fun `a transaction priced outside the app's own range never reaches the caller`() {
+        // Recognition re-runs the initiating device's validator, so an unbounded price is refused
+        // here too rather than quoted under a fee row that clamps its own display.
+        assertNull(
+            resolve(
+                depositInstructions(
+                    budget =
+                        computeBudgetInstructions(
+                            vault,
+                            KaminoAction.DEPOSIT,
+                            price = KaminoComputeBudget.MAX_UNIT_PRICE.add(BigInteger.ONE),
+                        )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `a transaction needing a second signature never reaches the caller`() {
+        val useCase =
+            ResolveKaminoRelayedIntentUseCase(
+                decode = { decoded(depositInstructions(), requiredSignatures = 2) },
+                tokenAccount = ::fakeTokenAccount,
+            )
+
+        assertNull(useCase(listOf(RAW), signer))
+    }
+
+    @Test
     fun `the network fee is the relayed budget plus the rent the deposit spends`() {
         val rent = BigInteger.valueOf(10_377_640)
 
@@ -195,30 +249,35 @@ class KaminoRelayedTransactionTest {
     private fun fakeTokenAccount(owner: String, mint: String): String? =
         if (owner == signer && mint == vault.sharesMint) shareAccount else "other-$mint"
 
-    private fun decoded(instructions: List<KaminoTxInstruction>) =
-        KaminoDecodedTransaction(feePayer = signer, instructions = instructions)
+    private fun decoded(instructions: List<KaminoTxInstruction>, requiredSignatures: Int = 1) =
+        KaminoDecodedTransaction(
+            feePayer = signer,
+            instructions = instructions,
+            requiredSignatures = requiredSignatures,
+            isUnsigned = true,
+        )
 
     private fun depositInstructions(
         amount: BigInteger = ONE_USDC,
         memoInstruction: KaminoTxInstruction? = memo,
+        budget: List<KaminoTxInstruction> = computeBudgetInstructions(vault, KaminoAction.DEPOSIT),
     ) =
-        listOfNotNull(
-            KaminoTxInstruction(COMPUTE_BUDGET, byteArrayOf(2)),
-            KaminoTxInstruction(COMPUTE_BUDGET, byteArrayOf(3)),
-            KaminoTxInstruction(ASSOCIATED_TOKEN, byteArrayOf(1)),
-            kvault(depositDiscriminator, amount),
-            KaminoTxInstruction(KaminoVaultRegistry.FARMS_PROGRAM_ID, hex("6f11b9fa3c7a26fe")),
-            KaminoTxInstruction(KaminoVaultRegistry.FARMS_PROGRAM_ID, hex("ceb0ca12c8d1b36c")),
-            memoInstruction,
-        )
+        budget +
+            listOfNotNull(
+                KaminoTxInstruction(ASSOCIATED_TOKEN, byteArrayOf(1)),
+                kvault(depositDiscriminator, amount),
+                KaminoTxInstruction(KaminoVaultRegistry.FARMS_PROGRAM_ID, hex("6f11b9fa3c7a26fe")),
+                KaminoTxInstruction(KaminoVaultRegistry.FARMS_PROGRAM_ID, hex("ceb0ca12c8d1b36c")),
+                memoInstruction,
+            )
 
     private fun withdrawInstructions(amount: BigInteger) =
-        listOf(
-            KaminoTxInstruction(COMPUTE_BUDGET, byteArrayOf(2)),
-            KaminoTxInstruction(ASSOCIATED_TOKEN, byteArrayOf(1)),
-            kvault(withdrawDiscriminator, amount),
-            memo,
-        )
+        computeBudgetInstructions(vault, KaminoAction.WITHDRAW) +
+            listOf(
+                KaminoTxInstruction(ASSOCIATED_TOKEN, byteArrayOf(1)),
+                kvault(withdrawDiscriminator, amount),
+                memo,
+            )
 
     private fun kvault(discriminator: ByteArray, amount: BigInteger) =
         KaminoTxInstruction(
@@ -238,7 +297,6 @@ class KaminoRelayedTransactionTest {
 
     private companion object {
         const val KVAULT = KaminoVaultRegistry.PROGRAM_ID
-        const val COMPUTE_BUDGET = KaminoComputeBudget.PROGRAM_ID
         const val ASSOCIATED_TOKEN = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 
         /** Any string: the decode is faked, so the bytes themselves are never read. */

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.blockchain.solana.kamino
 
+import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
@@ -16,16 +17,26 @@ class KaminoTransactionValidatorTest {
     private val memo =
         ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, KaminoAttributionMemo.TAG.toByteArray())
 
-    /** The shape a prepared deposit actually has: ATA, kVault, two farms, compute budget, memo. */
-    private fun depositInstructions(memoInstruction: KaminoTxInstruction? = memo) =
-        listOfNotNull(
-            ix("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),
-            ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)),
-            ix(KaminoVaultRegistry.FARMS_PROGRAM_ID),
-            ix(KaminoVaultRegistry.FARMS_PROGRAM_ID),
-            ix("ComputeBudget111111111111111111111111111111"),
-            memoInstruction,
-        )
+    /** The shape a prepared deposit actually has: compute budget, ATA, kVault, two farms, memo. */
+    private fun depositInstructions(
+        memoInstruction: KaminoTxInstruction? = memo,
+        budget: List<KaminoTxInstruction> = budget(),
+    ) =
+        budget +
+            listOfNotNull(
+                ix("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),
+                ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)),
+                ix(KaminoVaultRegistry.FARMS_PROGRAM_ID),
+                ix(KaminoVaultRegistry.FARMS_PROGRAM_ID),
+                memoInstruction,
+            )
+
+    private fun budget(
+        forVault: KaminoVault = vault,
+        action: KaminoAction = KaminoAction.DEPOSIT,
+        price: BigInteger = KaminoComputeBudget.FALLBACK_UNIT_PRICE,
+        limit: BigInteger = KaminoComputeBudget.unitLimitFor(forVault, action),
+    ) = computeBudgetInstructions(forVault, action, price, limit)
 
     /**
      * Most rules do not care who pays, so the fee payer defaults to a benign value; the fee-payer
@@ -34,7 +45,13 @@ class KaminoTransactionValidatorTest {
     private fun decoded(
         instructions: List<KaminoTxInstruction>,
         feePayer: String? = DEFAULT_FEE_PAYER,
-    ) = KaminoDecodedTransaction(feePayer = feePayer, instructions = instructions)
+    ) =
+        KaminoDecodedTransaction(
+            feePayer = feePayer,
+            instructions = instructions,
+            requiredSignatures = 1,
+            isUnsigned = true,
+        )
 
     private fun rejection(instructions: List<KaminoTxInstruction>): String =
         assertThrows<KaminoTransactionRejected> {
@@ -63,11 +80,8 @@ class KaminoTransactionValidatorTest {
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
                 decoded(
-                    listOf(
-                        ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(9)),
-                        ix("ComputeBudget111111111111111111111111111111"),
-                        memo,
-                    )
+                    budget(action = KaminoAction.WITHDRAW) +
+                        listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(9)), memo)
                 ),
                 vault,
                 KaminoAction.WITHDRAW,
@@ -228,7 +242,8 @@ class KaminoTransactionValidatorTest {
                 data = byteArrayOf(1),
                 accounts = listOf(wrappedSolAccount),
             )
-        val instructions = listOf(kvault, systemTransfer, memo)
+        val instructions =
+            budget(forVault = KaminoVaultRegistry.ALLEZ_SOL) + listOf(kvault, systemTransfer, memo)
 
         val reason = rejection(instructions)
         assertTrue(reason.contains("moves lamports"), reason)
@@ -274,14 +289,15 @@ class KaminoTransactionValidatorTest {
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
                 decoded(
-                    listOf(
-                        KaminoTxInstruction(
-                            programId = KaminoVaultRegistry.PROGRAM_ID,
-                            data = byteArrayOf(1),
-                            accounts = listOf(signer),
+                    budget() +
+                        listOf(
+                            KaminoTxInstruction(
+                                programId = KaminoVaultRegistry.PROGRAM_ID,
+                                data = byteArrayOf(1),
+                                accounts = listOf(signer),
+                            ),
+                            memo,
                         ),
-                        memo,
-                    ),
                     feePayer = signer,
                 ),
                 vault,
@@ -440,7 +456,10 @@ class KaminoTransactionValidatorTest {
             }
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
-                decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, justUnder), memo)),
+                decoded(
+                    budget(action = KaminoAction.WITHDRAW) +
+                        listOf(ix(KaminoVaultRegistry.PROGRAM_ID, justUnder), memo)
+                ),
                 vault,
                 KaminoAction.WITHDRAW,
             )
@@ -451,11 +470,108 @@ class KaminoTransactionValidatorTest {
     fun `a short kVault instruction carrying no amount is not mistaken for the sentinel`() {
         assertDoesNotThrow {
             KaminoTransactionValidator.validate(
-                decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)), memo)),
+                decoded(
+                    budget() +
+                        listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)), memo)
+                ),
                 vault,
                 KaminoAction.DEPOSIT,
             )
         }
+    }
+
+    @Test
+    fun `a transaction carrying no compute budget is refused`() {
+        // Not a fee question alone: these consume 250,000-310,000 units against a 200,000 default,
+        // so a budget-less Kamino transaction aborts on chain after a full signing ceremony.
+        val reason = rejection(depositInstructions(budget = emptyList()))
+
+        assertTrue(reason.contains("no compute budget"), reason)
+    }
+
+    @Test
+    fun `a compute-unit price above the ceiling is refused`() {
+        // The price is a u64 multiplied by a six-figure limit, so unbounded here is an unbounded
+        // fee — while the row that displays it clamps at MAX_UNIT_PRICE and would show a hundredth
+        // of what the runtime charges. It is also the range iOS's own decoder accepts.
+        val reason =
+            rejection(
+                depositInstructions(
+                    budget = budget(price = KaminoComputeBudget.MAX_UNIT_PRICE.multiply(TEN))
+                )
+            )
+
+        assertTrue(reason.contains("outside"), reason)
+    }
+
+    @Test
+    fun `a compute-unit limit this app would not reserve is refused`() {
+        // The fee row multiplies the local limit by the relayed price, so bytes reserving some
+        // other limit are charged for work the quoted figure never priced.
+        val reason =
+            rejection(depositInstructions(budget = budget(limit = BigInteger.valueOf(1_400_000))))
+
+        assertTrue(reason.contains("compute-unit limit"), reason)
+    }
+
+    @Test
+    fun `a deposit carrying the withdraw limit is refused`() {
+        // The limit is per action, so the pair is checked against the action in hand rather than
+        // against "some limit this app uses somewhere".
+        val reason = rejection(depositInstructions(budget = budget(action = KaminoAction.WITHDRAW)))
+
+        assertTrue(reason.contains("compute-unit limit"), reason)
+    }
+
+    @Test
+    fun `a compute budget behind the instructions Kamino built is refused`() {
+        // The leading pair is a cross-platform contract: iOS emits them at 0 and 1 and reads the
+        // rest positionally, so a budget appended at the end is a transaction it will not join.
+        val misplaced = depositInstructions(budget = emptyList()).dropLast(1) + budget() + memo
+
+        val reason = rejection(misplaced)
+        assertTrue(reason.contains("leading two instructions"), reason)
+    }
+
+    @Test
+    fun `a duplicated compute budget is refused rather than read from its first entry`() {
+        val reason = rejection(depositInstructions(budget = budget() + budget()))
+
+        assertTrue(reason.contains("cannot read"), reason)
+    }
+
+    @Test
+    fun `a transaction needing a second signature is refused`() {
+        // The signing path fills slot 0 and leaves the rest as it found them, so this would be
+        // broadcast a signature short — or completed by whoever supplied the bytes.
+        val reason =
+            assertThrows<KaminoTransactionRejected> {
+                    KaminoTransactionValidator.validate(
+                        decoded(depositInstructions()).copy(requiredSignatures = 2),
+                        vault,
+                        KaminoAction.DEPOSIT,
+                    )
+                }
+                .message
+                .orEmpty()
+
+        assertTrue(reason.contains("required signatures"), reason)
+    }
+
+    @Test
+    fun `a transaction whose signature slot is already filled is refused`() {
+        val reason =
+            assertThrows<KaminoTransactionRejected> {
+                    KaminoTransactionValidator.validate(
+                        decoded(depositInstructions()).copy(isUnsigned = false),
+                        vault,
+                        KaminoAction.DEPOSIT,
+                    )
+                }
+                .message
+                .orEmpty()
+
+        assertTrue(reason.contains("already carries a signature"), reason)
     }
 
     @Test
@@ -470,6 +586,7 @@ class KaminoTransactionValidatorTest {
 
     private companion object {
         const val DEFAULT_FEE_PAYER = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+        val TEN: BigInteger = BigInteger.valueOf(10)
         const val OTHER_ACCOUNT = "SomeoneElsesAccount11111111111111111111111"
     }
 }


### PR DESCRIPTION
Closes #5644

## The problem

A Kamino deposit read differently on the two devices of a co-signed vault. The initiating device showed `You're depositing 0.42921903 SOL` into Allez SOL with a `0.01172764 SOL` fee. The joining device showed a **Send overview** of `0.440591671 SOL` with a `0.000105 SOL` fee, no vault and no operation — so a co-signer could not tell what they were approving, and the two screens disagreed on both figures.

Three separate causes, none of them a wrong number in one place:

| | Cause |
|---|---|
| Framing | `JoinKeysignViewModel.isDepositPayload` has no case a Kamino payload can match — the specific is `Solana`, the memo is `null` — so it fell to the send branch. `operation` and the vault name live only in the initiating device's local `DepositTransaction`; nothing about them travels on the wire. |
| Amount | `loadBlockaidSimulation` overwrote the hero with Blockaid's simulated **total native-SOL debit**, which for a SOL-vault deposit is the principal plus the rent for the accounts the transaction creates. The initiator shows the principal alone. |
| Fee | `computeJoinKeysignNetworkFee` has no Solana branch, so the fee was a fresh estimate of a **plain transfer** — 5,000 lamports plus a median price over 100,000 compute units — for a transaction carrying its own 320,000–400,000 unit budget in the bytes being signed. |

The fee and framing causes are not Kamino-specific — every in-app raw-Solana flow (`SolanaDelegate`, `SolanaUnstake`, `SolanaMoveStake`, `SolanaFinishMove`) hits the same two paths. This PR fixes them for Kamino; the staking flows are unchanged and still show a send overview.

## The fix

The joining device recognises Kamino **from the transaction itself**, not from the display fields relayed beside it:

- reads the single kVault instruction's Anchor discriminator — `deposit` and `withdraw_from_available`
- names the vault by the signer's derived **share account**, because the vault's own address travels in an address lookup table and is not among the static account keys
- refuses the pairing unless the payload's destination, and a deposit's amount, match what that instruction carries
- runs the same `KaminoTransactionValidator` the initiating device ran before relaying — **which the joining device never did**: it was signing these bytes unchecked

Anything unrecognised falls back to today's screen rather than blocking a ceremony over a shape the reader does not know.

The fee and the rent move into one shared derivation (`kaminoNetworkFeeLamports`, `KaminoDepositRentReserve`) that **both** devices call. Two screens agreeing on a number is a property of deriving it once, not of two call sites happening to match today.

## Judgement calls for the reviewer

1. **Rent stays inside the displayed network fee.** The initiating device folds it in deliberately, so `amount + fee` reconciles against the wallet balance, and #5607 will want it for the affordability check. Both devices now agree on that definition rather than on a changed one. Splitting rent into its own row is the more honest UI and also an iOS-parity decision — happy to file it as a follow-up if you'd rather.
2. **Direction comes from the discriminator, the vault from the share account.** The alternative was trusting the relayed `toAddress`, which is display material. This way the pairing is checked rather than assumed, at the cost of two pinned discriminator constants (unit-tested against their `sha256("global:…")` derivation, and against live fixture bytes on device).
3. **No Blockaid badge on a recognised Kamino transaction.** Parity: the initiating device's `VerifyDepositViewModel` has never scanned one, and the app's own validator now runs on both sides.

## Test plan

25 new tests. 5 verified to fail when the fix is reverted.

- `KaminoRelayedTransactionTest` (14) — discriminators pinned against their Anchor derivation; deposit/withdraw read; refusals for no kVault instruction, two of them, an unknown discriminator, an unnamed vault, a truncated amount, a multi-transaction payload, undecodable bytes, and a transaction missing the attribution memo; the fee arithmetic
- `KaminoJoinIntentTest` (5) — a payload whose amount or destination disagrees with its own bytes loses the deposit framing; a withdraw's shares are never compared against tokens
- `JoinDepositKaminoTest` (3) — the co-signer's `DepositTransaction` carries the operation, the vault name, the principal, the bytes, and the relayed-budget fee; the transfer estimate is never consulted
- `KaminoRelayedTransactionAndroidTest` (3, emulator) — the same recognition against the **live** `KaminoFixtures` bytes, including that another wallet cannot name the vault. This is what proves the discriminators and the share-account derivation are what those transactions actually carry

Full `:app` and `:data` unit suites, `:app:lintDebug`, `:data:lintDebug` and ktfmt all green.

**Manual:** two devices on one multi-device vault → DeFi → Kamino Earn → Allez SOL → Deposit → sign on A → scan on B. B should read `Function overview` / `You're depositing` with A's amount, `Vault: Allez SOL`, and a network fee string identical to A's. A plain SOL send and a Solana staking delegate must both still join as a Send overview.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing and signing relayed Kamino Solana deposits and withdrawals.
  * Added validation for vault, destination, asset, amount, signature, and transaction fee details.
  * Added Kamino-specific operation details, fee calculation, deposit rent handling, and compute-budget validation.
  * Withdrawal verification now displays unverified vault-share amounts when the token amount cannot be confirmed.

* **Bug Fixes**
  * Improved rejection of malformed, ambiguous, or incorrectly targeted transactions.

* **Tests**
  * Added comprehensive unit and integration coverage for Kamino transaction flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->