### PR TITLE
fix(swap): tell the user a pair has no route instead of timing it out

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -684,9 +684,15 @@ constructor(
 
     /**
      * Ranks a failed-quote [error] so the most actionable failure is surfaced when every provider
-     * fails. Lower values win. Amount-related errors mean the pair is routable and the user can
-     * recover by adjusting the amount, so they rank above an upstream trading halt, which in turn
-     * ranks above the remaining recoverable/transient errors and then generic "no route" fallbacks.
+     * fails. Lower values win.
+     *
+     * A provider that answered with a verdict outranks one that never answered: the verdict
+     * describes the pair, while a timeout only says this provider was slow, and its "try again"
+     * copy sends the user round a retry loop that a deterministic rejection can never leave. Within
+     * the verdicts, the ones the user can act on come first — adjust the amount, wait out a halt,
+     * top up the balance — and "no route for this pair" last, since nothing about the form can
+     * change it. Below every verdict sits the transient group, and below that an unclassified body,
+     * which carries the provider's words but no reading of them.
      */
     private fun swapFailurePriority(error: Throwable): Int =
         when (error) {
@@ -696,27 +702,27 @@ constructor(
             is SwapException.AmountCannotBeZero,
             is SwapException.SameAssets -> 1
             // A halt explains the whole outage, and every other provider routing through the
-            // paused protocol just stalls until its fetch times out. Ranked ahead of the rest of
-            // the transient group so the user reads "trading is halted, try later" rather than a
-            // sibling's timeout, which reads as "retry now" and never succeeds (#5656).
+            // paused protocol just stalls until its fetch times out. It sits below the amount
+            // errors, which come from a pair that is routable right now, and above everything
+            // else, because no balance or route the user could change clears a paused pool.
             is SwapException.TradingHalted -> 2
             is SwapException.InsufficientFunds,
             is SwapException.HighPriceImpact,
-            is SwapException.RateLimitExceeded,
-            is SwapException.TimeOut,
-            is TimeoutCancellationException,
-            is SwapException.NetworkConnection,
-            is SwapKitError.Network,
             is SwapKitError.InsufficientBalance,
             is SwapKitError.InsufficientAllowance -> 3
             is SwapException.SwapRouteNotAvailable,
             is SwapException.SwapIsNotSupported,
-            is SwapException.UnkownSwapError,
             is SwapKitError.NoRoutes,
             is SwapKitError.SwapRouteNotFound,
             is SwapKitError.RouteFiltered,
             is SwapKitError.ProviderNotEnabled -> 4
-            else -> 5
+            is SwapException.RateLimitExceeded,
+            is SwapException.TimeOut,
+            is TimeoutCancellationException,
+            is SwapException.NetworkConnection,
+            is SwapKitError.Network -> 5
+            is SwapException.UnkownSwapError -> 6
+            else -> 7
         }
 
     private suspend fun fetchThorMayaQuote(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -691,8 +691,9 @@ constructor(
      * copy sends the user round a retry loop that a deterministic rejection can never leave. Within
      * the verdicts, the ones the user can act on come first — adjust the amount, wait out a halt,
      * top up the balance — and "no route for this pair" last, since nothing about the form can
-     * change it. Below every verdict sits the transient group, and below that an unclassified body,
-     * which carries the provider's words but no reading of them.
+     * change it. Below every verdict sits the transient group, then the failures nobody read as a
+     * verdict — an unclassified body, or an aggregator breaking on its own terms — and last a
+     * throwable outside the swap hierarchy altogether.
      */
     private fun swapFailurePriority(error: Throwable): Int =
         when (error) {
@@ -700,29 +701,64 @@ constructor(
             is SwapException.SmallSwapAmount,
             is SwapException.InsufficentSwapAmount,
             is SwapException.AmountCannotBeZero,
-            is SwapException.SameAssets -> 1
+            is SwapException.SameAssets -> PRIORITY_AMOUNT
             // A halt explains the whole outage, and every other provider routing through the
             // paused protocol just stalls until its fetch times out. It sits below the amount
             // errors, which come from a pair that is routable right now, and above everything
             // else, because no balance or route the user could change clears a paused pool.
-            is SwapException.TradingHalted -> 2
+            is SwapException.TradingHalted -> PRIORITY_HALT
             is SwapException.InsufficientFunds,
-            is SwapException.HighPriceImpact,
-            is SwapKitError.InsufficientBalance,
-            is SwapKitError.InsufficientAllowance -> 3
+            is SwapException.HighPriceImpact -> PRIORITY_FIXABLE
             is SwapException.SwapRouteNotAvailable,
-            is SwapException.SwapIsNotSupported,
-            is SwapKitError.NoRoutes,
-            is SwapKitError.SwapRouteNotFound,
-            is SwapKitError.RouteFiltered,
-            is SwapKitError.ProviderNotEnabled -> 4
+            is SwapException.SwapIsNotSupported -> PRIORITY_ROUTE
             is SwapException.RateLimitExceeded,
             is SwapException.TimeOut,
             is TimeoutCancellationException,
-            is SwapException.NetworkConnection,
-            is SwapKitError.Network -> 5
-            is SwapException.UnkownSwapError -> 6
-            else -> 7
+            is SwapException.NetworkConnection -> PRIORITY_TRANSIENT
+            is SwapException.UnkownSwapError -> PRIORITY_UNREAD
+            // Exhaustive over the sealed hierarchy on purpose: every typed verdict has to be
+            // placed, or a new variant would silently fall into the catch-all and lose to a
+            // sibling's timeout — which is the defect this ranking exists to fix.
+            is SwapKitError -> swapKitFailurePriority(error)
+            else -> PRIORITY_UNTYPED
+        }
+
+    /**
+     * Where each [SwapKitError] sits in the tiers [swapFailurePriority] defines. The aggregator
+     * reports a whole taxonomy of verdicts, and all of them reach this ranking: the quote path
+     * builds the transaction, so a `/v3/swap` code arrives while a sibling provider may still be
+     * stalling towards its timeout.
+     */
+    private fun swapKitFailurePriority(error: SwapKitError): Int =
+        when (error) {
+            // Wallet or recipient state the user can still change. A deviating quote joins them:
+            // it is the one failure that proves the pair *does* route — the price simply moved
+            // between the quote and the build — so "refresh" is truer than any route verdict.
+            is SwapKitError.InsufficientBalance,
+            is SwapKitError.InsufficientAllowance,
+            is SwapKitError.QuoteDeviation,
+            is SwapKitError.InvalidDestinationAddress,
+            is SwapKitError.AddressScreening -> PRIORITY_FIXABLE
+            // Verdicts on the pair itself. UnableToBuildTransaction is surfaced as "this route is
+            // currently unavailable", and a blocked asset or an unusable source address is the
+            // same answer reached by another door: nothing on the form changes any of them.
+            is SwapKitError.NoRoutes,
+            is SwapKitError.SwapRouteNotFound,
+            is SwapKitError.RouteFiltered,
+            is SwapKitError.ProviderNotEnabled,
+            is SwapKitError.UnableToBuildTransaction,
+            is SwapKitError.BlackListAsset,
+            is SwapKitError.InvalidSourceAddress -> PRIORITY_ROUTE
+            is SwapKitError.Network -> PRIORITY_TRANSIENT
+            // The aggregator failed on its own terms — a rejected key, a payload this client
+            // cannot read or sign, a bare HTTP status. None of it reads as a verdict on the pair,
+            // so it stays below a sibling's timeout, whose "try again" is at least true.
+            is SwapKitError.ApiKeyMissing,
+            is SwapKitError.ApiKeyInvalid,
+            is SwapKitError.UnsupportedTxType,
+            is SwapKitError.MalformedAmount,
+            is SwapKitError.Decoding,
+            is SwapKitError.Server -> PRIORITY_UNREAD
         }
 
     private suspend fun fetchThorMayaQuote(
@@ -1412,6 +1448,16 @@ constructor(
         UiText.FormattedText(resId, emptyList())
 
     companion object {
+        // Failure-ranking tiers, lowest wins. Named so the two ranking functions cannot drift
+        // apart and so a tier's meaning survives a variant moving between them.
+        private const val PRIORITY_AMOUNT = 1
+        private const val PRIORITY_HALT = 2
+        private const val PRIORITY_FIXABLE = 3
+        private const val PRIORITY_ROUTE = 4
+        private const val PRIORITY_TRANSIENT = 5
+        private const val PRIORITY_UNREAD = 6
+        private const val PRIORITY_UNTYPED = 7
+
         // All aggregators charge the same base affiliate as [BASE_AFFILIATE_FEE_BPS]; derive them
         // from it so the displayed percentage ([formatAffiliatePercent]) can't silently go stale if
         // the base changes, and a provider that genuinely needs a different rate has to break the

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -181,6 +181,10 @@ internal class SwapQuotePipeline(
             return SwapQuotePipelineResult.Empty
         }
 
+        // Set once the provider set is known, and read again from the catch blocks below, where
+        // the failure may have been thrown after the filter ran.
+        var recipientDroppedProviders = false
+
         return try {
             if (srcTokenValue == null || srcTokenValue <= BigInteger.ZERO) {
                 throw SwapException.AmountCannotBeZero("Amount must be positive")
@@ -210,6 +214,7 @@ internal class SwapQuotePipeline(
                             it == SwapProvider.SWAPKIT
                     }
                 }
+            recipientDroppedProviders = eligibleProviders.size < allEligibleProviders.size
             if (eligibleProviders.isEmpty()) {
                 throw SwapException.SwapIsNotSupported("Swap is not supported for this pair")
             }
@@ -262,7 +267,7 @@ internal class SwapQuotePipeline(
                                 recipientAwareError(
                                     resolution.formError,
                                     resolution.cause,
-                                    externalRecipient,
+                                    recipientDroppedProviders,
                                 ),
                             cause = resolution.cause,
                             tag = resolution.tag,
@@ -288,7 +293,7 @@ internal class SwapQuotePipeline(
                             selectedSrcTokenTitle,
                         ),
                         e,
-                        externalRecipient,
+                        recipientDroppedProviders,
                     ),
                 cause = e,
                 tag = "swapError",
@@ -311,12 +316,18 @@ internal class SwapQuotePipeline(
     }
 
     /**
-     * Rewrites a quote failure into a recipient-aware message when an external recipient is active.
+     * Rewrites a quote failure into a recipient-aware message when the recipient is what caused it.
      *
-     * Setting a recipient narrows the eligible providers to THORChain/Maya (the only protocols that
-     * route output to a custom address — see the native-only filter above). When the pair has no
-     * such route at all, the bare "not supported" error never explains that the recipient is the
-     * cause, so name it (#4858).
+     * Setting a recipient narrows the eligible providers to THORChain/Maya/SwapKit (the only ones
+     * that route output to a custom address — see the native-only filter above). When that filter
+     * is what emptied or crippled the candidate set, the bare "not supported" error never explains
+     * that the recipient is the cause, so name it (#4858).
+     *
+     * [recipientDroppedProviders] is the whole test: a pair the filter never touched fails for its
+     * own reasons, and telling the user to clear the recipient would send them to remove it and
+     * meet the identical error. A THORChain→THORChain pair is exactly that case — `bothThorChain`
+     * already leaves THORCHAIN as the only candidate — and it reaches here routinely now that a
+     * poolless pair answers with [SwapException.SwapRouteNotAvailable] instead of timing out.
      *
      * Sub-minimum failures are deliberately NOT rewritten here: THORChain surfaces the concrete
      * required minimum ("Minimum amount is X") via [SwapException.SmallSwapAmount], which is more
@@ -325,9 +336,9 @@ internal class SwapQuotePipeline(
     private fun recipientAwareError(
         error: UiText,
         cause: Throwable,
-        externalRecipient: String?,
+        recipientDroppedProviders: Boolean,
     ): UiText {
-        if (externalRecipient.isNullOrBlank()) return error
+        if (!recipientDroppedProviders) return error
         return when (cause) {
             is SwapException.SwapIsNotSupported,
             is SwapException.SwapRouteNotAvailable ->

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -300,7 +300,12 @@ internal class SwapQuotePipeline(
             )
         } catch (e: SwapKitError) {
             SwapQuotePipelineResult.Failure(
-                error = swapQuoteManager.mapSwapKitErrorToFormError(e),
+                error =
+                    recipientAwareError(
+                        swapQuoteManager.mapSwapKitErrorToFormError(e),
+                        e,
+                        recipientDroppedProviders,
+                    ),
                 cause = e,
                 tag = "swapKitError",
             )
@@ -343,9 +348,52 @@ internal class SwapQuotePipeline(
             is SwapException.SwapIsNotSupported,
             is SwapException.SwapRouteNotAvailable ->
                 UiText.StringResource(R.string.swap_external_recipient_unsupported)
+            // SwapKit survives the recipient filter, so it can be the provider whose verdict wins
+            // the ranking — and its route verdicts are the same news as SwapRouteNotAvailable,
+            // just typed by the aggregator instead of the native protocol.
+            is SwapKitError ->
+                if (swapKitSaysThePairHasNoRoute(cause)) {
+                    UiText.StringResource(R.string.swap_external_recipient_unsupported)
+                } else {
+                    error
+                }
             else -> error
         }
     }
+
+    /**
+     * Whether a SwapKit verdict means "none of the surviving providers can route this pair" — the
+     * only class of failure the recipient rewrite may claim, since it tells the user that clearing
+     * the recipient would hand the pair a provider the filter took away.
+     *
+     * Exhaustive over the sealed class on purpose: a new variant must be placed by hand rather than
+     * default into either answer. A verdict that proves a route *was* found (the id expired, the
+     * build failed) is left alone, as is one whose own copy is more specific than a generic
+     * recipient note — same reasoning that keeps [SwapException.SmallSwapAmount] out of the rewrite
+     * above.
+     */
+    private fun swapKitSaysThePairHasNoRoute(error: SwapKitError): Boolean =
+        when (error) {
+            is SwapKitError.NoRoutes,
+            is SwapKitError.RouteFiltered,
+            is SwapKitError.ProviderNotEnabled -> true
+            is SwapKitError.SwapRouteNotFound,
+            is SwapKitError.UnableToBuildTransaction,
+            is SwapKitError.QuoteDeviation,
+            is SwapKitError.BlackListAsset,
+            is SwapKitError.InsufficientBalance,
+            is SwapKitError.InsufficientAllowance,
+            is SwapKitError.InvalidSourceAddress,
+            is SwapKitError.InvalidDestinationAddress,
+            is SwapKitError.AddressScreening,
+            is SwapKitError.UnsupportedTxType,
+            is SwapKitError.MalformedAmount,
+            is SwapKitError.ApiKeyMissing,
+            is SwapKitError.ApiKeyInvalid,
+            is SwapKitError.Network,
+            is SwapKitError.Server,
+            is SwapKitError.Decoding -> false
+        }
 
     /**
      * Builds the display-ready [SwapQuotePipelineResult.Success] from the winning quote.

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.api.errors.SwapKitError
 import com.vultisig.wallet.data.api.models.FeatureFlagJson
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
@@ -3823,6 +3824,126 @@ internal class SwapFormViewModelTest {
 
             assertEquals(
                 UiText.StringResource(R.string.swap_route_not_available),
+                vm.uiState.value.formError,
+            )
+        }
+
+    @Test
+    fun `a SwapKit no-route verdict is blamed on the recipient that dropped a provider`() =
+        runTest(mainDispatcher) {
+            // SwapKit survives the recipient filter, so its verdict can be the one that wins the
+            // ranking. "No SwapKit route available" is the same news as SwapRouteNotAvailable and
+            // must earn the same recipient-aware copy: LI.FI was removed by the recipient, so
+            // clearing it really would give this pair another provider to try (#4858).
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.SWAPKIT, SwapProvider.LIFI)
+            coEvery {
+                // 11 matchers — see the note above; a non-null recipient is set in this test too.
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } throws SwapKitError.NoRoutes()
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.setExternalRecipient("bc1qrecipientaddress")
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0.001")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            assertEquals(
+                UiText.StringResource(R.string.swap_external_recipient_unsupported),
+                vm.uiState.value.formError,
+            )
+        }
+
+    @Test
+    fun `a SwapKit build failure keeps its own message even when the recipient dropped a provider`() =
+        runTest(mainDispatcher) {
+            // UnableToBuildTransaction proves a route WAS found and the build failed on it, so the
+            // recipient is not the reason — clearing it would not change this outcome. Only the
+            // verdicts that mean "this pair does not route" may be rewritten.
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.SWAPKIT, SwapProvider.LIFI)
+            coEvery {
+                // 11 matchers — see the note above; a non-null recipient is set in this test too.
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } throws SwapKitError.UnableToBuildTransaction
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.setExternalRecipient("bc1qrecipientaddress")
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0.001")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            assertEquals(
+                UiText.StringResource(R.string.swapkit_error_unable_to_build_transaction),
+                vm.uiState.value.formError,
+            )
+        }
+
+    @Test
+    fun `a SwapKit no-route verdict survives a recipient that removed no provider`() =
+        runTest(mainDispatcher) {
+            // The recipient filter keeps SwapKit, so a SwapKit-only pair loses nothing to it.
+            // Blaming the recipient would send the user to clear it and meet the identical error.
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.SWAPKIT)
+            coEvery {
+                // 11 matchers — see the note above; a non-null recipient is set in this test too.
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } throws SwapKitError.NoRoutes()
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.setExternalRecipient("bc1qrecipientaddress")
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0.001")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            assertEquals(
+                UiText.StringResource(R.string.swapkit_error_no_routes_found),
                 vm.uiState.value.formError,
             )
         }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -3749,9 +3749,10 @@ internal class SwapFormViewModelTest {
             // Setting a recipient drops the aggregators and keeps only THORChain/Maya. When the
             // pair
             // has no native route at all, the bare "not supported" must instead name the recipient
-            // as the reason (#4858).
+            // as the reason (#4858). LI.FI is in the eligible set so the recipient is what removed
+            // it — clearing the recipient really would give this pair another provider to try.
             every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
-                listOf(SwapProvider.THORCHAIN)
+                listOf(SwapProvider.THORCHAIN, SwapProvider.LIFI)
             coEvery {
                 // 11 matchers: the trailing slippageBps + externalRecipient must be matched
                 // explicitly, else MockK defaults them to null and the non-null recipient set below
@@ -3782,6 +3783,46 @@ internal class SwapFormViewModelTest {
 
             assertEquals(
                 UiText.StringResource(R.string.swap_external_recipient_unsupported),
+                vm.uiState.value.formError,
+            )
+        }
+
+    @Test
+    fun `a recipient that removed no provider leaves the route verdict alone`() =
+        runTest(mainDispatcher) {
+            // A THORChain-to-THORChain pair is offered THORCHAIN alone — MayaChain is dropped for
+            // the pair itself, not for the recipient — so the recipient filter takes nothing away.
+            // Blaming it would send the user to clear the recipient and meet the identical error.
+            every { swapQuoteRepository.getEligibleProviders(any(), any()) } returns
+                listOf(SwapProvider.THORCHAIN)
+            coEvery {
+                // 11 matchers — see the note above; a non-null recipient is set in this test too.
+                swapQuoteManager.fetchBestQuote(
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                    any(),
+                )
+            } throws SwapException.SwapRouteNotAvailable("pool does not exist")
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.setExternalRecipient("thor1recipientaddress")
+            vm.srcAmountState.setTextAndPlaceCursorAtEnd("0.001")
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(500)
+            advanceUntilIdle()
+
+            assertEquals(
+                UiText.StringResource(R.string.swap_route_not_available),
                 vm.uiState.value.formError,
             )
         }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -161,6 +161,150 @@ internal class SwapQuoteManagerTest {
     }
 
     @Test
+    fun `fetchBestQuote surfaces a no-route verdict over a sibling provider's timeout`() = runTest {
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } throws
+            SwapException.SwapRouteNotAvailable(
+                "failed to calculate min swap amount: fail to convert dest fee to src asset " +
+                    "pool does not exist"
+            )
+        // The pair has no pool anywhere, so the sibling never answers either — it just burns the
+        // whole fetch window. Its timeout must not decide the copy: "try again" cannot route a
+        // pair that does not exist.
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.MAYA, any()) } coAnswers
+            {
+                delay(Long.MAX_VALUE)
+                error("unreachable")
+            }
+
+        val manager = createManager()
+        val deferred = async {
+            runCatching {
+                manager.fetchBestQuote(
+                    candidates =
+                        listOf(
+                            QuoteCandidate(
+                                provider = SwapProvider.THORCHAIN,
+                                vultBPSDiscount = null,
+                                referral = null,
+                            ),
+                            QuoteCandidate(
+                                provider = SwapProvider.MAYA,
+                                vultBPSDiscount = null,
+                                referral = null,
+                            ),
+                        ),
+                    src = mockk(relaxed = true),
+                    dst = mockk(relaxed = true),
+                    srcToken = mockk(relaxed = true),
+                    dstToken = mockk(relaxed = true),
+                    srcTokenValue = BigInteger.ONE,
+                    tokenValue = mockk(relaxed = true),
+                    currency = AppCurrency.USD,
+                    amount = BigDecimal.ONE,
+                )
+            }
+        }
+
+        advanceTimeBy(15_001L)
+
+        deferred.await().exceptionOrNull().shouldBeInstanceOf<SwapException.SwapRouteNotAvailable>()
+    }
+
+    @Test
+    fun `fetchBestQuote surfaces an insufficient-funds verdict over a sibling provider's timeout`() =
+        runTest {
+            coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+                FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)
+            // The stalling provider is listed first, so a rank shared with the timeout would
+            // hand the form "try again" over a shortfall the user can actually fix.
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } coAnswers
+                {
+                    delay(Long.MAX_VALUE)
+                    error("unreachable")
+                }
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.MAYA, any()) } throws
+                SwapException.InsufficientFunds("insufficient funds")
+
+            val manager = createManager()
+            val deferred = async {
+                runCatching {
+                    manager.fetchBestQuote(
+                        candidates =
+                            listOf(
+                                QuoteCandidate(
+                                    provider = SwapProvider.THORCHAIN,
+                                    vultBPSDiscount = null,
+                                    referral = null,
+                                ),
+                                QuoteCandidate(
+                                    provider = SwapProvider.MAYA,
+                                    vultBPSDiscount = null,
+                                    referral = null,
+                                ),
+                            ),
+                        src = mockk(relaxed = true),
+                        dst = mockk(relaxed = true),
+                        srcToken = mockk(relaxed = true),
+                        dstToken = mockk(relaxed = true),
+                        srcTokenValue = BigInteger.ONE,
+                        tokenValue = mockk(relaxed = true),
+                        currency = AppCurrency.USD,
+                        amount = BigDecimal.ONE,
+                    )
+                }
+            }
+
+            advanceTimeBy(15_001L)
+
+            deferred.await().exceptionOrNull().shouldBeInstanceOf<SwapException.InsufficientFunds>()
+        }
+
+    @Test
+    fun `fetchBestQuote surfaces a no-route verdict over an unclassified provider body`() =
+        runTest {
+            coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+                FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)
+            // Listed first, so first-by-provider-order would hand the user a node body this app
+            // never
+            // read, over a sibling that named the actual outcome.
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } throws
+                SwapException.UnkownSwapError("internal error: 500")
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.MAYA, any()) } throws
+                SwapException.SwapRouteNotAvailable("pool does not exist")
+
+            val manager = createManager()
+            val result = runCatching {
+                manager.fetchBestQuote(
+                    candidates =
+                        listOf(
+                            QuoteCandidate(
+                                provider = SwapProvider.THORCHAIN,
+                                vultBPSDiscount = null,
+                                referral = null,
+                            ),
+                            QuoteCandidate(
+                                provider = SwapProvider.MAYA,
+                                vultBPSDiscount = null,
+                                referral = null,
+                            ),
+                        ),
+                    src = mockk(relaxed = true),
+                    dst = mockk(relaxed = true),
+                    srcToken = mockk(relaxed = true),
+                    dstToken = mockk(relaxed = true),
+                    srcTokenValue = BigInteger.ONE,
+                    tokenValue = mockk(relaxed = true),
+                    currency = AppCurrency.USD,
+                    amount = BigDecimal.ONE,
+                )
+            }
+
+            result.exceptionOrNull().shouldBeInstanceOf<SwapException.SwapRouteNotAvailable>()
+        }
+
+    @Test
     fun `fetchQuote keeps the SwapKit sub-provider label across a cache hit (Native path)`() =
         runTest {
             // Pins the SwapQuoteResult.Native arm + the `is SwapQuote.SwapKit -> subProvider`

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -4,6 +4,7 @@ package com.vultisig.wallet.ui.models.swap
 
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.api.errors.SwapKitError
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.Fees
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
@@ -48,6 +49,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
@@ -303,6 +305,98 @@ internal class SwapQuoteManagerTest {
 
             result.exceptionOrNull().shouldBeInstanceOf<SwapException.SwapRouteNotAvailable>()
         }
+
+    @Test
+    fun `fetchBestQuote surfaces a deviating quote over a sibling provider's timeout`() = runTest {
+        // A deviation is the one failure that proves the pair does route — the price moved between
+        // the quote and the build — so it has to outrank a sibling that never answered at all.
+        val chosen =
+            failureRacedAgainstATimeout(
+                stalling = SwapProvider.THORCHAIN,
+                answering = SwapProvider.SWAPKIT,
+                verdict = SwapKitError.QuoteDeviation(),
+            )
+
+        chosen.shouldBeInstanceOf<SwapKitError.QuoteDeviation>()
+    }
+
+    @Test
+    fun `fetchBestQuote surfaces an unbuildable route over a sibling provider's timeout`() =
+        runTest {
+            // "This route is currently unavailable" is a verdict on the pair; "try again" is not.
+            val chosen =
+                failureRacedAgainstATimeout(
+                    stalling = SwapProvider.THORCHAIN,
+                    answering = SwapProvider.SWAPKIT,
+                    verdict = SwapKitError.UnableToBuildTransaction,
+                )
+
+            chosen.shouldBeInstanceOf<SwapKitError.UnableToBuildTransaction>()
+        }
+
+    @Test
+    fun `fetchBestQuote keeps a sibling's timeout over an aggregator breaking on its own terms`() =
+        runTest {
+            // The other side of the ranking: a payload this client could not read says nothing
+            // about the pair, so it must not displace a timeout, whose "try again" is at least
+            // true.
+            val chosen =
+                failureRacedAgainstATimeout(
+                    stalling = SwapProvider.THORCHAIN,
+                    answering = SwapProvider.SWAPKIT,
+                    verdict = SwapKitError.Decoding("unreadable route payload"),
+                )
+
+            chosen.shouldBeInstanceOf<SwapException.TimeOut>()
+        }
+
+    /**
+     * Races [answering]'s [verdict] against [stalling], which never replies, and returns the
+     * failure the manager surfaced. The stalling provider is listed first, so a verdict that only
+     * ties with a timeout would lose to it on provider order.
+     */
+    private suspend fun TestScope.failureRacedAgainstATimeout(
+        stalling: SwapProvider,
+        answering: SwapProvider,
+        verdict: Throwable,
+    ): Throwable? {
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)
+        coEvery { swapQuoteRepository.getQuote(stalling, any()) } coAnswers
+            {
+                delay(Long.MAX_VALUE)
+                error("unreachable")
+            }
+        coEvery { swapQuoteRepository.getQuote(answering, any()) } throws verdict
+
+        val manager = createManager()
+        val deferred = async {
+            runCatching {
+                manager.fetchBestQuote(
+                    candidates =
+                        listOf(stalling, answering).map { provider ->
+                            QuoteCandidate(
+                                provider = provider,
+                                vultBPSDiscount = null,
+                                referral = null,
+                            )
+                        },
+                    src = mockk(relaxed = true),
+                    dst = mockk(relaxed = true),
+                    srcToken = mockk(relaxed = true),
+                    dstToken = mockk(relaxed = true),
+                    srcTokenValue = BigInteger.ONE,
+                    tokenValue = mockk(relaxed = true),
+                    currency = AppCurrency.USD,
+                    amount = BigDecimal.ONE,
+                )
+            }
+        }
+
+        advanceTimeBy(15_001L)
+
+        return deferred.await().exceptionOrNull()
+    }
 
     @Test
     fun `fetchQuote keeps the SwapKit sub-provider label across a cache hit (Native path)`() =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -55,6 +55,7 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -249,15 +250,26 @@ constructor(
                 // this method reads whatever the status. Under the shared policy those bodies
                 // were retried as if the node had faltered, and three exponential backoffs cost
                 // more than the caller's whole quote window, so the pair surfaced as a timeout
-                // the user could only retry. Transport failures and back-pressure still retry.
+                // the user could only retry. Only thornode's own verdict skips the retry; the
+                // gateway's 5xx, transport failures and back-pressure all still retry.
                 retry {
                     maxRetries = 3
                     retryOnExceptionIf { _, cause -> cause !is CancellationException }
                     retryIf { _, retryResponse ->
                         retryResponse.status == HttpStatusCode.TooManyRequests ||
-                            retryResponse.status == HttpStatusCode.RequestTimeout
+                            retryResponse.status == HttpStatusCode.RequestTimeout ||
+                            (retryResponse.status.value >= HTTP_SERVER_ERROR &&
+                                !retryResponse.isThornodeVerdict())
                     }
-                    exponentialDelay()
+                    // A retry is only worth attempting inside the caller's 15s quote window, and
+                    // the client-wide 2 + 4 + 8s backoff does not fit in it — nor does an
+                    // upstream `Retry-After` measured in seconds. A short fixed delay lets a
+                    // blip self-heal while the window still belongs to the user.
+                    constantDelay(
+                        millis = RETRY_DELAY_MS,
+                        randomizationMs = RETRY_JITTER_MS,
+                        respectRetryAfterHeader = false,
+                    )
                 }
                 parameter("from_asset", request.fromAsset)
                 parameter("to_asset", request.toAsset)
@@ -816,8 +828,25 @@ constructor(
             .bodyOrThrow<TcyStakersResponse>()
     }
 
+    /**
+     * True when a 5xx is thornode's own answer rather than the gateway's.
+     *
+     * The node sits behind `gateway.liquify.com`, so a 500 can come from either end, and only one
+     * of them is deterministic. Cosmos' gRPC gateway stamps every response it produces — including
+     * the rejections it reports as 500 — with the block height it answered at, and the proxy passes
+     * that header through (it even names it in `Access-Control-Expose-Headers`). Liquify's own
+     * failures are its edge speaking: `Server: fasthttp`, a `text/plain` body, no cosmos metadata.
+     * Verified live against the quote endpoint on 2026-08-22.
+     */
+    private fun HttpResponse.isThornodeVerdict(): Boolean =
+        headers[COSMOS_BLOCK_HEIGHT_HEADER] != null
+
     companion object {
         private const val THORNODE_BASE = "https://gateway.liquify.com/chain/thorchain_api"
+        private const val COSMOS_BLOCK_HEIGHT_HEADER = "Grpc-Metadata-X-Cosmos-Block-Height"
+        private const val HTTP_SERVER_ERROR = 500
+        private const val RETRY_DELAY_MS = 300L
+        private const val RETRY_JITTER_MS = 100L
         private const val MIDGARD_URL = "https://gateway.liquify.com/chain/thorchain_midgard/v2"
         private const val DEFAULT_LP_PERIOD = "30d"
         private const val THORCHAIN_RPC_URL = "https://gateway.liquify.com/chain/thorchain_rpc"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -49,6 +49,7 @@ import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.retry
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -243,6 +244,21 @@ constructor(
 
         val response =
             httpClient.get("$THORNODE_BASE/thorchain/quote/swap") {
+                // Thornode reports a deterministic rejection — no pool for the pair, a paused
+                // pool, an unparseable asset — as a 500 carrying the reason in the body, which
+                // this method reads whatever the status. Under the shared policy those bodies
+                // were retried as if the node had faltered, and three exponential backoffs cost
+                // more than the caller's whole quote window, so the pair surfaced as a timeout
+                // the user could only retry. Transport failures and back-pressure still retry.
+                retry {
+                    maxRetries = 3
+                    retryOnExceptionIf { _, cause -> cause !is CancellationException }
+                    retryIf { _, retryResponse ->
+                        retryResponse.status == HttpStatusCode.TooManyRequests ||
+                            retryResponse.status == HttpStatusCode.RequestTimeout
+                    }
+                    exponentialDelay()
+                }
                 parameter("from_asset", request.fromAsset)
                 parameter("to_asset", request.toAsset)
                 parameter("amount", request.amount)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSource.kt
@@ -57,8 +57,8 @@ internal class ThorChainQuoteSource @Inject constructor(private val thorChainApi
     /**
      * Fetches a THORChain quote, falling back to a streaming swap when rapid is unavailable or its
      * slippage is unacceptable. When both rapid and streaming succeed, picks whichever yields more
-     * output. A rapid failure that streaming cannot fix — an upstream trading halt — short-circuits
-     * instead of paying for the fallback round-trip.
+     * output. A rapid failure that streaming cannot fix short-circuits instead of paying for the
+     * fallback round-trip.
      */
     private suspend fun fetchWithStreamingFallback(
         rapidRequest: ThorChainSwapQuoteRequest
@@ -68,12 +68,7 @@ internal class ThorChainQuoteSource @Inject constructor(private val thorChainApi
             return rapid.data
         }
 
-        // A trading halt is a property of the pool or the chain, not of the swap interval, so the
-        // streaming request would be refused the same way. Failing here surfaces the halt at once
-        // instead of spending a second round-trip on a node that is already refusing to quote —
-        // the wait that pushed the whole candidate past the caller's fetch timeout and surfaced as
-        // "swap request timed out" (#5656).
-        if (rapid is RapidQuote.Failed && rapid.error is SwapException.TradingHalted) {
+        if (rapid is RapidQuote.Failed && rapid.error.survivesTheInterval()) {
             throw rapid.error
         }
 
@@ -154,6 +149,18 @@ internal class ThorChainQuoteSource @Inject constructor(private val thorChainApi
         val streamingOut = streaming.expectedAmountOut.toBigInteger()
         return if (streamingOut > rapid.expectedAmountOut.toBigInteger()) streaming else rapid
     }
+
+    /**
+     * Whether a rapid-quote rejection would be repeated word for word by the streaming request. A
+     * halt belongs to the pool or the chain and a missing route to the pair, so neither is anything
+     * the swap interval can change — asking again only spends a second round-trip out of the
+     * caller's quote window before it surfaces the same answer. Amount rejections are excluded on
+     * purpose: streaming splits the swap, so an amount the rapid path refuses can still quote.
+     */
+    private fun SwapException.survivesTheInterval(): Boolean =
+        this is SwapException.TradingHalted ||
+            this is SwapException.SwapRouteNotAvailable ||
+            this is SwapException.SwapIsNotSupported
 
     private sealed interface RapidQuote {
         data class Success(val data: THORChainSwapQuote) : RapidQuote {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainQuoteRetryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainQuoteRetryTest.kt
@@ -28,6 +28,10 @@ import org.junit.jupiter.api.Test
  * whose body carries the reason. Under the client-wide policy those bodies were retried three times
  * with exponential backoff, which costs more than the caller's whole quote window, so a pair that
  * can never route reached the user as "swap request timed out" instead of the reason.
+ *
+ * The node is reached through `gateway.liquify.com`, so a 500 can also be the proxy's own. Only the
+ * node's verdict — marked by the cosmos gRPC-gateway block-height header it stamps on everything it
+ * answers — skips the retry; the gateway's 5xx still gets one.
  */
 class ThorChainQuoteRetryTest {
 
@@ -36,8 +40,16 @@ class ThorChainQuoteRetryTest {
         explicitNulls = false
     }
 
-    private val jsonHeaders =
-        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+    /** What thornode's own reply looks like: JSON, stamped with the height it answered at. */
+    private val thornodeHeaders =
+        headersOf(
+            HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()),
+            "Grpc-Metadata-X-Cosmos-Block-Height" to listOf("27533810"),
+        )
+
+    /** What liquify's edge looks like when it fails before reaching the node. */
+    private val gatewayHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Text.Plain.toString())
 
     private val poollessBody =
         """
@@ -71,7 +83,7 @@ class ThorChainQuoteRetryTest {
             api(
                     MockEngine {
                         callCount++
-                        respond(poollessBody, HttpStatusCode.InternalServerError, jsonHeaders)
+                        respond(poollessBody, HttpStatusCode.InternalServerError, thornodeHeaders)
                     }
                 )
                 .getSwapQuotes(request())
@@ -88,15 +100,46 @@ class ThorChainQuoteRetryTest {
                 MockEngine {
                     callCount++
                     if (callCount == 1) {
-                        respond("", HttpStatusCode.TooManyRequests, jsonHeaders)
+                        respond("", HttpStatusCode.TooManyRequests, thornodeHeaders)
                     } else {
-                        respond(poollessBody, HttpStatusCode.InternalServerError, jsonHeaders)
+                        respond(poollessBody, HttpStatusCode.InternalServerError, thornodeHeaders)
                     }
                 }
             )
             .getSwapQuotes(request())
 
         callCount shouldBe 2
+    }
+
+    @Test
+    fun `a 500 the node never answered is retried`() = runTest {
+        var callCount = 0
+        val result =
+            api(
+                    MockEngine {
+                        callCount++
+                        if (callCount == 1) {
+                            respond(
+                                "upstream error",
+                                HttpStatusCode.InternalServerError,
+                                gatewayHeaders,
+                            )
+                        } else {
+                            respond(
+                                poollessBody,
+                                HttpStatusCode.InternalServerError,
+                                thornodeHeaders,
+                            )
+                        }
+                    }
+                )
+                .getSwapQuotes(request())
+
+        // The gateway failed before the node was reached, so the quote is asked for again — and
+        // the answer the user is shown is the node's, not the edge's.
+        callCount shouldBe 2
+        result.shouldBeInstanceOf<THORChainSwapQuoteDeserialized.Error>()
+        result.error.message shouldContain "pool does not exist"
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainQuoteRetryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainQuoteRetryTest.kt
@@ -1,0 +1,117 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteDeserialized
+import com.vultisig.wallet.data.api.models.quotes.ThorChainSwapQuoteRequest
+import com.vultisig.wallet.data.networkutils.HttpClientConfigurator
+import com.vultisig.wallet.data.utils.NetworkException
+import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializerImpl
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import java.io.IOException
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the retry policy the swap-quote endpoint runs under.
+ *
+ * Thornode answers a deterministic rejection — no pool for the pair, a paused pool — with a 500
+ * whose body carries the reason. Under the client-wide policy those bodies were retried three times
+ * with exponential backoff, which costs more than the caller's whole quote window, so a pair that
+ * can never route reached the user as "swap request timed out" instead of the reason.
+ */
+class ThorChainQuoteRetryTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private val jsonHeaders =
+        headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private val poollessBody =
+        """
+        {"code":2,"message":"failed to calculate min swap amount: fail to convert dest fee to src asset pool does not exist","details":[]}
+        """
+            .trimIndent()
+
+    private fun api(engine: MockEngine): ThorChainApi =
+        ThorChainApiImpl(
+            httpClient = HttpClient(engine) { HttpClientConfigurator(json).configure(this) },
+            thorChainSwapQuoteResponseJsonSerializer =
+                ThorChainSwapQuoteResponseJsonSerializerImpl(json),
+            json = json,
+        )
+
+    private fun request() =
+        ThorChainSwapQuoteRequest(
+            address = "thor1dst",
+            fromAsset = "THOR.RUNE",
+            toAsset = "THOR.KUJI",
+            amount = "100000000",
+            interval = "0",
+            referralCode = "",
+            bpsDiscount = 0,
+        )
+
+    @Test
+    fun `a 500 carrying a quote rejection is read, not retried`() = runTest {
+        var callCount = 0
+        val result =
+            api(
+                    MockEngine {
+                        callCount++
+                        respond(poollessBody, HttpStatusCode.InternalServerError, jsonHeaders)
+                    }
+                )
+                .getSwapQuotes(request())
+
+        callCount shouldBe 1
+        result.shouldBeInstanceOf<THORChainSwapQuoteDeserialized.Error>()
+        result.error.message shouldContain "pool does not exist"
+    }
+
+    @Test
+    fun `back-pressure on the quote endpoint is still retried`() = runTest {
+        var callCount = 0
+        api(
+                MockEngine {
+                    callCount++
+                    if (callCount == 1) {
+                        respond("", HttpStatusCode.TooManyRequests, jsonHeaders)
+                    } else {
+                        respond(poollessBody, HttpStatusCode.InternalServerError, jsonHeaders)
+                    }
+                }
+            )
+            .getSwapQuotes(request())
+
+        callCount shouldBe 2
+    }
+
+    @Test
+    fun `a transport failure on the quote endpoint is still retried`() = runTest {
+        var callCount = 0
+        val api =
+            api(
+                MockEngine {
+                    callCount++
+                    throw IOException("Connection failed")
+                }
+            )
+
+        assertFailsWith<NetworkException> { api.getSwapQuotes(request()) }
+
+        callCount shouldBe 4
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSourceTest.kt
@@ -1,20 +1,24 @@
 package com.vultisig.wallet.data.repositories.swap
 
 import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.api.models.quotes.Fees
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteDeserialized
+import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteError
 import com.vultisig.wallet.data.api.models.quotes.ThorChainSwapQuoteRequest
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
 import java.math.BigInteger
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class ThorChainQuoteSourceTest {
 
@@ -95,4 +99,60 @@ internal class ThorChainQuoteSourceTest {
                 requestSlot.captured.toAsset,
             )
         }
+
+    @Test
+    fun `a poolless pair is refused without paying for the streaming round-trip`() = runTest {
+        coEvery { thorChainApi.getSwapQuotes(any()) } returns
+            THORChainSwapQuoteDeserialized.Error(
+                THORChainSwapQuoteError(
+                    "failed to calculate min swap amount: fail to convert dest fee to src asset " +
+                        "pool does not exist"
+                )
+            )
+
+        val rune = coin(Chain.ThorChain, "RUNE", "", isNativeToken = true)
+        val kuji = coin(Chain.ThorChain, "KUJI", "thor.kuji", isNativeToken = false)
+
+        assertThrows<SwapException.SwapRouteNotAvailable> {
+            source()
+                .fetch(
+                    SwapQuoteRequest(
+                        srcToken = rune,
+                        dstToken = kuji,
+                        tokenValue =
+                            TokenValue(value = BigInteger.valueOf(100_000_000), token = rune),
+                        dstAddress = "thor1dst",
+                    )
+                )
+        }
+
+        coVerify(exactly = 1) { thorChainApi.getSwapQuotes(any()) }
+    }
+
+    @Test
+    fun `an amount the rapid path refuses still reaches the streaming request`() = runTest {
+        // Streaming splits the swap, so a minimum the rapid interval cannot meet is not the pair's
+        // final answer — unlike a missing pool, this one is worth asking again.
+        coEvery { thorChainApi.getSwapQuotes(any()) } returns
+            THORChainSwapQuoteDeserialized.Error(
+                THORChainSwapQuoteError("amount less than min swap amount")
+            )
+
+        val btc = coin(Chain.Bitcoin, "BTC", "", isNativeToken = true)
+        val rune = coin(Chain.ThorChain, "RUNE", "", isNativeToken = true)
+
+        assertThrows<SwapException.SmallSwapAmount> {
+            source()
+                .fetch(
+                    SwapQuoteRequest(
+                        srcToken = btc,
+                        dstToken = rune,
+                        tokenValue = TokenValue(value = BigInteger.valueOf(1_000), token = btc),
+                        dstAddress = "thor1dst",
+                    )
+                )
+        }
+
+        coVerify(exactly = 2) { thorChainApi.getSwapQuotes(any()) }
+    }
 }


### PR DESCRIPTION
Closes #5660

## Problem

Picking **RUNE → bRUNE** — or RUNE → KUJI, RKUJI, NSTK, FUZN, WINK, LVN, all pairs THORChain has no pool for — shows

> **Error** — Swap request timed out. Please try again

The quote does not time out. Thornode rejects it in well under a second:

```
GET .../thorchain/quote/swap?from_asset=THOR.RUNE&to_asset=THOR.KUJI&amount=100000000&...
HTTP 500  (0.8s)
{"code":2,"message":"failed to calculate min swap amount: fail to convert dest fee to src asset pool does not exist","details":[]}
```

The copy tells the user to retry something that can never succeed, and gives no hint that the pair simply is not routable.

## Cause

The rejection arrives as a **500**, and `HttpClientConfigurator` retries every idempotent GET on `status >= 500` three times with `exponentialDelay()` (~2s + 4s + 8s). So a 0.8s rejection costs roughly seventeen seconds — past the 15s `withTimeout` around each candidate in `SwapQuoteManager.fetchBestQuote`. The candidate dies as a `TimeoutCancellationException`, which is mapped to `SwapException.TimeOut`, before the classified `SwapRouteNotAvailable` ever exists. The streaming fallback would then repeat the whole thing.

`ThorChainApi.getSwapQuotes` already reads the body whatever the status (`THORChainSwapQuoteError` carries `@JsonNames("error", "message")`), and `"pool does not exist"` classifies correctly at `SwapException.kt:92` — so nothing but the retry stood between the node's answer and the user.

MayaChain is not affected: mayanode answers 200 with the error in the body.

## Changes

**1. The quote request carries its own retry policy.** Transport failures and 429/408 still retry three times; 5xx does not. This endpoint expresses business rejections as 5xx, and the caller reads the body on every status, so retrying one is spending the caller's quote window to be told the same thing four times.

**2. The streaming short-circuit generalizes from a halt to any rejection the interval cannot change** (`survivesTheInterval()`: trading halted, route not available, not supported). #5659 added this for halts only. Amount rejections deliberately still fall through — streaming splits the swap, so a minimum the rapid path refuses can still quote.

**3. A provider that answered with a verdict now outranks one that never answered.** `swapFailurePriority` becomes three tiers: verdicts (amount → halt → funds/impact → route) > transient/no-answer > unclassified body.

To be clear about #3: **it is not what fixes the reported pair.** A THORChain↔THORChain pair has exactly one eligible provider — `SwapProviderTable.kt:124` gives THORChain assets `{THORCHAIN, MAYA}` and `:213` drops MAYA when both sides are THORChain — so with one failure in the set the ranking never applied. The issue body's "a sibling provider's timeout outranks it" was wrong. It is included because it is the same defect one pair away: on a multi-provider pair a sibling's timeout could still bury a no-route verdict, and it costs one `when` block to close.

Two consequences of #3 worth naming, both replacing a nondeterministic provider-order tie with a fixed order:

- `InsufficientFunds` / `HighPriceImpact` now beat a sibling's timeout. Leaving them tied while a *weaker* route verdict wins outright would be incoherent.
- `RateLimitExceeded` moved into the transient tier, so route verdicts now outrank it too.
- `UnkownSwapError` no longer ties with a typed verdict. iOS does the same thing for the same reason — `SwapService.surfacedQuoteError` picks the first non-`serverError`, and its KDoc names the same nondeterminism ("same failure, different sentence on every refresh").

## Test plan

- `ThorChainQuoteRetryTest` (new, 3): a 500 carrying a rejection is read once, not retried; 429 still retries; a transport failure still retries four times.
- `ThorChainQuoteSourceTest` (+2): a poolless pair is refused without the streaming round-trip; an amount rejection still reaches it.
- `SwapQuoteManagerTest` (+3): route-over-timeout, funds-over-timeout, route-over-unclassified.
- Each new behaviour test verified to fail when its own production change is reverted.
- 3115 `:data` tests and the whole `:app` swap package green.

**On device**: vault with THORChain RUNE → Swap → From RUNE, To KUJI, amount 1. Was "Swap request timed out. Please try again" after ~15s; now "Swap route not available" almost immediately. RUJI and TCY do not reproduce — those pairs genuinely route.

## Out of scope

The issue's second question — why bRUNE is offered as a swap destination at all — is untouched. `Coin.isLpToken` still matches `x/brune`, so it stays out of the pickers on this tree; whether to land the RUJI Trade route (#5586) or keep it out is a product call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved swap quote selection by prioritizing actionable balance, allowance, amount, route, and trading-halt errors.
  - Added automatic retries for temporary quote failures, rate limits, gateway errors, and network interruptions.
  - Reduced unnecessary fallback attempts for unavailable routes, unsupported swaps, and trading halts while preserving amount-related fallback handling.
  - Improved external-recipient route error messages across supported swap providers.

- **Bug Fixes**
  - Swap results now report the most relevant provider error more consistently, regardless of response order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->