### PR TITLE
fix(defi): order the DeFi list by the amount each row shows

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -17,6 +17,7 @@ import com.vultisig.wallet.data.models.CryptoConnectionType
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.VaultId
+import com.vultisig.wallet.data.models.calculateAccountsPartialFiatValue
 import com.vultisig.wallet.data.models.calculateAccountsTotalFiatValue
 import com.vultisig.wallet.data.models.calculateAddressesPartialFiatValue
 import com.vultisig.wallet.data.models.isFastVault
@@ -54,6 +55,7 @@ import com.vultisig.wallet.ui.utils.pushNotificationErrorUiText
 import com.vultisig.wallet.ui.utils.textAsFlow
 import com.vultisig.wallet.ui.utils.throttleLatest
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.math.BigDecimal
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -597,7 +599,6 @@ constructor(
                 combine(
                         accountsRepository
                             .loadDeFiAddresses(vaultId, readsNetwork)
-                            .map { addresses -> addresses.sortByAccountsTotalFiatValue() }
                             .catch { error ->
                                 Timber.e(
                                     error,
@@ -654,6 +655,22 @@ constructor(
             )
         )
 
+    /**
+     * Orders DeFi rows by the very figure the row paints — the lenient per-address sum
+     * [AddressToUiModelMapper] renders — largest first, chain name as the tie-break, and rows with
+     * nothing resolved yet at the bottom rather than the top.
+     *
+     * Provider rows (Circle) sort on that same key, so a $0.00 position never sits above a funded
+     * chain.
+     */
+    private fun List<Address>.sortByDisplayedFiatValue() =
+        sortedWith(
+            compareBy(nullsLast(reverseOrder<BigDecimal>())) { address: Address ->
+                    address.accounts.calculateAccountsPartialFiatValue()?.value
+                }
+                .thenBy { it.chain.raw }
+        )
+
     private suspend fun List<Address>.updateUiStateFromList(
         searchQuery: String,
         isDefi: Boolean = false,
@@ -662,7 +679,14 @@ constructor(
         // list. The headline figure then always equals the sum its rows render (#4768), rather than
         // the total counting only freshly-resolved chains while a row still shows a cached one.
         val previous = if (isDefi) lastDeFiAddresses else lastWalletAddresses
-        val merged = this.retainLastKnownBalances(previous)
+        // DeFi orders after the merge, on the same sum the row shows. Sorting the incoming list
+        // ranked each chain on whatever that emission happened to carry — a chain still resolving
+        // scored null, which the strict fold puts at the *top* — and the cached values restored
+        // below then landed in that stale order instead of by amount.
+        val merged =
+            this.retainLastKnownBalances(previous).let {
+                if (isDefi) it.sortByDisplayedFiatValue() else it
+            }
         if (isDefi) lastDeFiAddresses = merged else lastWalletAddresses = merged
 
         val totalFiatValue =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/home/VaultAccountsViewModelTest.kt
@@ -59,6 +59,7 @@ import java.math.BigInteger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
@@ -788,6 +789,154 @@ internal class VaultAccountsViewModelTest {
                 "$10"
             vm.uiState.value.totalFiatValue shouldBe "$10"
         }
+
+    /**
+     * The DeFi list has to be ordered by the fiat each row paints. Dedo's report — Circle Yield
+     * $0.00, TerraClassic $4.24, Tron $1.75, THORChain $0.61, Solana $11.03, Maya $0.00, Terra
+     * $0.00 — left the largest row fifth, behind a provider row showing nothing, because the sort
+     * key was the strict all-or-nothing fold: one account still resolving scored the whole row
+     * null, and null is the top of the list.
+     */
+    @Test
+    fun `DeFi rows are ordered by the fiat each row shows`() =
+        runTest(testDispatcher) {
+            // The provider row paints $0.00 off its resolved native account while a second one is
+            // still pending — the shape that lifted it above every funded chain.
+            val circle =
+                buildMultiTokenAddress(
+                    Chain.Ethereum,
+                    "0xeth",
+                    nativeFiat = BigDecimal.ZERO,
+                    tokenFiat = null,
+                )
+            stubDeFi(
+                listOf(
+                    circle,
+                    buildTestAddress(Chain.TerraClassic, "lunc", BigDecimal("4.24")),
+                    buildTestAddress(Chain.Tron, "tron", BigDecimal("1.75")),
+                    buildTestAddress(Chain.ThorChain, "thor", BigDecimal("0.61")),
+                    buildTestAddress(Chain.Solana, "sol", BigDecimal("11.03")),
+                    buildTestAddress(Chain.MayaChain, "maya", BigDecimal.ZERO),
+                    buildTestAddress(Chain.Terra, "luna", BigDecimal.ZERO),
+                )
+            )
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.deFiChains() shouldBe
+                listOf(
+                    Chain.Solana,
+                    Chain.TerraClassic,
+                    Chain.Tron,
+                    Chain.ThorChain,
+                    // The zeros tie on value and fall back to the chain name.
+                    Chain.Ethereum,
+                    Chain.MayaChain,
+                    Chain.Terra,
+                )
+        }
+
+    /**
+     * A row with nothing resolved yet renders no figure at all, so it belongs under the rows that
+     * do — the strict fold scored it null and put it first.
+     */
+    @Test
+    fun `a DeFi row with nothing resolved yet sits below the funded ones`() =
+        runTest(testDispatcher) {
+            stubDeFi(
+                listOf(
+                    buildTestAddress(Chain.Tron, "tron", fiat = null),
+                    buildTestAddress(Chain.Solana, "sol", BigDecimal("5")),
+                )
+            )
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.deFiChains() shouldBe listOf(Chain.Solana, Chain.Tron)
+        }
+
+    /**
+     * Rows restored from the last-known snapshot have to be ordered by what they end up showing.
+     * Sorting the incoming list instead ranked both chains on an emission that carried no fiat at
+     * all, which collapsed them onto the chain-name tie-break and dropped the $20 row under the $5
+     * one.
+     */
+    @Test
+    fun `DeFi rows restored from the cache are ordered by the value they show`() =
+        runTest(testDispatcher) {
+            val deFiAddresses = MutableSharedFlow<List<Address>>()
+            stubDeFi(emptyList(), chains = setOf(Chain.Terra, Chain.Solana))
+            coEvery { accountsRepository.loadDeFiAddresses("vault-1", any()) } returns deFiAddresses
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            deFiAddresses.emit(
+                listOf(
+                    buildTestAddress(Chain.Solana, "sol", BigDecimal("5")),
+                    buildTestAddress(Chain.Terra, "luna", BigDecimal("20")),
+                )
+            )
+            advanceUntilIdle()
+
+            vm.deFiChains() shouldBe listOf(Chain.Terra, Chain.Solana)
+
+            // Both chains come back mid-refetch with no fiat; the merge restores $20 and $5, and
+            // the order has to follow those restored figures rather than the empty emission.
+            deFiAddresses.emit(
+                listOf(
+                    buildTestAddress(Chain.Solana, "sol", fiat = null),
+                    buildTestAddress(Chain.Terra, "luna", fiat = null),
+                )
+            )
+            advanceUntilIdle()
+
+            vm.deFiChains() shouldBe listOf(Chain.Terra, Chain.Solana)
+            vm.uiState.value.defiAccounts.first().fiatAmount shouldBe "$20"
+        }
+
+    /**
+     * The DeFi ordering is a DeFi-only change. This pins the wallet list to the order it has today
+     * — its own strict fold, pending chains first — so the shared helper is not "fixed" out from
+     * under it.
+     */
+    @Test
+    fun `the wallet list order is left alone`() =
+        runTest(testDispatcher) {
+            val eth = buildTestAddress(Chain.Ethereum, "0xeth", BigDecimal("10"))
+            val solPending = buildTestAddress(Chain.Solana, "sol", fiat = null)
+
+            every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+            coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
+            every { accountsRepository.loadAddressBalances("vault-1") } returns
+                flowOf(AddressBalancesUpdate(listOf(eth, solPending), isComplete = true))
+            stubBalanceMappers()
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.uiState.value.accounts.map { it.model.chain } shouldBe
+                listOf(Chain.Solana, Chain.Ethereum)
+        }
+
+    private fun VaultAccountsViewModel.deFiChains(): List<Chain> =
+        uiState.value.defiAccounts.map { it.model.chain }
+
+    /** Serves [addresses] as the vault's DeFi list, with every chain in it switched on. */
+    private fun stubDeFi(addresses: List<Address>, chains: Set<Chain>? = null) {
+        every { lastOpenedVaultRepository.lastOpenedVaultId } returns flowOf("vault-1")
+        coEvery { vaultRepository.get("vault-1") } returns Vault(id = "vault-1", name = "Test")
+        coEvery { accountsRepository.loadDeFiAddresses("vault-1", any()) } returns flowOf(addresses)
+        every { defaultDeFiChainsRepository.getDefaultChains("vault-1") } returns
+            flowOf(chains ?: addresses.mapTo(mutableSetOf()) { it.chain })
+        // The Ethereum row is only surfaced for vaults that already opened a Circle account.
+        coEvery { hasCircleAccount("vault-1") } returns true
+    }
 
     private fun VaultAccountsViewModel.solanaRow(): AccountUiModel =
         uiState.value.accounts.first { it.model.chain == Chain.Solana }


### PR DESCRIPTION
## Problem

The DeFi Portfolio chain list was not in balance order. From the report:

Circle Yield $0.00, TerraClassic $4.24, Tron $1.75, THORChain $0.61, Solana $11.03, Maya $0.00, Terra $0.00 — the largest row fifth, behind a provider row showing nothing.

## Cause

Two things, both in `VaultAccountsViewModel`.

**The sort key was not the figure the row paints.** It sorted on `calculateAccountsTotalFiatValue`, the strict all-or-nothing fold that returns `null` as soon as *any one* account in the row is still resolving; `compareBy` ranks `null` first. The row itself renders `calculateAccountsPartialFiatValue` (the lenient sum, #4768). So a row could show `$0.00` off its one resolved account, score `null` on the account still in flight, and take the top of the list. That is the Circle row in the report — and it is why the ordering looked arbitrary rather than merely reversed.

**The sort ran before the merge.** `.map { sortByAccountsTotalFiatValue() }` was applied to the incoming emission, while `retainLastKnownBalances` restores last-known values later, inside `updateUiStateFromList`. A chain was therefore ranked on figures it never displayed, and the restored values landed in that stale order — a cached merge could leave a $20 row under a $5 one.

## Fix

- Dropped the pre-merge sort from the DeFi stream.
- New `sortByDisplayedFiatValue()` orders on `calculateAccountsPartialFiatValue` — the same sum `AddressToUiModelMapper` paints — descending, `nullsLast` so a row with nothing resolved sits at the bottom rather than the top, chain name as the tie-break.
- It runs **after** `retainLastKnownBalances`, so a cached merge is re-ordered by what the rows end up showing rather than restoring enable-order.
- Provider rows (Circle) sort on that same key: a `$0.00` position can no longer outrank a funded chain.
- Gated on `isDefi`, so the wallet tab keeps its own sort untouched.

## Tests

4 new tests in `VaultAccountsViewModelTest` (31 in the class):

- the reported list renders Solana, TerraClassic, Tron, THORChain, then the three zeros;
- a row with nothing resolved yet sits below the funded ones;
- rows restored from the cache are re-ordered by the value they show ($20 Terra above $5 Solana — the old key collapsed both onto the chain-name tie-break);
- a pin that the wallet list order is left alone.

The first three were each verified to fail when the ViewModel change is reverted. Full suite: 2159 `:app` unit tests, 0 failures.

## Test plan

On the DeFi tab of a vault funded across several protocols:

1. Home → **DeFi** toggle: rows read top to bottom in descending order of the amount printed on each row, every $0.00 row at the bottom, Circle included.
2. Pull to refresh: each row keeps the amount it was showing and stays in place while the figures refetch; the settled order matches step 1.
3. Cold start into the DeFi tab while balances are still loading: a chain with no figure yet sits at the bottom, then slides into position when its amount lands.
4. Manage Positions → switch a chain off and back on: it returns to the position its amount deserves, not to the end of the list.
5. Wallet tab is unchanged.


Closes #5671


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DeFi account rows are now ordered by their displayed fiat values, with the highest values first.
  * Rows with unavailable values appear last, with chain name used to resolve ties.
  * Restored cached balances are now included before sorting, ensuring displayed order matches current values.
  * Wallet account ordering remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->