### PR TITLE
fix(swap): show trading-paused copy instead of a quote timeout

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -685,8 +685,8 @@ constructor(
     /**
      * Ranks a failed-quote [error] so the most actionable failure is surfaced when every provider
      * fails. Lower values win. Amount-related errors mean the pair is routable and the user can
-     * recover by adjusting the amount, so they rank above recoverable/transient errors, which in
-     * turn rank above generic "no route" fallbacks.
+     * recover by adjusting the amount, so they rank above an upstream trading halt, which in turn
+     * ranks above the remaining recoverable/transient errors and then generic "no route" fallbacks.
      */
     private fun swapFailurePriority(error: Throwable): Int =
         when (error) {
@@ -695,24 +695,28 @@ constructor(
             is SwapException.InsufficentSwapAmount,
             is SwapException.AmountCannotBeZero,
             is SwapException.SameAssets -> 1
+            // A halt explains the whole outage, and every other provider routing through the
+            // paused protocol just stalls until its fetch times out. Ranked ahead of the rest of
+            // the transient group so the user reads "trading is halted, try later" rather than a
+            // sibling's timeout, which reads as "retry now" and never succeeds (#5656).
+            is SwapException.TradingHalted -> 2
             is SwapException.InsufficientFunds,
             is SwapException.HighPriceImpact,
             is SwapException.RateLimitExceeded,
-            is SwapException.TradingHalted,
             is SwapException.TimeOut,
             is TimeoutCancellationException,
             is SwapException.NetworkConnection,
             is SwapKitError.Network,
             is SwapKitError.InsufficientBalance,
-            is SwapKitError.InsufficientAllowance -> 2
+            is SwapKitError.InsufficientAllowance -> 3
             is SwapException.SwapRouteNotAvailable,
             is SwapException.SwapIsNotSupported,
             is SwapException.UnkownSwapError,
             is SwapKitError.NoRoutes,
             is SwapKitError.SwapRouteNotFound,
             is SwapKitError.RouteFiltered,
-            is SwapKitError.ProviderNotEnabled -> 3
-            else -> 4
+            is SwapKitError.ProviderNotEnabled -> 4
+            else -> 5
         }
 
     private suspend fun fetchThorMayaQuote(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/errors/SwapException.kt
@@ -45,9 +45,30 @@ sealed class SwapException(message: String) : Exception(message) {
     class AmountBelowDustThreshold(message: String) : SwapException(message)
 
     companion object {
+        /**
+         * Substrings THORChain and MAYAChain emit when a chain or an asset is paused upstream: a
+         * protocol-wide trading halt, `global_trading_paused`, or `chain_trading_paused`. Matched
+         * against the lowercased body, and kept in step with the iOS marker set so both stacks
+         * classify the same node text the same way.
+         */
+        private val TRADING_HALT_MARKERS =
+            listOf(
+                "trading is halted",
+                "trading halted",
+                "trading paused",
+                "_trading_paused",
+                "is paused",
+            )
+
         fun handleSwapException(error: String): SwapException {
             with(error.lowercase()) {
                 return when {
+                    // A pause is temporary and retryable, so it is matched ahead of every other
+                    // class. The nodes often report it alongside a fee or amount clause ("trading
+                    // paused; not enough asset to pay for fees"), and reading that as an amount
+                    // problem sends the user off to adjust an amount that cannot help while
+                    // trading is down.
+                    TRADING_HALT_MARKERS.any { marker -> contains(marker) } -> TradingHalted(error)
                     contains("amount cannot be zero") -> AmountCannotBeZero(error)
                     contains("swap is not supported") -> SwapIsNotSupported(error)
                     contains("/fromamount must pass") -> AmountCannotBeZero(error)
@@ -74,8 +95,6 @@ sealed class SwapException(message: String) : Exception(message) {
                     contains("bad to asset") ||
                         contains("bad from asset") ||
                         contains("invalid symbol") -> SwapRouteNotAvailable(error)
-                    contains("trading is halted") || contains("trading halted") ->
-                        TradingHalted(error)
                     contains("timeout") -> TimeOut(error)
                     contains("unable to resolve host") -> NetworkConnection(error)
                     contains("no internet connection") -> NetworkConnection(error)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSource.kt
@@ -57,7 +57,8 @@ internal class ThorChainQuoteSource @Inject constructor(private val thorChainApi
     /**
      * Fetches a THORChain quote, falling back to a streaming swap when rapid is unavailable or its
      * slippage is unacceptable. When both rapid and streaming succeed, picks whichever yields more
-     * output.
+     * output. A rapid failure that streaming cannot fix — an upstream trading halt — short-circuits
+     * instead of paying for the fallback round-trip.
      */
     private suspend fun fetchWithStreamingFallback(
         rapidRequest: ThorChainSwapQuoteRequest
@@ -65,6 +66,15 @@ internal class ThorChainQuoteSource @Inject constructor(private val thorChainApi
         val rapid = fetchRapid(rapidRequest)
         if (rapid is RapidQuote.Success && !rapid.needsStreaming()) {
             return rapid.data
+        }
+
+        // A trading halt is a property of the pool or the chain, not of the swap interval, so the
+        // streaming request would be refused the same way. Failing here surfaces the halt at once
+        // instead of spending a second round-trip on a node that is already refusing to quote —
+        // the wait that pushed the whole candidate past the caller's fetch timeout and surfaced as
+        // "swap request timed out" (#5656).
+        if (rapid is RapidQuote.Failed && rapid.error is SwapException.TradingHalted) {
+            throw rapid.error
         }
 
         when (rapid) {


### PR DESCRIPTION
Closes #5656

## Problem

When THORChain pauses trading, the swap form shows **"Swap request timed out. Please try again"** — copy that invites a retry which cannot succeed while trading is down. The correct string (`swap_error_trading_halted`) already exists and is already translated into all 10 locales; it just never gets selected.

Two things combine to produce the wrong message:

1. **The pause wording isn't recognised.** The nodes word a pause several ways — `"trading paused for this asset"`, `"the pool is paused"` — but `handleSwapException` only matched `"trading is halted"` / `"trading halted"`. Everything else fell through to `UnkownSwapError`.
2. **An unclassified error loses to a sibling's timeout.** `SwapQuoteManager.swapFailurePriority` ranks `UnkownSwapError` at tier 3 and `TimeOut` at tier 2, so when every provider fails, `minBy` surfaces the timeout from whichever provider stalled — not the halt from THORChain.

Classifying the halt correctly is not enough on its own: `TradingHalted` and `TimeOut` shared tier 2, and ties resolve by provider order, so the timeout still won whenever THORChain wasn't first in the eligible-provider list.

## Changes

**`SwapException.kt`** — extract `TRADING_HALT_MARKERS` (`trading is halted`, `trading halted`, `trading paused`, `_trading_paused`, `is paused`) and match it *ahead of every other class*. Order matters: the nodes report a pause alongside a fee clause (`"trading paused; not enough asset to pay for fees"`), which previously classified as an amount error and sent the user off to adjust an amount that can't help. This is the same marker set and the same check order iOS uses, so both stacks now classify identical node text identically.

**`SwapQuoteManager.kt`** — give `TradingHalted` its own tier, ahead of the transient group. A halt explains the whole outage; a sibling provider routing through the same paused protocol just stalls until its fetch times out, and that symptom shouldn't outrank the cause.

**`ThorChainQuoteSource.kt`** — a rapid quote that failed on a halt now short-circuits instead of firing the streaming fallback. A halt is a property of the pool or the chain, not of the swap interval, so the second round-trip can only be refused the same way — and that wasted request was part of what pushed the candidate past the 15s fetch timeout. This addresses the issue's "don't wait for a timeout" directly.

No string changes: `swap_error_trading_halted` is already present in `values/` and all nine locale files.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest` — pass
- [x] `./gradlew :app:testDebugUnitTest` — pass
- [x] `./gradlew :data:lintDebug :app:lintDebug` — pass
- [x] ktfmt clean

Related: #4749 (introduced the `TradingHalted` class and the copy), #5319 (added the sign-time inbound halt gate). This PR closes the remaining gap at quote time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection and classification of trading-halted conditions during swaps.
  - Trading halts now take priority over transient or unavailable-route errors.
  - Prevented unnecessary fallback quote requests when trading is halted.
  - Improved handling of additional trading-halt messages from swap providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->