### PR TITLE
fix(solana): stop counting a reverted tx as a landed broadcast

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCase.kt
@@ -130,12 +130,24 @@ constructor(
                 evmApi.sendTransaction(tx.rawTransaction)
             }
 
+            // A signature status appears as soon as the tx is processed and carries `err` when it
+            // executed but reverted, so the mere presence of a status proves nothing: a reverted tx
+            // moved no funds and must not be reported as a successful broadcast. Require a clean
+            // `err`, the same standard the Cosmos branch below applies with code==0.
+            //
+            // SolanaStatusProvider's finalized-only ladder is deliberately not reused here.
+            // Finality takes ~13s, far past this verify window, and a duplicate broadcast is
+            // observed seconds after the peer's, so gating on it would reject every genuine
+            // recovery. An unreverted tx seen at processed/confirmed is the strongest proof
+            // available in time, and accepting it is the safe direction — the alternative is
+            // re-signing a transaction that is already in flight.
             Solana ->
                 recoverIfAlreadyBroadcast(
                     tx = tx,
                     broadcast = { solanaApi.broadcastTransaction(tx.rawTransaction) },
                     verify = { hash ->
-                        solanaApi.checkStatus(hash)?.result?.value?.any { it != null } == true
+                        val status = solanaApi.checkStatus(hash)?.result?.value?.firstOrNull()
+                        status != null && status.err == null
                     },
                 )
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/BroadcastTxUseCaseTest.kt
@@ -20,6 +20,9 @@ import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
 import com.vultisig.wallet.data.api.models.BlockChainStatusDeserialized
 import com.vultisig.wallet.data.api.models.BlockChairStatusResponse
 import com.vultisig.wallet.data.api.models.ContextData
+import com.vultisig.wallet.data.api.models.SolanaRpcResponseJson
+import com.vultisig.wallet.data.api.models.SolanaSignatureStatus
+import com.vultisig.wallet.data.api.models.SolanaSignatureStatusesResult
 import com.vultisig.wallet.data.api.models.TransactionData
 import com.vultisig.wallet.data.api.models.TransactionInfo
 import com.vultisig.wallet.data.api.models.cosmos.CosmosTxStatusJson
@@ -37,6 +40,8 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
 
 class BroadcastTxUseCaseTest {
 
@@ -207,6 +212,61 @@ class BroadcastTxUseCaseTest {
         assertEquals(rejection, thrown)
         coVerify(exactly = 3) { cosmosApi.getTxStatus(KNOWN_TRANSACTION_HASH) }
     }
+
+    @Test
+    fun `solana recovers with local hash when a rejected broadcast already landed cleanly`() =
+        runTest {
+            val solanaApi = mockk<SolanaApi>()
+            coEvery { solanaApi.broadcastTransaction(RAW_TRANSACTION) } throws alreadyProcessed()
+            // The peer's byte-identical tx is on chain and did not revert, so our locally
+            // computed signature is canonical even though our own broadcast was rejected.
+            coEvery { solanaApi.checkStatus(KNOWN_TRANSACTION_HASH) } returns
+                solanaStatus(confirmationStatus = "confirmed")
+
+            val txHash = createUseCase(solanaApi = solanaApi)(Chain.Solana, signedTransaction())
+
+            assertEquals(KNOWN_TRANSACTION_HASH, txHash)
+            coVerify(exactly = 1) { solanaApi.broadcastTransaction(RAW_TRANSACTION) }
+        }
+
+    @Test
+    fun `solana rethrows a rejected broadcast when the landed tx reverted`() = runTest {
+        val solanaApi = mockk<SolanaApi>()
+        val rejection = alreadyProcessed()
+        coEvery { solanaApi.broadcastTransaction(RAW_TRANSACTION) } throws rejection
+        // The signature is on chain but `err` is set: it executed and reverted, so no funds
+        // moved and the rejection must reach the user instead of being reported as success.
+        coEvery { solanaApi.checkStatus(KNOWN_TRANSACTION_HASH) } returns
+            solanaStatus(
+                confirmationStatus = "finalized",
+                err = JsonPrimitive("InsufficientFundsForRent"),
+            )
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                createUseCase(solanaApi = solanaApi)(Chain.Solana, signedTransaction())
+            }
+
+        assertEquals(rejection, thrown)
+    }
+
+    @Test
+    fun `solana rethrows a rejected broadcast when the signature is unknown to the cluster`() =
+        runTest {
+            val solanaApi = mockk<SolanaApi>()
+            val rejection = alreadyProcessed()
+            coEvery { solanaApi.broadcastTransaction(RAW_TRANSACTION) } throws rejection
+            // getSignatureStatuses returns a null entry for a signature the cluster never saw.
+            coEvery { solanaApi.checkStatus(KNOWN_TRANSACTION_HASH) } returns unknownSolanaStatus()
+
+            val thrown =
+                assertFailsWith<RuntimeException> {
+                    createUseCase(solanaApi = solanaApi)(Chain.Solana, signedTransaction())
+                }
+
+            assertEquals(rejection, thrown)
+            coVerify(exactly = 3) { solanaApi.checkStatus(KNOWN_TRANSACTION_HASH) }
+        }
 
     @Test
     fun `bitcoin cash broadcast returns hash from blockchair on success`() = runTest {
@@ -455,6 +515,7 @@ class BroadcastTxUseCaseTest {
         blockChairApi: BlockChairApi = mockk(relaxed = true),
         bittensorApi: BittensorApi = mockk(relaxed = true),
         cardanoApi: CardanoApi = mockk(relaxed = true),
+        solanaApi: SolanaApi = mockk(relaxed = true),
         transactionStatusRepository: TransactionStatusRepository = mockk(relaxed = true),
     ) =
         BroadcastTxUseCaseImpl(
@@ -463,7 +524,7 @@ class BroadcastTxUseCaseTest {
             blockChairApi = blockChairApi,
             mayaChainApi = mayaChainApi,
             cosmosApiFactory = cosmosApiFactory,
-            solanaApi = mockk<SolanaApi>(relaxed = true),
+            solanaApi = solanaApi,
             polkadotApi = mockk<PolkadotApi>(relaxed = true),
             bittensorApi = bittensorApi,
             suiApi = mockk<SuiApi>(relaxed = true),
@@ -472,6 +533,34 @@ class BroadcastTxUseCaseTest {
             tronApi = mockk<TronApi>(relaxed = true),
             cardanoApi = cardanoApi,
             transactionStatusRepository = transactionStatusRepository,
+        )
+
+    private fun solanaStatus(confirmationStatus: String?, err: JsonElement? = null) =
+        SolanaRpcResponseJson(
+            id = 1,
+            result =
+                SolanaSignatureStatusesResult(
+                    value =
+                        listOf(
+                            SolanaSignatureStatus(
+                                confirmationStatus = confirmationStatus,
+                                err = err,
+                            )
+                        )
+                ),
+            error = null,
+        )
+
+    private fun unknownSolanaStatus() =
+        SolanaRpcResponseJson(
+            id = 1,
+            result = SolanaSignatureStatusesResult(value = listOf(null)),
+            error = null,
+        )
+
+    private fun alreadyProcessed() =
+        RuntimeException(
+            "Transaction simulation failed: This transaction has already been processed"
         )
 
     private fun txStatus(code: Int) =


### PR DESCRIPTION
Closes #5692

## Summary

The Solana duplicate-broadcast recovery in `BroadcastTxUseCase` accepted **any** non-null signature status as proof our transaction was on chain:

```kotlin
verify = { hash ->
    solanaApi.checkStatus(hash)?.result?.value?.any { it != null } == true
}
```

`getSignatureStatuses` returns an entry the moment a tx is processed, and that entry carries `err` when the tx executed and reverted. So a transaction that moved nothing was reported to the user as a successful broadcast, and the rejection that triggered the check was swallowed.

The verify now requires the entry to exist **and** carry no `err`.

## Why the status provider's ladder is not reused

The issue suggests reusing `SolanaStatusProvider`, which holds the same `err` check. It is not reused here, and that is deliberate:

`SolanaStatusProvider` only reports `Confirmed` at `finalized`, which is ~13s away. The verify loop is 3 attempts over a ~4s window, and a duplicate broadcast is observed seconds after the peer's. Gating on finality would reject **every** genuine recovery and push the user to re-sign a transaction already in flight — trading this bug for a worse one.

The boundary implemented instead is: signature present, `err` clean, at any confirmation level. That is the issue's actual ask, and it matches the standard the Cosmos branch already applies with `code == 0` — an included-but-failed tx consumed no funds and must not stand in for a success.

This does leave Solana deliberately stricter than `isLandedOnChain`, which maps `Failed → true` for THORChain, Maya and Bittensor. Those two doctrines already coexist in this file: there the question is whether the account sequence was consumed, and any terminal outcome answers it. Solana has no sequence to consume.

## Test plan

Three tests added to `BroadcastTxUseCaseTest` (`createUseCase` gained a `solanaApi` seam):

| Test | Guards |
|---|---|
| `solana recovers with local hash when a rejected broadcast already landed cleanly` | no regression — a clean `confirmed` status still recovers |
| `solana rethrows a rejected broadcast when the landed tx reverted` | **the fix** — `finalized` + `err` now rethrows |
| `solana rethrows a rejected broadcast when the signature is unknown to the cluster` | null status entry, 3 verify attempts, rethrow |

- The behaviour test was verified to fail on revert: restoring `any { it != null }` gives `27 tests completed, 1 failed`, that test.
- With the fix, the XML report reads `tests="27" skipped="0" failures="0"` — count checked, not just `BUILD SUCCESSFUL`.
- Full `:data` and `:app` unit suites green.
- ktfmt applied to `:data`; the diff is scoped to the two files touched.

Not manually reproducible in-app — it needs a real duplicate broadcast racing a reverted Solana transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when broadcasting duplicate Solana transactions by confirming the transaction completed without execution errors.
  * Reverted or failed broadcasts are no longer incorrectly treated as successful.
  * Transaction status verification continues to support processed and confirmed states.

* **Tests**
  * Added coverage for duplicate broadcasts, reverted transactions, and unknown transaction signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->