### PR TITLE
fix(swap): stop a THORChain halt from speaking for the whole pair

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -445,64 +445,115 @@ constructor(
             throw SwapException.SwapIsNotSupported("Swap is not supported for this pair")
         }
 
-        val results: List<Result<BestQuote>> = coroutineScope {
-            candidates
+        // Local so the retry pass below can rerun exactly the same fetch without threading every
+        // request parameter through a helper. Outcomes come back paired with the candidate that
+        // produced them, and in the order they were asked for, so a failure stays attributable to
+        // its provider once the results are flattened.
+        suspend fun attempt(
+            subset: List<QuoteCandidate>
+        ): List<Pair<QuoteCandidate, Result<BestQuote>>> = coroutineScope {
+            subset
                 .map { candidate ->
                     async {
-                        runCatching {
-                                withTimeout(QUOTE_FETCH_TIMEOUT_MS) {
-                                    BestQuote(
-                                        candidate = candidate,
-                                        result =
-                                            fetchQuote(
-                                                provider = candidate.provider,
-                                                src = src,
-                                                dst = dst,
-                                                srcToken = srcToken,
-                                                dstToken = dstToken,
-                                                srcTokenValue = srcTokenValue,
-                                                tokenValue = tokenValue,
-                                                currency = currency,
-                                                vultBPSDiscount = candidate.vultBPSDiscount,
-                                                referral = candidate.referral,
-                                                amount = amount,
-                                                slippageBps = slippageBps,
-                                                externalRecipient = externalRecipient,
-                                            ),
+                        candidate to
+                            runCatching {
+                                    withTimeout(QUOTE_FETCH_TIMEOUT_MS) {
+                                        BestQuote(
+                                            candidate = candidate,
+                                            result =
+                                                fetchQuote(
+                                                    provider = candidate.provider,
+                                                    src = src,
+                                                    dst = dst,
+                                                    srcToken = srcToken,
+                                                    dstToken = dstToken,
+                                                    srcTokenValue = srcTokenValue,
+                                                    tokenValue = tokenValue,
+                                                    currency = currency,
+                                                    vultBPSDiscount = candidate.vultBPSDiscount,
+                                                    referral = candidate.referral,
+                                                    amount = amount,
+                                                    slippageBps = slippageBps,
+                                                    externalRecipient = externalRecipient,
+                                                ),
+                                        )
+                                    }
+                                }
+                                .onFailure { e ->
+                                    // TimeoutCancellationException extends CancellationException
+                                    // but is a transient per-provider failure — don't let it
+                                    // cancel sibling fetches via awaitAll.
+                                    if (
+                                        e is CancellationException &&
+                                            e !is TimeoutCancellationException
+                                    )
+                                        throw e
+                                    Timber.w(
+                                        e,
+                                        "Quote fetch failed provider=%s src=%s dst=%s amount=%s",
+                                        candidate.provider,
+                                        srcToken.id,
+                                        dstToken.id,
+                                        srcTokenValue,
                                     )
                                 }
-                            }
-                            .onFailure { e ->
-                                // TimeoutCancellationException extends CancellationException
-                                // but is a transient per-provider failure — don't let it
-                                // cancel sibling fetches via awaitAll.
-                                if (
-                                    e is CancellationException && e !is TimeoutCancellationException
-                                )
-                                    throw e
-                                Timber.w(
-                                    e,
-                                    "Quote fetch failed provider=%s src=%s dst=%s amount=%s",
-                                    candidate.provider,
-                                    srcToken.id,
-                                    dstToken.id,
-                                    srcTokenValue,
-                                )
-                            }
                     }
                 }
                 .awaitAll()
         }
 
-        val successes = results.mapNotNull { it.getOrNull() }
+        var results = attempt(candidates)
+        var successes = results.mapNotNull { it.second.getOrNull() }
+
         if (successes.isEmpty()) {
-            val failures = results.mapNotNull { it.exceptionOrNull() }
+            // A halt is one protocol's verdict on itself, not a verdict on the pair. When a native
+            // protocol reports a pause and an aggregator merely never answered inside the window,
+            // the pair may still route — so give exactly those aggregators one more window before
+            // the form settles on any copy (#5672). Bounded to a single extra pass and reached only
+            // from the all-failed branch, so a run that already holds a quote never pays for it.
+            val retryIndices =
+                results.indices.filter { index ->
+                    val (candidate, result) = results[index]
+                    isAggregator(candidate.provider) &&
+                        result.exceptionOrNull()?.let(::isTransientFailure) == true
+                }
+            val nativeHalt =
+                results.any { (candidate, result) ->
+                    !isAggregator(candidate.provider) &&
+                        result.exceptionOrNull() is SwapException.TradingHalted
+                }
+            if (nativeHalt && retryIndices.isNotEmpty()) {
+                Timber.i(
+                    "Retrying %d aggregator quote(s) after a native halt src=%s dst=%s",
+                    retryIndices.size,
+                    srcToken.id,
+                    dstToken.id,
+                )
+                val retried = attempt(retryIndices.map { results[it].first })
+                results =
+                    results.toMutableList().apply {
+                        retryIndices.forEachIndexed { slot, index -> this[index] = retried[slot] }
+                    }
+                successes = results.mapNotNull { it.second.getOrNull() }
+            }
+        }
+
+        if (successes.isEmpty()) {
+            val failures =
+                results.mapNotNull { (candidate, result) ->
+                    result.exceptionOrNull()?.let { candidate to it }
+                }
             // Surface the most actionable failure instead of the first by provider order
             // (iOS SwapService parity). When THORChain returns a generic "no route" error
             // while MAYA reports a recoverable amount/dust error for the same pair, the user
             // should see the amount error so they can adjust and retry. Ties keep provider
             // order (minBy returns the first match), so all-generic failures are unchanged.
-            val selected = failures.minBy { swapFailurePriority(it) }
+            val haltOutranked =
+                failures.any { (candidate, error) ->
+                    isAggregator(candidate.provider) && isTransientFailure(error)
+                }
+            val selected =
+                failures.minBy { (_, error) -> failurePriority(error, haltOutranked) }.second
             // withTimeout surfaces a raw TimeoutCancellationException; map it into the typed
             // SwapException hierarchy so the form renders the localized timeout copy instead of
             // leaking a coroutine cancellation as the generic "quote failed" error.
@@ -660,6 +711,25 @@ constructor(
         }
 
     /**
+     * Whether [provider] routes on its own book rather than through a native protocol's pools.
+     *
+     * The distinction only matters to failure handling: a native protocol answering "trading is
+     * halted" has described itself, while an aggregator in the same candidate set may still have a
+     * route the halt says nothing about. Exhaustive on purpose — a new provider has to be placed on
+     * one side, or a halt would start speaking for it.
+     */
+    private fun isAggregator(provider: SwapProvider): Boolean =
+        when (provider) {
+            SwapProvider.THORCHAIN,
+            SwapProvider.MAYA -> false
+            SwapProvider.JUPITER,
+            SwapProvider.SWAPKIT,
+            SwapProvider.KYBER,
+            SwapProvider.ONEINCH,
+            SwapProvider.LIFI -> true
+        }
+
+    /**
      * Source-chain gas (`gas × gasPrice`) in native wei for same-chain EVM aggregator quotes, used
      * only as the in-band lower-gas tie-break in [selectBestQuote]. A zero or absent gas/gasPrice
      * reads as "gas unknown" (null) so a quote with no usable gas estimate never wins the
@@ -683,6 +753,30 @@ constructor(
         }
 
     /**
+     * [swapFailurePriority] with the one adjustment the ranking cannot make from the error alone:
+     * when [haltOutranked], a halt drops below the transient tier.
+     *
+     * A halt is reported by one protocol about itself. On a pair where an aggregator is also
+     * eligible, the aggregator failing transiently means nobody has actually said the pair cannot
+     * be swapped — so "trading is halted", which reads as a verdict on the swap the user asked for
+     * and offers nothing to do but wait, must not beat the "try again" that is literally true
+     * (#5672). Where no aggregator is eligible, or every eligible one answered with a verdict of
+     * its own, [haltOutranked] is false and the halt keeps the tier #5656 gave it.
+     */
+    private fun failurePriority(error: Throwable, haltOutranked: Boolean): Int {
+        val priority = swapFailurePriority(error)
+        return if (haltOutranked && priority == PRIORITY_HALT) PRIORITY_HALT_DEMOTED else priority
+    }
+
+    /**
+     * Whether [error] is the kind of failure a second attempt could clear — a timeout, a dropped
+     * connection, a rate limit. Read off [swapFailurePriority] so the retry and demotion rules
+     * cannot drift from the tier table they are named after.
+     */
+    private fun isTransientFailure(error: Throwable): Boolean =
+        swapFailurePriority(error) == PRIORITY_TRANSIENT
+
+    /**
      * Ranks a failed-quote [error] so the most actionable failure is surfaced when every provider
      * fails. Lower values win.
      *
@@ -694,6 +788,9 @@ constructor(
      * change it. Below every verdict sits the transient group, then the failures nobody read as a
      * verdict — an unclassified body, or an aggregator breaking on its own terms — and last a
      * throwable outside the swap hierarchy altogether.
+     *
+     * Reads the error alone. [failurePriority] wraps this with the one adjustment that needs the
+     * rest of the candidate set, so rank a real failure list through that.
      */
     private fun swapFailurePriority(error: Throwable): Int =
         when (error) {
@@ -1455,8 +1552,13 @@ constructor(
         private const val PRIORITY_FIXABLE = 3
         private const val PRIORITY_ROUTE = 4
         private const val PRIORITY_TRANSIENT = 5
-        private const val PRIORITY_UNREAD = 6
-        private const val PRIORITY_UNTYPED = 7
+        /**
+         * Where a halt lands once an eligible aggregator has failed transiently — below the
+         * transient tier, so the retryable failure decides the copy. See [failurePriority].
+         */
+        private const val PRIORITY_HALT_DEMOTED = 6
+        private const val PRIORITY_UNREAD = 7
+        private const val PRIORITY_UNTYPED = 8
 
         // All aggregators charge the same base affiliate as [BASE_AFFILIATE_FEE_BPS]; derive them
         // from it so the displayed percentage ([formatAffiliatePercent]) can't silently go stale if

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -399,6 +399,213 @@ internal class SwapQuoteManagerTest {
     }
 
     @Test
+    fun `fetchBestQuote retries an aggregator once after a native halt and takes its quote`() =
+        runTest {
+            // ETH -> SOL with THORChain paused (#5672). LI.FI is eligible and merely missed the
+            // first 15s window; the halt describes THORChain, not the pair. One more window and
+            // the form holds a quote instead of "trading is halted".
+            val eth = coin(Chain.Ethereum, "ETH", "0xsrc", 18)
+            val usdc = coin(Chain.Ethereum, "USDC", "0xdst", 6)
+            coEvery { tokenRepository.getNativeToken(any()) } returns eth
+            coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+                FiatValue(BigDecimal.ONE, AppCurrency.USD.ticker)
+            every { mapTokenValueToDecimalUiString(any()) } returns "0"
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } throws
+                SwapException.TradingHalted("trading is halted")
+            var lifiAttempts = 0
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.LIFI, any()) } coAnswers
+                {
+                    lifiAttempts++
+                    if (lifiAttempts == 1) {
+                        delay(Long.MAX_VALUE)
+                        error("unreachable")
+                    }
+                    SwapQuoteResult.Evm(evmQuote(dstAmount = "1000000"))
+                }
+
+            val manager = createManager()
+            val deferred = async {
+                runCatching {
+                    manager.fetchBestQuote(
+                        candidates =
+                            listOf(SwapProvider.THORCHAIN, SwapProvider.LIFI).map { provider ->
+                                QuoteCandidate(provider, vultBPSDiscount = null, referral = null)
+                            },
+                        src = mockk(relaxed = true),
+                        dst = mockk(relaxed = true),
+                        srcToken = eth,
+                        dstToken = usdc,
+                        srcTokenValue = BigInteger.ONE,
+                        tokenValue = TokenValue(BigInteger.ONE, eth),
+                        currency = AppCurrency.USD,
+                        amount = BigDecimal.ONE,
+                    )
+                }
+            }
+
+            // The retry is dispatched the moment the first window closes and answers at once, so
+            // one window carries both attempts.
+            advanceTimeBy(15_001L)
+
+            val ranked = assertNotNull(deferred.await().getOrNull())
+            assertEquals(SwapProvider.LIFI, ranked.best.candidate.provider)
+            assertEquals(2, lifiAttempts)
+        }
+
+    @Test
+    fun `fetchBestQuote surfaces the aggregator timeout, not the halt, when the retry misses too`() =
+        runTest {
+            // Even when the second window closes empty, nobody has said the pair cannot route:
+            // THORChain spoke only for itself. "Try again" is the true copy; the halt tooltip
+            // would send the user off to wait out a pause that is not what blocked them.
+            coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+                FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } throws
+                SwapException.TradingHalted("trading is halted")
+            var lifiAttempts = 0
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.LIFI, any()) } coAnswers
+                {
+                    lifiAttempts++
+                    delay(Long.MAX_VALUE)
+                    error("unreachable")
+                }
+
+            val manager = createManager()
+            val deferred = async {
+                runCatching {
+                    manager.fetchBestQuote(
+                        candidates =
+                            listOf(SwapProvider.THORCHAIN, SwapProvider.LIFI).map { provider ->
+                                QuoteCandidate(provider, vultBPSDiscount = null, referral = null)
+                            },
+                        src = mockk(relaxed = true),
+                        dst = mockk(relaxed = true),
+                        srcToken = mockk(relaxed = true),
+                        dstToken = mockk(relaxed = true),
+                        srcTokenValue = BigInteger.ONE,
+                        tokenValue = mockk(relaxed = true),
+                        currency = AppCurrency.USD,
+                        amount = BigDecimal.ONE,
+                    )
+                }
+            }
+
+            // One window per attempt: the retry buys the aggregator a second full window.
+            advanceTimeBy(15_001L)
+            advanceTimeBy(15_001L)
+
+            deferred.await().exceptionOrNull().shouldBeInstanceOf<SwapException.TimeOut>()
+            assertEquals(2, lifiAttempts)
+        }
+
+    @Test
+    fun `fetchBestQuote keeps the halt when no aggregator is eligible`() = runTest {
+        // A THORChain/MayaChain-only pair is the case #5656 was written for: every provider
+        // routes through a paused protocol, so the sibling's timeout is a symptom of the halt
+        // and the halt is still the only copy that explains the outage.
+        val chosen =
+            failureRacedAgainstATimeout(
+                stalling = SwapProvider.MAYA,
+                answering = SwapProvider.THORCHAIN,
+                verdict = SwapException.TradingHalted("trading is halted"),
+            )
+
+        chosen.shouldBeInstanceOf<SwapException.TradingHalted>()
+    }
+
+    @Test
+    fun `fetchBestQuote keeps the halt when every eligible aggregator answered with a verdict`() =
+        runTest {
+            // The aggregator did reply, and its reply is about the pair rather than the window.
+            // With nothing retryable left, the halt is the most actionable thing to say. LI.FI is
+            // listed first so provider order cannot be what surfaces the halt.
+            coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+                FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)
+            var lifiAttempts = 0
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.LIFI, any()) } coAnswers
+                {
+                    lifiAttempts++
+                    throw SwapException.SwapRouteNotAvailable("no route available")
+                }
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } throws
+                SwapException.TradingHalted("trading is halted")
+
+            val error =
+                runCatching {
+                        createManager()
+                            .fetchBestQuote(
+                                candidates =
+                                    listOf(SwapProvider.LIFI, SwapProvider.THORCHAIN).map { provider
+                                        ->
+                                        QuoteCandidate(
+                                            provider,
+                                            vultBPSDiscount = null,
+                                            referral = null,
+                                        )
+                                    },
+                                src = mockk(relaxed = true),
+                                dst = mockk(relaxed = true),
+                                srcToken = mockk(relaxed = true),
+                                dstToken = mockk(relaxed = true),
+                                srcTokenValue = BigInteger.ONE,
+                                tokenValue = mockk(relaxed = true),
+                                currency = AppCurrency.USD,
+                                amount = BigDecimal.ONE,
+                            )
+                    }
+                    .exceptionOrNull()
+
+            error.shouldBeInstanceOf<SwapException.TradingHalted>()
+            assertEquals(1, lifiAttempts)
+        }
+
+    @Test
+    fun `fetchBestQuote does not retry an aggregator when no native provider is halted`() =
+        runTest {
+            // The second window is the halt's price, not every failed run's. With no halt to
+            // contradict, the ranking already surfaces the truest verdict on the first pass.
+            coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+                FiatValue(BigDecimal.ZERO, AppCurrency.USD.ticker)
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.THORCHAIN, any()) } throws
+                SwapException.SwapRouteNotAvailable("no route available")
+            var lifiAttempts = 0
+            coEvery { swapQuoteRepository.getQuote(SwapProvider.LIFI, any()) } coAnswers
+                {
+                    lifiAttempts++
+                    delay(Long.MAX_VALUE)
+                    error("unreachable")
+                }
+
+            val manager = createManager()
+            val deferred = async {
+                runCatching {
+                    manager.fetchBestQuote(
+                        candidates =
+                            listOf(SwapProvider.THORCHAIN, SwapProvider.LIFI).map { provider ->
+                                QuoteCandidate(provider, vultBPSDiscount = null, referral = null)
+                            },
+                        src = mockk(relaxed = true),
+                        dst = mockk(relaxed = true),
+                        srcToken = mockk(relaxed = true),
+                        dstToken = mockk(relaxed = true),
+                        srcTokenValue = BigInteger.ONE,
+                        tokenValue = mockk(relaxed = true),
+                        currency = AppCurrency.USD,
+                        amount = BigDecimal.ONE,
+                    )
+                }
+            }
+
+            advanceTimeBy(15_001L)
+
+            deferred
+                .await()
+                .exceptionOrNull()
+                .shouldBeInstanceOf<SwapException.SwapRouteNotAvailable>()
+            assertEquals(1, lifiAttempts)
+        }
+
+    @Test
     fun `fetchQuote keeps the SwapKit sub-provider label across a cache hit (Native path)`() =
         runTest {
             // Pins the SwapQuoteResult.Native arm + the `is SwapQuote.SwapKit -> subProvider`


### PR DESCRIPTION
Closes #5672

## Problem

When every provider in a candidate set fails, `SwapQuoteManager.fetchBestQuote` surfaces the most actionable failure rather than the first by provider order. #5656 placed `TradingHalted` above the transient tier, and on a THORChain-only pair that is right: every provider routes through the paused protocol, so a sibling's timeout is a symptom of the halt and "try again" sends the user round a loop the pause will never let them leave.

It does not hold on a pair an aggregator can also route. ETH → SOL carries THORChain, LI.FI and SwapKit. A halt there describes THORChain and nothing else, while LI.FI missing a cold 15s window says nothing about whether the pair routes at all — yet the halt outranked it, so the form painted "Trading is halted" and a manual retry then quoted immediately. Same defect iOS saw.

## Solution

Halt becomes per-provider, in the all-failed branch only:

- **One retry.** A halt from a native protocol (THORChain / MayaChain) plus a transient miss from an eligible aggregator gives exactly those aggregators one more fetch window before any copy is chosen. Bounded to a single extra pass.
- **Demotion.** If the second pass is also empty, a new `PRIORITY_HALT_DEMOTED` drops the halt below the transient tier so the "try again" that is literally true decides the message.
- **Unchanged where it was right.** With no aggregator eligible, or with every eligible one answering with a verdict of its own (no route, not supported, amount), the halt keeps the tier #5656 gave it.

Two supporting changes: `isAggregator` is an exhaustive `when` so a new provider has to be placed on one side rather than silently inheriting a halt's meaning, and failures now travel paired with the candidate that produced them — the ranking cannot tell whose halt it is looking at from a bare throwable. That re-pairing is most of the diff; the fetch body itself is only reindented.

The extra window is reached only when the first pass produced no quote at all, so a run that already holds a route never pays for it. Worst-case latency on a halted all-fail run goes 15s → 30s.

Out of scope, deliberately untouched: the streaming short-circuit in `ThorChainQuoteSource` (#5656) and the sign-time inbound halt gate in `SwapInboundHaltPreflight`.

## Test plan

`./gradlew :app:testDebugUnitTest` — **2174 tests, 0 failures** (8 skipped, pre-existing). `:app:ktfmtCheck` clean, no new compiler warnings.

Five new tests in `SwapQuoteManagerTest`. The two behaviour ones were verified to fail on revert of the source change:

| Test | Pins |
|---|---|
| `retries an aggregator once after a native halt and takes its quote` | THOR halt + LI.FI timeout + LI.FI retry success → a LI.FI quote, exactly 2 LI.FI attempts (**fails on revert**) |
| `surfaces the aggregator timeout, not the halt, when the retry misses too` | Second window also empty → `SwapException.TimeOut`, not the halt (**fails on revert**) |
| `keeps the halt when no aggregator is eligible` | MAYA timeout + THOR halt → halt still surfaces; #5656 intact on THOR-only pairs |
| `keeps the halt when every eligible aggregator answered with a verdict` | LI.FI "no route" + THOR halt → halt surfaces, no retry fired |
| `does not retry an aggregator when no native provider is halted` | THOR "no route" + LI.FI timeout → one LI.FI attempt; the second window is the halt's price, not every failed run's |

Manual: the fixed path needs a live THORChain halt, which is not reproducible on demand. Verified no regression on the healthy path — ETH → BTC quotes from THORChain, ETH → SOL quotes from SwapKit (NEAR), both with unchanged provider, fee and timing.

Siblings: iOS / SDK+Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swap quote recovery when providers experience temporary failures.
  - Retries eligible aggregator quotes after a native provider reports a trading halt.
  - Returns successful retry quotes when available, while preserving accurate timeout and trading-halt errors.
  - Refined failure prioritization to provide more relevant swap error messages.

- **Tests**
  - Added coverage for provider retries, repeated timeouts, trading halts, and cases where retries are not applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->