### PR TITLE
fix(defi): make the Kamino instruction guards allow-lists

### DIFF
--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoFixtures.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoFixtures.kt
@@ -50,8 +50,58 @@ internal object KaminoFixtures {
             "s3q6CtgzQiIGiofmyao3Sh0Dq7RowlSc92jsQgIFBgABAA0DFgEBBxYADwYLEgENAggWFhUEBw4MCQoTERQQEBOD" +
             "cJuq3CI5//////////8BgunUZsNGfS6ysNnMvrR72/SV7hwbtHfQ2q+tA1+n6+QIBTUlLxMCCQEHJxUECzcHAw=="
 
+    /**
+     * A live `POST /ktx/kvault/deposit` response for the Allez SOL vault: create the wrapped-SOL
+     * account, move the lamports into it, `SyncNative` to credit them, create the share account,
+     * then `kVault::deposit` and the two farms instructions.
+     *
+     * The wrapped-SOL shape the USDC fixtures never show. It is the only one of these that carries
+     * top-level System and Token instructions at all — a plain-token vault moves its tokens through
+     * the kVault program's own CPI — so it is what the validator's allow-lists are sized against.
+     *
+     * Captured against the same empty wallet as the fixtures above, which is what makes this shape
+     * observable without depositing real SOL: the endpoint builds the transaction regardless.
+     */
+    const val ALLEZ_SOL_DEPOSIT =
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
+            "AQAGDH//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuemJnd9pKyNWm8rX5WMWlaRpEuaYsAMd/0uKk2HNuIL" +
+            "qFNvAn5UvuGbp47XxazBMJL84XxTjp/284efVL2pzo4iIesfng/b+jhKCNqqrmiaZ6cpiUcyN06V+7/WNOGHIPzV" +
+            "+gzvPgp+u6Wl/vHysCWMtbXQzFi88aWnIsLgwAKpS9z6HoLYlf5IbdNEuFQby9p5byRMsWwK5OpCzyixXzveqAAA" +
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD9ps6fZhmN2HDYqYbzBnXEb4Pi9Sg0h5UvXVBWPj73qMlyWP" +
+            "TiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WdiwEBdj0+UfEm5hVt6F3oxhMFm4RGjQ2j/ooqIlHMcBBNkK8duJ" +
+            "Oew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25QG3fbh12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqSRNU541+dCq" +
+            "v0WinT6QVBdvd+mOjbLg8/uLSxi4xYKOBwgGAAMAHQYLAQEGAgADDAIAAACA8PoCAAAAAAsBAwERCAYABAASBgsB" +
+            "AQoZAA8FHRYSAwQcCwsHCg4QDRQRDBsVFxgaGRDyI8aJUuHytoDw+gIAAAAACQgAAAAAAhMGHghvEbn6PHom/gkI" +
+            "AAITAQQSCQsQzrDKEsjRs2z//////////wFcvAkvUgYmlpRjmt1MX98IzA/9elzQ9ld+Vs/yAHeYyAlbGwkBEjwF" +
+            "UDEKFAQdM0g+CwcCBg=="
+
+    /**
+     * A live `POST /ktx/kvault/withdraw` response for the Allez SOL vault: create the account,
+     * `kVault::withdraw`, then `Token::CloseAccount` to unwrap back to lamports.
+     *
+     * The unwrap pays the closed account's whole balance to its second account — on a full exit,
+     * the entire withdrawn amount — which is why the validator pins that account to the signer
+     * rather than accepting any close. Rewriting one address here would redirect the lot while
+     * every other instruction still read as the withdraw the user asked for.
+     *
+     * Carries the same `u64::MAX` rewrite as [WITHDRAW], for the same reason: the wallet holds no
+     * position.
+     */
+    const val ALLEZ_SOL_WITHDRAW =
+        "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACA" +
+            "AQAFCX//JB25KLX6LxwUe5Pw/FGXqeETK7Jj6GQYPDbOSuem6x+eD9v6OEoI2qquaJpnpymJRzI3TpX7v9Y04Ycg" +
+            "/NX6DO8+Cn67paX+8fKwJYy1tdDMWLzxpaciwuDAAqlL3PoegtiV/kht00S4VBvL2nlvJEyxbArk6kLPKLFfO96o" +
+            "D9ps6fZhmN2HDYqYbzBnXEb4Pi9Sg0h5UvXVBWPj73qMlyWPTiSJ8bs9ECkUjg2DC1oTmdr/EIQEjnvY2+n4WZlx" +
+            "KXooAEJJPkJxkMd7ZH6G99GZch/RVimWXJ1rZZT4BNkK8duJOew1/5TZZA1X3MMnlLs+G7Zv066EmoTc25QG3fbh" +
+            "12Whk9nL4UbO63msHLSF7V9bN5E6jPWFfv8AqeYlXCRbrgUpUt0oPyIIjMIS538zeau6KrxNXijxeJJRAwUGAAEA" +
+            "ERIIAQEHGgAMBgMUARECDwgIGgQHCw0KEA4JGRMVFhgXEBODcJuq3CI5//////////8IAwEAAAEJAVy8CS9SBiaW" +
+            "lGOa3Uxf3wjMD/16XND2V35Wz/IAd5jICVsbCQESPAUxAgkeFAQdM0g+Cwc="
+
     /** The wallet the fixtures above were built for — their fee payer and only required signer. */
     const val WALLET = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+
+    /** [WALLET]'s wrapped-SOL associated token account, which the Allez SOL fixtures wrap into. */
+    const val WALLET_WRAPPED_SOL = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
 }
 
 /** Returns the captured transaction for whatever is asked, so the pipeline is what's under test. */

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -36,6 +36,7 @@ class KaminoTransactionPreparerTest {
         vault: KaminoVault = KaminoVaultRegistry.STEAKHOUSE_USDC,
         action: KaminoAction = KaminoAction.DEPOSIT,
         networkUnitPrice: BigInteger? = null,
+        amount: String = AMOUNT,
     ): String = runBlocking {
         val resolved =
             api
@@ -48,10 +49,47 @@ class KaminoTransactionPreparerTest {
                 vault = vault,
                 action = action,
                 walletAddress = KaminoFixtures.WALLET,
-                amount = "1",
+                amount = amount,
                 networkUnitPrice = networkUnitPrice,
             )
     }
+
+    /** The wallet's own associated token account for [mint], as the preparer derives it. */
+    private fun ownAccount(mint: String): String =
+        SolanaAddress(KaminoFixtures.WALLET).defaultTokenAddress(mint)
+
+    /** Validates captured bytes the way the preparer does, with every account derived locally. */
+    private fun validate(
+        transaction: String,
+        vault: KaminoVault,
+        action: KaminoAction,
+        signerAddress: String = KaminoFixtures.WALLET,
+        amountBaseUnits: BigInteger? = BigInteger.ONE,
+    ) =
+        validateDecoded(
+            decoded = KaminoTransactionDecoder.decode(KaminoAttributionMemo.append(transaction)),
+            vault = vault,
+            action = action,
+            signerAddress = signerAddress,
+            amountBaseUnits = amountBaseUnits,
+        )
+
+    private fun validateDecoded(
+        decoded: KaminoDecodedTransaction,
+        vault: KaminoVault,
+        action: KaminoAction = KaminoAction.DEPOSIT,
+        signerAddress: String = KaminoFixtures.WALLET,
+        amountBaseUnits: BigInteger? = BigInteger.valueOf(1_000_000),
+    ) =
+        KaminoTransactionValidator.validate(
+            decoded = decoded,
+            vault = vault,
+            action = action,
+            signerAddress = signerAddress,
+            tokenAccount = ownAccount(vault.tokenMint),
+            shareAccount = ownAccount(vault.sharesMint),
+            amountBaseUnits = amountBaseUnits,
+        )
 
     @Test
     fun a_prepared_deposit_validates_and_its_memo_is_the_final_instruction() {
@@ -131,15 +169,19 @@ class KaminoTransactionPreparerTest {
 
     @Test
     fun a_SOL_vault_deposit_gets_the_larger_budget_it_needs_to_wrap_first() {
-        // Note the fixture: this is the captured **USDC** deposit prepared against the SOL vault,
-        // because no ALLEZ_SOL response has been captured — doing so needs a wallet depositing real
-        // SOL. So what this pins is that the vault selects the larger limit and that the limit
-        // reaches the wire; the wrap-and-sync instruction shape a real SOL deposit carries is not
-        // exercised here. Inventing bytes for it would assert against a transaction Kamino never
-        // sent. The 350,000 value itself rests on the iOS mainnet measurement of 287,029.
-        val prepared = prepare(vault = KaminoVaultRegistry.ALLEZ_SOL)
+        // Against the captured SOL deposit, so the limit is pinned to the wrap-and-sync shape it is
+        // sized for rather than to a USDC transaction standing in for it. The 350,000 value itself
+        // rests on the iOS mainnet measurement of 287,029.
+        val prepared = prepareSolDeposit()
         assertEquals(350_000L, SolanaTransaction.getComputeUnitLimit(prepared)?.toLong())
     }
+
+    private fun prepareSolDeposit(amount: String = SOL_AMOUNT) =
+        prepare(
+            api = KaminoFixtureApi(KaminoFixtures.ALLEZ_SOL_DEPOSIT),
+            vault = KaminoVaultRegistry.ALLEZ_SOL,
+            amount = amount,
+        )
 
     @Test
     fun the_unit_price_floors_rather_than_trusting_a_low_network_sample() {
@@ -308,16 +350,13 @@ class KaminoTransactionPreparerTest {
 
     @Test
     fun a_withdraw_is_refused_when_it_is_not_the_wallet_s_own_transaction() {
-        // The fixture's fee payer is ; validating it against a different signer must fail,
-        // which is what stops the app signing on another account's behalf.
+        // The fixture's fee payer is KaminoFixtures.WALLET; validating it against a different
+        // signer must fail, which is what stops the app signing on another account's behalf.
         val other = "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E"
         val rejection =
             assertThrows(KaminoTransactionRejected::class.java) {
-                KaminoTransactionValidator.validate(
-                    decoded =
-                        KaminoTransactionDecoder.decode(
-                            KaminoAttributionMemo.append(KaminoFixtures.WITHDRAW)
-                        ),
+                validate(
+                    transaction = KaminoFixtures.WITHDRAW,
                     vault = KaminoVaultRegistry.STEAKHOUSE_USDC,
                     action = KaminoAction.WITHDRAW,
                     signerAddress = other,
@@ -335,11 +374,7 @@ class KaminoTransactionPreparerTest {
         // account, then a SyncNative over it. Both are opcodes the validator has to permit by name,
         // which is the half of an allow-list that a deny-list never had to get right — too strict a
         // rule here refuses every real SOL deposit rather than letting an extra one through.
-        val prepared =
-            prepare(
-                api = KaminoFixtureApi(KaminoFixtures.ALLEZ_SOL_DEPOSIT),
-                vault = KaminoVaultRegistry.ALLEZ_SOL,
-            )
+        val prepared = prepareSolDeposit()
         val instructions = KaminoTransactionDecoder.decode(prepared).instructions
 
         // The address the validator derives locally, cross-checked against the one Kamino chose.
@@ -381,12 +416,10 @@ class KaminoTransactionPreparerTest {
 
         val rejection =
             assertThrows(KaminoTransactionRejected::class.java) {
-                KaminoTransactionValidator.validate(
-                    decoded = decoded,
+                validate(
+                    transaction = KaminoFixtures.ALLEZ_SOL_WITHDRAW,
                     vault = KaminoVaultRegistry.ALLEZ_SOL,
                     action = KaminoAction.WITHDRAW,
-                    signerAddress = KaminoFixtures.WALLET,
-                    wrappedSolAccount = KaminoFixtures.WALLET_WRAPPED_SOL,
                 )
             }
         assertTrue(
@@ -396,14 +429,151 @@ class KaminoTransactionPreparerTest {
     }
 
     @Test
+    fun the_captured_farms_instructions_are_the_ones_the_allow_list_names() {
+        // The farms program is allow-listed because every launch vault has a farm, and until the
+        // arm that reads these existed, anything it carried rode through unchecked — including
+        // `farms::transfer_ownership`, which moves the whole staked position on the signature the
+        // message already carries. So this asserts both halves: the captured deposit really does
+        // carry `initialize_user` and `stake`, and preparing it validates.
+        val instructions = KaminoTransactionDecoder.decode(prepareSolDeposit()).instructions
+        val farms = instructions.filter { it.programId == KaminoVaultRegistry.FARMS_PROGRAM_ID }
+
+        assertEquals(2, farms.size)
+        assertEquals(FARMS_INITIALIZE_USER, farms[0].data.take(8).toHex())
+        assertEquals(FARMS_STAKE, farms[1].data.take(8).toHex())
+        // Kamino stakes the whole share balance rather than the amount just minted.
+        assertEquals("ffffffffffffffff", farms[1].data.drop(8).toHex())
+    }
+
+    @Test
+    fun the_wrap_moves_exactly_what_is_being_deposited() {
+        // #5603's third finding, on the captured bytes: the transfer's lamports are the deposit's
+        // own amount, so a response that wrapped the whole SOL balance would no longer pass.
+        val instructions = KaminoTransactionDecoder.decode(prepareSolDeposit()).instructions
+        val transfer = instructions.single { it.programId == SYSTEM_PROGRAM }
+
+        assertEquals(50_000_000L, littleEndianLong(transfer.data, offset = 4))
+
+        val rejection =
+            assertThrows(KaminoTransactionRejected::class.java) {
+                prepareSolDeposit(amount = "0.5")
+            }
+        assertTrue(
+            "unexpected reason: ${rejection.message}",
+            rejection.message.orEmpty().contains("wraps 50000000 lamports"),
+        )
+    }
+
+    @Test
+    fun a_deposit_carrying_an_amount_other_than_the_one_asked_for_is_refused() {
+        // The captured response moves 1 USDC whatever it is asked for, so asking for two is the
+        // shape a response that inflated the figure would have.
+        val rejection =
+            assertThrows(KaminoTransactionRejected::class.java) { prepare(amount = "2") }
+        assertTrue(
+            "unexpected reason: ${rejection.message}",
+            rejection.message.orEmpty().contains("moves 1000000 base units rather than the 2000000"),
+        )
+    }
+
+    @Test
+    fun a_response_that_names_another_vault_is_refused_even_though_the_screen_says_this_one() {
+        // #5603's second finding, played out on captured bytes: the Steakhouse deposit prepared
+        // against the Allez SOL vault. Nothing in the instruction says which vault it is — the
+        // `vault_state` account travels in an address lookup table this decode does not resolve —
+        // but the share account is the wallet's associated token account for the vault's own share
+        // mint, derived locally, and that one does not match.
+        val decoded =
+            KaminoTransactionDecoder.decode(KaminoAttributionMemo.append(KaminoFixtures.DEPOSIT))
+        val allezSol = KaminoVaultRegistry.ALLEZ_SOL
+
+        // Caught twice over, and the first is the account the response creates: the Steakhouse
+        // share account is not one of this wallet's accounts for *this* vault.
+        val atCreation =
+            assertThrows(KaminoTransactionRejected::class.java) {
+                validateDecoded(decoded, allezSol)
+            }
+        assertTrue(
+            "unexpected reason: ${atCreation.message}",
+            atCreation.message.orEmpty().contains("not one of the wallet's own accounts"),
+        )
+
+        // With the creation dropped, the kVault instruction alone still gives the vault away: its
+        // share slot is the Steakhouse account, and this wallet's Allez SOL share account is a
+        // different address.
+        val withoutCreation =
+            decoded.copy(
+                instructions =
+                    decoded.instructions.filterNot {
+                        it.programId == "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+                    }
+            )
+        val atTheVaultMove =
+            assertThrows(KaminoTransactionRejected::class.java) {
+                validateDecoded(withoutCreation, allezSol)
+            }
+        assertTrue(
+            "unexpected reason: ${atTheVaultMove.message}",
+            atTheVaultMove.message.orEmpty().contains("share account for this vault"),
+        )
+    }
+
+    @Test
+    fun every_captured_shape_puts_the_wallets_own_accounts_where_the_layout_says() {
+        // The slots the validator checks, read back out of all four captured responses. They are
+        // fixed by the program's IDL rather than by the vault, which is what lets one index map
+        // serve both actions and all three vaults — and if that ever stopped being true, this is
+        // where it would show, rather than in a refusal on someone's device.
+        //
+        // Every one of them is also a STATIC key, which is the property that makes the check
+        // possible at all: the vault account itself travels in an address lookup table this decode
+        // does not resolve, so the wallet's own accounts are what identify the position offline.
+        listOf(
+                Triple(KaminoFixtures.DEPOSIT, KaminoVaultRegistry.STEAKHOUSE_USDC, 6),
+                Triple(KaminoFixtures.WITHDRAW, KaminoVaultRegistry.STEAKHOUSE_USDC, 5),
+                Triple(KaminoFixtures.ALLEZ_SOL_DEPOSIT, KaminoVaultRegistry.ALLEZ_SOL, 6),
+                Triple(KaminoFixtures.ALLEZ_SOL_WITHDRAW, KaminoVaultRegistry.ALLEZ_SOL, 5),
+            )
+            .forEach { (transaction, vault, tokenAccountSlot) ->
+                val move =
+                    KaminoTransactionDecoder.decode(transaction).instructions.single {
+                        it.programId == KaminoVaultRegistry.PROGRAM_ID
+                    }
+                assertEquals(KaminoFixtures.WALLET, move.accounts[0])
+                assertEquals(ownAccount(vault.tokenMint), move.accounts[tokenAccountSlot])
+                assertEquals(ownAccount(vault.sharesMint), move.accounts[7])
+            }
+    }
+
+    @Test
     fun a_malformed_response_from_Kamino_fails_loudly_instead_of_reaching_keysign() {
         assertThrows(IllegalStateException::class.java) {
             prepare(api = KaminoFixtureApi("not-base64-tx"))
         }
     }
 
+    private fun List<Byte>.toHex() = joinToString("") { "%02x".format(it) }
+
+    private fun ByteArray.toHex() = toList().toHex()
+
+    private fun littleEndianLong(data: ByteArray, offset: Int): Long =
+        (0 until 8).fold(0L) { acc, index ->
+            acc or ((data[offset + index].toLong() and 0xFF) shl (8 * index))
+        }
+
     private companion object {
         const val SYSTEM_PROGRAM = "11111111111111111111111111111111"
         const val TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+        /** 1 USDC, which is what the captured Steakhouse deposit moves. */
+        const val AMOUNT = "1"
+
+        /** 0.05 SOL, which is what the captured Allez SOL deposit wraps and deposits. */
+        const val SOL_AMOUNT = "0.05"
+
+        /** Anchor discriminators: the first eight bytes of `sha256("global:<name>")`. */
+        const val FARMS_INITIALIZE_USER = "6f11b9fa3c7a26fe"
+
+        const val FARMS_STAKE = "ceb0ca12c8d1b36c"
     }
 }

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -7,6 +7,7 @@ import java.util.Base64
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -88,6 +89,7 @@ class KaminoTransactionPreparerTest {
             signerAddress = signerAddress,
             tokenAccount = ownAccount(vault.tokenMint),
             shareAccount = ownAccount(vault.sharesMint),
+            farmUserState = KaminoFarmsUserState.derive(vault.farm, KaminoFixtures.WALLET),
             amountBaseUnits = amountBaseUnits,
         )
 
@@ -543,6 +545,71 @@ class KaminoTransactionPreparerTest {
                 assertEquals(ownAccount(vault.tokenMint), move.accounts[tokenAccountSlot])
                 assertEquals(ownAccount(vault.sharesMint), move.accounts[7])
             }
+    }
+
+    @Test
+    fun every_captured_farms_instruction_names_the_state_this_wallet_derives_for_the_farm() {
+        // The farm account is a lookup-table entry in both captured deposits, so it cannot identify
+        // anything offline. The wallet's state *in* that farm can: it is a program address over the
+        // farm and the owner, and both responses carry it as a STATIC key — which is what lets the
+        // validator recompute it locally and compare rather than trust the slot.
+        //
+        // The two slots differ because `initialize_user` is the instruction that creates the
+        // account: the IDL puts the authority, the payer, the owner and the delegatee ahead of it.
+        // If either index ever drifted, it would show here rather than as a refusal on a device.
+        listOf(
+                KaminoFixtures.DEPOSIT to KaminoVaultRegistry.STEAKHOUSE_USDC,
+                KaminoFixtures.ALLEZ_SOL_DEPOSIT to KaminoVaultRegistry.ALLEZ_SOL,
+            )
+            .forEach { (transaction, vault) ->
+                val expected = KaminoFarmsUserState.derive(vault.farm, KaminoFixtures.WALLET)
+                assertNotNull("the farm user state must derive for ${vault.address}", expected)
+
+                val farms =
+                    KaminoTransactionDecoder.decode(transaction).instructions.filter {
+                        it.programId == KaminoVaultRegistry.FARMS_PROGRAM_ID
+                    }
+                assertEquals(2, farms.size)
+
+                val initializeUser =
+                    farms.single { it.data.toHex().startsWith(FARMS_INITIALIZE_USER) }
+                val stake = farms.single { it.data.toHex().startsWith(FARMS_STAKE) }
+                assertEquals(expected, initializeUser.accounts[4])
+                assertEquals(expected, stake.accounts[1])
+
+                // And the farm itself is exactly what cannot be compared, in both of them.
+                assertEquals(KaminoTransactionDecoder.UNKNOWN_ACCOUNT, stake.accounts[2])
+            }
+    }
+
+    @Test
+    fun a_deposit_prepared_against_another_vaults_farm_is_refused() {
+        // The substitution the derivation exists to stop: the captured Steakhouse deposit checked
+        // against the state this wallet holds in the Allez SOL farm. Nothing else about the
+        // transaction changes, and the farm slot the mismatch would show in is unreadable.
+        val decoded =
+            KaminoTransactionDecoder.decode(KaminoAttributionMemo.append(KaminoFixtures.DEPOSIT))
+        val rejection =
+            assertThrows(KaminoTransactionRejected::class.java) {
+                KaminoTransactionValidator.validate(
+                    decoded = decoded,
+                    vault = KaminoVaultRegistry.STEAKHOUSE_USDC,
+                    action = KaminoAction.DEPOSIT,
+                    signerAddress = KaminoFixtures.WALLET,
+                    tokenAccount = ownAccount(KaminoVaultRegistry.STEAKHOUSE_USDC.tokenMint),
+                    shareAccount = ownAccount(KaminoVaultRegistry.STEAKHOUSE_USDC.sharesMint),
+                    farmUserState =
+                        KaminoFarmsUserState.derive(
+                            KaminoVaultRegistry.ALLEZ_SOL.farm,
+                            KaminoFixtures.WALLET,
+                        ),
+                    amountBaseUnits = CAPTURED_AMOUNT_BASE_UNITS,
+                )
+            }
+        assertTrue(
+            "unexpected reason: ${rejection.message}",
+            rejection.message.orEmpty().contains("state in the vault's farm"),
+        )
     }
 
     @Test

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import wallet.core.jni.SolanaAddress
 import wallet.core.jni.SolanaTransaction
 
 /**
@@ -329,9 +330,80 @@ class KaminoTransactionPreparerTest {
     }
 
     @Test
+    fun a_prepared_Allez_SOL_deposit_validates_with_its_wrap_intact() {
+        // The wrapped-SOL path no USDC fixture reaches: a top-level System transfer into the wSOL
+        // account, then a SyncNative over it. Both are opcodes the validator has to permit by name,
+        // which is the half of an allow-list that a deny-list never had to get right — too strict a
+        // rule here refuses every real SOL deposit rather than letting an extra one through.
+        val prepared =
+            prepare(
+                api = KaminoFixtureApi(KaminoFixtures.ALLEZ_SOL_DEPOSIT),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+            )
+        val instructions = KaminoTransactionDecoder.decode(prepared).instructions
+
+        // The address the validator derives locally, cross-checked against the one Kamino chose.
+        val wrappedSol =
+            SolanaAddress(KaminoFixtures.WALLET)
+                .defaultTokenAddress(KaminoVaultRegistry.WRAPPED_SOL_MINT)
+        assertEquals(KaminoFixtures.WALLET_WRAPPED_SOL, wrappedSol)
+
+        val transfer = instructions.single { it.programId == SYSTEM_PROGRAM }
+        assertEquals(wrappedSol, transfer.accounts[1])
+
+        val token = instructions.single { it.programId == TOKEN_PROGRAM }
+        // SPL Token `SyncNative` is discriminator 17.
+        assertEquals(17, token.data.first().toInt())
+        assertEquals(wrappedSol, token.accounts.first())
+    }
+
+    @Test
+    fun the_captured_Allez_SOL_withdraw_unwraps_to_the_wallet_and_nowhere_else() {
+        // The instruction #5603 is about. A compromised response need only re-address this one
+        // account to take the whole withdrawn amount, while every other instruction still reads as
+        // the withdraw the user asked for.
+        //
+        // Asserted twice over: the shape itself, and that validating gets as far as the sentinel
+        // refusal — which sits after the value-movement rules, so reaching it is proof the unwrap
+        // passed them rather than that nothing looked.
+        val decoded =
+            KaminoTransactionDecoder.decode(
+                KaminoAttributionMemo.append(KaminoFixtures.ALLEZ_SOL_WITHDRAW)
+            )
+
+        val close = decoded.instructions.single { it.programId == TOKEN_PROGRAM }
+        // SPL Token `CloseAccount` is discriminator 9: account, destination, owner.
+        assertEquals(9, close.data.first().toInt())
+        assertEquals(
+            listOf(KaminoFixtures.WALLET_WRAPPED_SOL, KaminoFixtures.WALLET, KaminoFixtures.WALLET),
+            close.accounts,
+        )
+
+        val rejection =
+            assertThrows(KaminoTransactionRejected::class.java) {
+                KaminoTransactionValidator.validate(
+                    decoded = decoded,
+                    vault = KaminoVaultRegistry.ALLEZ_SOL,
+                    action = KaminoAction.WITHDRAW,
+                    signerAddress = KaminoFixtures.WALLET,
+                    wrappedSolAccount = KaminoFixtures.WALLET_WRAPPED_SOL,
+                )
+            }
+        assertTrue(
+            "the unwrap must not be what is refused: ${rejection.message}",
+            rejection.message.orEmpty().contains("withdraw-everything sentinel"),
+        )
+    }
+
+    @Test
     fun a_malformed_response_from_Kamino_fails_loudly_instead_of_reaching_keysign() {
         assertThrows(IllegalStateException::class.java) {
             prepare(api = KaminoFixtureApi("not-base64-tx"))
         }
+    }
+
+    private companion object {
+        const val SYSTEM_PROGRAM = "11111111111111111111111111111111"
+        const val TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
     }
 }

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparerTest.kt
@@ -64,7 +64,7 @@ class KaminoTransactionPreparerTest {
         vault: KaminoVault,
         action: KaminoAction,
         signerAddress: String = KaminoFixtures.WALLET,
-        amountBaseUnits: BigInteger? = BigInteger.ONE,
+        amountBaseUnits: BigInteger? = CAPTURED_AMOUNT_BASE_UNITS,
     ) =
         validateDecoded(
             decoded = KaminoTransactionDecoder.decode(KaminoAttributionMemo.append(transaction)),
@@ -79,7 +79,7 @@ class KaminoTransactionPreparerTest {
         vault: KaminoVault,
         action: KaminoAction = KaminoAction.DEPOSIT,
         signerAddress: String = KaminoFixtures.WALLET,
-        amountBaseUnits: BigInteger? = BigInteger.valueOf(1_000_000),
+        amountBaseUnits: BigInteger? = CAPTURED_AMOUNT_BASE_UNITS,
     ) =
         KaminoTransactionValidator.validate(
             decoded = decoded,
@@ -567,6 +567,13 @@ class KaminoTransactionPreparerTest {
 
         /** 1 USDC, which is what the captured Steakhouse deposit moves. */
         const val AMOUNT = "1"
+
+        /**
+         * The same figure in base units, shared by both validation helpers so a test that gets as
+         * far as the amount check fails on the property it is about rather than on a stand-in
+         * amount that never matched the fixture.
+         */
+        val CAPTURED_AMOUNT_BASE_UNITS: BigInteger = BigInteger.valueOf(1_000_000)
 
         /** 0.05 SOL, which is what the captured Allez SOL deposit wraps and deposits. */
         const val SOL_AMOUNT = "0.05"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoFarmsUserState.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoFarmsUserState.kt
@@ -1,0 +1,43 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import com.vultisig.wallet.data.crypto.Base58Codec
+import com.vultisig.wallet.data.crypto.SolanaProgramDerivedAddress
+
+/**
+ * The farms program's per-user account: what decides *which* stake a farms instruction moves.
+ *
+ * Every farms instruction a deposit or withdraw carries names it, and its address is a program
+ * address over the farm and the owner — so recomputing it locally binds an instruction to one farm
+ * and one wallet at once. That is the only offline way to do it here: the farm account itself is an
+ * address-lookup-table entry in every captured response and this decode resolves no tables, while
+ * the user state is a static key in both captured deposits, in the as-built and the
+ * compute-budget-injected forms alike.
+ *
+ * Without it a farms instruction is bound to nothing but its authority, and the response chooses
+ * the farm — so `farms::stake` would sweep the wallet's whole share balance into a farm the
+ * response made, on the signature the message already carries. iOS derives the same address, for
+ * the same reason: `KaminoSolanaInstructions.swift:221`.
+ */
+object KaminoFarmsUserState {
+
+    /** The farms program's own seed prefix for this account. */
+    private val SEED = "user".toByteArray(Charsets.US_ASCII)
+
+    /**
+     * [owner]'s state in [farm], or null when either address cannot be read as a public key — which
+     * the validator treats as a refusal rather than as a check it may skip.
+     */
+    fun derive(farm: String, owner: String): String? {
+        val farmKey = publicKey(farm) ?: return null
+        val ownerKey = publicKey(owner) ?: return null
+        return SolanaProgramDerivedAddress.find(
+            seeds = listOf(SEED, farmKey, ownerKey),
+            programId = KaminoVaultRegistry.FARMS_PROGRAM_ID,
+        )
+    }
+
+    private fun publicKey(address: String): ByteArray? =
+        Base58Codec.decode(address)?.takeIf { it.size == PUBLIC_KEY_LENGTH }
+
+    private const val PUBLIC_KEY_LENGTH = 32
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoRelayedTransaction.kt
@@ -91,14 +91,29 @@ object KaminoRelayedTransactionReader {
  * The `u64` amount argument of a kVault instruction: an 8-byte Anchor discriminator followed by the
  * amount, little-endian. Null when the instruction is too short to carry one.
  */
-fun kvaultAmountArgument(data: ByteArray): BigInteger? {
-    if (data.size < 16) return null
+fun kvaultAmountArgument(data: ByteArray): BigInteger? = anchorArgument(data, bytes = 8)
+
+/**
+ * The little-endian argument of [bytes] bytes that follows an Anchor discriminator. Null when the
+ * instruction is too short to carry one.
+ *
+ * Width is a parameter because the arguments here are not all `u64`: the farms unstake amount is a
+ * `u128` scaled by 10^18, and reading its low half would compare a number that means nothing.
+ */
+internal fun anchorArgument(data: ByteArray, bytes: Int): BigInteger? {
+    if (data.size < ANCHOR_DISCRIMINATOR + bytes) return null
     var value = BigInteger.ZERO
-    for (offset in 7 downTo 0) {
-        value = value.shiftLeft(8).or(BigInteger.valueOf((data[8 + offset].toLong() and 0xFF)))
+    for (offset in bytes - 1 downTo 0) {
+        value =
+            value
+                .shiftLeft(8)
+                .or(BigInteger.valueOf(data[ANCHOR_DISCRIMINATOR + offset].toLong() and 0xFF))
     }
     return value
 }
+
+/** Anchor prefixes every instruction with eight discriminator bytes; arguments follow them. */
+internal const val ANCHOR_DISCRIMINATOR = 8
 
 /**
  * The wallet's associated token account for [mint], or null when WalletCore cannot derive one.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.blockchain.solana.kamino
 import com.vultisig.wallet.data.api.KaminoApi
 import io.ktor.util.decodeBase64Bytes
 import java.math.BigInteger
+import java.math.RoundingMode
 import javax.inject.Inject
 import wallet.core.jni.CoinType
 import wallet.core.jni.SolanaAddress
@@ -128,25 +129,55 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
             vault = vault,
             action = action,
             signerAddress = walletAddress,
-            wrappedSolAccount = wrappedSolAccountFor(vault, walletAddress),
+            tokenAccount = associatedTokenAccount(walletAddress, vault.tokenMint),
+            shareAccount = associatedTokenAccount(walletAddress, vault.sharesMint),
+            amountBaseUnits = baseUnits(amount, vault, action),
         )
 
         return withMemo
     }
 
     /**
-     * The wrapped-SOL associated token account a wrap must pay into, derived from the signer and
-     * the vault's own mint rather than read out of the transaction being checked.
+     * The wallet's associated token account for [mint], derived from the signer and a mint the
+     * registry pins rather than read out of the transaction being checked — which is the whole
+     * point of it: an address that came out of the response could not check the response.
      *
-     * Null for vaults whose underlying is a plain token, which have no wrap to make.
+     * Two of these are derived per transaction. The one for the vault's underlying mint is where a
+     * deposit's tokens come from and where a withdraw pays out — and on the SOL vault it is also
+     * the wrapped-SOL account a wrap funds. The one for its share mint is what ties an instruction
+     * to *this* vault at all: the vault account itself travels in an address lookup table that this
+     * decode does not resolve.
+     *
+     * Null when WalletCore cannot derive it, which the validator treats as a refusal rather than as
+     * a check it may skip.
      */
-    private fun wrappedSolAccountFor(vault: KaminoVault, walletAddress: String): String? {
-        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) return null
-        return runCatching {
-                SolanaAddress(walletAddress)
-                    .defaultTokenAddress(KaminoVaultRegistry.WRAPPED_SOL_MINT)
+    private fun associatedTokenAccount(walletAddress: String, mint: String): String? =
+        runCatching { SolanaAddress(walletAddress).defaultTokenAddress(mint) }.getOrNull()
+
+    /**
+     * The amount that was sent, in the base units the instruction carries — tokens for a deposit,
+     * shares for a withdraw, matching the `u64` each kVault instruction takes.
+     *
+     * Converted from the very string this app handed the API, so the comparison downstream is
+     * against the request rather than against anything the response echoed back.
+     *
+     * Truncates rather than throwing on sub-unit precision: the amount screen already quantises
+     * input to the token's own scale before it gets here, so this is a floor over a number that has
+     * nothing to floor. Null when the string is not a positive decimal at all, which the validator
+     * refuses rather than skips.
+     */
+    private fun baseUnits(amount: String, vault: KaminoVault, action: KaminoAction): BigInteger? {
+        val decimals =
+            when (action) {
+                KaminoAction.DEPOSIT -> vault.tokenDecimals
+                KaminoAction.WITHDRAW -> vault.sharesDecimals
             }
-            .getOrNull()
+        return amount
+            .toBigDecimalOrNull()
+            ?.movePointRight(decimals)
+            ?.setScale(0, RoundingMode.DOWN)
+            ?.toBigInteger()
+            ?.takeIf { it.signum() > 0 }
     }
 
     private fun injectComputeBudget(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionPreparer.kt
@@ -131,6 +131,7 @@ class KaminoTransactionPreparer @Inject constructor(private val kaminoApi: Kamin
             signerAddress = walletAddress,
             tokenAccount = associatedTokenAccount(walletAddress, vault.tokenMint),
             shareAccount = associatedTokenAccount(walletAddress, vault.sharesMint),
+            farmUserState = KaminoFarmsUserState.derive(vault.farm, walletAddress),
             amountBaseUnits = baseUnits(amount, vault, action),
         )
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -79,8 +79,6 @@ object KaminoTransactionValidator {
     /** The farms program holds stake at `WAD`: its `u128` amounts are share base units × 10^18. */
     private val FARMS_STAKE_SCALE = BigInteger.TEN.pow(18)
 
-    private const val ANCHOR_DISCRIMINATOR = 8
-
     /**
      * Anchor discriminators — the first eight bytes of `sha256("global:<name>")` — for the two
      * programs whose instructions Kamino's builder composes itself rather than reaching through a
@@ -968,22 +966,6 @@ object KaminoTransactionValidator {
         if (action != KaminoAction.WITHDRAW) {
             reject("instruction $index $detail, which no Kamino deposit performs")
         }
-    }
-
-    /**
-     * The little-endian argument of [bytes] bytes that follows an Anchor discriminator. Null when
-     * the instruction is too short to carry one.
-     */
-    private fun anchorArgument(data: ByteArray, bytes: Int): BigInteger? {
-        if (data.size < ANCHOR_DISCRIMINATOR + bytes) return null
-        var value = BigInteger.ZERO
-        for (offset in bytes - 1 downTo 0) {
-            value =
-                value
-                    .shiftLeft(8)
-                    .or(BigInteger.valueOf(data[ANCHOR_DISCRIMINATOR + offset].toLong() and 0xFF))
-        }
-        return value
     }
 
     private fun littleEndianInt(bytes: List<Byte>): Int? {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -109,6 +109,21 @@ object KaminoTransactionValidator {
     private val FARMS_WITHDRAW_UNSTAKED_DEPOSITS = anchor("2466bb31dc248443")
 
     /**
+     * The four farms instructions above, under the name each is bounded and reported by.
+     *
+     * One list rather than two: the walk asks whether an instruction is in here and [validate]
+     * counts each entry, so a farms instruction cannot become permitted in one place and unbounded
+     * in the other.
+     */
+    private val FARMS_INSTRUCTIONS =
+        mapOf(
+            "initialize_user" to FARMS_INITIALIZE_USER,
+            "stake" to FARMS_STAKE,
+            "unstake" to FARMS_UNSTAKE,
+            "withdraw_unstaked_deposits" to FARMS_WITHDRAW_UNSTAKED_DEPOSITS,
+        )
+
+    /**
      * Positions of the accounts each instruction is checked on.
      *
      * An Anchor instruction's account list is fixed by its IDL — only the trailing
@@ -193,6 +208,22 @@ object KaminoTransactionValidator {
         val systemInstructions = instructions.count { it.programId == SYSTEM_PROGRAM_ID }
         if (systemInstructions > 1) {
             reject("expected at most one System instruction, found $systemInstructions")
+        }
+
+        // And one of each on the farms side, where the same reasoning meets a program that carries
+        // more than one instruction. Every farms check below is per-instruction too: two unstakes
+        // each sitting within the bound release twice what the withdraw burns, and the surplus
+        // leaves the farm to sit in the share account earning nothing while the screen still shows
+        // one figure. A second `initialize_user` funds another farm's user state out of the
+        // wallet's rent. iOS bounds each of the four the same way — every farms step in
+        // `KaminoInstructionSequence.expected` is `repeatable: false`.
+        val farmsInstructions =
+            instructions.filter { it.programId == KaminoVaultRegistry.FARMS_PROGRAM_ID }
+        FARMS_INSTRUCTIONS.forEach { (name, discriminator) ->
+            val found = farmsInstructions.count { it.data.startsWith(discriminator) }
+            if (found > 1) {
+                reject("expected at most one farms $name instruction, found $found")
+            }
         }
 
         val memos = instructions.filter { it.programId == KaminoAttributionMemo.MEMO_PROGRAM_ID }
@@ -435,6 +466,9 @@ object KaminoTransactionValidator {
      * The farm and the farms user state are lookup-table entries in every captured response, so
      * they cannot be compared offline here; what is compared is what stays static — the authority
      * and the share account each instruction moves shares through, both derived locally.
+     *
+     * Everything below is per-instruction; how many of each may appear at all is bounded in
+     * [validate], since a check an instruction passes on its own it also passes twice.
      */
     private fun rejectUnlessPermittedFarmsInstruction(
         index: Int,
@@ -445,14 +479,7 @@ object KaminoTransactionValidator {
         amountBaseUnits: BigInteger?,
     ) {
         val data = instruction.data
-        val isOneWePerform =
-            listOf(
-                    FARMS_INITIALIZE_USER,
-                    FARMS_STAKE,
-                    FARMS_UNSTAKE,
-                    FARMS_WITHDRAW_UNSTAKED_DEPOSITS,
-                )
-                .any { data.startsWith(it) }
+        val isOneWePerform = FARMS_INSTRUCTIONS.values.any { data.startsWith(it) }
         if (!isOneWePerform) {
             reject(
                 "instruction $index is a farms instruction no Kamino deposit or withdraw performs"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -38,7 +38,8 @@ class KaminoTransactionRejected(message: String) : IllegalStateException(message
  * matching pair. Everything checked here comes from the local registry or from the app's own
  * intent.
  *
- * Kept free of JNI so the rules are unit-testable; decoding is the caller's job.
+ * Kept free of JNI so the rules are unit-testable; decoding and address derivation are the caller's
+ * job.
  */
 object KaminoTransactionValidator {
 
@@ -60,6 +61,7 @@ object KaminoTransactionValidator {
     private const val SYSTEM_PROGRAM_ID = "11111111111111111111111111111111"
     private const val TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
     private const val TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+    private const val ASSOCIATED_TOKEN_PROGRAM_ID = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 
     /** `CloseAccount` and `SyncNative` in the SPL Token instruction enum. */
     private const val TOKEN_CLOSE_ACCOUNT = 9
@@ -68,19 +70,95 @@ object KaminoTransactionValidator {
     /** `SystemInstruction::Transfer`. */
     private const val SYSTEM_TRANSFER = 2
 
+    /** `AssociatedTokenAccountInstruction::CreateIdempotent`. */
+    private const val CREATE_IDEMPOTENT = 1
+
     /** What the kVault program reads as "withdraw everything". */
     private val U64_MAX = BigInteger("18446744073709551615")
 
+    /** The farms program holds stake at `WAD`: its `u128` amounts are share base units × 10^18. */
+    private val FARMS_STAKE_SCALE = BigInteger.TEN.pow(18)
+
+    private const val ANCHOR_DISCRIMINATOR = 8
+
     /**
-     * @throws KaminoTransactionRejected if [instructions] is not a transaction the app is willing
-     *   to sign for [vault].
+     * Anchor discriminators — the first eight bytes of `sha256("global:<name>")` — for the two
+     * programs whose instructions Kamino's builder composes itself rather than reaching through a
+     * CPI of its own.
+     *
+     * Derived from each instruction's name and *then* found in the captured responses, which is
+     * what makes them named rather than pasted: a constant copied out of a transaction matches the
+     * shape it was copied from and asserts nothing. iOS pins the same seven in
+     * `KaminoSolanaInstructions.swift`.
+     */
+    private val KVAULT_DEPOSIT = anchor("f223c68952e1f2b6")
+
+    private val KVAULT_WITHDRAW = anchor("b712469c946da122")
+
+    /**
+     * The same withdraw served entirely out of the vault's liquid buffer. Which of the two arrives
+     * is a fact about the vault's balance sheet at build time, not about the request, so both are
+     * accepted — and they share an account layout by construction: the program's IDL declares
+     * `withdraw`'s accounts as `withdraw_from_available`'s followed by the reserve group.
+     */
+    private val KVAULT_WITHDRAW_FROM_AVAILABLE = anchor("1383709baadc2239")
+
+    private val FARMS_INITIALIZE_USER = anchor("6f11b9fa3c7a26fe")
+    private val FARMS_STAKE = anchor("ceb0ca12c8d1b36c")
+    private val FARMS_UNSTAKE = anchor("5a5f6b2acd7c32e1")
+    private val FARMS_WITHDRAW_UNSTAKED_DEPOSITS = anchor("2466bb31dc248443")
+
+    /**
+     * Positions of the accounts each instruction is checked on.
+     *
+     * An Anchor instruction's account list is fixed by its IDL — only the trailing
+     * `remaining_accounts` vary, which is why the observed lists differ in length between vaults
+     * while these prefixes do not. Every index below was read back out of the four captured
+     * responses in `KaminoFixtures`, and each is the index iOS checks in
+     * `KaminoSolanaInstructions.swift`.
+     */
+    private const val KVAULT_USER = 0
+
+    private const val KVAULT_DEPOSIT_TOKEN_ACCOUNT = 6
+
+    private const val KVAULT_WITHDRAW_TOKEN_ACCOUNT = 5
+
+    /** Both kVault instructions agree here, which is what lets one check serve either action. */
+    private const val KVAULT_SHARE_ACCOUNT = 7
+
+    private const val FARMS_OWNER = 0
+
+    private const val FARMS_STAKE_SHARE_ACCOUNT = 4
+
+    private const val FARMS_UNSTAKED_SHARE_DESTINATION = 3
+
+    private const val SYSTEM_TRANSFER_DESTINATION = 1
+
+    private const val CREATED_TOKEN_ACCOUNT = 1
+
+    private const val TOKEN_CLOSE_DESTINATION = 1
+
+    private const val TOKEN_CLOSE_AUTHORITY = 2
+
+    /**
+     * @param signerAddress the wallet this app is signing for
+     * @param tokenAccount the wallet's associated token account for [vault]'s underlying mint,
+     *   derived locally by the caller — on the SOL vault that is its wrapped-SOL account
+     * @param shareAccount the wallet's associated token account for [vault]'s share mint, likewise
+     *   derived locally: offline it is the only thing that binds an instruction to *this* vault
+     * @param amountBaseUnits what the user asked for, in the unit the instruction carries — the
+     *   underlying token for a deposit, shares for a withdraw
+     * @throws KaminoTransactionRejected if [decoded] is not a transaction the app is willing to
+     *   sign for [vault]
      */
     fun validate(
         decoded: KaminoDecodedTransaction,
         vault: KaminoVault,
         action: KaminoAction,
         signerAddress: String? = null,
-        wrappedSolAccount: String? = null,
+        tokenAccount: String? = null,
+        shareAccount: String? = null,
+        amountBaseUnits: BigInteger? = null,
     ) {
         val instructions = decoded.instructions
         if (!KaminoVaultRegistry.isAllowed(vault.address)) {
@@ -97,8 +175,24 @@ object KaminoTransactionValidator {
 
         // The whole point of the transaction. Without it, whatever the app is about to sign is not
         // the deposit or withdraw the user asked for.
-        if (instructions.none { it.programId == KaminoVaultRegistry.PROGRAM_ID }) {
-            reject("transaction never invokes the kVault program (expected for $action)")
+        //
+        // Exactly one, not merely at least one: every amount below is checked against the figure on
+        // screen instruction by instruction, so a second kVault instruction carrying that same
+        // figure would pass each check on its own and move the money twice.
+        val vaultInstructions =
+            instructions.count { it.programId == KaminoVaultRegistry.PROGRAM_ID }
+        when {
+            vaultInstructions == 0 ->
+                reject("transaction never invokes the kVault program (expected for $action)")
+            vaultInstructions > 1 ->
+                reject("expected exactly one kVault instruction, found $vaultInstructions")
+        }
+
+        // Same reasoning on the System side: the wrap is pinned to the deposit amount, so two of
+        // them wrap it twice while the screen still shows one figure.
+        val systemInstructions = instructions.count { it.programId == SYSTEM_PROGRAM_ID }
+        if (systemInstructions > 1) {
+            reject("expected at most one System instruction, found $systemInstructions")
         }
 
         val memos = instructions.filter { it.programId == KaminoAttributionMemo.MEMO_PROGRAM_ID }
@@ -129,9 +223,20 @@ object KaminoTransactionValidator {
             reject("memo must be the final instruction")
         }
 
-        rejectValueMovementAwayFromTheSigner(instructions, vault, signerAddress, wrappedSolAccount)
         rejectAnotherAccountsAuthority(decoded.feePayer, signerAddress)
+        // Ahead of the walk below, which checks the same `u64` against the amount that was asked
+        // for. A transaction carrying the sentinel fails both, and the sentinel is the refusal
+        // worth naming: it is the one amount whose consequence is the entire position.
         rejectTheWithdrawEverythingSentinel(instructions)
+        rejectValueMovementAwayFromTheSigner(
+            instructions = instructions,
+            vault = vault,
+            action = action,
+            signerAddress = signerAddress,
+            tokenAccount = tokenAccount,
+            shareAccount = shareAccount,
+            amountBaseUnits = amountBaseUnits,
+        )
     }
 
     /**
@@ -151,7 +256,7 @@ object KaminoTransactionValidator {
     private fun rejectTheWithdrawEverythingSentinel(instructions: List<KaminoTxInstruction>) {
         instructions.forEachIndexed { index, instruction ->
             if (instruction.programId != KaminoVaultRegistry.PROGRAM_ID) return@forEachIndexed
-            val amount = kvaultAmount(instruction.data) ?: return@forEachIndexed
+            val amount = anchorArgument(instruction.data, bytes = 8) ?: return@forEachIndexed
             if (amount == U64_MAX) {
                 reject(
                     "instruction $index carries the withdraw-everything sentinel, which this app " +
@@ -162,31 +267,20 @@ object KaminoTransactionValidator {
     }
 
     /**
-     * The `u64` amount argument of a kVault instruction: an 8-byte Anchor discriminator followed by
-     * the amount, little-endian. Null when the instruction is too short to carry one.
-     */
-    private fun kvaultAmount(data: ByteArray): BigInteger? {
-        if (data.size < 16) return null
-        var value = BigInteger.ZERO
-        for (offset in 7 downTo 0) {
-            value = value.shiftLeft(8).or(BigInteger.valueOf((data[8 + offset].toLong() and 0xFF)))
-        }
-        return value
-    }
-
-    /**
      * Refuses instructions that could move value somewhere the deposit or withdraw has no reason
      * to.
      *
      * Program allow-listing alone is not enough: a deposit legitimately needs the System and Token
      * programs, so a compromised response could add a transfer to an attacker and still invoke
-     * kVault and end with the memo. These checks are about *what* those programs are asked to do.
+     * kVault and end with the memo. These checks are about *what* those programs are asked to do,
+     * with what, and on whose accounts.
      *
-     * Both are allow-lists, and deliberately so. A deny-list of the opcodes that look dangerous is
-     * no control at all here — the same compromised response picks the opcode, so everything not
-     * thought of is waved through, and the ones that matter most do not look like transfers:
-     * `Assign` hands the wallet's system account to another program, `SetAuthority` hands over a
-     * token account, and neither moves a lamport itself.
+     * Every arm is an allow-list, and deliberately so. A deny-list of the opcodes that look
+     * dangerous is no control at all here — the same compromised response picks the opcode, so
+     * everything not thought of is waved through, and the ones that matter most do not look like
+     * transfers: `Assign` hands the wallet's system account to another program, `SetAuthority`
+     * hands over a token account, `farms::transfer_ownership` hands over a staked position, and
+     * none of them moves a lamport itself.
      *
      * The permitted set is what live Kamino responses carry. A wrapped-SOL vault deposit wraps with
      * `System::Transfer` then `Token::SyncNative`; its withdraw unwraps with `Token::CloseAccount`.
@@ -196,8 +290,11 @@ object KaminoTransactionValidator {
     private fun rejectValueMovementAwayFromTheSigner(
         instructions: List<KaminoTxInstruction>,
         vault: KaminoVault,
+        action: KaminoAction,
         signerAddress: String?,
-        wrappedSolAccount: String?,
+        tokenAccount: String?,
+        shareAccount: String?,
+        amountBaseUnits: BigInteger?,
     ) {
         instructions.forEachIndexed { index, instruction ->
             when (instruction.programId) {
@@ -208,7 +305,7 @@ object KaminoTransactionValidator {
                         instruction = instruction,
                         vault = vault,
                         signerAddress = signerAddress,
-                        wrappedSolAccount = wrappedSolAccount,
+                        tokenAccount = tokenAccount,
                     )
 
                 SYSTEM_PROGRAM_ID ->
@@ -216,9 +313,257 @@ object KaminoTransactionValidator {
                         index = index,
                         instruction = instruction,
                         vault = vault,
-                        wrappedSolAccount = wrappedSolAccount,
+                        action = action,
+                        tokenAccount = tokenAccount,
+                        amountBaseUnits = amountBaseUnits,
+                    )
+
+                KaminoVaultRegistry.PROGRAM_ID ->
+                    rejectUnlessTheVaultMoveThisAppAskedFor(
+                        index = index,
+                        instruction = instruction,
+                        action = action,
+                        signerAddress = signerAddress,
+                        tokenAccount = tokenAccount,
+                        shareAccount = shareAccount,
+                        amountBaseUnits = amountBaseUnits,
+                    )
+
+                ASSOCIATED_TOKEN_PROGRAM_ID ->
+                    rejectUnlessCreatingOneOfTheWalletsOwnAccounts(
+                        index = index,
+                        instruction = instruction,
+                        tokenAccount = tokenAccount,
+                        shareAccount = shareAccount,
+                    )
+
+                KaminoVaultRegistry.FARMS_PROGRAM_ID ->
+                    rejectUnlessPermittedFarmsInstruction(
+                        index = index,
+                        instruction = instruction,
+                        action = action,
+                        signerAddress = signerAddress,
+                        shareAccount = shareAccount,
+                        amountBaseUnits = amountBaseUnits,
                     )
             }
+        }
+    }
+
+    /**
+     * The one instruction that *is* the transaction, tied to the vault on screen and to the figure
+     * next to it.
+     *
+     * The vault account itself cannot do the tying here. It is an address-lookup-table entry in
+     * every captured response and this decode resolves no tables, so comparing it would be a check
+     * that passes by being unreadable. The user's own accounts can: the share account and the token
+     * account are static keys in all four captured shapes, both are associated token addresses over
+     * mints the registry pins, and the caller derives them locally. A response that substituted
+     * another vault — including one it made itself through the permissionless `init_vault` — would
+     * have to name a share account this wallet does not own for that vault's mint. iOS identifies
+     * the vault the same way round, and for the same reason: `KaminoTransactionDecoder.swift:90`.
+     *
+     * The amount is checked against the figure the app sent rather than against anything the
+     * response echoed back, which is what makes it a check and not a restatement.
+     */
+    private fun rejectUnlessTheVaultMoveThisAppAskedFor(
+        index: Int,
+        instruction: KaminoTxInstruction,
+        action: KaminoAction,
+        signerAddress: String?,
+        tokenAccount: String?,
+        shareAccount: String?,
+        amountBaseUnits: BigInteger?,
+    ) {
+        val tokenAccountSlot =
+            when (action) {
+                KaminoAction.DEPOSIT -> {
+                    if (!instruction.data.startsWith(KVAULT_DEPOSIT)) {
+                        reject("instruction $index is not the kVault deposit this app asked for")
+                    }
+                    KVAULT_DEPOSIT_TOKEN_ACCOUNT
+                }
+
+                KaminoAction.WITHDRAW -> {
+                    val isWithdraw =
+                        instruction.data.startsWith(KVAULT_WITHDRAW) ||
+                            instruction.data.startsWith(KVAULT_WITHDRAW_FROM_AVAILABLE)
+                    if (!isWithdraw) {
+                        reject("instruction $index is not the kVault withdraw this app asked for")
+                    }
+                    KVAULT_WITHDRAW_TOKEN_ACCOUNT
+                }
+            }
+
+        rejectUnlessAccountIs(
+            index,
+            instruction,
+            KVAULT_USER,
+            signerAddress,
+            "the authority this vault move runs under",
+        )
+        // The share account first: it is what says *which vault* this is, so a substituted
+        // `vault_state` is named as that rather than as a token account that happens to disagree.
+        rejectUnlessAccountIs(
+            index,
+            instruction,
+            KVAULT_SHARE_ACCOUNT,
+            shareAccount,
+            "the wallet's share account for this vault",
+        )
+        rejectUnlessAccountIs(
+            index,
+            instruction,
+            tokenAccountSlot,
+            tokenAccount,
+            "the wallet's token account for this vault",
+        )
+        rejectUnlessAmountIs(index, instruction, amountBaseUnits)
+    }
+
+    /**
+     * Every farms instruction a curated vault's deposit or withdraw has cause to carry, and nothing
+     * else.
+     *
+     * A deposit stakes its shares into the vault's farm, so the shares never land in the wallet as
+     * a token balance — which is why the farms program is allow-listed as a program at all. That
+     * made it the one program here whose instructions went unread: `transfer_ownership` hands the
+     * whole staked position to an account that never signs, and nothing about it looks like a
+     * transfer. iOS names exactly these four at `KaminoInstructionSequence.swift:301`, and the
+     * shapes match its live template — a deposit stakes, a withdraw unstakes, neither does both.
+     *
+     * The farm and the farms user state are lookup-table entries in every captured response, so
+     * they cannot be compared offline here; what is compared is what stays static — the authority
+     * and the share account each instruction moves shares through, both derived locally.
+     */
+    private fun rejectUnlessPermittedFarmsInstruction(
+        index: Int,
+        instruction: KaminoTxInstruction,
+        action: KaminoAction,
+        signerAddress: String?,
+        shareAccount: String?,
+        amountBaseUnits: BigInteger?,
+    ) {
+        val data = instruction.data
+        val isOneWePerform =
+            listOf(
+                    FARMS_INITIALIZE_USER,
+                    FARMS_STAKE,
+                    FARMS_UNSTAKE,
+                    FARMS_WITHDRAW_UNSTAKED_DEPOSITS,
+                )
+                .any { data.startsWith(it) }
+        if (!isOneWePerform) {
+            reject(
+                "instruction $index is a farms instruction no Kamino deposit or withdraw performs"
+            )
+        }
+        rejectUnlessAccountIs(index, instruction, FARMS_OWNER, signerAddress, "the farm authority")
+
+        when {
+            data.startsWith(FARMS_INITIALIZE_USER) -> {
+                rejectUnlessDeposit(index, action, "creates the wallet's farm state")
+            }
+
+            data.startsWith(FARMS_STAKE) -> {
+                rejectUnlessDeposit(index, action, "stakes shares into the farm")
+                rejectUnlessAccountIs(
+                    index,
+                    instruction,
+                    FARMS_STAKE_SHARE_ACCOUNT,
+                    shareAccount,
+                    "the wallet's share account for this vault",
+                )
+                // Kamino stakes the whole share balance rather than the amount just minted, so the
+                // argument is the sentinel. A different value is a behaviour change rather than a
+                // variation, and is worth stopping on.
+                if (anchorArgument(data, bytes = 8) != U64_MAX) {
+                    reject(
+                        "instruction $index stakes an amount this app has never seen Kamino ask for"
+                    )
+                }
+            }
+
+            data.startsWith(FARMS_UNSTAKE) -> {
+                rejectUnlessWithdraw(index, action, "releases shares from the farm")
+                // The exact figure is `requested − alreadyUnstaked`, and the second term is a
+                // balance this app does not hold at prepare time. So what is checked is the bound
+                // that needs no balance: a withdraw cannot legitimately take more out of the farm
+                // than it burns. Released shares the withdraw then leaves behind are out of the
+                // farm, no longer earning, and invisible on a screen that shows an amount.
+                //
+                // The argument is a `u128` scaled by 10^18, the only one in this feature. Reading
+                // it as a `u64` would take the low half and compare a number that means nothing.
+                val scaled =
+                    anchorArgument(data, bytes = 16)
+                        ?: reject("instruction $index carries no farms amount to check")
+                if (amountBaseUnits == null) {
+                    reject(
+                        "instruction $index releases shares but the requested amount could not be " +
+                            "read, so how many it releases cannot be checked"
+                    )
+                }
+                if (scaled > amountBaseUnits.multiply(FARMS_STAKE_SCALE)) {
+                    reject(
+                        "instruction $index releases more shares from the farm than the withdraw " +
+                            "burns"
+                    )
+                }
+            }
+
+            data.startsWith(FARMS_WITHDRAW_UNSTAKED_DEPOSITS) -> {
+                rejectUnlessWithdraw(index, action, "moves released shares out of the farm")
+                // Where the released shares land, and the account the vault withdraw then burns
+                // from. A destination belonging to anyone else hands the position over.
+                rejectUnlessAccountIs(
+                    index,
+                    instruction,
+                    FARMS_UNSTAKED_SHARE_DESTINATION,
+                    shareAccount,
+                    "the wallet's share account for this vault",
+                )
+            }
+        }
+    }
+
+    /**
+     * The accounts a transaction creates are the wallet's own two, and nothing else.
+     *
+     * Kamino creates whatever the operation needs — the share account a deposit mints into, the
+     * wrapped-SOL account it wraps through, the payout account a withdraw pays into — and each is
+     * created idempotently, so one that already exists is left alone. Every one of them is an
+     * account this app derives for itself, which makes the check exact.
+     *
+     * Rent is what makes it worth checking rather than waving through: creation is funded by the
+     * fee payer, so an account created for someone else is the wallet paying rent into an address
+     * the response chose, on the signature the message already carries.
+     */
+    private fun rejectUnlessCreatingOneOfTheWalletsOwnAccounts(
+        index: Int,
+        instruction: KaminoTxInstruction,
+        tokenAccount: String?,
+        shareAccount: String?,
+    ) {
+        val discriminator =
+            instruction.data.firstOrNull()?.toInt()?.and(0xFF)
+                ?: reject("instruction $index carries no account-creation instruction to check")
+        if (discriminator != CREATE_IDEMPOTENT) {
+            reject(
+                "instruction $index is associated-token instruction $discriminator, which no " +
+                    "Kamino deposit or withdraw performs"
+            )
+        }
+        if (tokenAccount == null || shareAccount == null) {
+            reject(
+                "instruction $index creates a token account but the wallet's own accounts could " +
+                    "not be derived, so the account it creates cannot be checked"
+            )
+        }
+        val created = instruction.accounts.getOrNull(CREATED_TOKEN_ACCOUNT)
+        if (created != tokenAccount && created != shareAccount) {
+            reject(
+                "instruction $index creates $created, which is not one of the wallet's own accounts"
+            )
         }
     }
 
@@ -246,7 +591,7 @@ object KaminoTransactionValidator {
         instruction: KaminoTxInstruction,
         vault: KaminoVault,
         signerAddress: String?,
-        wrappedSolAccount: String?,
+        tokenAccount: String?,
     ) {
         val discriminator =
             instruction.data.firstOrNull()?.toInt()?.and(0xFF)
@@ -260,14 +605,14 @@ object KaminoTransactionValidator {
                             "cause to do"
                     )
                 }
-                if (wrappedSolAccount == null) {
+                if (tokenAccount == null) {
                     reject(
                         "instruction $index credits a wrap but the wrapped-SOL account could not " +
                             "be derived, so the account it credits cannot be checked"
                     )
                 }
                 val subject = instruction.accounts.firstOrNull()
-                if (subject != wrappedSolAccount) {
+                if (subject != tokenAccount) {
                     reject(
                         "instruction $index credits $subject rather than the wallet's wrapped-SOL " +
                             "account"
@@ -284,14 +629,14 @@ object KaminoTransactionValidator {
                             "its recipient cannot be checked"
                     )
                 }
-                val destination = instruction.accounts.getOrNull(1)
+                val destination = instruction.accounts.getOrNull(TOKEN_CLOSE_DESTINATION)
                 if (destination != signerAddress) {
                     reject(
                         "instruction $index pays a closed token account out to $destination " +
                             "rather than to the wallet"
                     )
                 }
-                val owner = instruction.accounts.getOrNull(2)
+                val owner = instruction.accounts.getOrNull(TOKEN_CLOSE_AUTHORITY)
                 if (owner != signerAddress) {
                     reject(
                         "instruction $index closes a token account under the authority of $owner " +
@@ -309,18 +654,27 @@ object KaminoTransactionValidator {
     }
 
     /**
-     * Lamports only ever move to wrap SOL, and only for the wrapped-SOL vault.
+     * Lamports only ever move to wrap SOL, only for the wrapped-SOL vault, only into the wallet's
+     * own wrapped-SOL account and only for the amount being deposited.
      *
      * Every other `SystemInstruction` is refused rather than ignored. `Assign` on the signer's own
      * account reassigns it to a program the response chose, and `CreateAccountWithSeed` funds an
      * account it chose with an amount it chose — both authorised by the fee-payer signature this
      * message already carries, and neither one a transfer.
+     *
+     * The lamport figure is checked too, not just the destination. Reading only the four
+     * discriminator bytes leaves the amount unbound, and a response is free to wrap the whole SOL
+     * balance while the screen shows the typed amount: the deposit consumes what was asked for and
+     * the remainder sits in a wrapped-SOL account with no screen in this app. iOS pins the same
+     * equality in `KaminoTransactionDecoder.swift:398`.
      */
     private fun rejectUnlessWrap(
         index: Int,
         instruction: KaminoTxInstruction,
         vault: KaminoVault,
-        wrappedSolAccount: String?,
+        action: KaminoAction,
+        tokenAccount: String?,
+        amountBaseUnits: BigInteger?,
     ) {
         val discriminator =
             littleEndianInt(instruction.data.take(4))
@@ -337,6 +691,7 @@ object KaminoTransactionValidator {
                 "instruction $index moves lamports, which only the wrapped-SOL vault has cause to do"
             )
         }
+        rejectUnlessDeposit(index, action, "moves lamports")
         // Permitted, but only to one address: the wrapped-SOL account derived from the signer and
         // the vault's own mint.
         //
@@ -345,17 +700,32 @@ object KaminoTransactionValidator {
         // instruction's account list, so it could name an attacker there and have the transfer
         // waved through. The expected address is derived locally by the caller and compared
         // exactly.
-        if (wrappedSolAccount == null) {
+        if (tokenAccount == null) {
             reject(
                 "instruction $index moves lamports but the wrapped-SOL account could not be " +
                     "derived, so its destination cannot be checked"
             )
         }
-        val destination = instruction.accounts.getOrNull(1)
-        if (destination != wrappedSolAccount) {
+        val destination = instruction.accounts.getOrNull(SYSTEM_TRANSFER_DESTINATION)
+        if (destination != tokenAccount) {
             reject(
                 "instruction $index moves lamports to $destination rather than to the wallet's " +
                     "wrapped-SOL account"
+            )
+        }
+        if (amountBaseUnits == null) {
+            reject(
+                "instruction $index moves lamports but the requested amount could not be read, so " +
+                    "how many it moves cannot be checked"
+            )
+        }
+        val lamports =
+            littleEndianLong(instruction.data, offset = 4)
+                ?: reject("instruction $index carries no lamport amount to check")
+        if (lamports != amountBaseUnits) {
+            reject(
+                "instruction $index wraps $lamports lamports rather than the $amountBaseUnits " +
+                    "this app asked to deposit"
             )
         }
     }
@@ -375,12 +745,110 @@ object KaminoTransactionValidator {
         }
     }
 
+    /**
+     * Compares slot [slot] of [instruction] against an address the caller derived locally.
+     *
+     * A null [expected] is a refusal rather than a skip, and so is an instruction too short to have
+     * the slot: with nothing to compare against, "cannot tell" is not "not a mismatch".
+     */
+    private fun rejectUnlessAccountIs(
+        index: Int,
+        instruction: KaminoTxInstruction,
+        slot: Int,
+        expected: String?,
+        role: String,
+    ) {
+        if (expected == null) {
+            reject(
+                "instruction $index names $role, which could not be derived locally, so the " +
+                    "account it uses cannot be checked"
+            )
+        }
+        val actual =
+            instruction.accounts.getOrNull(slot)
+                ?: reject("instruction $index names too few accounts to check $role")
+        if (actual != expected) {
+            reject(
+                "instruction $index uses $actual as $role rather than the wallet's own $expected"
+            )
+        }
+    }
+
+    /** Pins an Anchor instruction's `u64` argument to the figure the app asked for. */
+    private fun rejectUnlessAmountIs(
+        index: Int,
+        instruction: KaminoTxInstruction,
+        expected: BigInteger?,
+    ) {
+        if (expected == null) {
+            reject(
+                "instruction $index moves an amount but the figure this app asked for could not " +
+                    "be read, so it cannot be checked"
+            )
+        }
+        val actual =
+            anchorArgument(instruction.data, bytes = 8)
+                ?: reject("instruction $index carries no amount to check")
+        if (actual != expected) {
+            reject(
+                "instruction $index moves $actual base units rather than the $expected this app " +
+                    "asked for"
+            )
+        }
+    }
+
+    private fun rejectUnlessDeposit(index: Int, action: KaminoAction, detail: String) {
+        if (action != KaminoAction.DEPOSIT) {
+            reject("instruction $index $detail, which no Kamino withdraw performs")
+        }
+    }
+
+    private fun rejectUnlessWithdraw(index: Int, action: KaminoAction, detail: String) {
+        if (action != KaminoAction.WITHDRAW) {
+            reject("instruction $index $detail, which no Kamino deposit performs")
+        }
+    }
+
+    /**
+     * The little-endian argument of [bytes] bytes that follows an Anchor discriminator. Null when
+     * the instruction is too short to carry one.
+     */
+    private fun anchorArgument(data: ByteArray, bytes: Int): BigInteger? {
+        if (data.size < ANCHOR_DISCRIMINATOR + bytes) return null
+        var value = BigInteger.ZERO
+        for (offset in bytes - 1 downTo 0) {
+            value =
+                value
+                    .shiftLeft(8)
+                    .or(BigInteger.valueOf(data[ANCHOR_DISCRIMINATOR + offset].toLong() and 0xFF))
+        }
+        return value
+    }
+
     private fun littleEndianInt(bytes: List<Byte>): Int? {
         if (bytes.size < 4) return null
         return bytes.foldIndexed(0) { index, acc, byte ->
             acc or ((byte.toInt() and 0xFF) shl (8 * index))
         }
     }
+
+    /** The `u64` at [offset], little-endian. Null when [data] is too short to carry one. */
+    private fun littleEndianLong(data: ByteArray, offset: Int): BigInteger? {
+        if (data.size < offset + 8) return null
+        var value = BigInteger.ZERO
+        for (index in 7 downTo 0) {
+            value =
+                value.shiftLeft(8).or(BigInteger.valueOf(data[offset + index].toLong() and 0xFF))
+        }
+        return value
+    }
+
+    private fun ByteArray.startsWith(prefix: ByteArray): Boolean =
+        size >= prefix.size && prefix.indices.all { this[it] == prefix[it] }
+
+    /** The bytes [hex] names, which is how every Anchor discriminator above is written. */
+    private fun anchor(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { hex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
 
     private fun reject(reason: String): Nothing = throw KaminoTransactionRejected(reason)
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -61,8 +61,9 @@ object KaminoTransactionValidator {
     private const val TOKEN_PROGRAM_ID = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
     private const val TOKEN_2022_PROGRAM_ID = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
 
-    /** `Transfer` (3) and `TransferChecked` (12) in the SPL Token instruction enum. */
-    private val TOKEN_TRANSFER_DISCRIMINATORS = setOf(3, 12)
+    /** `CloseAccount` and `SyncNative` in the SPL Token instruction enum. */
+    private const val TOKEN_CLOSE_ACCOUNT = 9
+    private const val TOKEN_SYNC_NATIVE = 17
 
     /** `SystemInstruction::Transfer`. */
     private const val SYSTEM_TRANSFER = 2
@@ -128,7 +129,7 @@ object KaminoTransactionValidator {
             reject("memo must be the final instruction")
         }
 
-        rejectValueMovementAwayFromTheSigner(instructions, vault, wrappedSolAccount)
+        rejectValueMovementAwayFromTheSigner(instructions, vault, signerAddress, wrappedSolAccount)
         rejectAnotherAccountsAuthority(decoded.feePayer, signerAddress)
         rejectTheWithdrawEverythingSentinel(instructions)
     }
@@ -178,66 +179,184 @@ object KaminoTransactionValidator {
      * to.
      *
      * Program allow-listing alone is not enough: a deposit legitimately needs the System and Token
-     * programs, so a compromised response could add a plain transfer to an attacker and still
-     * invoke kVault and end with the memo. These checks are about *what* those programs are asked
-     * to do.
+     * programs, so a compromised response could add a transfer to an attacker and still invoke
+     * kVault and end with the memo. These checks are about *what* those programs are asked to do.
+     *
+     * Both are allow-lists, and deliberately so. A deny-list of the opcodes that look dangerous is
+     * no control at all here — the same compromised response picks the opcode, so everything not
+     * thought of is waved through, and the ones that matter most do not look like transfers:
+     * `Assign` hands the wallet's system account to another program, `SetAuthority` hands over a
+     * token account, and neither moves a lamport itself.
+     *
+     * The permitted set is what live Kamino responses carry. A wrapped-SOL vault deposit wraps with
+     * `System::Transfer` then `Token::SyncNative`; its withdraw unwraps with `Token::CloseAccount`.
+     * A plain-token vault carries none of the three — it moves its tokens entirely through the
+     * kVault program's own CPI.
      */
     private fun rejectValueMovementAwayFromTheSigner(
         instructions: List<KaminoTxInstruction>,
         vault: KaminoVault,
+        signerAddress: String?,
         wrappedSolAccount: String?,
     ) {
         instructions.forEachIndexed { index, instruction ->
             when (instruction.programId) {
                 TOKEN_PROGRAM_ID,
-                TOKEN_2022_PROGRAM_ID -> {
-                    // The vault moves tokens through its own program's CPI. A *top-level* token
-                    // transfer is not part of any shape observed here, and is exactly how a stray
-                    // instruction would drain an account the wallet has already authorised.
-                    val discriminator = instruction.data.firstOrNull()?.toInt()?.and(0xFF)
-                    if (discriminator in TOKEN_TRANSFER_DISCRIMINATORS) {
-                        reject(
-                            "instruction $index is a top-level SPL token transfer, which no Kamino " +
-                                "deposit or withdraw performs"
-                        )
-                    }
-                }
+                TOKEN_2022_PROGRAM_ID ->
+                    rejectUnlessPermittedTokenInstruction(
+                        index = index,
+                        instruction = instruction,
+                        vault = vault,
+                        signerAddress = signerAddress,
+                        wrappedSolAccount = wrappedSolAccount,
+                    )
 
-                SYSTEM_PROGRAM_ID -> {
-                    // Lamports only ever move to wrap SOL, and only for the wrapped-SOL vault.
-                    val discriminator = instruction.data.take(4).let(::littleEndianInt)
-                    if (discriminator == SYSTEM_TRANSFER) {
-                        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) {
-                            reject(
-                                "instruction $index moves lamports, which only the wrapped-SOL " +
-                                    "vault has cause to do"
-                            )
-                        }
-                        // Permitted, but only to one address: the wrapped-SOL account derived from
-                        // the signer and the vault's own mint.
-                        //
-                        // An earlier version accepted any destination the kVault instruction also
-                        // named, which is no check at all against a compromised response — the same
-                        // response chooses that instruction's account list, so it could name an
-                        // attacker there and have the transfer waved through. The expected address
-                        // is
-                        // derived locally by the caller and compared exactly.
-                        val destination = instruction.accounts.getOrNull(1)
-                        if (wrappedSolAccount == null) {
-                            reject(
-                                "instruction $index moves lamports but the wrapped-SOL account " +
-                                    "could not be derived, so its destination cannot be checked"
-                            )
-                        }
-                        if (destination != wrappedSolAccount) {
-                            reject(
-                                "instruction $index moves lamports to $destination rather than to " +
-                                    "the wallet's wrapped-SOL account"
-                            )
-                        }
-                    }
+                SYSTEM_PROGRAM_ID ->
+                    rejectUnlessWrap(
+                        index = index,
+                        instruction = instruction,
+                        vault = vault,
+                        wrappedSolAccount = wrappedSolAccount,
+                    )
+            }
+        }
+    }
+
+    /**
+     * The only SPL Token instructions one of these transactions has cause to carry at top level.
+     *
+     * `SyncNative` credits the lamports a wrap just sent, and is pinned to the wrapped-SOL account
+     * derived locally from the signer: the deposit carrying it was captured, so its shape is known
+     * exactly.
+     *
+     * `CloseAccount` returns what an unwrap released, and is checked by *recipient* rather than by
+     * subject — both the destination it pays out to and the authority closing it must be the
+     * signer. The looser subject is deliberate. Only the unstaked withdraw could be captured, and a
+     * staked exit may close accounts this app has never seen; pinning the subject would refuse
+     * those, while pinning the recipient still refuses the redirect the check exists for. Nothing
+     * is given up by it: the wallet can only close accounts it owns, and every lamport released
+     * lands on the wallet either way.
+     *
+     * Comparisons are exact, so an account the response hides behind its own address lookup table —
+     * which decodes to [KaminoTransactionDecoder.UNKNOWN_ACCOUNT] — fails them rather than skipping
+     * them.
+     */
+    private fun rejectUnlessPermittedTokenInstruction(
+        index: Int,
+        instruction: KaminoTxInstruction,
+        vault: KaminoVault,
+        signerAddress: String?,
+        wrappedSolAccount: String?,
+    ) {
+        val discriminator =
+            instruction.data.firstOrNull()?.toInt()?.and(0xFF)
+                ?: reject("instruction $index carries no SPL token instruction to check")
+
+        when (discriminator) {
+            TOKEN_SYNC_NATIVE -> {
+                if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) {
+                    reject(
+                        "instruction $index credits a wrap, which only the wrapped-SOL vault has " +
+                            "cause to do"
+                    )
+                }
+                if (wrappedSolAccount == null) {
+                    reject(
+                        "instruction $index credits a wrap but the wrapped-SOL account could not " +
+                            "be derived, so the account it credits cannot be checked"
+                    )
+                }
+                val subject = instruction.accounts.firstOrNull()
+                if (subject != wrappedSolAccount) {
+                    reject(
+                        "instruction $index credits $subject rather than the wallet's wrapped-SOL " +
+                            "account"
+                    )
                 }
             }
+
+            TOKEN_CLOSE_ACCOUNT -> {
+                // Closing pays out the account's entire lamport balance, which on a full exit is
+                // the whole withdrawn amount, so the recipient is what has to be pinned.
+                if (signerAddress == null) {
+                    reject(
+                        "instruction $index closes a token account but the signer is unknown, so " +
+                            "its recipient cannot be checked"
+                    )
+                }
+                val destination = instruction.accounts.getOrNull(1)
+                if (destination != signerAddress) {
+                    reject(
+                        "instruction $index pays a closed token account out to $destination " +
+                            "rather than to the wallet"
+                    )
+                }
+                val owner = instruction.accounts.getOrNull(2)
+                if (owner != signerAddress) {
+                    reject(
+                        "instruction $index closes a token account under the authority of $owner " +
+                            "rather than the wallet's"
+                    )
+                }
+            }
+
+            else ->
+                reject(
+                    "instruction $index is SPL token instruction $discriminator, which no Kamino " +
+                        "deposit or withdraw performs"
+                )
+        }
+    }
+
+    /**
+     * Lamports only ever move to wrap SOL, and only for the wrapped-SOL vault.
+     *
+     * Every other `SystemInstruction` is refused rather than ignored. `Assign` on the signer's own
+     * account reassigns it to a program the response chose, and `CreateAccountWithSeed` funds an
+     * account it chose with an amount it chose — both authorised by the fee-payer signature this
+     * message already carries, and neither one a transfer.
+     */
+    private fun rejectUnlessWrap(
+        index: Int,
+        instruction: KaminoTxInstruction,
+        vault: KaminoVault,
+        wrappedSolAccount: String?,
+    ) {
+        val discriminator =
+            littleEndianInt(instruction.data.take(4))
+                ?: reject("instruction $index carries no System instruction to check")
+
+        if (discriminator != SYSTEM_TRANSFER) {
+            reject(
+                "instruction $index is System instruction $discriminator, which no Kamino deposit " +
+                    "or withdraw performs"
+            )
+        }
+        if (vault.tokenMint != KaminoVaultRegistry.WRAPPED_SOL_MINT) {
+            reject(
+                "instruction $index moves lamports, which only the wrapped-SOL vault has cause to do"
+            )
+        }
+        // Permitted, but only to one address: the wrapped-SOL account derived from the signer and
+        // the vault's own mint.
+        //
+        // An earlier version accepted any destination the kVault instruction also named, which is
+        // no check at all against a compromised response — the same response chooses that
+        // instruction's account list, so it could name an attacker there and have the transfer
+        // waved through. The expected address is derived locally by the caller and compared
+        // exactly.
+        if (wrappedSolAccount == null) {
+            reject(
+                "instruction $index moves lamports but the wrapped-SOL account could not be " +
+                    "derived, so its destination cannot be checked"
+            )
+        }
+        val destination = instruction.accounts.getOrNull(1)
+        if (destination != wrappedSolAccount) {
+            reject(
+                "instruction $index moves lamports to $destination rather than to the wallet's " +
+                    "wrapped-SOL account"
+            )
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidator.kt
@@ -143,6 +143,17 @@ object KaminoTransactionValidator {
 
     private const val FARMS_OWNER = 0
 
+    /**
+     * Where each farms instruction names the wallet's state in the farm.
+     *
+     * `initialize_user` is the odd one out because it is the instruction that *creates* the
+     * account: the IDL puts the authority, the payer, the owner and the delegatee ahead of it,
+     * where the other three take the owner and then the state it already has.
+     */
+    private const val FARMS_USER_STATE = 1
+
+    private const val FARMS_INITIALIZE_USER_STATE = 4
+
     private const val FARMS_STAKE_SHARE_ACCOUNT = 4
 
     private const val FARMS_UNSTAKED_SHARE_DESTINATION = 3
@@ -160,7 +171,11 @@ object KaminoTransactionValidator {
      * @param tokenAccount the wallet's associated token account for [vault]'s underlying mint,
      *   derived locally by the caller — on the SOL vault that is its wrapped-SOL account
      * @param shareAccount the wallet's associated token account for [vault]'s share mint, likewise
-     *   derived locally: offline it is the only thing that binds an instruction to *this* vault
+     *   derived locally: offline it is the only thing that binds a kVault instruction to *this*
+     *   vault
+     * @param farmUserState the wallet's state in [vault]'s farm, a program address over the two and
+     *   so likewise derived locally — what binds a farms instruction to this vault's farm, which
+     *   the farm account itself cannot do from a lookup table
      * @param amountBaseUnits what the user asked for, in the unit the instruction carries — the
      *   underlying token for a deposit, shares for a withdraw
      * @throws KaminoTransactionRejected if [decoded] is not a transaction the app is willing to
@@ -173,6 +188,7 @@ object KaminoTransactionValidator {
         signerAddress: String? = null,
         tokenAccount: String? = null,
         shareAccount: String? = null,
+        farmUserState: String? = null,
         amountBaseUnits: BigInteger? = null,
     ) {
         val instructions = decoded.instructions
@@ -266,6 +282,7 @@ object KaminoTransactionValidator {
             signerAddress = signerAddress,
             tokenAccount = tokenAccount,
             shareAccount = shareAccount,
+            farmUserState = farmUserState,
             amountBaseUnits = amountBaseUnits,
         )
     }
@@ -325,6 +342,7 @@ object KaminoTransactionValidator {
         signerAddress: String?,
         tokenAccount: String?,
         shareAccount: String?,
+        farmUserState: String?,
         amountBaseUnits: BigInteger?,
     ) {
         instructions.forEachIndexed { index, instruction ->
@@ -375,6 +393,7 @@ object KaminoTransactionValidator {
                         action = action,
                         signerAddress = signerAddress,
                         shareAccount = shareAccount,
+                        farmUserState = farmUserState,
                         amountBaseUnits = amountBaseUnits,
                     )
             }
@@ -463,9 +482,16 @@ object KaminoTransactionValidator {
      * transfer. iOS names exactly these four at `KaminoInstructionSequence.swift:301`, and the
      * shapes match its live template — a deposit stakes, a withdraw unstakes, neither does both.
      *
-     * The farm and the farms user state are lookup-table entries in every captured response, so
-     * they cannot be compared offline here; what is compared is what stays static — the authority
-     * and the share account each instruction moves shares through, both derived locally.
+     * The authority alone does not bind one of these to this vault, and the farm account cannot: it
+     * is an address-lookup-table entry in every captured response and this decode resolves no
+     * tables, so comparing it would be a check that passes by being unreadable. The farms **user
+     * state** does bind it. Its address is a program address over the farm and the owner, it is a
+     * static key in both captured deposits, and the caller derives it locally — so an instruction
+     * naming another farm's state, or another holder's, is refused. Without that check
+     * `farms::stake` sweeps the wallet's whole share balance into a farm the response made, since
+     * the argument it carries is the whole-balance sentinel. iOS derives the same address and pins
+     * it at `KaminoTransactionValidator.swift:1006`; it is pinned on all four here rather than on
+     * the two it names, because the farm slot it checks alongside is unreadable offline.
      *
      * Everything below is per-instruction; how many of each may appear at all is bounded in
      * [validate], since a check an instruction passes on its own it also passes twice.
@@ -476,6 +502,7 @@ object KaminoTransactionValidator {
         action: KaminoAction,
         signerAddress: String?,
         shareAccount: String?,
+        farmUserState: String?,
         amountBaseUnits: BigInteger?,
     ) {
         val data = instruction.data
@@ -486,6 +513,14 @@ object KaminoTransactionValidator {
             )
         }
         rejectUnlessAccountIs(index, instruction, FARMS_OWNER, signerAddress, "the farm authority")
+        rejectUnlessAccountIs(
+            index,
+            instruction,
+            if (data.startsWith(FARMS_INITIALIZE_USER)) FARMS_INITIALIZE_USER_STATE
+            else FARMS_USER_STATE,
+            farmUserState,
+            "this wallet's state in the vault's farm",
+        )
 
         when {
             data.startsWith(FARMS_INITIALIZE_USER) -> {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/Base58Codec.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/Base58Codec.kt
@@ -1,0 +1,56 @@
+package com.vultisig.wallet.data.crypto
+
+import java.math.BigInteger
+
+/**
+ * Base58 over the Bitcoin alphabet, without a checksum — the encoding Solana addresses use.
+ *
+ * Pure Kotlin rather than WalletCore's `Base58`, so that the rules built on it stay unit-testable
+ * off-device: an address derivation that needs JNI can only be exercised in an instrumented test,
+ * and the checks that compare derived addresses are the ones most worth running everywhere.
+ */
+internal object Base58Codec {
+
+    private const val ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+
+    private val BASE = BigInteger.valueOf(58)
+
+    /**
+     * The bytes [input] encodes, or null on any character outside the alphabet.
+     *
+     * Leading `1`s are the encoding of leading zero bytes and are restored as such, which matters
+     * for fixed-width keys: dropping them would shorten a 32-byte pubkey.
+     */
+    fun decode(input: String): ByteArray? {
+        var number = BigInteger.ZERO
+        for (character in input) {
+            val digit = ALPHABET.indexOf(character)
+            if (digit < 0) return null
+            number = number.multiply(BASE).add(BigInteger.valueOf(digit.toLong()))
+        }
+        var bytes = number.toByteArray()
+        // Drop the sign byte BigInteger prepends for values whose high bit is set.
+        if (bytes.size > 1 && bytes[0].toInt() == 0) {
+            bytes = bytes.copyOfRange(1, bytes.size)
+        }
+        if (bytes.size == 1 && bytes[0].toInt() == 0) {
+            bytes = ByteArray(0)
+        }
+        val leadingZeros = input.takeWhile { it == '1' }.length
+        return ByteArray(leadingZeros) + bytes
+    }
+
+    /** The Base58 form of [bytes], with each leading zero byte written as a `1`. */
+    fun encode(bytes: ByteArray): String {
+        val leadingZeros = bytes.takeWhile { it.toInt() == 0 }.size
+        var number = BigInteger(1, bytes)
+        val builder = StringBuilder()
+        while (number.signum() > 0) {
+            val (quotient, remainder) = number.divideAndRemainder(BASE)
+            builder.append(ALPHABET[remainder.toInt()])
+            number = quotient
+        }
+        repeat(leadingZeros) { builder.append(ALPHABET[0]) }
+        return builder.reverse().toString()
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SolanaProgramDerivedAddress.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SolanaProgramDerivedAddress.kt
@@ -1,0 +1,104 @@
+package com.vultisig.wallet.data.crypto
+
+import java.math.BigInteger
+import java.security.MessageDigest
+
+/**
+ * Solana's `find_program_address`: the account address a program owns for a given set of seeds.
+ *
+ * A program address is the first `sha256(seeds ‖ bump ‖ programId ‖ "ProgramDerivedAddress")` that
+ * is **not** a point on the ed25519 curve — no private key can exist for it, which is what lets a
+ * program sign for it. The bump counts down from 255, so the address is a pure function of the
+ * seeds and the program.
+ *
+ * That is what makes it worth deriving locally rather than reading out of a transaction: an account
+ * whose address is fixed by the seeds cannot be substituted, so recomputing it here says *which*
+ * position an instruction moves without asking the response to be honest about it.
+ *
+ * Pure Kotlin and JNI-free on purpose — WalletCore exposes only the associated-token special case,
+ * and the checks that use this have to run in plain unit tests.
+ */
+internal object SolanaProgramDerivedAddress {
+
+    /** The domain separator the runtime appends before hashing. */
+    private val PDA_MARKER = "ProgramDerivedAddress".toByteArray(Charsets.US_ASCII)
+
+    /** Solana's own limits: at most 16 seeds, each at most 32 bytes. */
+    private const val MAX_SEEDS = 16
+
+    private const val MAX_SEED_LENGTH = 32
+
+    private const val PUBLIC_KEY_LENGTH = 32
+
+    private const val FIRST_BUMP = 255
+
+    /**
+     * The program address for [seeds] under [programId], or null when there is none to derive — an
+     * unparseable program id, seeds outside the runtime's limits, or (with probability about
+     * 2^-256) no off-curve candidate at any bump.
+     *
+     * Null is a refusal for every caller here rather than a check to skip: an address that could
+     * not be derived is one that cannot be compared.
+     */
+    fun find(seeds: List<ByteArray>, programId: String): String? {
+        if (seeds.size > MAX_SEEDS || seeds.any { it.size > MAX_SEED_LENGTH }) return null
+        val program =
+            Base58Codec.decode(programId)?.takeIf { it.size == PUBLIC_KEY_LENGTH } ?: return null
+
+        for (bump in FIRST_BUMP downTo 0) {
+            val digest = MessageDigest.getInstance("SHA-256")
+            seeds.forEach(digest::update)
+            digest.update(byteArrayOf(bump.toByte()))
+            digest.update(program)
+            digest.update(PDA_MARKER)
+            val candidate = digest.digest()
+            if (!isOnCurve(candidate)) return Base58Codec.encode(candidate)
+        }
+        return null
+    }
+
+    /** `BigInteger.TWO` is API 33 and this module ships to minSdk 26. */
+    private val TWO = BigInteger.valueOf(2)
+
+    /** 2^255 − 19, the ed25519 field prime. */
+    private val FIELD = TWO.pow(255).subtract(BigInteger.valueOf(19))
+
+    /** The curve constant `d = −121665 / 121666`. */
+    private val D =
+        BigInteger.valueOf(-121665)
+            .multiply(BigInteger.valueOf(121666).modInverse(FIELD))
+            .mod(FIELD)
+
+    /** `sqrt(−1)`, the factor that recovers the other root when the first attempt misses. */
+    private val SQRT_MINUS_ONE =
+        TWO.modPow(FIELD.subtract(BigInteger.ONE).divide(BigInteger.valueOf(4)), FIELD)
+
+    /**
+     * Whether [compressed] decodes to a point on ed25519 — that is, whether it could be a public
+     * key someone holds the private half of.
+     *
+     * The 32 bytes are a little-endian `y` with the sign of `x` in the top bit. A point exists when
+     * `x² = (y² − 1) / (d·y² + 1)` has a square root, so this solves for `x` and checks it back.
+     */
+    private fun isOnCurve(compressed: ByteArray): Boolean {
+        val encoded = BigInteger(1, compressed.reversedArray())
+        val sign = encoded.testBit(255)
+        val y = encoded.clearBit(255)
+        if (y >= FIELD) return false
+
+        val ySquared = y.multiply(y).mod(FIELD)
+        val numerator = ySquared.subtract(BigInteger.ONE).mod(FIELD)
+        val denominator = D.multiply(ySquared).add(BigInteger.ONE).mod(FIELD)
+        if (denominator.signum() == 0) return false
+
+        val xSquared = numerator.multiply(denominator.modInverse(FIELD)).mod(FIELD)
+        var x =
+            xSquared.modPow(FIELD.add(BigInteger.valueOf(3)).divide(BigInteger.valueOf(8)), FIELD)
+        if (x.multiply(x).mod(FIELD) != xSquared) {
+            x = x.multiply(SQRT_MINUS_ONE).mod(FIELD)
+        }
+        if (x.multiply(x).mod(FIELD) != xSquared) return false
+        // x = 0 has one root, so asking for its negative is an encoding no point answers to.
+        return !(x.signum() == 0 && sign)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoFarmsUserStateTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoFarmsUserStateTest.kt
@@ -1,0 +1,63 @@
+package com.vultisig.wallet.data.blockchain.solana.kamino
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins [KaminoFarmsUserState] against the addresses the captured deposits actually name.
+ *
+ * Both fixtures carry this account as a *static* key — not a lookup-table entry — so these two
+ * expectations were read off the wire and then reproduced from the farm the registry pins, which is
+ * what makes the derivation a check rather than a restatement.
+ */
+class KaminoFarmsUserStateTest {
+
+    @Test
+    fun `it derives the state the captured deposits name`() {
+        assertEquals(
+            "A1b83WVHAKXeRQAHsdAzJY23ShXCPjqKshzmFFXwGP4Z",
+            KaminoFarmsUserState.derive(KaminoVaultRegistry.STEAKHOUSE_USDC.farm, WALLET),
+        )
+        assertEquals(
+            "8ULTfRg47DWt5VBDT7UURTPW6P5Fc5vPMfncfPKpZc3J",
+            KaminoFarmsUserState.derive(KaminoVaultRegistry.ALLEZ_SOL.farm, WALLET),
+        )
+    }
+
+    @Test
+    fun `one wallet has a different state in every farm`() {
+        // Which is the property the validator leans on: the farm slot is unreadable offline, so
+        // this
+        // address is what says which farm an instruction moves shares in.
+        val states =
+            KaminoVaultRegistry.ALLOW_LIST.map { KaminoFarmsUserState.derive(it.farm, WALLET) }
+        assertEquals(states.size, states.toSet().size, states.toString())
+        assertEquals(false, states.any { it == null })
+    }
+
+    @Test
+    fun `and every wallet a different state in one farm`() {
+        val farm = KaminoVaultRegistry.STEAKHOUSE_USDC.farm
+        assertNotEquals(
+            KaminoFarmsUserState.derive(farm, WALLET),
+            KaminoFarmsUserState.derive(farm, "HDsayqAsDWy3QvANGqh2yNraqcD8Fnjgh73Mhb3WRS5E"),
+        )
+    }
+
+    @Test
+    fun `an address that is not a public key derives nothing`() {
+        // Null travels to the validator as a refusal, so a farm or an owner it cannot read stops
+        // the
+        // transaction rather than skipping the check.
+        assertNull(KaminoFarmsUserState.derive("not a farm", WALLET))
+        assertNull(KaminoFarmsUserState.derive(KaminoVaultRegistry.STEAKHOUSE_USDC.farm, "nope"))
+        assertNull(KaminoFarmsUserState.derive(KaminoVaultRegistry.STEAKHOUSE_USDC.farm, "1111"))
+    }
+
+    private companion object {
+        /** The wallet both captured deposits were built for. */
+        const val WALLET = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -618,6 +618,49 @@ class KaminoTransactionValidatorTest {
     }
 
     @Test
+    fun `a second unstake is refused rather than releasing twice what the withdraw burns`() {
+        // The bound each unstake is held to is per-instruction, so two of them each carrying the
+        // requested figure both pass it. The withdraw then burns that figure once, and the shares
+        // the second release took out of the farm stay out of it — earning nothing, and invisible
+        // on a screen that shows one amount. Exactly the harm the per-instruction bound names, and
+        // the only way to close it is to count them.
+        val unstake =
+            farms(FARMS_UNSTAKE, argument = littleEndian(unstakeScaled(AMOUNT), bytes = 16))
+        val reason =
+            rejection(
+                listOf(
+                    unstake,
+                    unstake,
+                    farms(FARMS_WITHDRAW_UNSTAKED_DEPOSITS),
+                    kvault(action = KaminoAction.WITHDRAW),
+                    memo,
+                ),
+                action = KaminoAction.WITHDRAW,
+            )
+        assertTrue(reason.contains("at most one farms unstake instruction, found 2"), reason)
+    }
+
+    @Test
+    fun `each of the four farms instructions is bounded to one, not merely checked one at a time`() {
+        // Every one of the four passes its own checks a second time, so each needs the count as
+        // well: a repeated `initialize_user` funds another farm's user state out of the wallet's
+        // rent, and a repeated stake or unstaked withdrawal moves shares a second time. iOS names
+        // all four `repeatable: false` in `KaminoInstructionSequence.expected`.
+        val bounded =
+            mapOf(
+                FARMS_INITIALIZE_USER to "initialize_user",
+                FARMS_STAKE to "stake",
+                FARMS_UNSTAKE to "unstake",
+                FARMS_WITHDRAW_UNSTAKED_DEPOSITS to "withdraw_unstaked_deposits",
+            )
+        bounded.forEach { (discriminator, name) ->
+            val duplicate = farms(discriminator)
+            val reason = rejection(listOf(kvault(), duplicate, duplicate, memo))
+            assertTrue(reason.contains("at most one farms $name instruction, found 2"), reason)
+        }
+    }
+
+    @Test
     fun `a stake that moves shares through another account is refused`() {
         val reason =
             rejection(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.blockchain.solana.kamino
 
+import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
@@ -16,32 +17,123 @@ class KaminoTransactionValidatorTest {
     private val memo =
         ix(KaminoAttributionMemo.MEMO_PROGRAM_ID, KaminoAttributionMemo.TAG.toByteArray())
 
+    /**
+     * A kVault instruction shaped like the captured ones: the wallet as authority, its own token
+     * and share accounts in the slots the IDL fixes, and the amount that was asked for.
+     *
+     * The filler in the other slots stands in for the accounts a real transaction loads from the
+     * vault's address lookup table, which decode to [KaminoTransactionDecoder.UNKNOWN_ACCOUNT].
+     */
+    private fun kvault(
+        action: KaminoAction = KaminoAction.DEPOSIT,
+        discriminator: String = discriminatorFor(action),
+        amount: BigInteger = AMOUNT,
+        user: String = DEFAULT_FEE_PAYER,
+        tokenAccount: String = TOKEN_ACCOUNT,
+        shareAccount: String = SHARE_ACCOUNT,
+    ): KaminoTxInstruction {
+        val accounts = MutableList(9) { KaminoTransactionDecoder.UNKNOWN_ACCOUNT }
+        accounts[0] = user
+        accounts[if (action == KaminoAction.DEPOSIT) 6 else 5] = tokenAccount
+        accounts[7] = shareAccount
+        return KaminoTxInstruction(
+            programId = KaminoVaultRegistry.PROGRAM_ID,
+            data = bytes(discriminator) + littleEndian(amount, bytes = 8),
+            accounts = accounts,
+        )
+    }
+
+    private fun discriminatorFor(action: KaminoAction) =
+        when (action) {
+            KaminoAction.DEPOSIT -> KVAULT_DEPOSIT
+            KaminoAction.WITHDRAW -> KVAULT_WITHDRAW_FROM_AVAILABLE
+        }
+
+    /**
+     * A farms instruction with the wallet as authority and its share account in both slots the
+     * checked instructions read one of — slot 4 for the stake, slot 3 for the unstaked withdrawal.
+     */
+    private fun farms(
+        discriminator: String,
+        argument: ByteArray = ByteArray(0),
+        owner: String = DEFAULT_FEE_PAYER,
+        shareAccount: String = SHARE_ACCOUNT,
+    ): KaminoTxInstruction {
+        val accounts = MutableList(6) { KaminoTransactionDecoder.UNKNOWN_ACCOUNT }
+        accounts[0] = owner
+        accounts[3] = shareAccount
+        accounts[4] = shareAccount
+        return KaminoTxInstruction(
+            programId = KaminoVaultRegistry.FARMS_PROGRAM_ID,
+            data = bytes(discriminator) + argument,
+            accounts = accounts,
+        )
+    }
+
+    /** `CreateIdempotent` for one of the wallet's own accounts, as every captured shape opens. */
+    private fun createAta(account: String = SHARE_ACCOUNT, discriminator: Int = 1) =
+        KaminoTxInstruction(
+            programId = ASSOCIATED_TOKEN_PROGRAM,
+            data = byteArrayOf(discriminator.toByte()),
+            accounts = listOf(DEFAULT_FEE_PAYER, account, DEFAULT_FEE_PAYER),
+        )
+
     /** The shape a prepared deposit actually has: ATA, kVault, two farms, compute budget, memo. */
     private fun depositInstructions(memoInstruction: KaminoTxInstruction? = memo) =
         listOfNotNull(
-            ix("ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"),
-            ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)),
-            ix(KaminoVaultRegistry.FARMS_PROGRAM_ID),
-            ix(KaminoVaultRegistry.FARMS_PROGRAM_ID),
+            createAta(),
+            kvault(),
+            farms(FARMS_INITIALIZE_USER),
+            farms(FARMS_STAKE, argument = littleEndian(U64_MAX, bytes = 8)),
             ix("ComputeBudget111111111111111111111111111111"),
             memoInstruction,
         )
 
     /**
-     * Most rules do not care who pays, so the fee payer defaults to a benign value; the fee-payer
-     * test sets it explicitly.
+     * Everything the preparer derives locally before it validates, defaulted so each test overrides
+     * only what it is about. The fee payer defaults to the signer, since most rules do not care who
+     * pays and the fee-payer test sets it explicitly.
      */
-    private fun decoded(
+    private fun validate(
         instructions: List<KaminoTxInstruction>,
+        vault: KaminoVault = this.vault,
+        action: KaminoAction = KaminoAction.DEPOSIT,
         feePayer: String? = DEFAULT_FEE_PAYER,
-    ) = KaminoDecodedTransaction(feePayer = feePayer, instructions = instructions)
+        signerAddress: String? = DEFAULT_FEE_PAYER,
+        tokenAccount: String? = TOKEN_ACCOUNT,
+        shareAccount: String? = SHARE_ACCOUNT,
+        amountBaseUnits: BigInteger? = AMOUNT,
+    ) =
+        KaminoTransactionValidator.validate(
+            decoded = KaminoDecodedTransaction(feePayer = feePayer, instructions = instructions),
+            vault = vault,
+            action = action,
+            signerAddress = signerAddress,
+            tokenAccount = tokenAccount,
+            shareAccount = shareAccount,
+            amountBaseUnits = amountBaseUnits,
+        )
 
-    private fun rejection(instructions: List<KaminoTxInstruction>): String =
+    private fun rejection(
+        instructions: List<KaminoTxInstruction>,
+        vault: KaminoVault = this.vault,
+        action: KaminoAction = KaminoAction.DEPOSIT,
+        feePayer: String? = DEFAULT_FEE_PAYER,
+        signerAddress: String? = DEFAULT_FEE_PAYER,
+        tokenAccount: String? = TOKEN_ACCOUNT,
+        shareAccount: String? = SHARE_ACCOUNT,
+        amountBaseUnits: BigInteger? = AMOUNT,
+    ): String =
         assertThrows<KaminoTransactionRejected> {
-                KaminoTransactionValidator.validate(
-                    decoded(instructions),
-                    vault,
-                    KaminoAction.DEPOSIT,
+                validate(
+                    instructions = instructions,
+                    vault = vault,
+                    action = action,
+                    feePayer = feePayer,
+                    signerAddress = signerAddress,
+                    tokenAccount = tokenAccount,
+                    shareAccount = shareAccount,
+                    amountBaseUnits = amountBaseUnits,
                 )
             }
             .message
@@ -49,29 +141,38 @@ class KaminoTransactionValidatorTest {
 
     @Test
     fun `a well-formed deposit passes`() {
-        assertDoesNotThrow {
-            KaminoTransactionValidator.validate(
-                decoded(depositInstructions()),
-                vault,
-                KaminoAction.DEPOSIT,
-            )
-        }
+        assertDoesNotThrow { validate(depositInstructions()) }
     }
 
     @Test
     fun `a withdraw without the farms instructions passes`() {
         assertDoesNotThrow {
-            KaminoTransactionValidator.validate(
-                decoded(
-                    listOf(
-                        ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(9)),
-                        ix("ComputeBudget111111111111111111111111111111"),
-                        memo,
-                    )
+            validate(
+                listOf(
+                    kvault(action = KaminoAction.WITHDRAW),
+                    ix("ComputeBudget111111111111111111111111111111"),
+                    memo,
                 ),
-                vault,
-                KaminoAction.WITHDRAW,
+                action = KaminoAction.WITHDRAW,
             )
+        }
+    }
+
+    @Test
+    fun `both withdraw shapes are accepted, because which one arrives is the vault's business`() {
+        // `withdraw` and `withdraw_from_available` are the same withdraw; which the builder emits
+        // says only whether the vault's liquid buffer covered the request, and both are in live
+        // use. They share an account layout by IDL construction, so one check serves both.
+        listOf(KVAULT_WITHDRAW, KVAULT_WITHDRAW_FROM_AVAILABLE).forEach { discriminator ->
+            assertDoesNotThrow {
+                validate(
+                    listOf(
+                        kvault(action = KaminoAction.WITHDRAW, discriminator = discriminator),
+                        memo,
+                    ),
+                    action = KaminoAction.WITHDRAW,
+                )
+            }
         }
     }
 
@@ -92,6 +193,27 @@ class KaminoTransactionValidatorTest {
     fun `a transaction that never touches the kVault program is refused`() {
         val reason = rejection(listOf(ix("11111111111111111111111111111111"), memo))
         assertTrue(reason.contains("never invokes the kVault program"), reason)
+    }
+
+    @Test
+    fun `a second kVault instruction is refused rather than checked twice`() {
+        // Every amount below is compared instruction by instruction, so two instructions each
+        // carrying the figure on screen would both pass and move the money twice.
+        val reason = rejection(listOf(kvault(), kvault(), memo))
+        assertTrue(reason.contains("exactly one kVault instruction"), reason)
+    }
+
+    @Test
+    fun `a second System instruction is refused rather than wrapping twice`() {
+        val wrap = systemIx(2, listOf(DEFAULT_FEE_PAYER, WRAPPED_SOL_ACCOUNT))
+        val reason =
+            rejection(
+                listOf(solVaultKvault(), wrap, wrap, memo),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+                tokenAccount = WRAPPED_SOL_ACCOUNT,
+                shareAccount = SOL_SHARE_ACCOUNT,
+            )
+        assertTrue(reason.contains("at most one System instruction"), reason)
     }
 
     @Test
@@ -127,17 +249,16 @@ class KaminoTransactionValidatorTest {
     @Test
     fun `a memo naming accounts is refused, tag or no tag`() {
         // A memo listing accounts is the Memo program attesting that they signed. Attribution is
-        // not
-        // that, and the app's own injection names none — so an account list means it came from
+        // not that, and the app's own injection names none — so an account list means it came from
         // somewhere else, even when the bytes happen to be right.
         val reason =
             rejection(
                 listOf(
-                    ix(KaminoVaultRegistry.PROGRAM_ID),
+                    kvault(),
                     KaminoTxInstruction(
                         programId = KaminoAttributionMemo.MEMO_PROGRAM_ID,
                         data = KaminoAttributionMemo.TAG.toByteArray(),
-                        accounts = listOf("9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"),
+                        accounts = listOf(DEFAULT_FEE_PAYER),
                     ),
                 )
             )
@@ -147,13 +268,7 @@ class KaminoTransactionValidatorTest {
     @Test
     fun `a memo that is not last is refused`() {
         val reason =
-            rejection(
-                listOf(
-                    ix(KaminoVaultRegistry.PROGRAM_ID),
-                    memo,
-                    ix("ComputeBudget111111111111111111111111111111"),
-                )
-            )
+            rejection(listOf(kvault(), memo, ix("ComputeBudget111111111111111111111111111111")))
         assertTrue(reason.contains("final instruction"), reason)
     }
 
@@ -165,16 +280,7 @@ class KaminoTransactionValidatorTest {
     @Test
     fun `a vault outside the registry is refused before anything else is checked`() {
         val uncurated = vault.copy(address = "2Z6C84pCc2ri8t39jvRCXnTGFQqUJf1mMpUMtpeFfhyB")
-        val reason =
-            assertThrows<KaminoTransactionRejected> {
-                    KaminoTransactionValidator.validate(
-                        decoded(depositInstructions()),
-                        uncurated,
-                        KaminoAction.DEPOSIT,
-                    )
-                }
-                .message
-                .orEmpty()
+        val reason = rejection(depositInstructions(), vault = uncurated)
         assertTrue(reason.contains("not a vault this app transacts with"), reason)
     }
 
@@ -185,7 +291,7 @@ class KaminoTransactionValidatorTest {
         val reason =
             rejection(
                 listOf(
-                    ix(KaminoVaultRegistry.PROGRAM_ID),
+                    kvault(),
                     // SPL Token `Transfer` is discriminator 3.
                     ix(TOKEN_PROGRAM, byteArrayOf(3, 0, 0, 0)),
                     memo,
@@ -199,7 +305,7 @@ class KaminoTransactionValidatorTest {
         val reason =
             rejection(
                 listOf(
-                    ix(KaminoVaultRegistry.PROGRAM_ID),
+                    kvault(),
                     // `TransferChecked` is discriminator 12.
                     ix(TOKEN_PROGRAM, byteArrayOf(12, 0)),
                     memo,
@@ -210,252 +316,470 @@ class KaminoTransactionValidatorTest {
 
     @Test
     fun `moving lamports is refused for a token vault and allowed for the wrapped-SOL one`() {
-        // System `Transfer` is 2, little-endian over four bytes. Its second account is the
-        // destination, which on a real wrap is the wSOL account the vault deposit also names — so
-        // the
-        // fixture has to say so, or the destination check refuses it for the right reason.
-        // Stands in for the address the preparer derives from the signer and the wSOL mint.
-        val wrappedSolAccount = "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8"
-        val systemTransfer =
-            KaminoTxInstruction(
-                programId = "11111111111111111111111111111111",
-                data = byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4),
-                accounts = listOf(DEFAULT_FEE_PAYER, wrappedSolAccount),
-            )
-        val kvault =
-            KaminoTxInstruction(
-                programId = KaminoVaultRegistry.PROGRAM_ID,
-                data = byteArrayOf(1),
-                accounts = listOf(wrappedSolAccount),
-            )
-        val instructions = listOf(kvault, systemTransfer, memo)
+        // System `Transfer` is 2, little-endian over four bytes, followed by the lamport `u64`.
+        val transfer = wrapOf(SOL_AMOUNT)
 
-        val reason = rejection(instructions)
+        val reason = rejection(listOf(kvault(), transfer, memo))
         assertTrue(reason.contains("moves lamports"), reason)
 
         // The SOL vault has to wrap, so the same instruction is expected there.
         assertDoesNotThrow {
-            KaminoTransactionValidator.validate(
-                decoded(instructions),
-                KaminoVaultRegistry.ALLEZ_SOL,
-                KaminoAction.DEPOSIT,
-                wrappedSolAccount = wrappedSolAccount,
+            validate(
+                listOf(solVaultKvault(), transfer, memo),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+                tokenAccount = WRAPPED_SOL_ACCOUNT,
+                shareAccount = SOL_SHARE_ACCOUNT,
+                amountBaseUnits = SOL_AMOUNT,
             )
         }
     }
 
     @Test
-    fun `a transaction authorised by someone other than the wallet is refused`() {
-        val signer = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
-        val instructions =
-            listOf(
-                KaminoTxInstruction(
-                    programId = KaminoVaultRegistry.PROGRAM_ID,
-                    data = byteArrayOf(1),
-                    accounts = listOf("SomeoneElsesAccount11111111111111111111111"),
-                ),
-                memo,
-            )
-
+    fun `a wrap of more lamports than the deposit is refused`() {
+        // The instruction #5603's third finding is about: reading only the four discriminator bytes
+        // leaves the lamports unbound, so a response could wrap the whole SOL balance while the
+        // screen shows the typed amount. The deposit then consumes what was asked for and the rest
+        // sits in a wrapped-SOL account this app has no screen for.
         val reason =
-            assertThrows<KaminoTransactionRejected> {
-                    KaminoTransactionValidator.validate(
-                        decoded(instructions, feePayer = OTHER_ACCOUNT),
-                        vault,
-                        KaminoAction.DEPOSIT,
-                        signerAddress = signer,
-                    )
-                }
-                .message
-                .orEmpty()
+            rejection(
+                listOf(solVaultKvault(), wrapOf(SOL_AMOUNT.multiply(BigInteger.TEN)), memo),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+                tokenAccount = WRAPPED_SOL_ACCOUNT,
+                shareAccount = SOL_SHARE_ACCOUNT,
+                amountBaseUnits = SOL_AMOUNT,
+            )
+        assertTrue(reason.contains("rather than the $SOL_AMOUNT"), reason)
+    }
+
+    @Test
+    fun `a wrap is refused when the amount that was asked for could not be read`() {
+        // The wrap leads, as it does on the wire: the deposit cannot spend wrapped SOL that has not
+        // been wrapped yet.
+        val reason =
+            rejection(
+                listOf(wrapOf(SOL_AMOUNT), solVaultKvault(), memo),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+                tokenAccount = WRAPPED_SOL_ACCOUNT,
+                shareAccount = SOL_SHARE_ACCOUNT,
+                amountBaseUnits = null,
+            )
+        assertTrue(reason.contains("could not be read"), reason)
+    }
+
+    @Test
+    fun `a wrap carrying no lamport amount at all is refused`() {
+        // Four discriminator bytes and nothing after them: the shape the old check read, and the
+        // one it accepted.
+        val truncated =
+            KaminoTxInstruction(
+                programId = SYSTEM_PROGRAM,
+                data = byteArrayOf(2, 0, 0, 0),
+                accounts = listOf(DEFAULT_FEE_PAYER, WRAPPED_SOL_ACCOUNT),
+            )
+        val reason =
+            rejection(
+                listOf(solVaultKvault(), truncated, memo),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+                tokenAccount = WRAPPED_SOL_ACCOUNT,
+                shareAccount = SOL_SHARE_ACCOUNT,
+                amountBaseUnits = SOL_AMOUNT,
+            )
+        assertTrue(reason.contains("no lamport amount"), reason)
+    }
+
+    @Test
+    fun `a wrap is refused on a withdraw, which has nothing to wrap`() {
+        val reason =
+            rejection(
+                listOf(solVaultKvault(action = KaminoAction.WITHDRAW), wrapOf(SOL_AMOUNT), memo),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+                action = KaminoAction.WITHDRAW,
+                tokenAccount = WRAPPED_SOL_ACCOUNT,
+                shareAccount = SOL_SHARE_ACCOUNT,
+                amountBaseUnits = SOL_AMOUNT,
+            )
+        assertTrue(reason.contains("no Kamino withdraw performs"), reason)
+    }
+
+    @Test
+    fun `a transaction authorised by someone other than the wallet is refused`() {
+        val reason = rejection(listOf(kvault(), memo), feePayer = OTHER_ACCOUNT)
         assertTrue(reason.contains("authorised by"), reason)
 
         // The wallet's own transaction passes.
-        assertDoesNotThrow {
-            KaminoTransactionValidator.validate(
-                decoded(
-                    listOf(
-                        KaminoTxInstruction(
-                            programId = KaminoVaultRegistry.PROGRAM_ID,
-                            data = byteArrayOf(1),
-                            accounts = listOf(signer),
-                        ),
-                        memo,
-                    ),
-                    feePayer = signer,
-                ),
-                vault,
-                KaminoAction.DEPOSIT,
-                signerAddress = signer,
-            )
-        }
+        assertDoesNotThrow { validate(listOf(kvault(), memo)) }
     }
 
     @Test
     fun `a lamport transfer to an address the deposit does not reference is refused`() {
         // Allowed on the wrapped-SOL vault, but not to anywhere: the only lamports a deposit moves
-        // go
-        // into the wSOL account it then deposits from. A transfer somewhere else is not a wrap.
-        val kvault =
-            KaminoTxInstruction(
-                programId = KaminoVaultRegistry.PROGRAM_ID,
-                data = byteArrayOf(1),
-                accounts = listOf("AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8"),
-            )
+        // go into the wSOL account it then deposits from. A transfer somewhere else is not a wrap.
         val strayTransfer =
             KaminoTxInstruction(
-                programId = "11111111111111111111111111111111",
-                data = byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4),
+                programId = SYSTEM_PROGRAM,
+                data = byteArrayOf(2, 0, 0, 0) + littleEndian(SOL_AMOUNT, bytes = 8),
                 accounts = listOf(DEFAULT_FEE_PAYER, OTHER_ACCOUNT),
             )
 
         val reason =
-            assertThrows<KaminoTransactionRejected> {
-                    KaminoTransactionValidator.validate(
-                        decoded(listOf(kvault, strayTransfer, memo)),
-                        KaminoVaultRegistry.ALLEZ_SOL,
-                        KaminoAction.DEPOSIT,
-                        wrappedSolAccount = "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8",
-                    )
-                }
-                .message
-                .orEmpty()
+            rejection(
+                listOf(solVaultKvault(), strayTransfer, memo),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+                tokenAccount = WRAPPED_SOL_ACCOUNT,
+                shareAccount = SOL_SHARE_ACCOUNT,
+                amountBaseUnits = SOL_AMOUNT,
+            )
         assertTrue(reason.contains("rather than to the wallet"), reason)
     }
 
     @Test
     fun `a transaction paid for by another account is refused on the message, not an instruction`() {
         // The earlier check read the first account of the first instruction, which says nothing
-        // about
-        // who authorises the transaction: this fixture names the wallet there while the message is
-        // paid for by someone else.
-        val instructions =
-            listOf(
-                KaminoTxInstruction(
-                    programId = KaminoVaultRegistry.PROGRAM_ID,
-                    data = byteArrayOf(1),
-                    accounts = listOf(DEFAULT_FEE_PAYER),
-                ),
-                memo,
-            )
-
-        val reason =
-            assertThrows<KaminoTransactionRejected> {
-                    KaminoTransactionValidator.validate(
-                        decoded(instructions, feePayer = OTHER_ACCOUNT),
-                        vault,
-                        KaminoAction.DEPOSIT,
-                        signerAddress = DEFAULT_FEE_PAYER,
-                    )
-                }
-                .message
-                .orEmpty()
+        // about who authorises the transaction: this fixture names the wallet there while the
+        // message is paid for by someone else.
+        val reason = rejection(listOf(kvault(), memo), feePayer = OTHER_ACCOUNT)
         assertTrue(reason.contains("authorised by"), reason)
-    }
-
-    @Test
-    fun `a lamport transfer is refused when the destination is only named by the kVault instruction`() {
-        // The check this replaced accepted any destination the kVault instruction also named, which
-        // a
-        // compromised response could satisfy by listing an attacker there — the same response
-        // chooses
-        // that account list. Only the locally derived wrapped-SOL address is accepted.
-        val attacker = OTHER_ACCOUNT
-        val kvault =
-            KaminoTxInstruction(
-                programId = KaminoVaultRegistry.PROGRAM_ID,
-                data = byteArrayOf(1),
-                accounts = listOf(attacker),
-            )
-        val transferToAttacker =
-            KaminoTxInstruction(
-                programId = "11111111111111111111111111111111",
-                data = byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4),
-                accounts = listOf(DEFAULT_FEE_PAYER, attacker),
-            )
-
-        val reason =
-            assertThrows<KaminoTransactionRejected> {
-                    KaminoTransactionValidator.validate(
-                        decoded(listOf(kvault, transferToAttacker, memo)),
-                        KaminoVaultRegistry.ALLEZ_SOL,
-                        KaminoAction.DEPOSIT,
-                        wrappedSolAccount = "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8",
-                    )
-                }
-                .message
-                .orEmpty()
-        assertTrue(reason.contains("rather than to the wallet"), reason)
     }
 
     @Test
     fun `a wrap is refused outright when the expected account could not be derived`() {
         // Unverifiable is not the same as fine: with no derived address there is nothing to compare
         // the destination against.
-        val transfer =
-            KaminoTxInstruction(
-                programId = "11111111111111111111111111111111",
-                data = byteArrayOf(2, 0, 0, 0, 1, 2, 3, 4),
-                accounts = listOf(DEFAULT_FEE_PAYER, "AyY6VCkHfTWdFs7SqBbu6AnCqLUhgzVHBzW3WcJu5Jc8"),
-            )
         val reason =
-            assertThrows<KaminoTransactionRejected> {
-                    KaminoTransactionValidator.validate(
-                        decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID), transfer, memo)),
-                        KaminoVaultRegistry.ALLEZ_SOL,
-                        KaminoAction.DEPOSIT,
-                        wrappedSolAccount = null,
-                    )
-                }
-                .message
-                .orEmpty()
+            rejection(
+                listOf(wrapOf(SOL_AMOUNT), solVaultKvault(), memo),
+                vault = KaminoVaultRegistry.ALLEZ_SOL,
+                tokenAccount = null,
+                shareAccount = SOL_SHARE_ACCOUNT,
+                amountBaseUnits = SOL_AMOUNT,
+            )
         assertTrue(reason.contains("could not be derived"), reason)
     }
 
     @Test
     fun `the withdraw-everything sentinel is refused on any device`() {
         // u64::MAX is what the kVault program reads as "withdraw everything". This app never
-        // produces
-        // one — the form's maximum sits strictly below the balance so the API cannot answer with
-        // it,
-        // and an over-request is refused rather than clamped — so a transaction carrying it did not
-        // come from here. It is also the one amount whose consequence is the whole position rather
-        // than the figure on screen, which is why it is refused rather than merely disclosed.
-        val sentinel =
-            ByteArray(16).also { data ->
-                // 8-byte Anchor discriminator, then the amount little-endian.
-                for (i in 8 until 16) data[i] = 0xFF.toByte()
-            }
-        val reason = rejection(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, sentinel), memo))
+        // produces one — the form's maximum sits strictly below the balance so the API cannot
+        // answer with it, and an over-request is refused rather than clamped — so a transaction
+        // carrying it did not come from here. It is also the one amount whose consequence is the
+        // whole position rather than the figure on screen, which is why it is refused rather than
+        // merely disclosed, and why it is named ahead of the plain amount mismatch it also is.
+        val reason =
+            rejection(
+                listOf(kvault(action = KaminoAction.WITHDRAW, amount = U64_MAX), memo),
+                action = KaminoAction.WITHDRAW,
+            )
         assertTrue(reason.contains("withdraw-everything sentinel"), reason)
     }
 
     @Test
-    fun `an ordinary amount one below the sentinel is allowed`() {
+    fun `an ordinary amount one below the sentinel is allowed when it is what was asked for`() {
         // The guard must key on the sentinel exactly, not on "a large amount".
-        val justUnder =
-            ByteArray(16).also { data ->
-                for (i in 8 until 15) data[i] = 0xFF.toByte()
-                data[15] = 0xFE.toByte()
-            }
+        val justUnder = U64_MAX.subtract(BigInteger.ONE)
         assertDoesNotThrow {
-            KaminoTransactionValidator.validate(
-                decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, justUnder), memo)),
-                vault,
-                KaminoAction.WITHDRAW,
+            validate(
+                listOf(kvault(action = KaminoAction.WITHDRAW, amount = justUnder), memo),
+                action = KaminoAction.WITHDRAW,
+                amountBaseUnits = justUnder,
             )
         }
     }
 
     @Test
-    fun `a short kVault instruction carrying no amount is not mistaken for the sentinel`() {
+    fun `a kVault instruction moving another figure than the one on screen is refused`() {
+        val reason = rejection(listOf(kvault(amount = AMOUNT.multiply(BigInteger.TEN)), memo))
+        assertTrue(reason.contains("rather than the $AMOUNT"), reason)
+    }
+
+    @Test
+    fun `a short kVault instruction carrying no amount is refused rather than skipped`() {
+        val truncated =
+            KaminoTxInstruction(
+                programId = KaminoVaultRegistry.PROGRAM_ID,
+                data = bytes(KVAULT_DEPOSIT),
+                accounts = kvault().accounts,
+            )
+        val reason = rejection(listOf(truncated, memo))
+        assertTrue(reason.contains("no amount to check"), reason)
+    }
+
+    @Test
+    fun `a kVault instruction that is not the action the app asked for is refused`() {
+        val reason = rejection(listOf(kvault(discriminator = KVAULT_WITHDRAW_FROM_AVAILABLE), memo))
+        assertTrue(reason.contains("not the kVault deposit"), reason)
+
+        val theOtherWay =
+            rejection(
+                listOf(
+                    kvault(action = KaminoAction.WITHDRAW, discriminator = KVAULT_DEPOSIT),
+                    memo,
+                ),
+                action = KaminoAction.WITHDRAW,
+            )
+        assertTrue(theOtherWay.contains("not the kVault withdraw"), theOtherWay)
+    }
+
+    @Test
+    fun `a kVault instruction naming another share account is refused`() {
+        // The finding this pins: nothing else in the transaction binds the instruction to the vault
+        // on screen. The vault account travels in an address lookup table this decode does not
+        // resolve, so a substituted `vault_state` — including one the response made itself through
+        // the permissionless `init_vault` — would deposit the balance into a vault the app never
+        // curated while the screen showed the registry address. The share account is derived
+        // locally from the registry's share mint and this signer, so it cannot be substituted.
+        val reason = rejection(listOf(kvault(shareAccount = OTHER_ACCOUNT), memo))
+        assertTrue(reason.contains("share account for this vault"), reason)
+    }
+
+    @Test
+    fun `a kVault instruction hiding its share account behind a lookup table is refused`() {
+        // "Cannot tell" is not "not a mismatch": an account the response loads from its own table
+        // decodes as unresolved and must fail the comparison rather than skip it.
+        val reason =
+            rejection(listOf(kvault(shareAccount = KaminoTransactionDecoder.UNKNOWN_ACCOUNT), memo))
+        assertTrue(reason.contains("share account for this vault"), reason)
+    }
+
+    @Test
+    fun `a kVault instruction paying out to another token account is refused`() {
+        // Slot 5 of a withdraw is where the tokens land. Rewriting it hands the payout to whoever
+        // the response names while every other instruction still reads as the withdraw asked for.
+        val reason =
+            rejection(
+                listOf(kvault(action = KaminoAction.WITHDRAW, tokenAccount = OTHER_ACCOUNT), memo),
+                action = KaminoAction.WITHDRAW,
+            )
+        assertTrue(reason.contains("token account for this vault"), reason)
+    }
+
+    @Test
+    fun `a kVault instruction authorised by another account is refused`() {
+        val reason = rejection(listOf(kvault(user = OTHER_ACCOUNT), memo))
+        assertTrue(reason.contains("the authority this vault move runs under"), reason)
+    }
+
+    @Test
+    fun `a kVault instruction is refused when the wallet's own accounts could not be derived`() {
+        val noShares = rejection(listOf(kvault(), memo), shareAccount = null)
+        assertTrue(noShares.contains("could not be derived locally"), noShares)
+
+        val noTokens = rejection(listOf(kvault(), memo), tokenAccount = null)
+        assertTrue(noTokens.contains("could not be derived locally"), noTokens)
+
+        val noAmount = rejection(listOf(kvault(), memo), amountBaseUnits = null)
+        assertTrue(noAmount.contains("could not be read"), noAmount)
+    }
+
+    @Test
+    fun `a kVault instruction naming too few accounts is refused`() {
+        val short =
+            KaminoTxInstruction(
+                programId = KaminoVaultRegistry.PROGRAM_ID,
+                data = bytes(KVAULT_DEPOSIT) + littleEndian(AMOUNT, bytes = 8),
+                accounts = listOf(DEFAULT_FEE_PAYER),
+            )
+        val reason = rejection(listOf(short, memo))
+        assertTrue(reason.contains("too few accounts"), reason)
+    }
+
+    @Test
+    fun `a farms instruction the app never performs is refused`() {
+        // The gap an allow-list of programs alone leaves on the farms side. Every launch vault has
+        // a farm, so the program is allow-listed and its instructions went unread — and
+        // `transfer_ownership` moves the whole staked position to an account that never signs,
+        // authorised by the signature the message already carries. Nothing about it looks like a
+        // transfer. The discriminator is the Anchor one: sha256("global:transfer_ownership")[0..8].
+        val reason =
+            rejection(depositInstructions().dropLast(1) + farms(FARMS_TRANSFER_OWNERSHIP) + memo)
+        assertTrue(reason.contains("farms instruction no Kamino deposit or withdraw"), reason)
+    }
+
+    @Test
+    fun `the farms instructions a real deposit and withdraw carry are allowed`() {
+        // The other half of an allow-list, and the half a deny-list never had to get right: these
+        // four are what the captured deposit carries and what a staked withdraw adds, so refusing
+        // any of them would block a real position rather than let an extra instruction through.
+        assertDoesNotThrow { validate(depositInstructions()) }
+
         assertDoesNotThrow {
-            KaminoTransactionValidator.validate(
-                decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1, 2, 3)), memo)),
-                vault,
-                KaminoAction.DEPOSIT,
+            validate(
+                listOf(
+                    farms(
+                        FARMS_UNSTAKE,
+                        argument = littleEndian(unstakeScaled(AMOUNT), bytes = 16),
+                    ),
+                    farms(FARMS_WITHDRAW_UNSTAKED_DEPOSITS),
+                    kvault(action = KaminoAction.WITHDRAW),
+                    memo,
+                ),
+                action = KaminoAction.WITHDRAW,
             )
         }
+    }
+
+    @Test
+    fun `a stake that moves shares through another account is refused`() {
+        val reason =
+            rejection(
+                listOf(
+                    kvault(),
+                    farms(
+                        FARMS_STAKE,
+                        argument = littleEndian(U64_MAX, bytes = 8),
+                        shareAccount = OTHER_ACCOUNT,
+                    ),
+                    memo,
+                )
+            )
+        assertTrue(reason.contains("share account for this vault"), reason)
+    }
+
+    @Test
+    fun `a stake of anything but the whole balance is refused`() {
+        // Kamino stakes the entire share balance rather than the amount just minted, so the
+        // argument is the sentinel every time. A different value is a behaviour change.
+        val reason =
+            rejection(
+                listOf(
+                    kvault(),
+                    farms(FARMS_STAKE, argument = littleEndian(AMOUNT, bytes = 8)),
+                    memo,
+                )
+            )
+        assertTrue(reason.contains("stakes an amount this app has never seen"), reason)
+    }
+
+    @Test
+    fun `an unstake releasing more shares than the withdraw burns is refused`() {
+        // How many a withdraw legitimately releases is `requested − alreadyUnstaked`, and the
+        // second term is a balance this app does not hold here. The bound needs neither: a withdraw
+        // cannot take more out of the farm than it burns, and shares released beyond that sit
+        // outside the farm earning nothing, invisible on a screen that shows an amount.
+        val tooMuch = unstakeScaled(AMOUNT.add(BigInteger.ONE))
+        val reason =
+            rejection(
+                listOf(
+                    farms(FARMS_UNSTAKE, argument = littleEndian(tooMuch, bytes = 16)),
+                    farms(FARMS_WITHDRAW_UNSTAKED_DEPOSITS),
+                    kvault(action = KaminoAction.WITHDRAW),
+                    memo,
+                ),
+                action = KaminoAction.WITHDRAW,
+            )
+        assertTrue(reason.contains("more shares from the farm"), reason)
+    }
+
+    @Test
+    fun `an unstake read as a u64 would compare a number that means nothing`() {
+        // `1 share × 10^18` is 0x0DE0B6B3A7640000; its low eight bytes are the whole value only
+        // because the figure is small. A release of 100 shares is 16 bytes wide, and reading its
+        // low half gives 0x6BC75E2D63100000 — a plausible-looking number that is not the one on the
+        // wire. The check reads all sixteen, so the bound holds at any size.
+        val hundredShares = BigInteger.valueOf(100).multiply(BigInteger.TEN.pow(6))
+        assertDoesNotThrow {
+            validate(
+                listOf(
+                    farms(
+                        FARMS_UNSTAKE,
+                        argument = littleEndian(unstakeScaled(hundredShares), bytes = 16),
+                    ),
+                    farms(FARMS_WITHDRAW_UNSTAKED_DEPOSITS),
+                    kvault(action = KaminoAction.WITHDRAW, amount = hundredShares),
+                    memo,
+                ),
+                action = KaminoAction.WITHDRAW,
+                amountBaseUnits = hundredShares,
+            )
+        }
+    }
+
+    @Test
+    fun `the unstaked share withdrawal must land in the wallet's own share account`() {
+        // Where the released shares land, and the account the vault withdraw then burns from.
+        val reason =
+            rejection(
+                listOf(
+                    farms(
+                        FARMS_UNSTAKE,
+                        argument = littleEndian(unstakeScaled(AMOUNT), bytes = 16),
+                    ),
+                    farms(FARMS_WITHDRAW_UNSTAKED_DEPOSITS, shareAccount = OTHER_ACCOUNT),
+                    kvault(action = KaminoAction.WITHDRAW),
+                    memo,
+                ),
+                action = KaminoAction.WITHDRAW,
+            )
+        assertTrue(reason.contains("share account for this vault"), reason)
+    }
+
+    @Test
+    fun `a farms instruction under another authority is refused`() {
+        val reason =
+            rejection(
+                listOf(
+                    kvault(),
+                    farms(
+                        FARMS_STAKE,
+                        argument = littleEndian(U64_MAX, bytes = 8),
+                        owner = OTHER_ACCOUNT,
+                    ),
+                    memo,
+                )
+            )
+        assertTrue(reason.contains("farm authority"), reason)
+    }
+
+    @Test
+    fun `farms instructions belonging to the other action are refused`() {
+        // A deposit stakes and a withdraw unstakes; neither does both, in the template iOS matches
+        // live transactions against. An unstake riding on a deposit would pull the position out of
+        // the farm, where it stops earning and shows up on no screen.
+        val stakeOnWithdraw =
+            rejection(
+                listOf(
+                    kvault(action = KaminoAction.WITHDRAW),
+                    farms(FARMS_STAKE, argument = littleEndian(U64_MAX, bytes = 8)),
+                    memo,
+                ),
+                action = KaminoAction.WITHDRAW,
+            )
+        assertTrue(stakeOnWithdraw.contains("no Kamino withdraw performs"), stakeOnWithdraw)
+
+        val unstakeOnDeposit =
+            rejection(
+                listOf(
+                    kvault(),
+                    farms(
+                        FARMS_UNSTAKE,
+                        argument = littleEndian(unstakeScaled(AMOUNT), bytes = 16),
+                    ),
+                    memo,
+                )
+            )
+        assertTrue(unstakeOnDeposit.contains("no Kamino deposit performs"), unstakeOnDeposit)
+    }
+
+    @Test
+    fun `an account created for anyone but the wallet is refused`() {
+        // Creation is funded by the fee payer, so an account created for someone else is the wallet
+        // paying rent into an address the response chose.
+        val reason = rejection(listOf(createAta(OTHER_ACCOUNT), kvault(), memo))
+        assertTrue(reason.contains("not one of the wallet's own accounts"), reason)
+    }
+
+    @Test
+    fun `the wallet's own two accounts are both allowed to be created`() {
+        assertDoesNotThrow {
+            validate(listOf(createAta(SHARE_ACCOUNT), createAta(TOKEN_ACCOUNT), kvault(), memo))
+        }
+    }
+
+    @Test
+    fun `an associated-token instruction other than the idempotent create is refused`() {
+        // `Create` (0) fails outright when the account exists, so a response emitting it would be
+        // doing something other than making sure the account is there.
+        val reason = rejection(listOf(createAta(discriminator = 0), kvault(), memo))
+        assertTrue(reason.contains("associated-token instruction 0"), reason)
     }
 
     @Test
@@ -468,9 +792,13 @@ class KaminoTransactionValidatorTest {
         )
     }
 
-    private fun tokenIx(discriminator: Int, accounts: List<String>) =
+    private fun tokenIx(
+        discriminator: Int,
+        accounts: List<String>,
+        programId: String = TOKEN_PROGRAM,
+    ) =
         KaminoTxInstruction(
-            programId = TOKEN_PROGRAM,
+            programId = programId,
             data = byteArrayOf(discriminator.toByte()),
             accounts = accounts,
         )
@@ -478,29 +806,51 @@ class KaminoTransactionValidatorTest {
     private fun systemIx(discriminator: Int, accounts: List<String>) =
         KaminoTxInstruction(
             programId = SYSTEM_PROGRAM,
-            data = byteArrayOf(discriminator.toByte(), 0, 0, 0, 1, 2, 3, 4),
+            data =
+                byteArrayOf(discriminator.toByte(), 0, 0, 0) + littleEndian(SOL_AMOUNT, bytes = 8),
             accounts = accounts,
+        )
+
+    /**
+     * The wrap a real Allez SOL deposit carries: lamports out of the wallet, into its wSOL account.
+     */
+    private fun wrapOf(lamports: BigInteger) =
+        KaminoTxInstruction(
+            programId = SYSTEM_PROGRAM,
+            data = byteArrayOf(2, 0, 0, 0) + littleEndian(lamports, bytes = 8),
+            accounts = listOf(DEFAULT_FEE_PAYER, WRAPPED_SOL_ACCOUNT),
+        )
+
+    private fun solVaultKvault(action: KaminoAction = KaminoAction.DEPOSIT) =
+        kvault(
+            action = action,
+            amount = SOL_AMOUNT,
+            tokenAccount = WRAPPED_SOL_ACCOUNT,
+            shareAccount = SOL_SHARE_ACCOUNT,
         )
 
     /** [instruction] riding along on an otherwise valid wrapped-SOL vault transaction. */
     private fun validateOnSolVault(
         instruction: KaminoTxInstruction,
-        wrappedSolAccount: String? = WRAPPED_SOL_ACCOUNT,
+        tokenAccount: String? = WRAPPED_SOL_ACCOUNT,
+        action: KaminoAction = KaminoAction.DEPOSIT,
     ) =
-        KaminoTransactionValidator.validate(
-            decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1)), instruction, memo)),
-            KaminoVaultRegistry.ALLEZ_SOL,
-            KaminoAction.DEPOSIT,
-            signerAddress = DEFAULT_FEE_PAYER,
-            wrappedSolAccount = wrappedSolAccount,
+        validate(
+            listOf(instruction, solVaultKvault(action), memo),
+            vault = KaminoVaultRegistry.ALLEZ_SOL,
+            action = action,
+            tokenAccount = tokenAccount,
+            shareAccount = SOL_SHARE_ACCOUNT,
+            amountBaseUnits = SOL_AMOUNT,
         )
 
     private fun solVaultRejection(
         instruction: KaminoTxInstruction,
-        wrappedSolAccount: String? = WRAPPED_SOL_ACCOUNT,
+        tokenAccount: String? = WRAPPED_SOL_ACCOUNT,
+        action: KaminoAction = KaminoAction.DEPOSIT,
     ): String =
         assertThrows<KaminoTransactionRejected> {
-                validateOnSolVault(instruction, wrappedSolAccount)
+                validateOnSolVault(instruction, tokenAccount, action)
             }
             .message
             .orEmpty()
@@ -522,6 +872,19 @@ class KaminoTransactionValidatorTest {
     }
 
     @Test
+    fun `a System instruction carrying no discriminator at all is refused`() {
+        val reason =
+            solVaultRejection(
+                KaminoTxInstruction(
+                    programId = SYSTEM_PROGRAM,
+                    data = byteArrayOf(2, 0),
+                    accounts = listOf(DEFAULT_FEE_PAYER, WRAPPED_SOL_ACCOUNT),
+                )
+            )
+        assertTrue(reason.contains("no System instruction to check"), reason)
+    }
+
+    @Test
     fun `every SPL token instruction other than the wrapped-SOL bookkeeping is refused`() {
         // Likewise on the token side: `Approve` (4) and `SetAuthority` (6) hand the account over
         // instead of draining it, so the drain arrives later and unsigned by this wallet, and
@@ -530,6 +893,23 @@ class KaminoTransactionValidatorTest {
             val reason = solVaultRejection(tokenIx(discriminator, listOf(WRAPPED_SOL_ACCOUNT)))
             assertTrue(reason.contains("SPL token instruction $discriminator"), reason)
         }
+    }
+
+    @Test
+    fun `Token-2022 is held to the same allow-list as Token`() {
+        // Both dispatch to the same check, so an instruction the Token program may not carry must
+        // not become permitted by arriving under the newer program id.
+        val reason =
+            solVaultRejection(
+                tokenIx(3, listOf(WRAPPED_SOL_ACCOUNT), programId = TOKEN_2022_PROGRAM)
+            )
+        assertTrue(reason.contains("SPL token instruction 3"), reason)
+    }
+
+    @Test
+    fun `an SPL token instruction carrying no discriminator at all is refused`() {
+        val reason = solVaultRejection(KaminoTxInstruction(TOKEN_PROGRAM, ByteArray(0)))
+        assertTrue(reason.contains("no SPL token instruction to check"), reason)
     }
 
     @Test
@@ -611,14 +991,7 @@ class KaminoTransactionValidatorTest {
         // Neither captured USDC shape carries a top-level token instruction at all — that vault
         // moves its tokens through the kVault program's own CPI — so a wrap is allowed only where
         // there is something to wrap.
-        val reason =
-            rejection(
-                listOf(
-                    ix(KaminoVaultRegistry.PROGRAM_ID),
-                    tokenIx(17, listOf(WRAPPED_SOL_ACCOUNT)),
-                    memo,
-                )
-            )
+        val reason = rejection(listOf(kvault(), tokenIx(17, listOf(TOKEN_ACCOUNT)), memo))
         assertTrue(reason.contains("only the wrapped-SOL vault"), reason)
     }
 
@@ -627,7 +1000,7 @@ class KaminoTransactionValidatorTest {
         // Same posture the transfer already took: with nothing to compare against, refuse rather
         // than wave through.
         val reason =
-            solVaultRejection(tokenIx(17, listOf(WRAPPED_SOL_ACCOUNT)), wrappedSolAccount = null)
+            solVaultRejection(tokenIx(17, listOf(WRAPPED_SOL_ACCOUNT)), tokenAccount = null)
         assertTrue(reason.contains("could not be derived"), reason)
     }
 
@@ -636,8 +1009,49 @@ class KaminoTransactionValidatorTest {
         const val OTHER_ACCOUNT = "SomeoneElsesAccount11111111111111111111111"
         const val SYSTEM_PROGRAM = "11111111111111111111111111111111"
         const val TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        const val TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+        const val ASSOCIATED_TOKEN_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
 
-        /** [DEFAULT_FEE_PAYER]'s wrapped-SOL account, as the Allez SOL fixtures derive it. */
+        /**
+         * The accounts [DEFAULT_FEE_PAYER] actually owns, as the captured fixtures name them: its
+         * USDC account and its Steakhouse share account, and on the SOL side its wrapped-SOL and
+         * Allez SOL share accounts. Real derivations rather than placeholders, so these tests
+         * compare the same addresses the preparer hands the validator on device.
+         */
+        const val TOKEN_ACCOUNT = "4nkDh9aubXGWVeWfnnWsQ24rGm2RVmRLabRXAQwsEGpB"
+
+        const val SHARE_ACCOUNT = "GSayQpRaoh1LFdBbja4vensNKDfihcixzCcQShKMCdMJ"
         const val WRAPPED_SOL_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
+        const val SOL_SHARE_ACCOUNT = "Hq6N6sNE638VLULNEeAZRTMFmYtsG9ZLLPJYefxwPNWf"
+
+        /** Anchor discriminators: the first eight bytes of `sha256("global:<name>")`. */
+        const val KVAULT_DEPOSIT = "f223c68952e1f2b6"
+
+        const val KVAULT_WITHDRAW = "b712469c946da122"
+        const val KVAULT_WITHDRAW_FROM_AVAILABLE = "1383709baadc2239"
+        const val FARMS_INITIALIZE_USER = "6f11b9fa3c7a26fe"
+        const val FARMS_STAKE = "ceb0ca12c8d1b36c"
+        const val FARMS_UNSTAKE = "5a5f6b2acd7c32e1"
+        const val FARMS_WITHDRAW_UNSTAKED_DEPOSITS = "2466bb31dc248443"
+
+        /** Not one this app performs — the point of the test that uses it. */
+        const val FARMS_TRANSFER_OWNERSHIP = "41b1d749352d632f"
+
+        /** 1 USDC, at the Steakhouse vault's six decimals. */
+        val AMOUNT: BigInteger = BigInteger.valueOf(1_000_000)
+
+        /** 0.05 SOL, the figure the captured Allez SOL deposit wraps. */
+        val SOL_AMOUNT: BigInteger = BigInteger.valueOf(50_000_000)
+
+        val U64_MAX: BigInteger = BigInteger("18446744073709551615")
+
+        fun bytes(hex: String) =
+            ByteArray(hex.length / 2) { hex.substring(it * 2, it * 2 + 2).toInt(16).toByte() }
+
+        fun littleEndian(value: BigInteger, bytes: Int) =
+            ByteArray(bytes) { value.shiftRight(8 * it).and(BigInteger.valueOf(0xFF)).toByte() }
+
+        /** The farms program holds stake at `WAD`, so its amounts are share base units × 10^18. */
+        fun unstakeScaled(shares: BigInteger): BigInteger = shares.multiply(BigInteger.TEN.pow(18))
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -50,19 +50,26 @@ class KaminoTransactionValidatorTest {
         }
 
     /**
-     * A farms instruction with the wallet as authority and its share account in both slots the
-     * checked instructions read one of — slot 4 for the stake, slot 3 for the unstaked withdrawal.
+     * A farms instruction with the wallet as authority, its state in the farm, and its share
+     * account in both slots the checked instructions read one of — slot 4 for the stake, slot 3 for
+     * the unstaked withdrawal.
+     *
+     * The user state sits at slot 4 on `initialize_user` and at slot 1 on the other three, which is
+     * the layout the captured deposits carry: the instruction that *creates* the account is handed
+     * the authority, the payer, the owner and the delegatee first.
      */
     private fun farms(
         discriminator: String,
         argument: ByteArray = ByteArray(0),
         owner: String = DEFAULT_FEE_PAYER,
         shareAccount: String = SHARE_ACCOUNT,
+        userState: String = FARM_USER_STATE,
     ): KaminoTxInstruction {
         val accounts = MutableList(6) { KaminoTransactionDecoder.UNKNOWN_ACCOUNT }
         accounts[0] = owner
         accounts[3] = shareAccount
         accounts[4] = shareAccount
+        accounts[if (discriminator == FARMS_INITIALIZE_USER) 4 else 1] = userState
         return KaminoTxInstruction(
             programId = KaminoVaultRegistry.FARMS_PROGRAM_ID,
             data = bytes(discriminator) + argument,
@@ -102,6 +109,7 @@ class KaminoTransactionValidatorTest {
         signerAddress: String? = DEFAULT_FEE_PAYER,
         tokenAccount: String? = TOKEN_ACCOUNT,
         shareAccount: String? = SHARE_ACCOUNT,
+        farmUserState: String? = FARM_USER_STATE,
         amountBaseUnits: BigInteger? = AMOUNT,
     ) =
         KaminoTransactionValidator.validate(
@@ -111,6 +119,7 @@ class KaminoTransactionValidatorTest {
             signerAddress = signerAddress,
             tokenAccount = tokenAccount,
             shareAccount = shareAccount,
+            farmUserState = farmUserState,
             amountBaseUnits = amountBaseUnits,
         )
 
@@ -122,6 +131,7 @@ class KaminoTransactionValidatorTest {
         signerAddress: String? = DEFAULT_FEE_PAYER,
         tokenAccount: String? = TOKEN_ACCOUNT,
         shareAccount: String? = SHARE_ACCOUNT,
+        farmUserState: String? = FARM_USER_STATE,
         amountBaseUnits: BigInteger? = AMOUNT,
     ): String =
         assertThrows<KaminoTransactionRejected> {
@@ -133,6 +143,7 @@ class KaminoTransactionValidatorTest {
                     signerAddress = signerAddress,
                     tokenAccount = tokenAccount,
                     shareAccount = shareAccount,
+                    farmUserState = farmUserState,
                     amountBaseUnits = amountBaseUnits,
                 )
             }
@@ -618,6 +629,63 @@ class KaminoTransactionValidatorTest {
     }
 
     @Test
+    fun `a farms instruction moving another holder's stake is refused`() {
+        // The authority alone binds a farms instruction to nothing: the farm it names travels in a
+        // lookup table, so without the user state the response picks which stake moves. `stake`
+        // carries the whole-balance sentinel, so the one it picks gives up the wallet's entire
+        // share balance.
+        val reason =
+            rejection(
+                listOf(
+                    kvault(),
+                    farms(
+                        FARMS_STAKE,
+                        argument = littleEndian(U64_MAX, bytes = 8),
+                        userState = OTHER_ACCOUNT,
+                    ),
+                    memo,
+                )
+            )
+        assertTrue(reason.contains("state in the vault's farm"), reason)
+    }
+
+    @Test
+    fun `the user state is what tells one vault's farm from another`() {
+        // A program address over the farm and the owner, so the same wallet has a different one in
+        // every farm. That is what makes it the offline answer to "which vault is this?" on an
+        // instruction whose farm slot cannot be read.
+        val reason =
+            rejection(
+                depositInstructions(),
+                farmUserState = SOL_FARM_USER_STATE,
+                amountBaseUnits = AMOUNT,
+            )
+        assertTrue(reason.contains(FARM_USER_STATE), reason)
+    }
+
+    @Test
+    fun `initialize_user is pinned at its own slot, not the one the other three use`() {
+        // It is the instruction that creates the account, so the IDL puts the authority, the payer,
+        // the owner and the delegatee ahead of it. Reading slot 1 here would compare the wallet
+        // against the user state and refuse every real deposit.
+        val reason =
+            rejection(
+                listOf(kvault(), farms(FARMS_INITIALIZE_USER, userState = OTHER_ACCOUNT), memo)
+            )
+        assertTrue(reason.contains("state in the vault's farm"), reason)
+
+        assertDoesNotThrow { validate(depositInstructions()) }
+    }
+
+    @Test
+    fun `a farms instruction is refused when the wallet's state in the farm could not be derived`() {
+        // Same rule the other derived accounts follow: an address that could not be computed is one
+        // that cannot be compared, and treating that as "not a mismatch" is the hole moved.
+        val reason = rejection(depositInstructions(), farmUserState = null)
+        assertTrue(reason.contains("could not be derived"), reason)
+    }
+
+    @Test
     fun `a second unstake is refused rather than releasing twice what the withdraw burns`() {
         // The bound each unstake is held to is per-instruction, so two of them each carrying the
         // requested figure both pass it. The withdraw then burns that figure once, and the shares
@@ -1066,6 +1134,15 @@ class KaminoTransactionValidatorTest {
         const val SHARE_ACCOUNT = "GSayQpRaoh1LFdBbja4vensNKDfihcixzCcQShKMCdMJ"
         const val WRAPPED_SOL_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
         const val SOL_SHARE_ACCOUNT = "Hq6N6sNE638VLULNEeAZRTMFmYtsG9ZLLPJYefxwPNWf"
+
+        /**
+         * [DEFAULT_FEE_PAYER]'s state in the Steakhouse vault's farm, as the captured deposit names
+         * it — and as [KaminoFarmsUserState] derives it from the farm the registry pins.
+         */
+        const val FARM_USER_STATE = "A1b83WVHAKXeRQAHsdAzJY23ShXCPjqKshzmFFXwGP4Z"
+
+        /** The same wallet's state in the Allez SOL farm, which is a different account entirely. */
+        const val SOL_FARM_USER_STATE = "8ULTfRg47DWt5VBDT7UURTPW6P5Fc5vPMfncfPKpZc3J"
 
         /** Anchor discriminators: the first eight bytes of `sha256("global:<name>")`. */
         const val KVAULT_DEPOSIT = "f223c68952e1f2b6"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoTransactionValidatorTest.kt
@@ -187,11 +187,11 @@ class KaminoTransactionValidatorTest {
                 listOf(
                     ix(KaminoVaultRegistry.PROGRAM_ID),
                     // SPL Token `Transfer` is discriminator 3.
-                    ix("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", byteArrayOf(3, 0, 0, 0)),
+                    ix(TOKEN_PROGRAM, byteArrayOf(3, 0, 0, 0)),
                     memo,
                 )
             )
-        assertTrue(reason.contains("top-level SPL token transfer"), reason)
+        assertTrue(reason.contains("SPL token instruction 3"), reason)
     }
 
     @Test
@@ -201,11 +201,11 @@ class KaminoTransactionValidatorTest {
                 listOf(
                     ix(KaminoVaultRegistry.PROGRAM_ID),
                     // `TransferChecked` is discriminator 12.
-                    ix("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA", byteArrayOf(12, 0)),
+                    ix(TOKEN_PROGRAM, byteArrayOf(12, 0)),
                     memo,
                 )
             )
-        assertTrue(reason.contains("top-level SPL token transfer"), reason)
+        assertTrue(reason.contains("SPL token instruction 12"), reason)
     }
 
     @Test
@@ -468,8 +468,176 @@ class KaminoTransactionValidatorTest {
         )
     }
 
+    private fun tokenIx(discriminator: Int, accounts: List<String>) =
+        KaminoTxInstruction(
+            programId = TOKEN_PROGRAM,
+            data = byteArrayOf(discriminator.toByte()),
+            accounts = accounts,
+        )
+
+    private fun systemIx(discriminator: Int, accounts: List<String>) =
+        KaminoTxInstruction(
+            programId = SYSTEM_PROGRAM,
+            data = byteArrayOf(discriminator.toByte(), 0, 0, 0, 1, 2, 3, 4),
+            accounts = accounts,
+        )
+
+    /** [instruction] riding along on an otherwise valid wrapped-SOL vault transaction. */
+    private fun validateOnSolVault(
+        instruction: KaminoTxInstruction,
+        wrappedSolAccount: String? = WRAPPED_SOL_ACCOUNT,
+    ) =
+        KaminoTransactionValidator.validate(
+            decoded(listOf(ix(KaminoVaultRegistry.PROGRAM_ID, byteArrayOf(1)), instruction, memo)),
+            KaminoVaultRegistry.ALLEZ_SOL,
+            KaminoAction.DEPOSIT,
+            signerAddress = DEFAULT_FEE_PAYER,
+            wrappedSolAccount = wrappedSolAccount,
+        )
+
+    private fun solVaultRejection(
+        instruction: KaminoTxInstruction,
+        wrappedSolAccount: String? = WRAPPED_SOL_ACCOUNT,
+    ): String =
+        assertThrows<KaminoTransactionRejected> {
+                validateOnSolVault(instruction, wrappedSolAccount)
+            }
+            .message
+            .orEmpty()
+
+    @Test
+    fun `every System instruction other than the wrap is refused`() {
+        // What a deny-list of transfers cannot reach, all of it authorised by the fee-payer
+        // signature the message already carries: `Assign` (1) hands the signer's own system account
+        // to a program the response chose, `CreateAccountWithSeed` (3) funds an account it chose
+        // with an amount it chose, `AssignWithSeed` (10) does the first through a derived address.
+        // None of them is a transfer.
+        for (discriminator in listOf(0, 1, 3, 8, 10, 11)) {
+            val reason =
+                solVaultRejection(
+                    systemIx(discriminator, listOf(DEFAULT_FEE_PAYER, WRAPPED_SOL_ACCOUNT))
+                )
+            assertTrue(reason.contains("System instruction $discriminator"), reason)
+        }
+    }
+
+    @Test
+    fun `every SPL token instruction other than the wrapped-SOL bookkeeping is refused`() {
+        // Likewise on the token side: `Approve` (4) and `SetAuthority` (6) hand the account over
+        // instead of draining it, so the drain arrives later and unsigned by this wallet, and
+        // `Burn` (8) destroys the balance where it stands.
+        for (discriminator in listOf(3, 4, 6, 7, 8, 12)) {
+            val reason = solVaultRejection(tokenIx(discriminator, listOf(WRAPPED_SOL_ACCOUNT)))
+            assertTrue(reason.contains("SPL token instruction $discriminator"), reason)
+        }
+    }
+
+    @Test
+    fun `the wrap's sync and the unwrap are allowed on the wrapped-SOL vault`() {
+        // The other half of an allow-list, and the half a deny-list never had to get right: these
+        // two are what a live Allez SOL deposit and withdraw actually carry, so refusing them would
+        // block every real SOL position rather than let an extra instruction through.
+        assertDoesNotThrow { validateOnSolVault(tokenIx(17, listOf(WRAPPED_SOL_ACCOUNT))) }
+        assertDoesNotThrow {
+            validateOnSolVault(
+                tokenIx(9, listOf(WRAPPED_SOL_ACCOUNT, DEFAULT_FEE_PAYER, DEFAULT_FEE_PAYER))
+            )
+        }
+    }
+
+    @Test
+    fun `an unwrap paid out to another account is refused`() {
+        // Closing the wrapped-SOL account pays its whole balance out, which on a full exit is the
+        // entire withdrawn amount. Rewriting this one address redirects the lot while every other
+        // instruction still reads as the withdraw the user asked for.
+        val reason =
+            solVaultRejection(
+                tokenIx(9, listOf(WRAPPED_SOL_ACCOUNT, OTHER_ACCOUNT, DEFAULT_FEE_PAYER))
+            )
+        assertTrue(reason.contains("rather than to the wallet"), reason)
+    }
+
+    @Test
+    fun `an unwrap authorised by another account is refused`() {
+        val reason =
+            solVaultRejection(
+                tokenIx(9, listOf(WRAPPED_SOL_ACCOUNT, DEFAULT_FEE_PAYER, OTHER_ACCOUNT))
+            )
+        assertTrue(reason.contains("under the authority of"), reason)
+    }
+
+    @Test
+    fun `a wrap credited to another account is refused`() {
+        val reason = solVaultRejection(tokenIx(17, listOf(OTHER_ACCOUNT)))
+        assertTrue(reason.contains("credits $OTHER_ACCOUNT"), reason)
+    }
+
+    @Test
+    fun `an unwrap of an account this app has never seen is allowed once the wallet is paid`() {
+        // Deliberately looser than the wrap: only the unstaked withdraw could be captured, and a
+        // staked exit may close accounts no fixture shows, so the close is pinned by recipient
+        // rather than by subject. Nothing is conceded — the wallet can only close accounts it owns,
+        // and the lamports land on the wallet either way. Pinning the subject instead would refuse
+        // a real staked withdraw to buy no extra protection.
+        assertDoesNotThrow {
+            validateOnSolVault(
+                tokenIx(9, listOf(OTHER_ACCOUNT, DEFAULT_FEE_PAYER, DEFAULT_FEE_PAYER))
+            )
+        }
+    }
+
+    @Test
+    fun `an account hidden behind a lookup table is refused rather than skipped`() {
+        // A versioned message may load accounts from a lookup table, and the decoder cannot resolve
+        // those without fetching the tables, so it names them unresolved. A response that puts the
+        // recipient behind its own table must therefore fail the comparison — a check that treats
+        // "cannot tell" as "not a mismatch" is the same hole in a different place.
+        val reason =
+            solVaultRejection(
+                tokenIx(
+                    9,
+                    listOf(
+                        WRAPPED_SOL_ACCOUNT,
+                        KaminoTransactionDecoder.UNKNOWN_ACCOUNT,
+                        DEFAULT_FEE_PAYER,
+                    ),
+                )
+            )
+        assertTrue(reason.contains("rather than to the wallet"), reason)
+    }
+
+    @Test
+    fun `crediting a wrap is refused on a plain-token vault`() {
+        // Neither captured USDC shape carries a top-level token instruction at all — that vault
+        // moves its tokens through the kVault program's own CPI — so a wrap is allowed only where
+        // there is something to wrap.
+        val reason =
+            rejection(
+                listOf(
+                    ix(KaminoVaultRegistry.PROGRAM_ID),
+                    tokenIx(17, listOf(WRAPPED_SOL_ACCOUNT)),
+                    memo,
+                )
+            )
+        assertTrue(reason.contains("only the wrapped-SOL vault"), reason)
+    }
+
+    @Test
+    fun `crediting a wrap is refused when the wrapped-SOL account could not be derived`() {
+        // Same posture the transfer already took: with nothing to compare against, refuse rather
+        // than wave through.
+        val reason =
+            solVaultRejection(tokenIx(17, listOf(WRAPPED_SOL_ACCOUNT)), wrappedSolAccount = null)
+        assertTrue(reason.contains("could not be derived"), reason)
+    }
+
     private companion object {
         const val DEFAULT_FEE_PAYER = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
         const val OTHER_ACCOUNT = "SomeoneElsesAccount11111111111111111111111"
+        const val SYSTEM_PROGRAM = "11111111111111111111111111111111"
+        const val TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+        /** [DEFAULT_FEE_PAYER]'s wrapped-SOL account, as the Allez SOL fixtures derive it. */
+        const val WRAPPED_SOL_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/Base58CodecTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/Base58CodecTest.kt
@@ -1,0 +1,62 @@
+@file:OptIn(ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.data.crypto
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins [Base58Codec] against real Solana addresses, since everything derived from it is compared
+ * against an address that came off the wire.
+ */
+class Base58CodecTest {
+
+    @Test
+    fun `every well-known address survives a round trip as 32 bytes`() {
+        listOf(
+                "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF",
+                "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                "FarmsPZpWu9i7Kky8tPN37rs2TpmMrAZrC7S7vJa91Hr",
+                "So11111111111111111111111111111111111111112",
+            )
+            .forEach { address ->
+                val decoded = Base58Codec.decode(address)
+                assertEquals(32, decoded?.size, address)
+                assertEquals(address, Base58Codec.encode(decoded!!), address)
+            }
+    }
+
+    @Test
+    fun `leading zero bytes survive, which is what keeps a key 32 bytes wide`() {
+        // The System program is 32 zero bytes, so every character of its address is the
+        // leading-zero
+        // marker. Dropping them would hand a 0-byte key to a derivation that requires 32.
+        val system = "11111111111111111111111111111111"
+        val decoded = Base58Codec.decode(system)
+        assertArrayEquals(ByteArray(32), decoded)
+        assertEquals(system, Base58Codec.encode(ByteArray(32)))
+
+        // A single leading zero in front of a value whose high bit is set exercises both the
+        // leading-zero restore and the sign byte BigInteger prepends.
+        val mixed = byteArrayOf(0, 0xff.toByte(), 0x01)
+        assertArrayEquals(mixed, Base58Codec.decode(Base58Codec.encode(mixed)))
+    }
+
+    @Test
+    fun `characters the alphabet leaves out are refused rather than misread`() {
+        // Base58 drops the four that look like each other; reading them as anything would decode an
+        // address the user never had.
+        listOf("0", "O", "I", "l", "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF!").forEach {
+            assertNull(Base58Codec.decode(it), it)
+        }
+    }
+
+    @Test
+    fun `the empty string decodes to no bytes rather than to a zero`() {
+        assertArrayEquals(ByteArray(0), Base58Codec.decode(""))
+        assertEquals("", Base58Codec.encode(ByteArray(0)))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SolanaProgramDerivedAddressTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SolanaProgramDerivedAddressTest.kt
@@ -1,0 +1,82 @@
+package com.vultisig.wallet.data.crypto
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins [SolanaProgramDerivedAddress] against addresses this repo already trusts.
+ *
+ * The associated token account is the cross-check that matters: WalletCore derives it through JNI
+ * and the app compares transactions against what it returns, so reproducing three of them in pure
+ * Kotlin says this derivation agrees with the one already in production — including the on-curve
+ * test, since two of the three land on a bump below 255 and would come out differently if
+ * candidates were never rejected.
+ */
+class SolanaProgramDerivedAddressTest {
+
+    @Test
+    fun `it reproduces the associated token accounts WalletCore derives`() {
+        mapOf(
+                // The wallet's wrapped-SOL account, which the instrumented preparer test already
+                // asserts equals `SolanaAddress(WALLET).defaultTokenAddress(WRAPPED_SOL_MINT)`.
+                "So11111111111111111111111111111111111111112" to
+                    "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc",
+                // Its Steakhouse share account: slot 7 of the captured kVault deposit.
+                "7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS" to
+                    "GSayQpRaoh1LFdBbja4vensNKDfihcixzCcQShKMCdMJ",
+                // And its Allez SOL share account, from the captured SOL deposit.
+                "FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN" to
+                    "Hq6N6sNE638VLULNEeAZRTMFmYtsG9ZLLPJYefxwPNWf",
+            )
+            .forEach { (mint, expected) ->
+                val derived =
+                    SolanaProgramDerivedAddress.find(
+                        seeds =
+                            listOf(
+                                Base58Codec.decode(WALLET)!!,
+                                Base58Codec.decode(TOKEN_PROGRAM)!!,
+                                Base58Codec.decode(mint)!!,
+                            ),
+                        programId = ASSOCIATED_TOKEN_PROGRAM,
+                    )
+                assertEquals(expected, derived, mint)
+            }
+    }
+
+    @Test
+    fun `the same seeds under a different program give a different address`() {
+        val seeds = listOf(Base58Codec.decode(WALLET)!!)
+        val underToken = SolanaProgramDerivedAddress.find(seeds, TOKEN_PROGRAM)
+        val underAssociatedToken = SolanaProgramDerivedAddress.find(seeds, ASSOCIATED_TOKEN_PROGRAM)
+
+        assertNotNull(underToken)
+        assertNotNull(underAssociatedToken)
+        assertEquals(false, underToken == underAssociatedToken)
+    }
+
+    @Test
+    fun `there is nothing to derive from an unreadable program id`() {
+        // Null rather than a thrown exception or a plausible-looking address: every caller treats
+        // it
+        // as a refusal, and an address that could not be derived is one that cannot be compared.
+        assertNull(SolanaProgramDerivedAddress.find(listOf(ByteArray(1)), "not an address"))
+        assertNull(SolanaProgramDerivedAddress.find(listOf(ByteArray(1)), "1111"))
+    }
+
+    @Test
+    fun `seeds outside the runtime's limits are refused rather than hashed anyway`() {
+        // Solana's own bounds: at most 16 seeds, each at most 32 bytes. Deriving past them would
+        // produce an address the runtime never would, which is worse than refusing.
+        assertNull(SolanaProgramDerivedAddress.find(List(17) { ByteArray(1) }, TOKEN_PROGRAM))
+        assertNull(SolanaProgramDerivedAddress.find(listOf(ByteArray(33)), TOKEN_PROGRAM))
+        assertNotNull(SolanaProgramDerivedAddress.find(List(16) { ByteArray(32) }, TOKEN_PROGRAM))
+    }
+
+    private companion object {
+        const val WALLET = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
+        const val TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        const val ASSOCIATED_TOKEN_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+    }
+}


### PR DESCRIPTION
Closes #5603

## The problem

`KaminoTransactionValidator`'s SPL Token and System guards were deny-lists. Each refused a couple of hand-picked opcodes and let every other instruction of the same program through, while both programs stayed allow-listed:

```kotlin
// Token: no else, and instruction.accounts never read
if (discriminator in TOKEN_TRANSFER_DISCRIMINATORS) reject(…)

// System: every check nested inside the transfer branch
if (discriminator == SYSTEM_TRANSFER) { …vault and destination checks… }
```

A deny-list is no control against a compromised response, because the same response that adds the instruction also picks its opcode. And the opcodes that reach furthest are not transfers: `Assign` (1) on the signer's own system account reassigns it to another program, `CreateAccountWithSeed` (3) funds an account the response chose, `SetAuthority` (6) hands over a token account, `Approve` (4) delegates it. Each needs only the fee-payer signature the message already carries; none moves a lamport itself.

The Allez SOL withdraw makes it concrete — it legitimately carries a top-level `CloseAccount` to unwrap, so rewriting only that instruction's second account redirects the entire withdrawn amount while every other instruction still reads as the withdraw the user asked for.

Missing control rather than an observed exploit: it takes a compromised `api.kamino.finance` or a TLS-terminating proxy.

## What changed

Both guards are now allow-lists.

**System** — `Transfer` (2) only, keeping the existing wrapped-SOL-vault gate and the destination check against the locally derived wSOL account. Every other `SystemInstruction` is refused by name.

**Token / Token-2022** — `SyncNative` (17) and `CloseAccount` (9) only. Everything else refused, Token-2022 extensions included.

The two are checked differently on purpose:

- **`SyncNative` is pinned by subject** — the wrapped-SOL account derived locally from the signer, and only on the wrapped-SOL vault. Its deposit was captured, so the shape is known exactly.
- **`CloseAccount` is pinned by recipient** — both the payout destination and the closing authority must be the signer, while the account being closed is left free.

That last one is the deliberate deviation from the issue's suggested remediation, and the reason is coverage: only the *unstaked* withdraw could be captured, and a staked exit may close accounts no fixture shows. Pinning the subject would refuse a real staked withdraw and buy nothing — the wallet can only close accounts it owns, and every released lamport lands on the wallet either way. Pinning the recipient still refuses the redirect the check exists for.

**Lookup-table accounts fail comparisons rather than skipping them.** These are v0 messages where most accounts resolve through a lookup table and `KaminoTransactionDecoder` names them unresolved. A check that treats "cannot tell" as "not a mismatch" is the same hole in a different place, so every account comparison here is exact.

## Evidence

The suite recorded the wrapped-SOL shape as impossible to observe without depositing real funds. It isn't: Kamino's build endpoints construct a transaction for a wallet holding nothing — the same property that produced the existing `WITHDRAW` fixture — so both Allez SOL shapes were captured directly and are now fixtures:

```
ALLEZ_SOL_DEPOSIT   AssociatedToken → System::Transfer(wallet → wSOL ATA)
                  → Token::SyncNative(wSOL ATA) → AssociatedToken
                  → kVault::deposit → Farms → Farms

ALLEZ_SOL_WITHDRAW  AssociatedToken → kVault::withdraw
                  → Token::CloseAccount(wSOL ATA, wallet, wallet)
```

Neither USDC fixture carries a top-level System or Token instruction at all — that vault moves its tokens entirely through the kVault program's own CPI — which is why the allow-lists had to be sized against these and not against the shapes already in the repo.

The same capture also retires the note at `KaminoTransactionPreparerTest.kt:132`, where the SOL-vault compute-budget test had to assert against a USDC fixture for want of a SOL one.

A confirmed mainnet Allez SOL deposit was decoded independently and checked rule by rule against the new guards: its `System::Transfer` destination and its `SyncNative` account both equal the locally derived wSOL ATA, its memo is the sole final instruction, and its kVault amount is not the sentinel. It passes unchanged.

## Test plan

- `./gradlew :data:testDebugUnitTest` — **2999 tests green**
- `./gradlew :data:compileDebugAndroidTestKotlin :app:compileDebugKotlin` — green
- 11 new unit tests (33 in the validator, up from 23). **All 10 behaviour tests verified to fail on revert** — the old validator was restored and the suite re-run to confirm. The two allow-path tests pass under both, which is the point: they guard against over-tightening, which is the real risk in this change.
- 2 new instrumented tests pin the allow-lists against the real captures. The withdraw one asserts that validation reaches the *sentinel* refusal, which runs after the value-movement rules — so getting there is proof the unwrap passed them rather than that nothing looked.

Manual, on device:

1. DeFi → Solana → Manage Positions → enable **Allez SOL** → Deposit a small amount → Sign. Expect it to sign and broadcast as before; a refusal naming "SPL token instruction 17" or "System instruction 2" would mean the allow-list is too tight.
2. Withdraw part of it → Sign. This is the `CloseAccount` path.
3. Repeat with **Max** — the full-exit shape is the one variant that cannot be captured.
4. **Steakhouse USDC** deposit and withdraw, unchanged, as the plain-token regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened Kamino Solana transaction validation for deposits and withdrawals, including wrapped SOL, vaults, authorities, derived accounts, and farm state.
  - Rejected malformed, unsupported, duplicated, unauthorized, or incomplete instructions.
  - Improved amount handling for token and share actions, including fractional, invalid, and non-positive values.

- **Tests**
  - Added realistic coverage for deposits, withdrawals, synchronization, wrapping, unwrapping, and account closing.
  - Expanded checks for instruction allow-lists, ownership, account derivation, lookup tables, and mismatched transaction details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->