### PR TITLE
test(chains): close the sei.json gap in the golden fixture corpus

### DIFF
--- a/app/src/androidTest/assets/evm-chain-matrix.json
+++ b/app/src/androidTest/assets/evm-chain-matrix.json
@@ -262,5 +262,38 @@
         "expected_image_hash": [
             "77b6a09109b679f49c1912222859339906386d61857b237c9017b433cfb52b7e"
         ]
+    },
+    {
+        "name": "Send SEI",
+        "keysign_payload": {
+            "coin": {
+                "chain": "Sei",
+                "ticker": "SEI",
+                "address": "0x07773707BdA78aC4052f736544928b15dD31c5cc",
+                "decimals": 18,
+                "price_provider_id": "",
+                "is_native_token": true,
+                "hex_public_key": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+                "contract_address": "",
+                "logo": "sei"
+            },
+            "to_address": "0xe5F238C95142be312852e864B830daADB9B7D290",
+            "to_amount": "100000000000000000",
+            "BlockchainSpecific": {
+                "EthereumSpecific": {
+                    "max_fee_per_gas_wei": "1000000000",
+                    "priority_fee": "1000000000",
+                    "nonce": 1,
+                    "gas_limit": "21000"
+                }
+            },
+            "utxo_info": [],
+            "SwapPayload": null,
+            "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
+            "lib_type": "DKLS"
+        },
+        "expected_image_hash": [
+            "09d6110cf12c44513622e239605f2ef6d62abd33f66ed07a22b176f84cd5bb90"
+        ]
     }
 ]

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -653,8 +653,7 @@ class ChainHelpersTest {
     @Test
     fun sendUTXO() {
         val transactions =
-            loadTransactionData(UTXO_JSON_FILE) +
-                loadTransactionData(UTXO_DASH_ZCASH_JSON_FILE)
+            loadTransactionData(UTXO_JSON_FILE) + loadTransactionData(UTXO_DASH_ZCASH_JSON_FILE)
         transactions.forEach { transaction ->
             val payload = transaction.keysignPayload.toInternalKeySignPayload()
             val coin = payload.coin.coinType
@@ -1022,8 +1021,7 @@ class ChainHelpersTest {
         private const val CARDANO_JSON_FILE = "cardano.json"
 
         private const val THORCHAIN_SWAP_JSON_FILE = "thorchainswap.json"
-        private const val THORCHAIN_SWAP_LIMIT_ORDER_JSON_FILE =
-            "thorchainswap-limit-order.json"
+        private const val THORCHAIN_SWAP_LIMIT_ORDER_JSON_FILE = "thorchainswap-limit-order.json"
         private const val MAYA_SWAP_JSON_FILE = "mayaswap.json"
         private const val LIFI_SWAP_JSON_FILE = "lifiswap.json"
 
@@ -1069,9 +1067,11 @@ class ChainHelpersTest {
         // +5: cosmos-chain-matrix.json (issue #5421 item 5, Osmosis/Dydx/Noble/Akash + one IBC
         // transfer). +2: utxo-dash-zcash.json (item 4). +1: bittensor.json (item 6).
         // +1: qbtc.json (item 6). +1: thorchainswap-limit-order.json (item 7).
+        // +1: evm-chain-matrix.json "Send SEI" (issue #5673 — Sei is EVM-family, chain ID 1329,
+        // so it belongs in the matrix rather than a standalone file).
         // The standalone fixture files are shared byte-for-byte with the Swift and TS corpora,
         // preserving the cross-signer agreement required by #5421 and vultisig-sdk#1585.
-        private const val EXPECTED_CASE_COUNT = 87
+        private const val EXPECTED_CASE_COUNT = 88
 
         private const val HEX_PUBLIC_KEY =
             "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"


### PR DESCRIPTION
## What

Closes #5673.

Re-verified all four items the issue lists against the actual iOS/SDK fixture files (`VultisigApp/VultisigAppTests/TestData/` and `packages/core/mpc/keysign/tests/fixtures/mobile/`), comparing full `keysign_payload` and `expected_image_hash` — not just filenames:

| Item | Finding |
|---|---|
| `cosmos-sdk-sign-amino.json` | Already covered — both cases (ATOM, THORChain memo) exist in `cosmos.json`/`thorchain.json` with byte-identical payload + hash |
| `cosmos-sdk-sign-direct.json` | Already covered — both cases (ATOM, THORChain LTC) exist in `cosmos.json`/`thorchain.json` with byte-identical payload + hash |
| `solana-sign-data.json` | Already covered — the one case ("Send Solana USDC") is `solana.json`'s existing `sign_data.sign_solana` case; only difference is the field spelling `program_id` vs `has_program_id`, which `SolanaSpecific` already accepts via `@JsonNames` |
| `sei.json` | **Genuinely missing — fixed here.** Sei doesn't exist in iOS or the SDK yet either (blocked on vultisig-sdk#2148), so there was no upstream vector to copy |

Android's corpus wasn't actually short any of these cases — three of the four were already present, just organized inside the per-chain files instead of as standalone files matching iOS/SDK's layout. Only Sei was a real gap.

## How

`Chain.Sei` is EVM-family in this codebase (`Sei("Sei", EVM, "Gwei")`, signs via `CoinType.ETHEREUM`, EIP-155 chain ID `1329`), so its native-send pre-image hash belongs in `evm-chain-matrix.json` alongside AVAX/Optimism/Base/etc. rather than a standalone `sei.json`.

Added a "Send SEI" case using the exact same template payload as every other matrix entry (all fields identical except `coin.chain`/`ticker`/`logo` — see `sendEvmChainMatrixTest`'s KDoc). The `expected_image_hash` is not fabricated: computed by temporarily wiring the case into the fixture with a placeholder hash and running `sendEvmChainMatrixTest` on a connected emulator, reading the real hash out of the assertion failure, then pinning it back into the JSON. Confirmed all 35 `ChainHelpersTest` tests pass afterward, including `fixtureCorpusMatchesDeclaredFileSet` (bumped `EXPECTED_CASE_COUNT` 87 → 88) and `evmChainMatrixVectorsAreChainSpecific`.

Since Sei doesn't exist in iOS/SDK's corpora yet, `check_golden_corpus_sync.py` will show a non-fatal coverage warning (android has it, siblings don't) until those land — that's the expected staged-rollout behavior the script already documents.

## Test plan
- [x] `sendEvmChainMatrixTest`, `evmChainMatrixVectorsAreChainSpecific`, `fixtureCorpusMatchesDeclaredFileSet` all pass on-device (35/35 `ChainHelpersTest` tests green)
- [x] Verified cosmos/solana cases are already byte-identical to iOS/SDK by direct fixture comparison (no code change needed there)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for sending SEI on the Sei EVM chain.
  * Included SEI transaction metadata, payload validation, and expected image verification.
  * Updated the fixture suite to include the new test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->