### PR TITLE
chore(data): clear two Kotlin compiler warnings

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/MainDataModule.kt
@@ -131,6 +131,7 @@ internal interface MainDataModule {
          * Provides the singleton [SharedPreferences] backed by AndroidKeyStore AES-256-GCM
          * encryption.
          */
+        @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
         @Singleton
         @Provides
         fun provideEncryptedSharedPrefs(@ApplicationContext context: Context): SharedPreferences {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -155,8 +155,6 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
                             ?.let { Numeric.hexStringToByteArray(it) }
                             ?: REPRESENTATIVE_SWAP_CALLDATA,
                 )
-            else ->
-                error("Unsupported transaction type for L1 fee: ${transaction::class.simpleName}")
         }
     }
 


### PR DESCRIPTION
## Summary
- Opt in to `ExperimentalCoroutinesApi` on `provideEncryptedSharedPrefs`, which reads the prewarmed master key via `Deferred.getCompleted()`
- Drop the redundant `else` branch in `EthereumFeeService.resolveL1CallContext` now that the `when` is exhaustive over `BlockchainTransaction` — a new subtype missing a branch now fails to compile instead of failing at runtime

No behaviour change.

Fixes #5649

## Test plan
- [x] `./gradlew :data:compileDebugKotlin` — builds with no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ethereum transaction fee handling by removing an unnecessary error path for unsupported transaction types.
* **Stability**
  * Updated coroutine compatibility for encrypted preferences, supporting more reliable background operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->