### PR TITLE
feat(banners): let a dismissed promo banner stay gone for good

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -96,9 +96,9 @@ internal data class VaultAccountsUiModel(
     val accounts: List<AccountUiModel> = emptyList(),
     val defiAccounts: List<AccountUiModel> = emptyList(),
     val searchTextFieldState: TextFieldState = TextFieldState(),
-    // Per-banner visibility, each gated on a global, TTL-based dismissal (#5064). The upgrade
-    // banner
-    // additionally requires the vault to be GG20 (migration-eligible).
+    // Per-banner visibility, each gated on a global dismissal whose lifetime is the banner's own
+    // policy (#5064). The upgrade banner additionally requires the vault to be GG20
+    // (migration-eligible).
     val showUpgradeBanner: Boolean = false,
     val showFollowXBanner: Boolean = false,
     val showBuyVultBanner: Boolean = false,
@@ -435,10 +435,9 @@ constructor(
 
     fun dismissFollowXBanner() = dismissPromoBanner(PromoBanner.FollowXVultisig)
 
-    // Global, TTL-based dismissal: the banner stays hidden across vaults until its TTL elapses,
-    // then
-    // becomes eligible again (#5064). Writing the timestamp re-emits the dismissal flow, so the
-    // banner hides reactively without a session flag.
+    // Global dismissal: the banner stays hidden across vaults for as long as its policy says —
+    // until a TTL elapses, or for good (#5064). Writing the timestamp re-emits the dismissal flow,
+    // so the banner hides reactively without a session flag.
     private fun dismissPromoBanner(banner: PromoBanner) {
         viewModelScope.safeLaunch { promoBannerDismissalRepository.dismiss(banner) }
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepository.kt
@@ -10,28 +10,50 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 /**
- * Promo banners that support global, time-bounded dismissal.
+ * What a dismissal means for a banner: [Ttl] lets it come back once the window elapses, [Permanent]
+ * keeps it hidden for good.
+ */
+sealed interface DismissPolicy {
+    data class Ttl(val duration: Duration) : DismissPolicy
+
+    data object Permanent : DismissPolicy
+}
+
+/**
+ * Promo banners that support global dismissal.
  *
  * Dismissal is keyed by the banner's CTA intent ([id]) — not by vault — so closing a banner in one
- * vault keeps it hidden everywhere, and each banner carries its own [ttl]: once dismissed it stays
- * hidden until the TTL elapses, then becomes eligible to show again (#5064).
+ * vault keeps it hidden everywhere, and each banner carries its own [dismissPolicy]: a dismissal
+ * either lapses after a TTL or never does (#5064, #5669).
  *
- * TTLs are product knobs and are centralized here rather than hard-coded into view logic, so they
- * can be tuned per banner in one place.
+ * Policies are product knobs and are centralized here rather than hard-coded into view logic, so
+ * they can be reassigned per banner in one place.
  */
-enum class PromoBanner(val id: String, val ttl: Duration) {
-    UpgradeVaultDkls(id = "upgrade_vault_dkls", ttl = 15.days),
-    BuyVultSwap(id = "buy_vult_swap", ttl = 7.days),
-    FollowXVultisig(id = "follow_x_vultisig", ttl = 15.days),
+enum class PromoBanner(val id: String, val dismissPolicy: DismissPolicy) {
+    UpgradeVaultDkls(id = "upgrade_vault_dkls", dismissPolicy = DismissPolicy.Ttl(15.days)),
+    BuyVultSwap(id = "buy_vult_swap", dismissPolicy = DismissPolicy.Ttl(7.days)),
+    FollowXVultisig(id = "follow_x_vultisig", dismissPolicy = DismissPolicy.Ttl(15.days)),
 }
 
 interface PromoBannerDismissalRepository {
-    /**
-     * Emits true while [banner] is still within its dismissal TTL window (i.e. should stay hidden).
-     */
-    fun isDismissed(banner: PromoBanner): Flow<Boolean>
+    /** Emits true while a dismissal of [banner] still hides it under the banner's own policy. */
+    fun isDismissed(banner: PromoBanner): Flow<Boolean> = isDismissed(banner, banner.dismissPolicy)
 
-    /** Records that [banner] was dismissed now, starting its TTL window. */
+    /**
+     * Emits true while a dismissal of [banner] still hides it under [policy]: until the TTL window
+     * elapses, or forever when the policy is permanent.
+     *
+     * Taking the policy as an argument is the seam for one served from elsewhere; the overload
+     * above keeps the hardcoded assignment as the fallback, so call sites need no change when a
+     * served policy arrives.
+     */
+    fun isDismissed(banner: PromoBanner, policy: DismissPolicy): Flow<Boolean>
+
+    /**
+     * Records that [banner] was dismissed now, starting its dismissal window. The timestamp is
+     * stored the same way whatever the policy — how long it hides the banner is decided on read, so
+     * a policy can be reassigned without rewriting what is already stored.
+     */
     suspend fun dismiss(banner: PromoBanner)
 }
 
@@ -50,13 +72,18 @@ constructor(private val appDataStore: AppDataStore) : PromoBannerDismissalReposi
      */
     @VisibleForTesting internal var clock: Clock = Clock { System.currentTimeMillis() }
 
-    override fun isDismissed(banner: PromoBanner): Flow<Boolean> =
+    override fun isDismissed(banner: PromoBanner, policy: DismissPolicy): Flow<Boolean> =
         appDataStore.readData(dismissedAtKey(banner)).map { dismissedAt ->
-            // No stored timestamp → never dismissed. Otherwise hidden only until the TTL elapses;
-            // an
-            // expired dismissal reads as "show again". The comparison is re-evaluated whenever the
-            // flow is re-collected (home re-entry / vault switch), so an expired TTL surfaces then.
-            dismissedAt != null && clock.nowMillis() - dismissedAt < banner.ttl.inWholeMilliseconds
+            // No stored timestamp → never dismissed. Otherwise a permanent policy hides the banner
+            // from then on, while a TTL policy hides it only until the window elapses; that
+            // comparison is re-evaluated whenever the flow is re-collected (home re-entry / vault
+            // switch), so an expired TTL surfaces then.
+            dismissedAt != null &&
+                when (policy) {
+                    is DismissPolicy.Ttl ->
+                        clock.nowMillis() - dismissedAt < policy.duration.inWholeMilliseconds
+                    DismissPolicy.Permanent -> true
+                }
         }
 
     override suspend fun dismiss(banner: PromoBanner) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepositoryTest.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.emptyPreferences
 import com.vultisig.wallet.data.sources.AppDataStore
 import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,8 +15,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 /**
- * Covers the global, TTL-based dismissal model (#5064): a dismissal persists across reads, is keyed
- * per banner (so banners are independent), and lapses once the banner's TTL elapses.
+ * Covers the global dismissal model (#5064, #5669): a dismissal persists across reads, is keyed per
+ * banner (so banners are independent), and either lapses once the banner's TTL elapses or — under a
+ * permanent policy — never does.
  */
 internal class PromoBannerDismissalRepositoryTest {
 
@@ -42,7 +44,7 @@ internal class PromoBannerDismissalRepositoryTest {
         repo.isDismissed(PromoBanner.BuyVultSwap).first() shouldBe true
 
         // One millisecond before the TTL elapses it is still hidden.
-        now += PromoBanner.BuyVultSwap.ttl.inWholeMilliseconds - 1
+        now += ttlOf(PromoBanner.BuyVultSwap) - 1
         repo.isDismissed(PromoBanner.BuyVultSwap).first() shouldBe true
     }
 
@@ -50,8 +52,7 @@ internal class PromoBannerDismissalRepositoryTest {
     fun `a dismissal lapses once the TTL elapses`() = runTest {
         repo.dismiss(PromoBanner.FollowXVultisig)
 
-        now +=
-            PromoBanner.FollowXVultisig.ttl.inWholeMilliseconds + 1.milliseconds.inWholeMilliseconds
+        now += ttlOf(PromoBanner.FollowXVultisig) + 1.milliseconds.inWholeMilliseconds
 
         repo.isDismissed(PromoBanner.FollowXVultisig).first() shouldBe false
     }
@@ -63,6 +64,38 @@ internal class PromoBannerDismissalRepositoryTest {
         repo.isDismissed(PromoBanner.BuyVultSwap).first() shouldBe true
         repo.isDismissed(PromoBanner.FollowXVultisig).first() shouldBe false
         repo.isDismissed(PromoBanner.UpgradeVaultDkls).first() shouldBe false
+    }
+
+    @Test
+    fun `a permanent dismissal outlasts any TTL`() = runTest {
+        repo.dismiss(PromoBanner.BuyVultSwap)
+
+        now += 3650.days.inWholeMilliseconds
+
+        repo.isDismissed(PromoBanner.BuyVultSwap).first() shouldBe false
+        repo.isDismissed(PromoBanner.BuyVultSwap, DismissPolicy.Permanent).first() shouldBe true
+    }
+
+    @Test
+    fun `a permanent policy still shows a banner that was never dismissed`() = runTest {
+        repo.isDismissed(PromoBanner.BuyVultSwap, DismissPolicy.Permanent).first() shouldBe false
+    }
+
+    @Test
+    fun `a permanent policy on one banner leaves the others on their TTL`() = runTest {
+        repo.dismiss(PromoBanner.BuyVultSwap)
+        repo.dismiss(PromoBanner.FollowXVultisig)
+
+        now += ttlOf(PromoBanner.FollowXVultisig) + 1.milliseconds.inWholeMilliseconds
+
+        repo.isDismissed(PromoBanner.BuyVultSwap, DismissPolicy.Permanent).first() shouldBe true
+        repo.isDismissed(PromoBanner.FollowXVultisig).first() shouldBe false
+    }
+
+    private fun ttlOf(banner: PromoBanner): Long {
+        val policy = banner.dismissPolicy
+        check(policy is DismissPolicy.Ttl) { "Expected a TTL policy for $banner" }
+        return policy.duration.inWholeMilliseconds
     }
 
     private class FakeAppDataStore : AppDataStore {


### PR DESCRIPTION
## Problem

Every home promo banner dismissal expired. `PromoBanner` carried a single `ttl` knob (upgrade 15d, Follow X 15d, Buy \$VULT 7d), so the only question the store could answer was whether the TTL window had elapsed — there was no way to run a campaign whose dismiss is final.

## Change

- `ttl: Duration` becomes `dismissPolicy: DismissPolicy` — `Ttl(duration)` or `Permanent` — still assigned on the enum, so the per-banner rule stays in one place instead of leaking into the pager.
- `isDismissed` branches on the policy with an exhaustive `when`, so a third kind can't be added silently.
- The served-policy seam is `isDismissed(banner, policy)`; the single-arg overload supplies the banner's own assignment, so call sites need no change when a policy arrives from elsewhere. An overload rather than a default argument, because mockk resolves default arguments outside the proxy and would silently unstub existing callers.

Existing TTLs are carried over unchanged, per the ticket's "don't change existing TTL lengths".

## Notes

**No storage change was required.** DataStore already persists `banner_dismissed_at/<id>` indefinitely; what made a banner return was purely the in-memory comparison. So a permanent dismissal survives relaunch and vault switching with no storage work, and `dismiss()` writes the same timestamp under either policy — a policy can be reassigned later without rewriting what is already stored.

This matches the shape Windows shipped in vultisig/vultisig-windows#4718 (`{ ttl } | { permanent }` union, optional policy input, TTLs untouched). iOS #5238 has no PR yet; its `.session` rule has no Android counterpart, since the banner it exists for (backup reminder) isn't shipped here — so Android's policy is two cases, not three.

## Not included

Two ticket items are blocked on decisions outside this repo:

- **Honor remote policy from vultisig/notification#34** — that issue was closed with "no changes on the notification service" (see vultisig/notification#33), so there is no endpoint or payload shape to honor. The `policy` argument is the seam to wire one in once a contract exists.
- **Which banners should be never-return** — product has not assigned any, and the ticket forbids changing TTLs without an assignment. The mechanism ships here; the assignment is a one-line change per banner.

## Testing

`./gradlew :data:testDebugUnitTest` — 3119 tests green. `./gradlew :app:testDebugUnitTest` — 2169 green (one unrelated flake, `EnterVaultInfoViewModelTest`, failing on "uncaught exceptions before the test started" from another test's scope; passes 10/10 in isolation).

Three tests added: a permanent dismissal outlasting a 3650-day gap that the TTL policy lapses at, a permanent-policy banner that was never dismissed still showing, and a permanent banner leaving its neighbours on their TTL. Verified they bite — flipping `Permanent -> true` to `false` fails two of them.

Closes #5669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promo banners now support either time-limited or permanent dismissal.
  * Permanent dismissals remain hidden indefinitely, while time-limited banners reappear after their configured period.
  * Banner dismissal behavior is independently applied to each banner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->