### PR TITLE
fix(ton): stop a rejecting contract from absorbing a transfer

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonAddressFlags.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ton/TonAddressFlags.kt
@@ -1,0 +1,57 @@
+package com.vultisig.wallet.data.crypto.ton
+
+import java.util.Base64
+
+/** Bounceability a TON destination address declares, or [UNSPECIFIED] when it declares none. */
+enum class TonBounceability {
+    /** User-friendly `EQ…` form — a message the destination rejects is refunded. */
+    BOUNCEABLE,
+    /** User-friendly `UQ…` form — a message the destination rejects is absorbed. */
+    NON_BOUNCEABLE,
+    /** Raw `0:hex` form, or anything this reader cannot classify. Carries no flag at all. */
+    UNSPECIFIED,
+}
+
+/**
+ * Reads the bounceable tag out of a TON address rather than inferring it from the leading
+ * character.
+ *
+ * A user-friendly address is base64 of `tag(1) | workchain(1) | hash(32) | crc16(2)`, where the tag
+ * is `0x11` bounceable or `0x51` non-bounceable, optionally OR'd with the `0x80` testnet-only bit.
+ * The raw `0:hex` spelling of the same account carries no tag, which is the case a prefix check
+ * cannot express: it is neither bounceable nor non-bounceable, and the caller has to decide.
+ *
+ * Structural validity beyond the length and the tag (the CRC in particular) is not re-checked here
+ * — a destination reaches this reader only after `ChainAccountAddressRepository.isValid`, and an
+ * unrecognized input degrades to [TonBounceability.UNSPECIFIED] rather than to a flag it did not
+ * declare. Pure JVM (no WalletCore) so it stays unit testable.
+ */
+object TonAddressFlags {
+
+    private const val USER_FRIENDLY_LENGTH = 48
+    private const val USER_FRIENDLY_SIZE = 36
+    private const val TAG_MASK = 0x7f
+    private const val TAG_BOUNCEABLE = 0x11
+    private const val TAG_NON_BOUNCEABLE = 0x51
+
+    fun bounceabilityOf(address: String): TonBounceability {
+        val trimmed = address.trim()
+        if (trimmed.length != USER_FRIENDLY_LENGTH) return TonBounceability.UNSPECIFIED
+
+        val bytes = decodeBase64(trimmed) ?: return TonBounceability.UNSPECIFIED
+        if (bytes.size != USER_FRIENDLY_SIZE) return TonBounceability.UNSPECIFIED
+
+        return when (bytes[0].toInt() and TAG_MASK) {
+            TAG_BOUNCEABLE -> TonBounceability.BOUNCEABLE
+            TAG_NON_BOUNCEABLE -> TonBounceability.NON_BOUNCEABLE
+            else -> TonBounceability.UNSPECIFIED
+        }
+    }
+
+    /**
+     * TON friendly addresses appear in both base64url (`-_`) and standard base64 (`+/`) spelling.
+     */
+    private fun decodeBase64(value: String): ByteArray? =
+        runCatching { Base64.getUrlDecoder().decode(value) }.getOrNull()
+            ?: runCatching { Base64.getDecoder().decode(value) }.getOrNull()
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -34,6 +34,8 @@ import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.chains.helpers.TronHelper.Companion.TRON_DEFAULT_ESTIMATION_FEE
 import com.vultisig.wallet.data.crypto.SuiHelper
+import com.vultisig.wallet.data.crypto.ton.TonAddressFlags
+import com.vultisig.wallet.data.crypto.ton.TonBounceability
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenStandard
@@ -593,13 +595,26 @@ constructor(
                 coroutineScope {
                     val sequenceNumberDeferred = async { tonApi.getSeqno(address) }
                     val isBounceable = async {
+                        // A swap deposit address is a router / escrow contract, and the swap path
+                        // hands us no dstAddress to read a flag off (SwapTransactionBuilder calls
+                        // getSpecificAndUtxo without one; TON SwapKit then signs through the plain
+                        // TonHelper transfer path). A message such a contract rejects — an expired
+                        // quote, a paused pool — has to bounce back instead of being absorbed.
+                        if (isSwap) return@async true
+
                         if (dstAddress == null) return@async false
 
+                        // An undeployed wallet cannot accept a bounceable message; it would return
+                        // the funds and the transfer would simply fail.
                         val isUninitialized =
                             tonApi.getWalletState(dstAddress) == TON_WALLET_STATE_UNINITIALIZED
                         if (isUninitialized) return@async false
 
-                        dstAddress.startsWith("E")
+                        // Raw `0:hex` destinations declare no bounceability, so they default to
+                        // bounceable — the safe side for a contract. Only an explicit `UQ…` opts
+                        // out.
+                        TonAddressFlags.bounceabilityOf(dstAddress) !=
+                            TonBounceability.NON_BOUNCEABLE
                     }
                     val (destinationActive, jettonsAddress) =
                         if (!token.isNativeToken) {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/ton/TonAddressFlagsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/ton/TonAddressFlagsTest.kt
@@ -1,0 +1,91 @@
+package com.vultisig.wallet.data.crypto.ton
+
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Every vector below is the same account — a STON.fi v2 router — re-encoded with a different tag or
+ * spelling, so the reader is pinned on the tag alone and not on anything else that varies between
+ * two encodings of one address.
+ */
+internal class TonAddressFlagsTest {
+
+    @Test
+    fun `EQ tag reads as bounceable`() {
+        assertEquals(TonBounceability.BOUNCEABLE, TonAddressFlags.bounceabilityOf(EQ))
+    }
+
+    @Test
+    fun `UQ tag reads as non-bounceable`() {
+        assertEquals(TonBounceability.NON_BOUNCEABLE, TonAddressFlags.bounceabilityOf(UQ))
+    }
+
+    @Test
+    fun `raw form declares no bounceability`() {
+        assertEquals(TonBounceability.UNSPECIFIED, TonAddressFlags.bounceabilityOf(RAW))
+    }
+
+    @Test
+    fun `standard base64 spelling reads the same tag as base64url`() {
+        assertEquals(
+            TonAddressFlags.bounceabilityOf(EQ_URL_SAFE),
+            TonAddressFlags.bounceabilityOf(EQ_STANDARD),
+        )
+        assertEquals(TonBounceability.BOUNCEABLE, TonAddressFlags.bounceabilityOf(EQ_STANDARD))
+        assertEquals(TonBounceability.NON_BOUNCEABLE, TonAddressFlags.bounceabilityOf(UQ_STANDARD))
+    }
+
+    @Test
+    fun `testnet bit does not hide the bounceable tag`() {
+        assertEquals(TonBounceability.BOUNCEABLE, TonAddressFlags.bounceabilityOf(EQ_TESTNET))
+        assertEquals(TonBounceability.NON_BOUNCEABLE, TonAddressFlags.bounceabilityOf(UQ_TESTNET))
+    }
+
+    @Test
+    fun `surrounding whitespace does not change the tag`() {
+        assertEquals(TonBounceability.NON_BOUNCEABLE, TonAddressFlags.bounceabilityOf("  $UQ\n"))
+    }
+
+    @Test
+    fun `unclassifiable input never claims a flag it did not declare`() {
+        val unclassifiable =
+            listOf(
+                "",
+                "EQ",
+                "not an address at all",
+                // Right length, not base64 in either alphabet.
+                "!".repeat(48),
+                // Valid base64url of 36 bytes, but the tag is neither 0x11 nor 0x51.
+                BAD_TAG,
+                // An EVM address that happens to start with the same letter as an EQ address.
+                "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
+            )
+
+        unclassifiable.forEach { address ->
+            assertEquals(
+                TonBounceability.UNSPECIFIED,
+                TonAddressFlags.bounceabilityOf(address),
+                "expected no flag for: $address",
+            )
+        }
+    }
+
+    private companion object {
+        const val EQ = "EQABT9GCyDI60CbC4c6uS33HFDwaqd6MddiwIIw7CXTgNR3A"
+        const val UQ = "UQABT9GCyDI60CbC4c6uS33HFDwaqd6MddiwIIw7CXTgNUAF"
+        const val RAW = "0:014fd182c8323ad026c2e1ceae4b7dc7143c1aa9de8c75d8b0208c3b0974e035"
+
+        // tag OR'd with the 0x80 testnet-only bit: 0x91 and 0xd1.
+        const val EQ_TESTNET = "kQABT9GCyDI60CbC4c6uS33HFDwaqd6MddiwIIw7CXTgNaZK"
+        const val UQ_TESTNET = "0QABT9GCyDI60CbC4c6uS33HFDwaqd6MddiwIIw7CXTgNfuP"
+
+        // A second router, whose payload contains a byte that base64url spells `-` and standard
+        // base64 spells `+`, so the two spellings are actually distinct strings.
+        const val EQ_URL_SAFE = "EQACn16m9OrZ-mw186M4NlIpVP8Tb3q6SV9aX8NjSgVfJTo9"
+        const val EQ_STANDARD = "EQACn16m9OrZ+mw186M4NlIpVP8Tb3q6SV9aX8NjSgVfJTo9"
+        const val UQ_STANDARD = "UQACn16m9OrZ+mw186M4NlIpVP8Tb3q6SV9aX8NjSgVfJWf4"
+
+        // 36 bytes of base64url whose leading byte is 0x00.
+        const val BAD_TAG = "AAABT9GCyDI60CbC4c6uS33HFDwaqd6MddiwIIw7CXTgNR3A"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -46,6 +46,7 @@ import io.mockk.mockk
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
@@ -949,6 +950,73 @@ internal class BlockChainSpecificRepositoryImplTest {
             isNativeToken = true,
         )
 
+    @Test
+    fun `TON swap deposit is bounceable even though the swap path supplies no destination`() =
+        runTest {
+            assertTrue(tonSpecific(dstAddress = null, isSwap = true).bounceable)
+        }
+
+    @Test
+    fun `TON send to an EQ destination is bounceable`() = runTest {
+        assertTrue(tonSpecific(dstAddress = TON_EQ).bounceable)
+    }
+
+    @Test
+    fun `TON send to the UQ spelling of that same account is not bounceable`() = runTest {
+        assertFalse(tonSpecific(dstAddress = TON_UQ).bounceable)
+    }
+
+    @Test
+    fun `TON send to the raw spelling of that same account is bounceable`() = runTest {
+        assertTrue(tonSpecific(dstAddress = TON_RAW).bounceable)
+    }
+
+    @Test
+    fun `TON send to an uninitialized destination is not bounceable`() = runTest {
+        assertFalse(tonSpecific(dstAddress = TON_EQ, walletState = "uninit").bounceable)
+    }
+
+    private suspend fun tonSpecific(
+        dstAddress: String?,
+        isSwap: Boolean = false,
+        walletState: String = "active",
+    ): BlockChainSpecific.Ton {
+        val coin = tonCoin()
+        val tonApi =
+            mockk<TonApi> {
+                coEvery { getSeqno(any()) } returns BigInteger("3")
+                coEvery { getWalletState(any()) } returns walletState
+            }
+
+        val result =
+            repository(tonApi = tonApi)
+                .getSpecific(
+                    chain = Chain.Ton,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = isSwap,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                    dstAddress = dstAddress,
+                )
+
+        return result.blockChainSpecific as BlockChainSpecific.Ton
+    }
+
+    private fun tonCoin() =
+        Coin(
+            chain = Chain.Ton,
+            ticker = "TON",
+            logo = "",
+            address = SOURCE_ADDRESS,
+            decimal = 9,
+            hexPublicKey = "pub",
+            priceProviderID = "the-open-network",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
     private fun repository(
         evmApi: EvmApi = mockk<EvmApi>(relaxed = true),
         evmFeeService: FeeService = NoOpFeeService,
@@ -958,6 +1026,7 @@ internal class BlockChainSpecificRepositoryImplTest {
         dashApi: DashApi = mockk<DashApi>(relaxed = true),
         zcashApi: ZcashApi = mockk<ZcashApi>(relaxed = true),
         solanaApi: SolanaApi = mockk<SolanaApi>(relaxed = true),
+        tonApi: TonApi = mockk<TonApi>(relaxed = true),
     ): BlockChainSpecificRepositoryImpl {
         val evmApiFactory =
             object : EvmApiFactory {
@@ -976,7 +1045,7 @@ internal class BlockChainSpecificRepositoryImplTest {
             polkadotApi = mockk<PolkadotApi>(relaxed = true),
             bittensorApi = mockk<BittensorApi>(relaxed = true),
             suiApi = suiApi,
-            tonApi = mockk<TonApi>(relaxed = true),
+            tonApi = tonApi,
             rippleApi = mockk<RippleApi>(relaxed = true),
             tronApi = mockk<TronApi>(relaxed = true),
             cardanoApi = mockk<CardanoApi>(relaxed = true),
@@ -1079,6 +1148,11 @@ internal class BlockChainSpecificRepositoryImplTest {
     private companion object {
         val NONCE: BigInteger = BigInteger("7")
         const val SOURCE_ADDRESS = "0xsource"
+        // One STON.fi v2 router account in its three spellings: bounceable, non-bounceable,
+        // and raw (which declares no bounceability at all).
+        const val TON_EQ = "EQABT9GCyDI60CbC4c6uS33HFDwaqd6MddiwIIw7CXTgNR3A"
+        const val TON_UQ = "UQABT9GCyDI60CbC4c6uS33HFDwaqd6MddiwIIw7CXTgNUAF"
+        const val TON_RAW = "0:014fd182c8323ad026c2e1ceae4b7dc7143c1aa9de8c75d8b0208c3b0974e035"
         const val MEMO = "hi there"
         // "hi there" UTF-8 encoded — the payload the signed transaction carries.
         const val MEMO_CALL_DATA = "0x6869207468657265"


### PR DESCRIPTION
Closes #5686

## Problem

Bounceability of a TON destination was decided by `dstAddress.startsWith("E")`. Two kinds of transfer went out non-bounceable that should not have — and a non-bounceable message a contract rejects is absorbed, not refunded.

**Swap deposits, unconditionally.** `SwapTransactionBuilder` calls `getSpecificAndUtxo` without a `dstAddress`, so the null check returned `false` before any flag was read. TON SwapKit is not signed from payload bytes the way its siblings are — `SigningHelper.kt:201` routes `TX_TYPE_TON` through the plain `TonHelper` transfer path, which reads exactly this flag. So every TON swap reached its router or escrow contract non-bounceable. An expired quote or a paused pool absorbed the deposit instead of refunding it.

**Raw `0:hex` destinations.** They carry no bounceability tag at all, and fell through the prefix check to the unsafe default.

## Fix

`TonAddressFlags` reads the tag out of the address bytes — `tag(1) | workchain(1) | hash(32) | crc16(2)`, `0x11` bounceable / `0x51` non-bounceable, testnet bit masked — in both base64url and standard base64 spellings. It reports a third state, `UNSPECIFIED`, for the raw form, which is the case a prefix check cannot express: raw declares neither, so the caller decides. Pure JVM, no WalletCore, so it unit-tests on the host.

In `BlockChainSpecificRepository`:

- `isSwap` forces bounceable, so a deposit contract that rejects the message refunds it.
- Raw destinations default to bounceable — the safe side for a contract.
- An explicit `UQ…` still opts out, and an undeployed destination is still non-bounceable; a bounceable message there would only bounce back and fail the transfer.

Sibling of vultisig/vultisig-sdk#2181 (S1 item 2). iOS carries the identical defect at `BlockChainService.swift:1038`, so there is no iOS behaviour to match here.

## Not in scope

Overriding an explicit `UQ…` when the destination is a contract. Honouring the flag is what the TON standard says it means; going further needs an on-chain code-hash lookup and is a separate change.

## Test plan

12 new tests, all verified to actually run (`tests=` in the XML reports, not just a green build).

- `TonAddressFlagsTest` — 7 tests. Every vector is the same STON.fi router account re-encoded with a different tag or spelling, so the reader is pinned on the tag alone: EQ, UQ, raw, base64url vs standard base64, both testnet tags, whitespace, and six unclassifiable inputs that must not claim a flag they never declared.
- `BlockChainSpecificRepositoryImplTest` — 5 tests: swap-with-no-destination, EQ, UQ, raw, uninitialized.

Reverted the fix and re-ran: **"raw spelling is bounceable"** and **"swap deposit is bounceable"** fail against the old code. The other three pass on both, as regression locks.

Full `:data` suite: 3136 tests, 0 failures. `:app:compileDebugKotlin` clean. ktfmt applied.

### On device

Verified on TON mainnet as a controlled pair — same wallet, same account as the destination, same 0.01 TON, 13 minutes apart, only the spelling of the destination differing. Out-message `bounce` flag read from the indexer:

| tx | destination spelling | `bounce` |
|---|---|---|
| [`11aaeb52…`](https://tonviewer.com/transaction/11aaeb5234ced096b962a6b9f86d23be3bae50fcaf9ea52bbc2d52061e616014) | `UQCmBAnv…` | `false` |
| [`10e88ea6…`](https://tonviewer.com/transaction/10e88ea6f166e06dab4f3be512405affb2f6d0d2aac0c07ef490f08d470adf6b) | `0:a60409ef…` | **`true`** |

Both report `orig_status: active`, so the destination was deployed in each and the uninitialized branch is ruled out. The first is the regression lock — old and new code agree that an explicit `UQ…` opts out. The second is the change: on the old code `startsWith("E")` is false for a raw address, so it could not have produced `bounce = true`.

The swap leg has no on-device transaction — SwapKit returns `tokenPriceUnavailable` for `TON.TON`, and `SwapProviderTable.kt:177` makes SwapKit the only provider for the chain. It rests on the unit test verified to fail against the pre-fix code.
