### PR TITLE
fix(keysign): abort on DKLS malicious-party ban instead of retrying

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -35,6 +35,30 @@ import kotlinx.coroutines.Dispatchers
 import tss.KeysignResponse
 
 /**
+ * Thrown when `godkls` reports that it aborted the session and banned [partyID] for protocol-level
+ * misbehavior (`LIB_ABORT_PROTOCOL_AND_BAN_PARTY_1..10`). Never retried.
+ */
+class MaliciousPartyException(val partyID: String) :
+    Exception("party $partyID was banned for malicious behavior")
+
+// LIB_ABORT_PROTOCOL_AND_BAN_PARTY_1...10 (godkls.h): the library aborted the session and
+// banned a co-signer for protocol-level misbehavior. Hardcoded (not read off the lib_error
+// enum) so this check stays testable on the host JVM without loading the native godkls lib.
+private val BAN_PARTY_RANGE = 100..109
+
+/**
+ * Throws [MaliciousPartyException] if [resultValue] (a `lib_error.swigValue()`) is one of
+ * `LIB_ABORT_PROTOCOL_AND_BAN_PARTY_1..10`. Party N (1-based) is `keysignCommittee[N-1]`: the setup
+ * message embeds party ids in exactly this array order (see [DKLSKeysign]).
+ */
+internal fun checkForBannedParty(resultValue: Int, keysignCommittee: List<String>) {
+    if (resultValue !in BAN_PARTY_RANGE) return
+    val partyIndex = resultValue - BAN_PARTY_RANGE.first
+    val partyID = keysignCommittee.getOrNull(partyIndex) ?: "#${partyIndex + 1}"
+    throw MaliciousPartyException(partyID)
+}
+
+/**
  * Performs DKLS keysigning for one or more messages.
  *
  * @param onWaitingForPeers Invoked when no inbound messages have arrived for ~10 s; receives the
@@ -279,6 +303,7 @@ class DKLSKeysign(
                 } finally {
                     decryptedBodySlice.free()
                 }
+            checkForBannedParty(result.swigValue(), keysignCommittee)
             if (result != LIB_OK) {
                 error("fail to apply message to dkls, $result")
             }
@@ -378,6 +403,7 @@ class DKLSKeysign(
                     decodedSetupMsg.free()
                     localPartySlice.free()
                 }
+            checkForBannedParty(sessionResult.swigValue(), keysignCommittee)
             if (sessionResult != LIB_OK) {
                 error("fail to create sign session from setup message, error: $sessionResult")
             }
@@ -398,6 +424,10 @@ class DKLSKeysign(
                 signatures[messageToSign] = resp
             }
         } catch (e: CancellationException) {
+            throw e
+        } catch (e: MaliciousPartyException) {
+            // A banned party is a protocol-level verdict from the library, not a transient
+            // failure — retrying would just re-sign against a peer DKLS already banned.
             throw e
         } catch (e: Exception) {
             println("Failed to sign message ($messageToSign), error: ${e.localizedMessage}")
@@ -428,6 +458,7 @@ class DKLSKeysign(
         val buf = tss_buffer()
         try {
             val result = dkls_sign_session_finish(handle, buf)
+            checkForBannedParty(result.swigValue(), keysignCommittee)
             if (result != LIB_OK) {
                 error("fail to get keysign signature $result")
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.api.models.FeatureFlagJson
 import com.vultisig.wallet.data.common.md5
 import com.vultisig.wallet.data.common.toHexBytes
 import com.vultisig.wallet.data.keygen.DKLSKeysign
+import com.vultisig.wallet.data.keygen.MaliciousPartyException
 import com.vultisig.wallet.data.keygen.MldsaKeysign
 import com.vultisig.wallet.data.keygen.SchnorrKeysign
 import com.vultisig.wallet.data.models.Chain
@@ -719,6 +720,16 @@ constructor(
         } catch (e: CancellationException) {
             if (cancelPullJobOnFinish) pullTssMessagesJob?.cancel()
             throw e
+        } catch (e: MaliciousPartyException) {
+            Timber.e(e)
+            _state.update {
+                it.copy(
+                    signingState =
+                        KeysignState.Error(
+                            R.string.keysign_malicious_party_detected.asUiText(e.partyID)
+                        )
+                )
+            }
         } catch (e: Exception) {
             Timber.e(e)
             _state.update {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -120,6 +120,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">MLDSA-Schlüssel kopiert</string>
     <string name="welcome_screen_skip">Überspringen</string>
     <string name="keysign_screen_preparing_vault">TRESOR VORBEREITEN…</string>
+    <string name="keysign_malicious_party_detected">Das Gerät „%1$s“ in dieser Keysign-Sitzung wurde bei böswilligem Verhalten erkannt. Verwende es nicht erneut zum Signieren.</string>
     <string name="vault_settings_delete_vault_caution1">Mir ist bewusst, dass der Tresor dauerhaft gelöscht wird</string>
     <string name="vault_settings_delete_vault_caution2">Mir ist bewusst, dass ich Geld verlieren kann</string>
     <string name="vault_settings_delete_vault_caution3">Ich habe eine Sicherung des Tresors für eine spätere Wiederherstellung erstellt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -144,6 +144,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">Clave MLDSA Copiada</string>
     <string name="welcome_screen_skip">Saltar</string>
     <string name="keysign_screen_preparing_vault">PREPARANDO BÓVEDA..</string>
+    <string name="keysign_malicious_party_detected">Se detectó que el dispositivo \"%1$s\" en esta sesión de keysign actuó de forma maliciosa. No lo uses de nuevo para firmar.</string>
     <string name="vault_settings_delete_vault_caution1">Soy consciente de que la bóveda será eliminada permanentemente</string>
     <string name="vault_settings_delete_vault_caution2">Soy consciente de que puedo perder fondos.</string>
     <string name="vault_settings_delete_vault_caution3">He hecho una copia de seguridad de la bóveda para restaurarla más tarde</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -118,6 +118,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">MLDSA ključ kopiran</string>
     <string name="welcome_screen_skip">Preskoči</string>
     <string name="keysign_screen_preparing_vault">PRIPREMA SEFA…</string>
+    <string name="keysign_malicious_party_detected">Otkriveno je da se uređaj \"%1$s\" u ovoj keysign sesiji zlonamjerno ponaša. Nemoj ga ponovno koristiti za potpisivanje.</string>
     <string name="vault_settings_delete_vault_caution1">Ovaj sef će biti trajno uklonjen</string>
     <string name="vault_settings_delete_vault_caution2">Svjestan sam da mogu izgubiti sredstva</string>
     <string name="vault_settings_delete_vault_caution3">Napravio sam sigurnosnu kopiju spremišta za kasniju obnovu</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -118,6 +118,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">Chiave MLDSA Copiata</string>
     <string name="welcome_screen_skip">Salta</string>
     <string name="keysign_screen_preparing_vault">PREPARANDO LA CASSAFORTE…</string>
+    <string name="keysign_malicious_party_detected">È stato rilevato che il dispositivo \"%1$s\" in questa sessione di keysign si è comportato in modo malevolo. Non utilizzarlo più per firmare.</string>
     <string name="vault_settings_delete_vault_caution1">Sono consapevole che il caveau sarà eliminato permanentemente</string>
     <string name="vault_settings_delete_vault_caution2">Sono consapevole che posso perdere fondi</string>
     <string name="vault_settings_delete_vault_caution3">Ho fatto un backup del caveau per ripristinarlo in seguito</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -251,6 +251,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">MLDSA 키 복사됨</string>
     <string name="welcome_screen_skip">건너뛰기</string>
     <string name="keysign_screen_preparing_vault">볼트 준비 중…</string>
+    <string name="keysign_malicious_party_detected">이 keysign 세션의 기기 \"%1$s\"가 악의적으로 동작한 것이 감지되었습니다. 다시는 서명에 사용하지 마세요.</string>
     <string name="vault_settings_delete_vault_caution1">볼트가 영구적으로 삭제된다는 것을 알고 있습니다</string>
     <string name="vault_settings_delete_vault_caution2">자금을 잃을 수 있다는 것을 알고 있습니다</string>
     <string name="vault_settings_delete_vault_caution3">나중에 복원할 수 있도록 볼트 백업을 완료했습니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -149,6 +149,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">MLDSA-sleutel gekopieerd</string>
     <string name="welcome_screen_skip">Overslaan</string>
     <string name="keysign_screen_preparing_vault">Kluis voorbereiden…</string>
+    <string name="keysign_malicious_party_detected">Het apparaat \"%1$s\" in deze keysign-sessie is betrapt op kwaadaardig gedrag. Gebruik het niet opnieuw om te ondertekenen.</string>
     <string name="vault_settings_delete_vault_caution1">Ik ben me ervan bewust dat de kluis permanent zal worden verwijderd</string>
     <string name="vault_settings_delete_vault_caution2">Ik ben me ervan bewust dat ik geld kan verliezen</string>
     <string name="vault_settings_delete_vault_caution3">Ik heb een kluisback-up gemaakt om later te kunnen herstellen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -125,6 +125,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">Chave MLDSA Copiada</string>
     <string name="welcome_screen_skip">Pular</string>
     <string name="keysign_screen_preparing_vault">PREPARANDO COFRE…</string>
+    <string name="keysign_malicious_party_detected">Foi detetado que o dispositivo \"%1$s\" nesta sessão de keysign agiu de forma maliciosa. Não o uses novamente para assinar.</string>
     <string name="vault_settings_delete_vault_caution1">Estou ciente de que o cofre será excluído permanentemente</string>
     <string name="vault_settings_delete_vault_caution2">Estou ciente de que posso perder fundos</string>
     <string name="vault_settings_delete_vault_caution3">Fiz um backup do cofre para restaurá-lo mais tarde</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -149,6 +149,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">Ключ MLDSA скопирован</string>
     <string name="welcome_screen_skip">Пропустить</string>
     <string name="keysign_screen_preparing_vault">Подготовка хранилища…</string>
+    <string name="keysign_malicious_party_detected">Устройство \"%1$s\" в этой сессии keysign было замечено в злонамеренном поведении. Не используйте его для подписания снова.</string>
     <string name="vault_settings_delete_vault_caution1">Я понимаю, что хранилище будет удалено навсегда</string>
     <string name="vault_settings_delete_vault_caution2">Я понимаю, что могу потерять средства</string>
     <string name="vault_settings_delete_vault_caution3">Я сделал резервную копию хранилища для последующего восстановления</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -297,6 +297,7 @@
 
     <!-- Keysign Screen -->
     <string name="keysign_screen_preparing_vault">准备保险库…</string>
+    <string name="keysign_malicious_party_detected">检测到此 keysign 会话中的设备“%1$s”存在恶意行为。请勿再使用它进行签名。</string>
 
     <!-- Camera Bind Error -->
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -255,6 +255,7 @@
     <string name="vault_detail_screen_mldsa_key_copied">MLDSA Key Copied</string>
     <string name="welcome_screen_skip">Skip</string>
     <string name="keysign_screen_preparing_vault">Preparing vault…</string>
+    <string name="keysign_malicious_party_detected">The device \"%1$s\" in this keysign session was detected acting maliciously. Do not use it for signing again.</string>
     <string name="vault_settings_delete_vault_caution1">I am aware that the vault will be deleted permanently</string>
     <string name="vault_settings_delete_vault_caution2">I am aware that I can lose funds</string>
     <string name="vault_settings_delete_vault_caution3">I have made a vault backup to restore later</string>

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/DklsBannedPartyDetectionTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/DklsBannedPartyDetectionTest.kt
@@ -1,0 +1,40 @@
+package com.vultisig.wallet.data.keygen
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * `godkls` returns `LIB_ABORT_PROTOCOL_AND_BAN_PARTY_1..10` (100-109) when it aborts a session
+ * after catching a co-signer misbehaving. That must abort the keysign with
+ * [MaliciousPartyException], not the generic runtime error other `lib_error` codes get retried
+ * against. See #5648 / iOS #5226.
+ */
+class DklsBannedPartyDetectionTest {
+
+    private val committee = listOf("partyA", "partyB")
+
+    @Test
+    fun `ban range throws with committee id`() {
+        shouldThrow<MaliciousPartyException> { checkForBannedParty(100, committee) }
+            .partyID shouldBe "partyA"
+        shouldThrow<MaliciousPartyException> { checkForBannedParty(101, committee) }
+            .partyID shouldBe "partyB"
+    }
+
+    @Test
+    fun `ban range beyond committee size falls back to index`() {
+        shouldThrow<MaliciousPartyException> { checkForBannedParty(102, committee) }
+            .partyID shouldBe "#3"
+    }
+
+    @Test
+    fun `non-ban codes do not throw`() {
+        // LIB_OK, an ordinary error, and the neighboring non-ban LIB_ABORT_PROTOCOL_PARTY_*
+        // range (200-209) must not be mistaken for a ban.
+        listOf(0, 13, 99, 110, 200, 209).forEach { value ->
+            shouldNotThrowAny { checkForBannedParty(value, committee) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `godkls` returns `LIB_ABORT_PROTOCOL_AND_BAN_PARTY_1..10` (100-109) when it aborts a DKLS keysign session after catching a co-signer misbehaving. `DklsKeysign.kt` never inspected these codes — every `dkls_sign_session_*` failure was only compared against `LIB_OK`, so `keysignOneMessageWithRetry` retried up to 3 times against the already-banned peer, and the user only ever saw a generic keysign-failed message.
- Adds `MaliciousPartyException(partyID)` and a pure `checkForBannedParty(resultValue, keysignCommittee)` check (100-109 range) wired into the 3 `dkls_sign_session_*` call sites that already throw (`input_message`, `from_setup`, `finish`), and skips retry for that case in `keysignOneMessageWithRetry`'s catch block the same way cancellation is already skipped.
- `KeysignViewModel.runSigningFlow` now surfaces a dedicated localized error (`keysign_malicious_party_detected`, added to all 10 shipping locales) naming the banned device, instead of the raw exception text.
- Mirrors vultisig-ios#5235 (fixes vultisig-ios#5226).

## Issue
Fixes #5648

## Test Plan
- [x] Added `DklsBannedPartyDetectionTest` covering the full ban range (100-109 → correct 1-based committee lookup + `#N` fallback beyond committee size) and confirms `LIB_OK`/ordinary errors/the neighboring non-ban `LIB_ABORT_PROTOCOL_PARTY_*` range (200-209) don't throw
- [x] `./gradlew :app:testDebugUnitTest` — new test + existing `data.keygen`/`ui.models.keysign` suites pass
- [x] `./gradlew lint` passes
- [x] `./gradlew :app:compileDebugKotlin` succeeds

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keysign sessions now detect and identify devices exhibiting malicious behavior.
  * Signing stops with a clear warning and affected device identifier.
  * Detected devices are flagged as unsuitable for future signing.

* **Bug Fixes**
  * Malicious-device errors no longer trigger automatic retry or relay recovery.

* **Localization**
  * Added translated warnings in German, Spanish, Croatian, Italian, Korean, Dutch, Portuguese, Russian, and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->