### PR TITLE
fix(solana): stop a token account from passing as a send recipient

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.repositories.AddressParserRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.utils.asAddressInput
@@ -60,13 +61,12 @@ internal class AddressManager(
     private val _isDstAddressComplete = MutableStateFlow(false)
     val isDstAddressComplete: StateFlow<Boolean> = _isDstAddressComplete.asStateFlow()
 
-    // True when a non-empty recipient failed chain validation and couldn't resolve to a valid
-    // address. Drives the inline "not a valid address for this chain" error; false once the input
-    // is valid or empty. While name resolution is in flight the flag holds its previous value, so a
+    // Why a non-empty recipient was rejected, or null once the input is accepted or empty. Drives
+    // the inline recipient error. While name resolution is in flight the value is held, so a
     // standing error stays put until the new input resolves instead of blinking off and back on.
     // Chain-general: every send chain validates through the same path below.
-    private val _invalidAddress = MutableStateFlow(false)
-    val invalidAddress: StateFlow<Boolean> = _invalidAddress.asStateFlow()
+    private val _addressError = MutableStateFlow<RecipientValidity?>(null)
+    val addressError: StateFlow<RecipientValidity?> = _addressError.asStateFlow()
 
     private val _onAddressValidated = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     val onAddressValidated: SharedFlow<Unit> = _onAddressValidated.asSharedFlow()
@@ -144,27 +144,36 @@ internal class AddressManager(
             }
         }
 
-        when {
-            chainAccountAddressRepository.isValid(chain, addressStr) -> {
+        if (addressStr.isEmpty()) {
+            _resolvedDstAddress.value = null
+            _dstAddressLabel.value = null
+            _addressError.value = null
+            return
+        }
+
+        when (chainAccountAddressRepository.validateRecipient(chain, addressStr)) {
+            RecipientValidity.Valid -> {
                 // Only clear ENS label if the user typed a new raw address,
                 // not when we programmatically set the field to the resolved address.
                 if (addressStr != _resolvedDstAddress.value) {
                     _dstAddressLabel.value = null
                 }
                 _resolvedDstAddress.value = addressStr
-                _invalidAddress.value = false
+                _addressError.value = null
                 _onAddressValidated.tryEmit(Unit)
             }
-            addressStr.isNotEmpty() -> {
+            // A token account or program address is a well-formed address, so there is no name for
+            // the resolver to find — reject it here instead of sending it round that path.
+            RecipientValidity.NotAWalletAddress -> {
+                _resolvedDstAddress.value = null
+                _dstAddressLabel.value = null
+                _addressError.value = RecipientValidity.NotAWalletAddress
+            }
+            RecipientValidity.InvalidForChain -> {
                 // Clear stale resolved address while async resolution is in-flight
                 _resolvedDstAddress.value = null
                 _dstAddressLabel.value = null
                 tryResolveName(addressStr, token)
-            }
-            else -> {
-                _resolvedDstAddress.value = null
-                _dstAddressLabel.value = null
-                _invalidAddress.value = false
             }
         }
     }
@@ -196,7 +205,7 @@ internal class AddressManager(
             addressFieldState.setTextAndPlaceCursorAtEnd(decoded.classicAddress)
         }
         _resolvedDstAddress.value = decoded.classicAddress
-        _invalidAddress.value = false
+        _addressError.value = null
         // Surface the pasted X-address as the label so Verify/Done show what the user entered.
         _dstAddressLabel.value = originalInput
         _onAddressValidated.tryEmit(Unit)
@@ -208,16 +217,17 @@ internal class AddressManager(
             val resolved = addressParserRepository.resolveName(addressStr, chain)
             // Ignore stale result if user changed input while resolving
             if (addressFieldState.text.asAddressInput() != addressStr) return
-            if (chainAccountAddressRepository.isValid(chain, resolved)) {
+            val validity = chainAccountAddressRepository.validateRecipient(chain, resolved)
+            if (validity == RecipientValidity.Valid) {
                 _dstAddressLabel.value = addressStr
                 _resolvedDstAddress.value = resolved
-                _invalidAddress.value = false
+                _addressError.value = null
                 addressFieldState.setTextAndPlaceCursorAtEnd(resolved)
                 _onAddressValidated.tryEmit(Unit)
             } else {
                 _resolvedDstAddress.value = null
                 _dstAddressLabel.value = null
-                _invalidAddress.value = true
+                _addressError.value = validity
             }
         } catch (e: CancellationException) {
             throw e
@@ -227,7 +237,7 @@ internal class AddressManager(
             Timber.w(e, "Failed to resolve address %s on %s", addressStr, chain)
             _resolvedDstAddress.value = null
             _dstAddressLabel.value = null
-            _invalidAddress.value = true
+            _addressError.value = RecipientValidity.InvalidForChain
         }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.data.repositories.AdvanceGasUiRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.StakingDetailsRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
@@ -447,17 +448,23 @@ internal class SendFormGraph(
             }
         }
         scope.launch {
-            addressManager.invalidAddress.collect { invalid ->
+            addressManager.addressError.collect { error ->
                 uiState.update {
                     it.copy(
                         dstAddressError =
-                            if (invalid) {
-                                UiText.StringResource(
-                                    com.vultisig.wallet.R.string
-                                        .send_error_invalid_recipient_address
-                                )
-                            } else {
-                                null
+                            when (error) {
+                                RecipientValidity.InvalidForChain ->
+                                    UiText.StringResource(
+                                        com.vultisig.wallet.R.string
+                                            .send_error_invalid_recipient_address
+                                    )
+                                RecipientValidity.NotAWalletAddress ->
+                                    UiText.StringResource(
+                                        com.vultisig.wallet.R.string
+                                            .error_recipient_not_a_wallet_address
+                                    )
+                                RecipientValidity.Valid,
+                                null -> null
                             }
                     )
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.repositories.TransactionRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
@@ -134,10 +135,22 @@ internal class DefaultSendStrategy(
                                 chainAccountAddressRepository.isValid(chain, dstAddress)
                         }
 
-                    if (!chainAccountAddressRepository.isValid(chain, dstAddress)) {
-                        throw InvalidTransactionDataException(
-                            UiText.StringResource(R.string.send_error_no_address)
-                        )
+                    // The form's own recipient check is debounced and drives nothing but the
+                    // Continue button, and this path re-resolves the address from the raw field
+                    // rather than reading what the form resolved. Re-check here so a submit that
+                    // races that debounce still can't build a transaction for a recipient the
+                    // form would have refused — a Solana token account above all, which strands
+                    // an SPL transfer for good.
+                    when (chainAccountAddressRepository.validateRecipient(chain, dstAddress)) {
+                        RecipientValidity.Valid -> Unit
+                        RecipientValidity.InvalidForChain ->
+                            throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.send_error_no_address)
+                            )
+                        RecipientValidity.NotAWalletAddress ->
+                            throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
+                            )
                     }
 
                     val selectedTokenValue =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -145,6 +145,8 @@ constructor(
     // address and stamped on the built transaction so it is shown on the verify screen (#4858).
     private val externalRecipient = MutableStateFlow<String?>(null)
 
+    private var externalRecipientRoutingJob: Job? = null
+
     // The recipient actually fed into the quote pipeline: only a present-and-valid address (else
     // null = route to the vault). Gating here keeps partially-typed / invalid addresses from
     // triggering native (THOR/Maya) quote calls with a malformed destination (#4858 review).
@@ -397,45 +399,6 @@ constructor(
         // on-chain deposit) before the UI updates.
         if (isLoadingNextScreen) return
 
-        // Same hard gate as swap(): the recipient is baked into the `=<` memo's dest_addr, and it
-        // survives a destination-chain change unvalidated, so a stale or malformed address must be
-        // rejected here rather than signed into an order that pays out to nowhere.
-        externalRecipientError()?.let { error ->
-            showError(error)
-            return
-        }
-
-        val targetPrice = limitTargetPrice.value
-        if (targetPrice == null) {
-            showError(UiText.StringResource(R.string.swap_screen_invalid_quote_calculation))
-            return
-        }
-
-        val inputs =
-            try {
-                isLoadingNextScreen = true
-                swapInputCollector.collect(
-                    vaultId = vaultId,
-                    selectedSrc = selectedSrc.value,
-                    selectedDst = selectedDst.value,
-                    srcAmount = srcAmountState.text.toString(),
-                    quote = quoteState.quote,
-                    gasFee = quotePipeline.gasFee.value,
-                    estimatedNetworkFeeTokenValue =
-                        quotePipeline.estimatedNetworkFeeTokenValue.value,
-                    estimatedNetworkFeeFiatValue = quotePipeline.estimatedNetworkFeeFiatValue.value,
-                )
-            } catch (e: InvalidTransactionDataException) {
-                isLoadingNextScreen = false
-                showError(e.text)
-                return
-            } catch (e: Exception) {
-                isLoadingNextScreen = false
-                Timber.e(e)
-                showError(UiText.StringResource(R.string.swap_screen_invalid_quote_calculation))
-                return
-            }
-
         viewModelScope.safeLaunch(
             onError = { e ->
                 isLoadingNextScreen = false
@@ -447,6 +410,47 @@ constructor(
                 }
             }
         ) {
+            // Same hard gate as swap(): the recipient is baked into the `=<` memo's dest_addr, and
+            // it survives a destination-chain change unvalidated, so a stale or malformed address
+            // must be rejected here rather than signed into an order that pays out to nowhere. The
+            // whole body runs in the coroutine because the verdict can need a cluster round trip,
+            // and it stays the first thing checked so its error is the one the user sees.
+            externalRecipientError()?.let { throw InvalidTransactionDataException(it) }
+
+            val targetPrice = limitTargetPrice.value
+            if (targetPrice == null) {
+                showError(UiText.StringResource(R.string.swap_screen_invalid_quote_calculation))
+                return@safeLaunch
+            }
+
+            val inputs =
+                try {
+                    isLoadingNextScreen = true
+                    swapInputCollector.collect(
+                        vaultId = vaultId,
+                        selectedSrc = selectedSrc.value,
+                        selectedDst = selectedDst.value,
+                        srcAmount = srcAmountState.text.toString(),
+                        quote = quoteState.quote,
+                        gasFee = quotePipeline.gasFee.value,
+                        estimatedNetworkFeeTokenValue =
+                            quotePipeline.estimatedNetworkFeeTokenValue.value,
+                        estimatedNetworkFeeFiatValue =
+                            quotePipeline.estimatedNetworkFeeFiatValue.value,
+                    )
+                } catch (e: InvalidTransactionDataException) {
+                    isLoadingNextScreen = false
+                    showError(e.text)
+                    return@safeLaunch
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    isLoadingNextScreen = false
+                    Timber.e(e)
+                    showError(UiText.StringResource(R.string.swap_screen_invalid_quote_calculation))
+                    return@safeLaunch
+                }
+
             val transaction =
                 buildLimitSwapTransactionUseCase.build(
                     BuildLimitSwapTransactionUseCase.Params(
@@ -644,7 +648,7 @@ constructor(
      * off or valid for the destination chain. Used both for inline feedback and as the [swap]
      * pre-flight gate so a malformed address can never be baked into the swap memo/destination.
      */
-    private fun externalRecipientError(): UiText? {
+    private suspend fun externalRecipientError(): UiText? {
         val address = externalRecipient.value ?: return null
         val dstChain = selectedDst.value?.account?.token?.chain ?: return null
         return when (chainAccountAddressRepository.validateRecipient(dstChain, address)) {
@@ -675,53 +679,10 @@ constructor(
     }
 
     fun swap() {
-        // Hard gate: never stage a keysign that would route funds to a malformed recipient. The
-        // initiator and joiner both sign this address from the shared payload, so an invalid value
-        // must be caught here, before the transaction is built (#4858).
-        externalRecipientError()?.let { error ->
-            showError(error)
-            return
-        }
-
-        val inputs =
-            try {
-                isLoadingNextScreen = true
-                swapInputCollector.collect(
-                    vaultId = vaultId,
-                    selectedSrc = selectedSrc.value,
-                    selectedDst = selectedDst.value,
-                    srcAmount = srcAmountState.text.toString(),
-                    quote = quoteState.quote,
-                    gasFee = quotePipeline.gasFee.value,
-                    estimatedNetworkFeeTokenValue =
-                        quotePipeline.estimatedNetworkFeeTokenValue.value,
-                    estimatedNetworkFeeFiatValue = quotePipeline.estimatedNetworkFeeFiatValue.value,
-                )
-            } catch (e: InvalidTransactionDataException) {
-                isLoadingNextScreen = false
-                showError(e.text)
-                return
-            } catch (e: Exception) {
-                isLoadingNextScreen = false
-                Timber.e(e)
-                showError(UiText.StringResource(R.string.swap_screen_invalid_quote_calculation))
-                return
-            }
-
-        // Snapshot the fee/discount display alongside `inputs`, before launching. Reading
-        // _uiState.value inside the coroutine could attach a later quote's fee label or discounts
-        // to this transaction if polling lands a new quote in the meantime (#5358).
-        val feeDisplay =
-            _uiState.value.let { state ->
-                SwapFeeDisplay(
-                    swapFeePercent = state.feeBreakdown.swapFeePercent,
-                    swapFeeIncludedInRate = state.feeBreakdown.swapFeeIncludedInRate,
-                    vultBpsDiscount = state.discountInfo.vultBpsDiscount,
-                    vultBpsDiscountFiatValue = state.discountInfo.vultBpsDiscountFiatValue,
-                    referralBpsDiscount = state.discountInfo.referralBpsDiscount,
-                    referralBpsDiscountFiatValue = state.discountInfo.referralBpsDiscountFiatValue,
-                )
-            }
+        // Re-entry guard, as in placeLimitOrder(): isLoadingNextScreen now flips inside the
+        // coroutine, and the recipient check ahead of it can wait on the cluster, so a fast second
+        // tap could otherwise stage the same swap twice before the CTA disables.
+        if (isLoadingNextScreen) return
 
         viewModelScope.safeLaunch(
             onError = { e ->
@@ -734,6 +695,57 @@ constructor(
                 }
             }
         ) {
+            // Hard gate: never stage a keysign that would route funds to a malformed recipient. The
+            // initiator and joiner both sign this address from the shared payload, so an invalid
+            // value must be caught here, before the transaction is built (#4858). The whole body
+            // runs in the coroutine because the verdict can need a cluster round trip, and it stays
+            // the first thing checked so its error is the one the user sees.
+            externalRecipientError()?.let { throw InvalidTransactionDataException(it) }
+
+            val inputs =
+                try {
+                    isLoadingNextScreen = true
+                    swapInputCollector.collect(
+                        vaultId = vaultId,
+                        selectedSrc = selectedSrc.value,
+                        selectedDst = selectedDst.value,
+                        srcAmount = srcAmountState.text.toString(),
+                        quote = quoteState.quote,
+                        gasFee = quotePipeline.gasFee.value,
+                        estimatedNetworkFeeTokenValue =
+                            quotePipeline.estimatedNetworkFeeTokenValue.value,
+                        estimatedNetworkFeeFiatValue =
+                            quotePipeline.estimatedNetworkFeeFiatValue.value,
+                    )
+                } catch (e: InvalidTransactionDataException) {
+                    isLoadingNextScreen = false
+                    showError(e.text)
+                    return@safeLaunch
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    isLoadingNextScreen = false
+                    Timber.e(e)
+                    showError(UiText.StringResource(R.string.swap_screen_invalid_quote_calculation))
+                    return@safeLaunch
+                }
+
+            // Snapshot the fee/discount display alongside `inputs`, before the build. Reading
+            // _uiState.value after it could attach a later quote's fee label or discounts to this
+            // transaction if polling lands a new quote in the meantime (#5358).
+            val feeDisplay =
+                _uiState.value.let { state ->
+                    SwapFeeDisplay(
+                        swapFeePercent = state.feeBreakdown.swapFeePercent,
+                        swapFeeIncludedInRate = state.feeBreakdown.swapFeeIncludedInRate,
+                        vultBpsDiscount = state.discountInfo.vultBpsDiscount,
+                        vultBpsDiscountFiatValue = state.discountInfo.vultBpsDiscountFiatValue,
+                        referralBpsDiscount = state.discountInfo.referralBpsDiscount,
+                        referralBpsDiscountFiatValue =
+                            state.discountInfo.referralBpsDiscountFiatValue,
+                    )
+                }
+
             val transaction =
                 swapTransactionBuilder.build(
                     vaultId = inputs.vaultId,
@@ -1065,7 +1077,11 @@ constructor(
      */
     fun setExternalRecipient(address: String?) {
         externalRecipient.value = address?.trim()?.takeIf { it.isNotEmpty() }
-        syncExternalRecipientRouting()
+        // Cancel the in-flight validation rather than letting two overlap: the verdict can need a
+        // cluster round trip, and a slower one for an earlier keystroke would otherwise land last
+        // and describe an address the user has already replaced.
+        externalRecipientRoutingJob?.cancel()
+        externalRecipientRoutingJob = viewModelScope.launch { syncExternalRecipientRouting() }
     }
 
     /**
@@ -1075,7 +1091,7 @@ constructor(
      * with a malformed destination (#4858 review). The typed value still drives the field and the
      * swap() pre-flight gate.
      */
-    private fun syncExternalRecipientRouting() {
+    private suspend fun syncExternalRecipientRouting() {
         val typed = externalRecipient.value
         val error = externalRecipientError()
         quoteRecipient.value = typed?.takeIf { error == null }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -415,7 +415,7 @@ constructor(
             // must be rejected here rather than signed into an order that pays out to nowhere. The
             // whole body runs in the coroutine because the verdict can need a cluster round trip,
             // and it stays the first thing checked so its error is the one the user sees.
-            externalRecipientError()?.let { throw InvalidTransactionDataException(it) }
+            val recipient = validatedExternalRecipient()
 
             val targetPrice = limitTargetPrice.value
             if (targetPrice == null) {
@@ -463,7 +463,7 @@ constructor(
                         // anything longer with an exception rather than rounding it itself.
                         targetPrice = LimitOrderPricing.toMemoScale(targetPrice),
                         expiryHours = limitExpiry.value.hours,
-                        destinationAddress = externalRecipient.value ?: inputs.dstToken.address,
+                        destinationAddress = recipient ?: inputs.dstToken.address,
                         gasFee = inputs.gasFee,
                         gasFeeFiatValue = inputs.gasFeeFiatValue,
                         estimatedNetworkFeeTokenValue = inputs.estimatedNetworkFeeTokenValue,
@@ -644,13 +644,15 @@ constructor(
         assetFormat.format(value.stripTrailingZeros())
 
     /**
-     * The address-format error for the current external recipient, or `null` when the recipient is
-     * off or valid for the destination chain. Used both for inline feedback and as the [swap]
-     * pre-flight gate so a malformed address can never be baked into the swap memo/destination.
+     * The error for [address] as a recipient on [dstChain], or `null` when the recipient is off or
+     * can receive the swap. Used both for inline feedback and as the [swap] pre-flight gate so a
+     * malformed address can never be baked into the swap memo/destination.
+     *
+     * Takes both as arguments rather than reading them: the verdict can cost a cluster round trip,
+     * so what the fields hold when it returns is not necessarily what was asked about.
      */
-    private suspend fun externalRecipientError(): UiText? {
-        val address = externalRecipient.value ?: return null
-        val dstChain = selectedDst.value?.account?.token?.chain ?: return null
+    private suspend fun externalRecipientError(address: String?, dstChain: Chain?): UiText? {
+        if (address == null || dstChain == null) return null
         return when (chainAccountAddressRepository.validateRecipient(dstChain, address)) {
             RecipientValidity.Valid -> null
             RecipientValidity.InvalidForChain ->
@@ -658,6 +660,29 @@ constructor(
             RecipientValidity.NotAWalletAddress ->
                 UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
         }
+    }
+
+    /**
+     * The external recipient the transaction may be built with — `null` when the recipient is off —
+     * throwing [InvalidTransactionDataException] when it cannot receive the swap.
+     *
+     * The checked address is returned rather than left for the caller to re-read, and the
+     * destination is re-read and compared, because the form stays live across the round trip the
+     * verdict can cost: [setExternalRecipient] and the token pickers run on the same dispatcher
+     * this suspends on. Building from the fields afterwards could sign an address that was never
+     * checked, or one checked against a chain that is no longer the destination — and nothing
+     * re-validates the recipient when the destination moves.
+     */
+    private suspend fun validatedExternalRecipient(): String? {
+        val address = externalRecipient.value
+        val dstChain = selectedDst.value?.account?.token?.chain
+        externalRecipientError(address, dstChain)?.let { throw InvalidTransactionDataException(it) }
+        if (address != null && selectedDst.value?.account?.token?.chain != dstChain) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.swap_external_recipient_invalid)
+            )
+        }
+        return address
     }
 
     /**
@@ -700,7 +725,7 @@ constructor(
             // value must be caught here, before the transaction is built (#4858). The whole body
             // runs in the coroutine because the verdict can need a cluster round trip, and it stays
             // the first thing checked so its error is the one the user sees.
-            externalRecipientError()?.let { throw InvalidTransactionDataException(it) }
+            val recipient = validatedExternalRecipient()
 
             val inputs =
                 try {
@@ -759,7 +784,7 @@ constructor(
                     estimatedNetworkFeeTokenValue = inputs.estimatedNetworkFeeTokenValue,
                     estimatedNetworkFeeFiatValue = inputs.estimatedNetworkFeeFiatValue,
                     gasLimitOverride = gasLimitOverride.value,
-                    externalRecipient = externalRecipient.value,
+                    externalRecipient = recipient,
                     feeDisplay = feeDisplay,
                 )
 
@@ -1081,7 +1106,18 @@ constructor(
         // cluster round trip, and a slower one for an earlier keystroke would otherwise land last
         // and describe an address the user has already replaced.
         externalRecipientRoutingJob?.cancel()
-        externalRecipientRoutingJob = viewModelScope.launch { syncExternalRecipientRouting() }
+        externalRecipientRoutingJob =
+            viewModelScope.safeLaunch(
+                onError = { e ->
+                    // A verdict that never arrived is not a verdict. Keep the recipient out of the
+                    // quote pipeline rather than routing quotes to an address nothing vouched for;
+                    // the pre-flight gate asks again before anything is built.
+                    Timber.e(e)
+                    quoteRecipient.value = null
+                }
+            ) {
+                syncExternalRecipientRouting()
+            }
     }
 
     /**
@@ -1093,7 +1129,7 @@ constructor(
      */
     private suspend fun syncExternalRecipientRouting() {
         val typed = externalRecipient.value
-        val error = externalRecipientError()
+        val error = externalRecipientError(typed, selectedDst.value?.account?.token?.chain)
         quoteRecipient.value = typed?.takeIf { error == null }
         _uiState.update { it.copy(externalRecipient = typed, externalRecipientError = error) }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -21,6 +21,7 @@ import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.FeatureFlagRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.repositories.SwapTransactionRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
@@ -646,10 +647,12 @@ constructor(
     private fun externalRecipientError(): UiText? {
         val address = externalRecipient.value ?: return null
         val dstChain = selectedDst.value?.account?.token?.chain ?: return null
-        return if (chainAccountAddressRepository.isValid(dstChain, address)) {
-            null
-        } else {
-            UiText.StringResource(R.string.swap_external_recipient_invalid)
+        return when (chainAccountAddressRepository.validateRecipient(dstChain, address)) {
+            RecipientValidity.Valid -> null
+            RecipientValidity.InvalidForChain ->
+                UiText.StringResource(R.string.swap_external_recipient_invalid)
+            RecipientValidity.NotAWalletAddress ->
+                UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.models.VaultId
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.order.OrderRepository
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
@@ -265,12 +266,18 @@ constructor(
         }
     }
 
-    private fun validateAddress(chain: Chain, address: String): UiText? =
-        if (address.isBlank() || !chainAccountAddressRepository.isValid(chain, address)) {
-            UiText.FormattedText(R.string.address_bookmark_error_invalid_address, listOf(chain))
-        } else {
-            null
+    private fun validateAddress(chain: Chain, address: String): UiText? {
+        if (address.isBlank()) return invalidForChain(chain)
+        return when (chainAccountAddressRepository.validateRecipient(chain, address)) {
+            RecipientValidity.Valid -> null
+            RecipientValidity.InvalidForChain -> invalidForChain(chain)
+            RecipientValidity.NotAWalletAddress ->
+                UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
         }
+    }
+
+    private fun invalidForChain(chain: Chain): UiText =
+        UiText.FormattedText(R.string.address_bookmark_error_invalid_address, listOf(chain))
 
     fun scanAddress() {
         viewModelScope.launch {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
@@ -223,16 +223,8 @@ constructor(
             }
         }
 
-        validateAddress(chain, address)?.let {
-            state.update {
-                it.copy(
-                    addressError =
-                        UiText.FormattedText(
-                            R.string.address_bookmark_error_invalid_address,
-                            listOf(chain),
-                        )
-                )
-            }
+        validateAddress(chain, address)?.let { addressError ->
+            state.update { it.copy(addressError = addressError) }
             return
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
@@ -19,6 +19,7 @@ import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.order.OrderRepository
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.NetworkUiModel
 import com.vultisig.wallet.ui.models.evmNetworkUiModel
 import com.vultisig.wallet.ui.models.toNetworkUiModel
@@ -223,10 +224,12 @@ constructor(
             }
         }
 
-        viewModelScope.launch {
+        // safeLaunch, not launch: the verdict now goes to the cluster and the body writes to the
+        // address book, so a failure on either belongs in the log rather than in a crash.
+        viewModelScope.safeLaunch {
             validateAddress(chain, address)?.let { addressError ->
                 state.update { it.copy(addressError = addressError) }
-                return@launch
+                return@safeLaunch
             }
 
             if (

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
@@ -223,12 +223,12 @@ constructor(
             }
         }
 
-        validateAddress(chain, address)?.let { addressError ->
-            state.update { it.copy(addressError = addressError) }
-            return
-        }
-
         viewModelScope.launch {
+            validateAddress(chain, address)?.let { addressError ->
+                state.update { it.copy(addressError = addressError) }
+                return@launch
+            }
+
             if (
                 !addressBookEntryChainId.isNullOrBlank() &&
                     !addressBookEntryAddress.isNullOrBlank() &&
@@ -258,7 +258,7 @@ constructor(
         }
     }
 
-    private fun validateAddress(chain: Chain, address: String): UiText? {
+    private suspend fun validateAddress(chain: Chain, address: String): UiText? {
         if (address.isBlank()) return invalidForChain(chain)
         return when (chainAccountAddressRepository.validateRecipient(chain, address)) {
             RecipientValidity.Valid -> null

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -239,6 +239,7 @@
     <string name="verify_transaction_value">Wert</string>
     <string name="send_error_no_address">Adresse ist ungültig</string>
     <string name="send_error_invalid_recipient_address">Dieser Empfänger ist keine gültige Adresse für diese Blockchain.</string>
+    <string name="error_recipient_not_a_wallet_address">Dieser Empfänger ist ein Token-Konto oder eine Programmadresse, keine Wallet. Geben Sie die Wallet-Adresse des Inhabers ein.</string>
     <string name="send_error_memo_too_long">Memo ist zu lang: %1$d Bytes (Maximum %2$d).</string>
     <string name="vault_settings_error_backup_file">ein Fehler ist aufgetreten</string>
     <string name="vault_settings_error_backup_failed">Backup fehlgeschlagen. Es wurde keine Datei gespeichert. Bitte versuchen Sie es erneut.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -236,6 +236,7 @@
     <string name="vault_settings_error_backup_failed">La copia de seguridad falló. No se guardó ningún archivo. Inténtalo de nuevo.</string>
     <string name="send_error_no_address">La dirección no es válida</string>
     <string name="send_error_invalid_recipient_address">Ese destinatario no es una dirección válida para esta cadena.</string>
+    <string name="error_recipient_not_a_wallet_address">Ese destinatario es una cuenta de token o una dirección de programa, no una billetera. Introduce la dirección de billetera del propietario.</string>
     <string name="send_error_memo_too_long">El memo es demasiado largo: %1$d bytes (máximo %2$d).</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="camera_permission_open_settings">Abrir configuración</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -239,6 +239,7 @@
     <string name="verify_transaction_value">Vrijednost</string>
     <string name="send_error_no_address">Adresa je nevažeća</string>
     <string name="send_error_invalid_recipient_address">Taj primatelj nije valjana adresa za ovaj lanac.</string>
+    <string name="error_recipient_not_a_wallet_address">Taj primatelj je token račun ili adresa programa, a ne novčanik. Unesite adresu novčanika vlasnika.</string>
     <string name="send_error_memo_too_long">Memo je predugačak: %1$d bajtova (najviše %2$d).</string>
     <string name="vault_settings_error_backup_file">dogodila se pogreška</string>
     <string name="vault_settings_error_backup_failed">Sigurnosno kopiranje nije uspjelo. Nijedna datoteka nije spremljena. Pokušajte ponovno.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -239,6 +239,7 @@
     <string name="verify_transaction_value">Valore</string>
     <string name="send_error_no_address">L\'indirizzo non è valido</string>
     <string name="send_error_invalid_recipient_address">Quel destinatario non è un indirizzo valido per questa catena.</string>
+    <string name="error_recipient_not_a_wallet_address">Questo destinatario è un account token o un indirizzo di programma, non un portafoglio. Inserisci l\'indirizzo del portafoglio del proprietario.</string>
     <string name="send_error_memo_too_long">Il memo è troppo lungo: %1$d byte (massimo %2$d).</string>
     <string name="vault_settings_error_backup_file">si è verificato un errore</string>
     <string name="vault_settings_error_backup_failed">Backup non riuscito. Nessun file è stato salvato. Riprova.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -206,6 +206,7 @@
     <string name="send_error_no_gas_fee">가스 수수료 없음</string>
     <string name="send_error_no_address">주소가 유효하지 않습니다</string>
     <string name="send_error_invalid_recipient_address">해당 수신자는 이 체인에 유효한 주소가 아닙니다.</string>
+    <string name="error_recipient_not_a_wallet_address">해당 수신자는 지갑이 아니라 토큰 계정 또는 프로그램 주소입니다. 소유자의 지갑 주소를 입력하세요.</string>
     <string name="send_error_memo_too_long">메모가 너무 깁니다: %1$d바이트 (최대 %2$d바이트).</string>
     <string name="send_error_no_amount">금액은 양수여야 합니다</string>
     <string name="send_error_too_many_decimals">금액은 소수점 이하 최대 %1$d자리까지 입력할 수 있습니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -104,6 +104,7 @@
     <string name="send_error_no_gas_fee">Geen gasvergoeding</string>
     <string name="send_error_no_address">Adres is ongeldig</string>
     <string name="send_error_invalid_recipient_address">Die ontvanger is geen geldig adres voor deze keten.</string>
+    <string name="error_recipient_not_a_wallet_address">Die ontvanger is een tokenaccount of programma-adres, geen wallet. Voer het walletadres van de eigenaar in.</string>
     <string name="send_error_memo_too_long">Memo is te lang: %1$d bytes (maximaal %2$d).</string>
     <string name="send_error_no_amount">Het bedrag moet een positief getal zijn</string>
     <string name="send_error_too_many_decimals">Het bedrag mag maximaal %1$d decimalen hebben</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -239,6 +239,7 @@
     <string name="verify_transaction_value">Valor</string>
     <string name="send_error_no_address">Endereço inválido</string>
     <string name="send_error_invalid_recipient_address">Esse destinatário não é um endereço válido para esta cadeia.</string>
+    <string name="error_recipient_not_a_wallet_address">Esse destinatário é uma conta de token ou endereço de programa, não uma carteira. Insira o endereço da carteira do proprietário.</string>
     <string name="send_error_memo_too_long">O memorando é muito longo: %1$d bytes (máximo %2$d).</string>
     <string name="vault_settings_error_backup_file">um erro ocorreu</string>
     <string name="vault_settings_error_backup_failed">O backup falhou. Nenhum ficheiro foi guardado. Tente novamente.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -104,6 +104,7 @@
     <string name="send_error_no_gas_fee">Нет платы за газ</string>
     <string name="send_error_no_address">Адрес недействителен</string>
     <string name="send_error_invalid_recipient_address">Этот получатель не является действительным адресом для этой сети.</string>
+    <string name="error_recipient_not_a_wallet_address">Этот получатель — токен-аккаунт или адрес программы, а не кошелёк. Введите адрес кошелька владельца.</string>
     <string name="send_error_memo_too_long">Мемо слишком длинное: %1$d байт (максимум %2$d).</string>
     <string name="send_error_no_amount">Сумма должна быть положительным числом</string>
     <string name="send_error_too_many_decimals">Сумма может содержать не более %1$d знаков после запятой</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -226,6 +226,7 @@
     <string name="send_error_no_gas_fee">无燃料费</string>
     <string name="send_error_no_address">地址无效</string>
     <string name="send_error_invalid_recipient_address">该收款人不是此链的有效地址。</string>
+    <string name="error_recipient_not_a_wallet_address">该收款方是代币账户或程序地址，而非钱包。请输入所有者的钱包地址。</string>
     <string name="send_error_memo_too_long">备注过长：%1$d 个字节（最多 %2$d 个）。</string>
     <string name="send_error_no_amount">金额必须是正数</string>
     <string name="send_error_too_many_decimals">金额最多可保留 %1$d 位小数</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -210,6 +210,7 @@
     <string name="send_error_no_gas_fee">No gas fees</string>
     <string name="send_error_no_address">Address is invalid</string>
     <string name="send_error_invalid_recipient_address">That recipient is not a valid address for this chain.</string>
+    <string name="error_recipient_not_a_wallet_address">That recipient is a token account or program address, not a wallet. Enter the owner\'s wallet address.</string>
     <string name="send_error_memo_too_long">Memo is too long: %1$d bytes (maximum %2$d).</string>
     <string name="send_error_no_amount">Amount must be a positive number</string>
     <string name="send_error_too_many_decimals">Amount can have at most %1$d decimal places</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.repositories.AddressParserRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.usecases.RequestAddressBookEntryUseCase
 import io.kotest.assertions.withClue
 import io.kotest.matchers.booleans.shouldBeFalse
@@ -56,6 +57,17 @@ internal class AddressManagerTest {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
+        // The manager validates through validateRecipient, which only parts ways with isValid for
+        // an off-curve Solana recipient; the cases below are all EVM and XRP, so deriving one from
+        // the other here keeps each test's own isValid stub as the thing that decides the outcome.
+        every { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
+            {
+                if (chainAccountAddressRepository.isValid(firstArg(), secondArg())) {
+                    RecipientValidity.Valid
+                } else {
+                    RecipientValidity.InvalidForChain
+                }
+            }
     }
 
     @AfterEach
@@ -276,7 +288,7 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            manager.invalidAddress.value.shouldBeTrue()
+            manager.addressError.value shouldBe RecipientValidity.InvalidForChain
             manager.resolvedDstAddress.value.shouldBeNull()
         }
 
@@ -307,9 +319,65 @@ internal class AddressManagerTest {
                 advanceUntilIdle()
 
                 withClue("${coin.chain} should flag $badInput as invalid") {
-                    manager.invalidAddress.value.shouldBeTrue()
+                    manager.addressError.value shouldBe RecipientValidity.InvalidForChain
                 }
             }
+        }
+
+    @Test
+    fun `a solana token account is rejected as a recipient and never sent to the resolver`() =
+        runTest(mainDispatcher) {
+            // An associated token account is a well-formed Solana address, so the resolver has no
+            // name to find; an SPL send to it would create an ATA-of-an-ATA nobody controls.
+            val tokenAccount = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
+            every {
+                chainAccountAddressRepository.validateRecipient(Chain.Solana, tokenAccount)
+            } returns RecipientValidity.NotAWalletAddress
+
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = token(Chain.Solana, "SOL")
+
+            val emissions = collectValidations(manager)
+
+            addressFieldState.setTextAndPlaceCursorAtEnd(tokenAccount)
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            manager.addressError.value shouldBe RecipientValidity.NotAWalletAddress
+            manager.resolvedDstAddress.value.shouldBeNull()
+            emissions.shouldBeEmpty()
+            coVerify(exactly = 0) { addressParserRepository.resolveName(tokenAccount, any()) }
+        }
+
+    @Test
+    fun `a solana wallet address that follows a rejected token account clears the error`() =
+        runTest(mainDispatcher) {
+            val tokenAccount = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
+            val wallet = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+            every {
+                chainAccountAddressRepository.validateRecipient(Chain.Solana, tokenAccount)
+            } returns RecipientValidity.NotAWalletAddress
+            every { chainAccountAddressRepository.isValid(Chain.Solana, wallet) } returns true
+
+            val manager = build(backgroundScope)
+            manager.start()
+            selectedToken.value = token(Chain.Solana, "SOL")
+
+            addressFieldState.setTextAndPlaceCursorAtEnd(tokenAccount)
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+            manager.addressError.value shouldBe RecipientValidity.NotAWalletAddress
+
+            addressFieldState.setTextAndPlaceCursorAtEnd(wallet)
+            Snapshot.sendApplyNotifications()
+            advanceTimeBy(400)
+            advanceUntilIdle()
+
+            manager.addressError.value.shouldBeNull()
+            manager.resolvedDstAddress.value shouldBe wallet
         }
 
     @Test
@@ -328,14 +396,14 @@ internal class AddressManagerTest {
             Snapshot.sendApplyNotifications()
             advanceTimeBy(400)
             advanceUntilIdle()
-            manager.invalidAddress.value.shouldBeTrue()
+            manager.addressError.value shouldBe RecipientValidity.InvalidForChain
 
             addressFieldState.setTextAndPlaceCursorAtEnd("0xabc")
             Snapshot.sendApplyNotifications()
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            manager.invalidAddress.value.shouldBeFalse()
+            manager.addressError.value.shouldBeNull()
             manager.resolvedDstAddress.value shouldBe "0xabc"
         }
 
@@ -354,14 +422,14 @@ internal class AddressManagerTest {
             Snapshot.sendApplyNotifications()
             advanceTimeBy(400)
             advanceUntilIdle()
-            manager.invalidAddress.value.shouldBeTrue()
+            manager.addressError.value shouldBe RecipientValidity.InvalidForChain
 
             addressFieldState.setTextAndPlaceCursorAtEnd("")
             Snapshot.sendApplyNotifications()
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            manager.invalidAddress.value.shouldBeFalse()
+            manager.addressError.value.shouldBeNull()
         }
 
     @Test
@@ -381,7 +449,7 @@ internal class AddressManagerTest {
             advanceTimeBy(400)
             advanceUntilIdle()
 
-            manager.invalidAddress.value.shouldBeTrue()
+            manager.addressError.value shouldBe RecipientValidity.InvalidForChain
         }
 
     private fun TestScope.collectValidations(manager: AddressManager): MutableList<Unit> {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/AddressManagerTest.kt
@@ -60,7 +60,7 @@ internal class AddressManagerTest {
         // The manager validates through validateRecipient, which only parts ways with isValid for
         // an off-curve Solana recipient; the cases below are all EVM and XRP, so deriving one from
         // the other here keeps each test's own isValid stub as the thing that decides the outcome.
-        every { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
+        coEvery { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
             {
                 if (chainAccountAddressRepository.isValid(firstArg(), secondArg())) {
                     RecipientValidity.Valid
@@ -330,7 +330,7 @@ internal class AddressManagerTest {
             // An associated token account is a well-formed Solana address, so the resolver has no
             // name to find; an SPL send to it would create an ATA-of-an-ATA nobody controls.
             val tokenAccount = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
-            every {
+            coEvery {
                 chainAccountAddressRepository.validateRecipient(Chain.Solana, tokenAccount)
             } returns RecipientValidity.NotAWalletAddress
 
@@ -356,7 +356,7 @@ internal class AddressManagerTest {
         runTest(mainDispatcher) {
             val tokenAccount = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
             val wallet = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
-            every {
+            coEvery {
                 chainAccountAddressRepository.validateRecipient(Chain.Solana, tokenAccount)
             } returns RecipientValidity.NotAWalletAddress
             every { chainAccountAddressRepository.isValid(Chain.Solana, wallet) } returns true

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.repositories.TransactionRepository
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.data.usecases.GetAvailableTokenBalanceUseCase
@@ -104,6 +105,8 @@ internal class DefaultSendStrategyTest {
     fun setUp() {
         Dispatchers.setMain(mainDispatcher)
         every { addressManager.dstAddressLabel } returns dstAddressLabelFlow
+        coEvery { chainAccountAddressRepository.validateRecipient(any(), any()) } returns
+            RecipientValidity.Valid
     }
 
     @AfterEach
@@ -1929,6 +1932,98 @@ internal class DefaultSendStrategyTest {
         return captured
     }
 
+    /**
+     * The submit path re-resolves the destination from the raw address field instead of reading
+     * what the form resolved, and the form's own check is debounced, so a submit landing inside
+     * that window would otherwise build a transaction for a recipient the form rejects. On Solana
+     * that recipient is unrecoverable: an SPL transfer to a token account derives an associated
+     * token account of a token account.
+     */
+    @Test
+    fun `submit rejects a solana token account the form's debounced check would have missed`() =
+        runTest {
+            val solCoin = solCoin()
+            val account =
+                Account(
+                    token = solCoin,
+                    tokenValue = TokenValue(BigInteger.valueOf(1_000_000_000L), solCoin),
+                    fiatValue = null,
+                    price = null,
+                )
+            vaultId = "vault-1"
+            selectedAccount = account
+            addressFieldState.setTextAndPlaceCursorAtEnd(SOL_TOKEN_ACCOUNT)
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+            coEvery { accountValidator.validate() } returns
+                ValidatedAccount(
+                    vaultId = "vault-1",
+                    selectedAccount = account,
+                    chain = Chain.Solana,
+                    gasFee = TokenValue(BigInteger.valueOf(5_000), solCoin),
+                    dstAddress = SOL_TOKEN_ACCOUNT,
+                )
+            // Well-formed for the chain: only the recipient rule separates it from a wallet.
+            coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            coEvery {
+                chainAccountAddressRepository.validateRecipient(Chain.Solana, SOL_TOKEN_ACCOUNT)
+            } returns RecipientValidity.NotAWalletAddress
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertEquals(
+                R.string.error_recipient_not_a_wallet_address,
+                (lastError as UiText.StringResource).resId,
+            )
+            coVerify(exactly = 0) { transactionRepository.addTransaction(any()) }
+        }
+
+    @Test
+    fun `submit still reports a malformed recipient as an invalid address`() = runTest {
+        val solCoin = solCoin()
+        val account =
+            Account(
+                token = solCoin,
+                tokenValue = TokenValue(BigInteger.valueOf(1_000_000_000L), solCoin),
+                fiatValue = null,
+                price = null,
+            )
+        vaultId = "vault-1"
+        selectedAccount = account
+        addressFieldState.setTextAndPlaceCursorAtEnd("garbage")
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("0.5")
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount = account,
+                chain = Chain.Solana,
+                gasFee = TokenValue(BigInteger.valueOf(5_000), solCoin),
+                dstAddress = "garbage",
+            )
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns false
+        coEvery { chainAccountAddressRepository.validateRecipient(Chain.Solana, "garbage") } returns
+            RecipientValidity.InvalidForChain
+
+        build(this).submit()
+        advanceUntilIdle()
+
+        assertEquals(R.string.send_error_no_address, (lastError as UiText.StringResource).resId)
+        coVerify(exactly = 0) { transactionRepository.addTransaction(any()) }
+    }
+
+    private fun solCoin(): Coin =
+        Coin(
+            chain = Chain.Solana,
+            ticker = "SOL",
+            logo = "",
+            address = "SelfSolanaWallet",
+            decimal = 9,
+            hexPublicKey = "",
+            priceProviderID = "solana",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
     private fun btcCoin(): Coin =
         Coin(
             chain = Chain.Bitcoin,
@@ -1980,6 +2075,11 @@ internal class DefaultSendStrategyTest {
             contractAddress = "",
             isNativeToken = true,
         )
+
+    private companion object {
+        /** A wrapped-SOL associated token account: well-formed, off the curve, unspendable. */
+        const val SOL_TOKEN_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
+    }
 
     private fun build(
         scope: CoroutineScope,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -3699,9 +3699,17 @@ internal class SwapFormViewModelTest {
     fun `a solana token account as external recipient gets its own error`() =
         runTest(mainDispatcher) {
             val tokenAccount = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
-            coEvery { chainAccountAddressRepository.validateRecipient(any(), tokenAccount) } returns
-                RecipientValidity.NotAWalletAddress
-            val vm = createViewModelWithSwapTokens()
+            coEvery {
+                chainAccountAddressRepository.validateRecipient(Chain.Solana, tokenAccount)
+            } returns RecipientValidity.NotAWalletAddress
+            // The destination has to actually be Solana, or the verdict this asserts would be one
+            // the repository never reaches for.
+            val vm =
+                createViewModelWithAddresses(
+                    addresses = listOf(ethAddress(), solanaAddress()),
+                    srcTokenId = ETH_COIN.id,
+                    dstTokenId = SOL_COIN.id,
+                )
             advanceUntilIdle()
 
             vm.setExternalRecipient(tokenAccount)
@@ -3713,6 +3721,7 @@ internal class SwapFormViewModelTest {
                 UiText.StringResource(R.string.error_recipient_not_a_wallet_address),
                 vm.uiState.value.externalRecipientError,
             )
+            coVerify { chainAccountAddressRepository.validateRecipient(Chain.Solana, tokenAccount) }
         }
 
     @Test
@@ -3774,6 +3783,41 @@ internal class SwapFormViewModelTest {
             )
             // The pre-flight gate returns before staging keysign, so no navigation to verify.
             coVerify(exactly = 0) { navigator.route(any()) }
+        }
+
+    @Test
+    fun `swap is refused when the destination moves while the recipient is being validated`() =
+        runTest(mainDispatcher) {
+            // The verdict can wait on the cluster, and nothing re-validates the recipient when the
+            // destination changes, so a swap judged against Bitcoin must not go on to build for an
+            // Ethereum destination the address was never judged for.
+            val recipient = "bc1qvalidrecipient"
+            val verdict = CompletableDeferred<Unit>()
+            coEvery {
+                chainAccountAddressRepository.validateRecipient(Chain.Bitcoin, recipient)
+            } coAnswers
+                {
+                    verdict.await()
+                    RecipientValidity.Valid
+                }
+
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+            vm.setExternalRecipient(recipient)
+
+            vm.swap()
+            // The form stays live while the cluster is asked: flipping the pair makes Ethereum the
+            // destination, and the outstanding verdict is about Bitcoin.
+            vm.flipSelectedTokens()
+            advanceUntilIdle()
+            verdict.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(
+                UiText.StringResource(R.string.swap_external_recipient_invalid),
+                vm.uiState.value.error,
+            )
+            coVerify(exactly = 0) { swapTransactionRepository.addTransaction(any()) }
         }
 
     @Test
@@ -4371,6 +4415,13 @@ internal class SwapFormViewModelTest {
             chain = Chain.Bitcoin,
             address = "bc1qbtcaddress",
             accounts = listOf(createAccount(BTC_COIN, BigInteger("100000000"))),
+        )
+
+    private fun solanaAddress(): Address =
+        Address(
+            chain = Chain.Solana,
+            address = "soladdress",
+            accounts = listOf(createAccount(SOL_COIN, BigInteger("1000000000"))),
         )
 
     private fun btcAddressLargeBalance(): Address =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -176,7 +176,7 @@ internal class SwapFormViewModelTest {
         // The form validates through validateRecipient, which only parts ways with isValid for an
         // off-curve Solana recipient; deriving one from the other keeps each test's own isValid
         // stub as the thing that decides the outcome.
-        every { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
+        coEvery { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
             {
                 if (chainAccountAddressRepository.isValid(firstArg(), secondArg())) {
                     RecipientValidity.Valid
@@ -3699,7 +3699,7 @@ internal class SwapFormViewModelTest {
     fun `a solana token account as external recipient gets its own error`() =
         runTest(mainDispatcher) {
             val tokenAccount = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
-            every { chainAccountAddressRepository.validateRecipient(any(), tokenAccount) } returns
+            coEvery { chainAccountAddressRepository.validateRecipient(any(), tokenAccount) } returns
                 RecipientValidity.NotAWalletAddress
             val vm = createViewModelWithSwapTokens()
             advanceUntilIdle()

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -28,6 +28,7 @@ import com.vultisig.wallet.data.repositories.AllowanceRepository
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.FeatureFlagRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
@@ -172,6 +173,17 @@ internal class SwapFormViewModelTest {
         // are unaffected. The external-recipient validation tests override this per case.
         chainAccountAddressRepository = mockk(relaxed = true)
         every { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        // The form validates through validateRecipient, which only parts ways with isValid for an
+        // off-curve Solana recipient; deriving one from the other keeps each test's own isValid
+        // stub as the thing that decides the outcome.
+        every { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
+            {
+                if (chainAccountAddressRepository.isValid(firstArg(), secondArg())) {
+                    RecipientValidity.Valid
+                } else {
+                    RecipientValidity.InvalidForChain
+                }
+            }
 
         // Limit-order collaborators. The flag is off by default, so the limit form stays inert for
         // every test that doesn't opt into it.
@@ -3681,6 +3693,26 @@ internal class SwapFormViewModelTest {
             io.mockk.verify {
                 chainAccountAddressRepository.isValid(Chain.Bitcoin, "not-a-valid-address")
             }
+        }
+
+    @Test
+    fun `a solana token account as external recipient gets its own error`() =
+        runTest(mainDispatcher) {
+            val tokenAccount = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
+            every { chainAccountAddressRepository.validateRecipient(any(), tokenAccount) } returns
+                RecipientValidity.NotAWalletAddress
+            val vm = createViewModelWithSwapTokens()
+            advanceUntilIdle()
+
+            vm.setExternalRecipient(tokenAccount)
+
+            // Not the generic "invalid recipient": the address is well-formed, it just isn't a
+            // wallet, and telling the user which one it is is the difference between retyping the
+            // same account and going to find the owner's address.
+            assertEquals(
+                UiText.StringResource(R.string.error_recipient_not_a_wallet_address),
+                vm.uiState.value.externalRecipientError,
+            )
         }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModelTest.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.models.AddressBookEntry
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.RecipientValidity
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.order.OrderRepository
 import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
@@ -61,6 +62,17 @@ internal class AddressEntryViewModelTest {
         requestQrScan = mockk(relaxed = true)
         addressBookRepository = mockk(relaxed = true)
         chainAccountAddressRepository = mockk(relaxed = true)
+        // The screen validates through validateRecipient, which only parts ways with isValid for
+        // an off-curve Solana recipient; deriving one from the other keeps each test's own isValid
+        // stub as the thing that decides the outcome.
+        every { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
+            {
+                if (chainAccountAddressRepository.isValid(firstArg(), secondArg())) {
+                    RecipientValidity.Valid
+                } else {
+                    RecipientValidity.InvalidForChain
+                }
+            }
         orderRepository = mockk(relaxed = true)
         requestResultRepository = mockk(relaxed = true)
     }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModelTest.kt
@@ -67,7 +67,7 @@ internal class AddressEntryViewModelTest {
         // The screen validates through validateRecipient, which only parts ways with isValid for
         // an off-curve Solana recipient; deriving one from the other keeps each test's own isValid
         // stub as the thing that decides the outcome.
-        every { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
+        coEvery { chainAccountAddressRepository.validateRecipient(any(), any()) } answers
             {
                 if (chainAccountAddressRepository.isValid(firstArg(), secondArg())) {
                     RecipientValidity.Valid
@@ -138,9 +138,16 @@ internal class AddressEntryViewModelTest {
     @Test
     fun `saveAddress with a token account keeps the non-wallet error`() =
         runTest(testDispatcher) {
+            every { any<SavedStateHandle>().toRoute<Route.AddressEntry>() } returns
+                Route.AddressEntry(
+                    chainId = "Solana",
+                    address = SOL_TOKEN_ACCOUNT,
+                    vaultId = VAULT_ID,
+                )
             every { chainAccountAddressRepository.isValid(any(), any()) } returns true
-            every { chainAccountAddressRepository.validateRecipient(any(), any()) } returns
-                RecipientValidity.NotAWalletAddress
+            coEvery {
+                chainAccountAddressRepository.validateRecipient(Chain.Solana, SOL_TOKEN_ACCOUNT)
+            } returns RecipientValidity.NotAWalletAddress
             val vm = createViewModel()
             vm.titleTextFieldState.edit { replace(0, length, "Alice") }
             vm.addressTextFieldState.edit { replace(0, length, SOL_TOKEN_ACCOUNT) }
@@ -150,6 +157,9 @@ internal class AddressEntryViewModelTest {
 
             vm.state.value.addressError shouldBe
                 UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
+            coVerify {
+                chainAccountAddressRepository.validateRecipient(Chain.Solana, SOL_TOKEN_ACCOUNT)
+            }
             coVerify(exactly = 0) { addressBookRepository.add(any()) }
         }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModelTest.kt
@@ -4,6 +4,7 @@ package com.vultisig.wallet.ui.models.transaction
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.db.models.AddressBookOrderEntity
 import com.vultisig.wallet.data.models.AddressBookEntry
 import com.vultisig.wallet.data.models.Chain
@@ -16,6 +17,7 @@ import com.vultisig.wallet.data.usecases.RequestQrScanUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.UiText
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -127,6 +129,28 @@ internal class AddressEntryViewModelTest {
             every { chainAccountAddressRepository.isValid(any(), any()) } returns false
             vm.saveAddress()
             vm.state.value.addressError.shouldNotBeNull()
+        }
+
+    /**
+     * Verifies saveAddress keeps the specific non-wallet message for an off-curve Solana recipient
+     * rather than replacing it with the generic invalid-for-chain text.
+     */
+    @Test
+    fun `saveAddress with a token account keeps the non-wallet error`() =
+        runTest(testDispatcher) {
+            every { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            every { chainAccountAddressRepository.validateRecipient(any(), any()) } returns
+                RecipientValidity.NotAWalletAddress
+            val vm = createViewModel()
+            vm.titleTextFieldState.edit { replace(0, length, "Alice") }
+            vm.addressTextFieldState.edit { replace(0, length, SOL_TOKEN_ACCOUNT) }
+
+            vm.saveAddress()
+            advanceUntilIdle()
+
+            vm.state.value.addressError shouldBe
+                UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
+            coVerify(exactly = 0) { addressBookRepository.add(any()) }
         }
 
     /** Verifies setOutputAddress sets the address field text. */
@@ -321,6 +345,7 @@ internal class AddressEntryViewModelTest {
         const val VAULT_ID = "vault-1"
         const val ETH_ADDRESS = "0x1234567890123456789012345678901234567890"
         const val SOL_ADDRESS = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+        const val SOL_TOKEN_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
 
         // Length that exceeds the private LABEL_MAX_LENGTH constant in AddressEntryViewModel.
         // If the production constant changes, update this and the matching test name.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -119,6 +119,13 @@ interface SolanaApi {
      */
     suspend fun getAccountOwner(account: String): String?
 
+    /**
+     * Same lookup as [getAccountOwner], keeping "the cluster says there is no such account" apart
+     * from "the cluster did not answer". Callers that would act on the absence of an owner need
+     * that distinction: a missing account is a fact, a failed lookup is not.
+     */
+    suspend fun getAccountOwnership(account: String): SolanaAccountOwnership
+
     suspend fun checkStatus(txHash: String): SolanaRpcResponseJson<SolanaSignatureStatusesResult>?
 
     /**
@@ -141,6 +148,19 @@ interface SolanaApi {
      * or an empty list on RPC failure. Never stale-cached — always a fresh read.
      */
     suspend fun getStakeAccounts(ownerAddress: String): List<SolanaProgramAccountJson>
+}
+
+/** What `getAccountInfo` reports about the program that owns an account. */
+sealed interface SolanaAccountOwnership {
+
+    /** The account exists on-chain and [programId] owns it. */
+    data class Owned(val programId: String) : SolanaAccountOwnership
+
+    /** The cluster answered and there is no account at that address. */
+    data object Missing : SolanaAccountOwnership
+
+    /** The lookup failed, so the cluster's answer is unknown — not "no". */
+    data object Unavailable : SolanaAccountOwnership
 }
 
 internal class SolanaApiImp(
@@ -538,6 +558,9 @@ internal class SolanaApiImp(
     }
 
     override suspend fun getAccountOwner(account: String): String? =
+        (getAccountOwnership(account) as? SolanaAccountOwnership.Owned)?.programId
+
+    override suspend fun getAccountOwnership(account: String): SolanaAccountOwnership =
         try {
             val response =
                 httpClient.postRpc<SolanaAccountInfoResponseJson>(
@@ -550,19 +573,27 @@ internal class SolanaApiImp(
                         },
                 )
             // postRpc returns a 200 carrying a JSON-RPC `error` body without throwing, so a
-            // transient
-            // RPC failure would otherwise resolve to a null owner indistinguishable from a
-            // genuinely
-            // missing account — and silently drop the now-preferred Jupiter route. Log it so the
-            // failure is observable rather than masquerading as "mint not found".
+            // transient RPC failure would otherwise resolve to a null owner indistinguishable from
+            // a genuinely missing account — and silently drop the now-preferred Jupiter route. Log
+            // it so the failure is observable rather than masquerading as "mint not found".
             response.error?.let {
-                Timber.tag("SolanaApiImp").w("getAccountOwner RPC error for %s: %s", account, it)
+                Timber.tag("SolanaApiImp")
+                    .w("getAccountOwnership RPC error for %s: %s", account, it)
             }
-            response.result?.value?.owner
+            when {
+                response.error != null || response.result == null ->
+                    SolanaAccountOwnership.Unavailable
+                // `value` is null exactly when the cluster looked and found nothing. An owner
+                // missing from a present value is a malformed answer, not an absent account.
+                response.result?.value == null -> SolanaAccountOwnership.Missing
+                else ->
+                    response.result?.value?.owner?.let(SolanaAccountOwnership::Owned)
+                        ?: SolanaAccountOwnership.Unavailable
+            }
         } catch (e: Exception) {
             if (e is CancellationException) throw e
-            Timber.tag("SolanaApiImp").e(e, "getAccountOwner failed for %s", account)
-            null
+            Timber.tag("SolanaApiImp").e(e, "getAccountOwnership failed for %s", account)
+            SolanaAccountOwnership.Unavailable
         }
 
     override suspend fun getFeeForMessage(message: String): BigInteger {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SolanaProgramDerivedAddress.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/SolanaProgramDerivedAddress.kt
@@ -57,6 +57,21 @@ internal object SolanaProgramDerivedAddress {
         return null
     }
 
+    /**
+     * Whether [address] is a Solana address whose private half someone can hold — a 32-byte ed25519
+     * point.
+     *
+     * Every address the runtime derives for a program (a PDA, and so every associated token
+     * account) is by construction *not* on the curve: that is what lets the owning program sign for
+     * it, and it is exactly why no user can. Base58 length is all WalletCore checks, so an address
+     * that fails here is still a well-formed Solana address — it just isn't a wallet.
+     */
+    fun isWalletAddress(address: String): Boolean {
+        val decoded =
+            Base58Codec.decode(address)?.takeIf { it.size == PUBLIC_KEY_LENGTH } ?: return false
+        return isOnCurve(decoded)
+    }
+
     /** `BigInteger.TWO` is API 33 and this module ships to minSdk 26. */
     private val TWO = BigInteger.valueOf(2)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepository.kt
@@ -7,6 +7,7 @@ import com.vultisig.wallet.data.chains.helpers.MayaChainHelper
 import com.vultisig.wallet.data.chains.helpers.PublicKeyHelper
 import com.vultisig.wallet.data.crypto.CardanoUtils
 import com.vultisig.wallet.data.crypto.QbtcHelper
+import com.vultisig.wallet.data.crypto.SolanaProgramDerivedAddress
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.ChainPublicKey
 import com.vultisig.wallet.data.models.Coin
@@ -30,6 +31,29 @@ interface ChainAccountAddressRepository {
     suspend fun getAddress(coin: Coin, vault: Vault): Pair<String, String>
 
     fun isValid(chain: Chain, address: String): Boolean
+
+    /**
+     * Whether [address] can be handed funds on [chain], and why not when it can't.
+     *
+     * Stricter than [isValid] on purpose, and separate from it on purpose: [isValid] also screens
+     * contract and mint addresses, which are routinely program-derived, so the recipient rule
+     * cannot live there without rejecting them.
+     */
+    fun validateRecipient(chain: Chain, address: String): RecipientValidity
+}
+
+/** The verdict [ChainAccountAddressRepository.validateRecipient] returns. */
+enum class RecipientValidity {
+    Valid,
+
+    /** Not an address on this chain at all. */
+    InvalidForChain,
+
+    /**
+     * A well-formed address that no user holds a key to — on Solana, an off-curve address: a token
+     * account or a program address. Sending to one strands the funds.
+     */
+    NotAWalletAddress,
 }
 
 private const val EDDSA_PUB_KEY_HEX_LENGTH = 64
@@ -138,6 +162,14 @@ internal class ChainAccountAddressRepositoryImpl @Inject constructor() :
             Chain.Bittensor -> AnyAddress.isValidSS58(address, CoinType.POLKADOT, 42)
 
             else -> chain.coinType.validate(address)
+        }
+
+    override fun validateRecipient(chain: Chain, address: String): RecipientValidity =
+        when {
+            !isValid(chain, address) -> RecipientValidity.InvalidForChain
+            chain == Chain.Solana && !SolanaProgramDerivedAddress.isWalletAddress(address) ->
+                RecipientValidity.NotAWalletAddress
+            else -> RecipientValidity.Valid
         }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepository.kt
@@ -2,6 +2,8 @@
 
 package com.vultisig.wallet.data.repositories
 
+import com.vultisig.wallet.data.api.SolanaAccountOwnership
+import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.chains.helpers.BittensorHelper
 import com.vultisig.wallet.data.chains.helpers.MayaChainHelper
 import com.vultisig.wallet.data.chains.helpers.PublicKeyHelper
@@ -38,8 +40,11 @@ interface ChainAccountAddressRepository {
      * Stricter than [isValid] on purpose, and separate from it on purpose: [isValid] also screens
      * contract and mint addresses, which are routinely program-derived, so the recipient rule
      * cannot live there without rejecting them.
+     *
+     * Suspends because an off-curve Solana address is only rejected once the cluster says it is a
+     * token account; see [RecipientValidity.NotAWalletAddress].
      */
-    fun validateRecipient(chain: Chain, address: String): RecipientValidity
+    suspend fun validateRecipient(chain: Chain, address: String): RecipientValidity
 }
 
 /** The verdict [ChainAccountAddressRepository.validateRecipient] returns. */
@@ -50,13 +55,27 @@ enum class RecipientValidity {
     InvalidForChain,
 
     /**
-     * A well-formed address that no user holds a key to — on Solana, an off-curve address: a token
-     * account or a program address. Sending to one strands the funds.
+     * A well-formed address that cannot receive funds: on Solana, a token account. Sending to one
+     * makes an SPL transfer derive an associated token account *of* a token account, which nobody
+     * can spend from.
+     *
+     * Off-curve alone does not earn this verdict. Every program-derived address is off-curve, and
+     * plenty of them are real destinations — a Squads vault or a DAO treasury holds SPL through
+     * `ATA(pda, mint)` and spends it with `invoke_signed`. Only an address the cluster reports as
+     * owned by a token program is refused; an off-curve address the cluster cannot be reached about
+     * is refused too, since an unanswered lookup is not an answer.
      */
     NotAWalletAddress,
 }
 
 private const val EDDSA_PUB_KEY_HEX_LENGTH = 64
+
+/** The programs that own token accounts: classic SPL Token and Token-2022. */
+private val SOLANA_TOKEN_PROGRAM_IDS =
+    setOf(
+        "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+        "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    )
 
 private val HEX_CHARS = Regex("^[0-9a-fA-F]+$")
 
@@ -76,8 +95,9 @@ internal fun validateEddsaPubKey(chain: Chain, eddsaPubKey: String) {
     }
 }
 
-internal class ChainAccountAddressRepositoryImpl @Inject constructor() :
-    ChainAccountAddressRepository {
+internal class ChainAccountAddressRepositoryImpl
+@Inject
+constructor(private val solanaApi: SolanaApi) : ChainAccountAddressRepository {
 
     override suspend fun getAddress(chain: Chain, vault: Vault): Pair<String, String> {
         // For KeyImport vaults, chain-specific public keys are already derived.
@@ -164,12 +184,36 @@ internal class ChainAccountAddressRepositoryImpl @Inject constructor() :
             else -> chain.coinType.validate(address)
         }
 
-    override fun validateRecipient(chain: Chain, address: String): RecipientValidity =
+    override suspend fun validateRecipient(chain: Chain, address: String): RecipientValidity =
         when {
             !isValid(chain, address) -> RecipientValidity.InvalidForChain
-            chain == Chain.Solana && !SolanaProgramDerivedAddress.isWalletAddress(address) ->
-                RecipientValidity.NotAWalletAddress
-            else -> RecipientValidity.Valid
+            chain != Chain.Solana -> RecipientValidity.Valid
+            SolanaProgramDerivedAddress.isWalletAddress(address) -> RecipientValidity.Valid
+            else -> solanaOffCurveVerdict(address)
+        }
+
+    /**
+     * The verdict for a well-formed Solana address that is off the ed25519 curve, which the owning
+     * program alone can sign for. That covers both the account this guard exists for — a token
+     * account, which strands an SPL transfer — and destinations that are perfectly spendable, so
+     * the cluster decides which one this is.
+     *
+     * A lookup that fails is refused rather than waved through: on the send path the same cluster
+     * supplies the blockhash and the fee, so a transaction cannot be built while it is unreachable
+     * anyway, and the address book can be retried.
+     */
+    private suspend fun solanaOffCurveVerdict(address: String): RecipientValidity =
+        when (val ownership = solanaApi.getAccountOwnership(address)) {
+            is SolanaAccountOwnership.Owned ->
+                if (ownership.programId in SOLANA_TOKEN_PROGRAM_IDS) {
+                    RecipientValidity.NotAWalletAddress
+                } else {
+                    RecipientValidity.Valid
+                }
+            // No account at that address, so it is not a token account. A program vault that only
+            // ever holds SPL never needs its own account on-chain: the tokens live in ATAs it owns.
+            SolanaAccountOwnership.Missing -> RecipientValidity.Valid
+            SolanaAccountOwnership.Unavailable -> RecipientValidity.NotAWalletAddress
         }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepository.kt
@@ -41,8 +41,8 @@ interface ChainAccountAddressRepository {
      * contract and mint addresses, which are routinely program-derived, so the recipient rule
      * cannot live there without rejecting them.
      *
-     * Suspends because an off-curve Solana address is only rejected once the cluster says it is a
-     * token account; see [RecipientValidity.NotAWalletAddress].
+     * Suspends because a Solana address is only judged once the cluster says which program owns the
+     * account at it; see [RecipientValidity.NotAWalletAddress].
      */
     suspend fun validateRecipient(chain: Chain, address: String): RecipientValidity
 }
@@ -59,11 +59,10 @@ enum class RecipientValidity {
      * makes an SPL transfer derive an associated token account *of* a token account, which nobody
      * can spend from.
      *
-     * Off-curve alone does not earn this verdict. Every program-derived address is off-curve, and
-     * plenty of them are real destinations — a Squads vault or a DAO treasury holds SPL through
-     * `ATA(pda, mint)` and spends it with `invoke_signed`. Only an address the cluster reports as
-     * owned by a token program is refused; an off-curve address the cluster cannot be reached about
-     * is refused too, since an unanswered lookup is not an answer.
+     * The address's own bytes do not earn this verdict either way. Every program-derived address is
+     * off-curve, and plenty of them are real destinations — a Squads vault or a DAO treasury holds
+     * SPL through `ATA(pda, mint)` and spends it with `invoke_signed` — while an auxiliary token
+     * account sits on the curve like any wallet. Only what the cluster reports is refused.
      */
     NotAWalletAddress,
 }
@@ -188,21 +187,26 @@ constructor(private val solanaApi: SolanaApi) : ChainAccountAddressRepository {
         when {
             !isValid(chain, address) -> RecipientValidity.InvalidForChain
             chain != Chain.Solana -> RecipientValidity.Valid
-            SolanaProgramDerivedAddress.isWalletAddress(address) -> RecipientValidity.Valid
-            else -> solanaOffCurveVerdict(address)
+            else -> solanaRecipientVerdict(address)
         }
 
     /**
-     * The verdict for a well-formed Solana address that is off the ed25519 curve, which the owning
-     * program alone can sign for. That covers both the account this guard exists for — a token
-     * account, which strands an SPL transfer — and destinations that are perfectly spendable, so
-     * the cluster decides which one this is.
+     * The verdict for a well-formed Solana address, which only the cluster can settle: the account
+     * this guard exists for — a token account, which strands an SPL transfer — is not something an
+     * address can be told apart from a wallet by looking at it.
      *
-     * A lookup that fails is refused rather than waved through: on the send path the same cluster
-     * supplies the blockhash and the fee, so a transaction cannot be built while it is unreachable
-     * anyway, and the address book can be retried.
+     * The curve test is not that answer. A token account is usually an associated one and so
+     * off-curve, but the auxiliary form — `create-account` against a fresh keypair, how wallets
+     * made them before ATAs existed and how some exchanges still hold them — is on the curve like
+     * any wallet, so both get asked about.
+     *
+     * What the curve does decide is how an unreachable cluster resolves. Off the curve, only the
+     * owning program can sign, so an unanswered lookup leaves a real chance this is a token account
+     * and it stays refused. On the curve, someone can hold the key — the ordinary case for every
+     * address a user pastes — and refusing those on a failed lookup would block Solana sends
+     * outright whenever the RPC blinks, so an unanswered lookup lets them through as before.
      */
-    private suspend fun solanaOffCurveVerdict(address: String): RecipientValidity =
+    private suspend fun solanaRecipientVerdict(address: String): RecipientValidity =
         when (val ownership = solanaApi.getAccountOwnership(address)) {
             is SolanaAccountOwnership.Owned ->
                 if (ownership.programId in SOLANA_TOKEN_PROGRAM_IDS) {
@@ -213,7 +217,12 @@ constructor(private val solanaApi: SolanaApi) : ChainAccountAddressRepository {
             // No account at that address, so it is not a token account. A program vault that only
             // ever holds SPL never needs its own account on-chain: the tokens live in ATAs it owns.
             SolanaAccountOwnership.Missing -> RecipientValidity.Valid
-            SolanaAccountOwnership.Unavailable -> RecipientValidity.NotAWalletAddress
+            SolanaAccountOwnership.Unavailable ->
+                if (SolanaProgramDerivedAddress.isWalletAddress(address)) {
+                    RecipientValidity.Valid
+                } else {
+                    RecipientValidity.NotAWalletAddress
+                }
         }
 
     /**

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SolanaProgramDerivedAddressTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/SolanaProgramDerivedAddressTest.kt
@@ -74,9 +74,58 @@ class SolanaProgramDerivedAddressTest {
         assertNotNull(SolanaProgramDerivedAddress.find(List(16) { ByteArray(32) }, TOKEN_PROGRAM))
     }
 
+    @Test
+    fun `an associated token account is not a wallet address`() {
+        // Every address this object derives is off the curve — that is what find() selects for —
+        // so the three accounts pinned above are exactly the recipients that would strand a
+        // transfer: an SPL send to one creates an ATA-of-an-ATA nobody holds a key to.
+        listOf(
+                "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc",
+                "GSayQpRaoh1LFdBbja4vensNKDfihcixzCcQShKMCdMJ",
+                "Hq6N6sNE638VLULNEeAZRTMFmYtsG9ZLLPJYefxwPNWf",
+            )
+            .forEach { assertEquals(false, SolanaProgramDerivedAddress.isWalletAddress(it), it) }
+    }
+
+    @Test
+    fun `a wallet address is one`() {
+        assertEquals(true, SolanaProgramDerivedAddress.isWalletAddress(ON_CURVE_WALLET))
+        // A program id is generated as a keypair and so sits on the curve: off-curve is a test for
+        // "no key can exist", not for "dangerous", and the burn and program addresses need their
+        // own list.
+        assertEquals(true, SolanaProgramDerivedAddress.isWalletAddress(TOKEN_PROGRAM))
+    }
+
+    @Test
+    fun `anything that is not 32 base58 bytes is not a wallet address`() {
+        listOf("", "1111", "not an address", Base58Codec.encode(ByteArray(31))).forEach {
+            assertEquals(false, SolanaProgramDerivedAddress.isWalletAddress(it), it)
+        }
+    }
+
+    @Test
+    fun `mints are program-derived often enough that the guard cannot be part of chain validation`() {
+        // Kamino's share mints are PDAs. Chain address validation also screens contract addresses
+        // (SearchTokenUseCase), so folding the recipient rule into it would make exactly these
+        // tokens unsearchable — which is why the two checks stay separate.
+        listOf(
+                "7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS",
+                "DgHN3q3dSYAchNX7V3D4aYiTWMx8RHTgHbfPiwiqBkE9",
+                "FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN",
+            )
+            .forEach { assertEquals(false, SolanaProgramDerivedAddress.isWalletAddress(it), it) }
+    }
+
     private companion object {
         const val WALLET = "9ceRgz579BcfWogs3RE11FKNQaWW7Lmtnev3MXspxUjF"
         const val TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         const val ASSOCIATED_TOKEN_PROGRAM = "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+
+        /**
+         * A real Solana wallet address. [WALLET] cannot stand in here: it is a synthetic fixture
+         * whose bytes happen to be off the curve, which is harmless for derivation but would make
+         * it the wrong witness for "this is a key someone holds".
+         */
+        const val ON_CURVE_WALLET = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryEddsaValidationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryEddsaValidationTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.repositories
 
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Vault
+import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -117,7 +118,7 @@ class ChainAccountAddressRepositoryEddsaValidationTest {
      */
     @Test
     fun `getAddress rejects blank pubKeyEDDSA before reaching JNI`() = runBlocking {
-        val repo = ChainAccountAddressRepositoryImpl()
+        val repo = ChainAccountAddressRepositoryImpl(solanaApi = mockk(relaxed = true))
         val vault = Vault(id = "test-vault", name = "test", pubKeyECDSA = "", pubKeyEDDSA = "")
         val ex = assertThrows<IllegalArgumentException> { repo.getAddress(Chain.Solana, vault) }
         assertEquals("EdDSA public key for ${Chain.Solana.raw} is missing", ex.message)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryRecipientTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryRecipientTest.kt
@@ -1,0 +1,66 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.models.Chain
+import io.mockk.every
+import io.mockk.spyk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the ordering in `validateRecipient`. Chain validation itself is WalletCore JNI, so it is
+ * stubbed here; what is under test is that an address failing it is reported as such, and that the
+ * Solana curve rule is applied only after it and only to Solana.
+ */
+class ChainAccountAddressRepositoryRecipientTest {
+
+    private val repository = spyk(ChainAccountAddressRepositoryImpl())
+
+    @Test
+    fun `a solana token account is well-formed but not a wallet`() {
+        every { repository.isValid(Chain.Solana, TOKEN_ACCOUNT) } returns true
+
+        assertEquals(
+            RecipientValidity.NotAWalletAddress,
+            repository.validateRecipient(Chain.Solana, TOKEN_ACCOUNT),
+        )
+    }
+
+    @Test
+    fun `a solana wallet address is a valid recipient`() {
+        every { repository.isValid(Chain.Solana, WALLET) } returns true
+
+        assertEquals(RecipientValidity.Valid, repository.validateRecipient(Chain.Solana, WALLET))
+    }
+
+    @Test
+    fun `failing chain validation is reported as such, not as the curve rule`() {
+        every { repository.isValid(Chain.Solana, "garbage") } returns false
+
+        assertEquals(
+            RecipientValidity.InvalidForChain,
+            repository.validateRecipient(Chain.Solana, "garbage"),
+        )
+    }
+
+    @Test
+    fun `the curve rule is scoped to solana`() {
+        // The same bytes on another chain must not be second-guessed: off-curve means nothing
+        // outside ed25519, and every non-Solana chain here validates through its own rules.
+        every { repository.isValid(any(), any()) } returns true
+
+        listOf(Chain.Ethereum, Chain.Bitcoin, Chain.Ton, Chain.Sui, Chain.Polkadot).forEach {
+            assertEquals(
+                RecipientValidity.Valid,
+                repository.validateRecipient(it, TOKEN_ACCOUNT),
+                it.raw,
+            )
+        }
+    }
+
+    private companion object {
+        /** The wallet's wrapped-SOL associated token account, pinned in the derivation test. */
+        const val TOKEN_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
+
+        const val WALLET = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryRecipientTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryRecipientTest.kt
@@ -15,8 +15,9 @@ import org.junit.jupiter.api.Test
 /**
  * Covers the ordering in `validateRecipient`. Chain validation itself is WalletCore JNI, so it is
  * stubbed here; what is under test is that an address failing it is reported as such, that the
- * Solana curve rule is applied only after it and only to Solana, and that being off the curve buys
- * the cluster a question rather than a refusal.
+ * ownership question is asked only after it and only on Solana, that it is asked of every Solana
+ * address rather than only the off-curve ones, and that the curve decides nothing but which way an
+ * unreachable cluster resolves.
  */
 class ChainAccountAddressRepositoryRecipientTest {
 
@@ -90,15 +91,48 @@ class ChainAccountAddressRepositoryRecipientTest {
     }
 
     @Test
-    fun `a solana wallet address is a valid recipient without asking the cluster`() = runTest {
+    fun `an on-curve wallet the cluster calls system-owned is a valid recipient`() = runTest {
         every { repository.isValid(Chain.Solana, WALLET) } returns true
+        coEvery { solanaApi.getAccountOwnership(WALLET) } returns
+            SolanaAccountOwnership.Owned(SYSTEM_PROGRAM)
 
         assertEquals(RecipientValidity.Valid, repository.validateRecipient(Chain.Solana, WALLET))
-        coVerify(exactly = 0) { solanaApi.getAccountOwnership(any()) }
     }
 
     @Test
-    fun `failing chain validation is reported as such, not as the curve rule`() = runTest {
+    fun `an on-curve auxiliary token account is not a wallet either`() = runTest {
+        // Being on the curve is not what makes an address a wallet. A token account opened against
+        // a fresh keypair rather than derived as an ATA looks exactly like one, and strands an SPL
+        // transfer exactly like an ATA would, so the cluster is asked about these too.
+        every { repository.isValid(Chain.Solana, AUXILIARY_TOKEN_ACCOUNT) } returns true
+        coEvery { solanaApi.getAccountOwnership(AUXILIARY_TOKEN_ACCOUNT) } returns
+            SolanaAccountOwnership.Owned(TOKEN_PROGRAM)
+
+        assertEquals(
+            RecipientValidity.NotAWalletAddress,
+            repository.validateRecipient(Chain.Solana, AUXILIARY_TOKEN_ACCOUNT),
+        )
+    }
+
+    @Test
+    fun `an on-curve address the cluster cannot be asked about stays a valid recipient`() =
+        runTest {
+            // The opposite fallback to the off-curve case, and deliberately so: an address someone
+            // can
+            // hold the key for is what every user pastes, so a blinking RPC must not refuse them
+            // all.
+            every { repository.isValid(Chain.Solana, WALLET) } returns true
+            coEvery { solanaApi.getAccountOwnership(WALLET) } returns
+                SolanaAccountOwnership.Unavailable
+
+            assertEquals(
+                RecipientValidity.Valid,
+                repository.validateRecipient(Chain.Solana, WALLET),
+            )
+        }
+
+    @Test
+    fun `failing chain validation is reported as such, not as the ownership rule`() = runTest {
         every { repository.isValid(Chain.Solana, "garbage") } returns false
 
         assertEquals(
@@ -109,9 +143,9 @@ class ChainAccountAddressRepositoryRecipientTest {
     }
 
     @Test
-    fun `the curve rule is scoped to solana`() = runTest {
-        // The same bytes on another chain must not be second-guessed: off-curve means nothing
-        // outside ed25519, and every non-Solana chain here validates through its own rules.
+    fun `the ownership rule is scoped to solana`() = runTest {
+        // The same bytes on another chain must not be second-guessed: account ownership means
+        // nothing outside Solana, and every chain here validates through its own rules.
         every { repository.isValid(any(), any()) } returns true
 
         listOf(Chain.Ethereum, Chain.Bitcoin, Chain.Ton, Chain.Sui, Chain.Polkadot).forEach {
@@ -129,6 +163,9 @@ class ChainAccountAddressRepositoryRecipientTest {
         const val TOKEN_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
 
         const val WALLET = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+
+        /** On the curve, unlike [TOKEN_ACCOUNT]: a token account opened against its own keypair. */
+        const val AUXILIARY_TOKEN_ACCOUNT = "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9"
 
         const val TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryRecipientTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryRecipientTest.kt
@@ -1,23 +1,34 @@
 package com.vultisig.wallet.data.repositories
 
+import com.vultisig.wallet.data.api.SolanaAccountOwnership
+import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.models.Chain
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.spyk
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 /**
  * Covers the ordering in `validateRecipient`. Chain validation itself is WalletCore JNI, so it is
- * stubbed here; what is under test is that an address failing it is reported as such, and that the
- * Solana curve rule is applied only after it and only to Solana.
+ * stubbed here; what is under test is that an address failing it is reported as such, that the
+ * Solana curve rule is applied only after it and only to Solana, and that being off the curve buys
+ * the cluster a question rather than a refusal.
  */
 class ChainAccountAddressRepositoryRecipientTest {
 
-    private val repository = spyk(ChainAccountAddressRepositoryImpl())
+    private val solanaApi: SolanaApi = mockk()
+
+    private val repository = spyk(ChainAccountAddressRepositoryImpl(solanaApi = solanaApi))
 
     @Test
-    fun `a solana token account is well-formed but not a wallet`() {
+    fun `a solana token account is well-formed but not a wallet`() = runTest {
         every { repository.isValid(Chain.Solana, TOKEN_ACCOUNT) } returns true
+        coEvery { solanaApi.getAccountOwnership(TOKEN_ACCOUNT) } returns
+            SolanaAccountOwnership.Owned(TOKEN_PROGRAM)
 
         assertEquals(
             RecipientValidity.NotAWalletAddress,
@@ -26,24 +37,79 @@ class ChainAccountAddressRepositoryRecipientTest {
     }
 
     @Test
-    fun `a solana wallet address is a valid recipient`() {
-        every { repository.isValid(Chain.Solana, WALLET) } returns true
+    fun `a token-2022 account is not a wallet either`() = runTest {
+        every { repository.isValid(Chain.Solana, TOKEN_ACCOUNT) } returns true
+        coEvery { solanaApi.getAccountOwnership(TOKEN_ACCOUNT) } returns
+            SolanaAccountOwnership.Owned(TOKEN_2022_PROGRAM)
 
-        assertEquals(RecipientValidity.Valid, repository.validateRecipient(Chain.Solana, WALLET))
+        assertEquals(
+            RecipientValidity.NotAWalletAddress,
+            repository.validateRecipient(Chain.Solana, TOKEN_ACCOUNT),
+        )
     }
 
     @Test
-    fun `failing chain validation is reported as such, not as the curve rule`() {
+    fun `an off-curve address another program owns is a valid recipient`() = runTest {
+        // A Squads vault or a DAO treasury: off the curve like every program address, but it holds
+        // SPL through the ATAs it owns and spends them with invoke_signed.
+        every { repository.isValid(Chain.Solana, TOKEN_ACCOUNT) } returns true
+        coEvery { solanaApi.getAccountOwnership(TOKEN_ACCOUNT) } returns
+            SolanaAccountOwnership.Owned(SYSTEM_PROGRAM)
+
+        assertEquals(
+            RecipientValidity.Valid,
+            repository.validateRecipient(Chain.Solana, TOKEN_ACCOUNT),
+        )
+    }
+
+    @Test
+    fun `an off-curve address with no account on-chain is a valid recipient`() = runTest {
+        // A vault that has only ever held SPL has no account of its own; the tokens sit in ATAs
+        // derived from it. Refusing it would refuse the very destination the curve rule is accused
+        // of blocking.
+        every { repository.isValid(Chain.Solana, TOKEN_ACCOUNT) } returns true
+        coEvery { solanaApi.getAccountOwnership(TOKEN_ACCOUNT) } returns
+            SolanaAccountOwnership.Missing
+
+        assertEquals(
+            RecipientValidity.Valid,
+            repository.validateRecipient(Chain.Solana, TOKEN_ACCOUNT),
+        )
+    }
+
+    @Test
+    fun `an off-curve address the cluster cannot be asked about is refused`() = runTest {
+        every { repository.isValid(Chain.Solana, TOKEN_ACCOUNT) } returns true
+        coEvery { solanaApi.getAccountOwnership(TOKEN_ACCOUNT) } returns
+            SolanaAccountOwnership.Unavailable
+
+        assertEquals(
+            RecipientValidity.NotAWalletAddress,
+            repository.validateRecipient(Chain.Solana, TOKEN_ACCOUNT),
+        )
+    }
+
+    @Test
+    fun `a solana wallet address is a valid recipient without asking the cluster`() = runTest {
+        every { repository.isValid(Chain.Solana, WALLET) } returns true
+
+        assertEquals(RecipientValidity.Valid, repository.validateRecipient(Chain.Solana, WALLET))
+        coVerify(exactly = 0) { solanaApi.getAccountOwnership(any()) }
+    }
+
+    @Test
+    fun `failing chain validation is reported as such, not as the curve rule`() = runTest {
         every { repository.isValid(Chain.Solana, "garbage") } returns false
 
         assertEquals(
             RecipientValidity.InvalidForChain,
             repository.validateRecipient(Chain.Solana, "garbage"),
         )
+        coVerify(exactly = 0) { solanaApi.getAccountOwnership(any()) }
     }
 
     @Test
-    fun `the curve rule is scoped to solana`() {
+    fun `the curve rule is scoped to solana`() = runTest {
         // The same bytes on another chain must not be second-guessed: off-curve means nothing
         // outside ed25519, and every non-Solana chain here validates through its own rules.
         every { repository.isValid(any(), any()) } returns true
@@ -55,6 +121,7 @@ class ChainAccountAddressRepositoryRecipientTest {
                 it.raw,
             )
         }
+        coVerify(exactly = 0) { solanaApi.getAccountOwnership(any()) }
     }
 
     private companion object {
@@ -62,5 +129,11 @@ class ChainAccountAddressRepositoryRecipientTest {
         const val TOKEN_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
 
         const val WALLET = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM"
+
+        const val TOKEN_PROGRAM = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+
+        const val TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+
+        const val SYSTEM_PROGRAM = "11111111111111111111111111111111"
     }
 }


### PR DESCRIPTION
Closes #5689

## The problem

Solana address validation is WalletCore's base58 length check and nothing more, so an associated token account or a program address passes it. Paste one as a recipient and the SPL send path does this:

- `getTokenAccountsByOwner(ata, mint)` returns nothing — a token account owns no token accounts
- the derivation fallback computes `ATA(ata, mint)` and finds no such account on chain
- `toAddressPubKey` comes back null, so `SolanaHelper` takes the `CreateAndTransferToken` branch and **creates** the ATA-of-an-ATA, then transfers into it

That account's owner is the first token account, which holds no key and whose program cannot sign for it. The tokens are unrecoverable. S1 in the Solana money-path hardening epic (vultisig/vultisig-sdk#2182, item 1).

Verified offline against a real derivation:

```
owner  9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM   32 bytes, on-curve
ATA    FGETo8T8wMcN2wCjav8VK6eh3dLk63evNDPxzLSJra8B   32 bytes, off-curve  ← passes validation today
```

## The check

Every program-derived address is off the ed25519 curve by construction — that is what lets the owning program sign for it, and precisely why no user can. `SolanaProgramDerivedAddress` already computes that for derivation, so the guard reuses it: `isWalletAddress` decodes base58, requires 32 bytes, and asks whether they decompress to a point.

Pure Kotlin, no JNI, so it is covered by ordinary unit tests.

## Why it is not part of `isValid`

`SearchTokenUseCase` validates **mint** addresses through the same `isValid`, and mints are routinely program-derived. All three Kamino share mints in `KaminoVaultRegistry` are off-curve:

```
7D8C5pDFxug58L9zkwK7bCiDg4kD4AygzbcZUmf5usHS
DgHN3q3dSYAchNX7V3D4aYiTWMx8RHTgHbfPiwiqBkE9
FiM4VQdXXnTXL7GgChryf9zHNG9cmvKECwf34L2y3CkN
```

Folding the rule into `isValid` would have made exactly the tokens #5588 shipped unsearchable. So `validateRecipient` sits beside it and returns which of the two failures happened — `InvalidForChain` or `NotAWalletAddress` — leaving `isValid` untouched. There is a test pinning that distinction so the shortcut is not taken later.

## What changed

- `SolanaProgramDerivedAddress.isWalletAddress` — the curve check, promoted from the private derivation path
- `ChainAccountAddressRepository.validateRecipient` → `RecipientValidity` (`Valid` / `InvalidForChain` / `NotAWalletAddress`); `isValid` unchanged
- Wired into the three surfaces where a human names a recipient: the send form (`AddressManager` — `invalidAddress: StateFlow<Boolean>` became `addressError: StateFlow<RecipientValidity?>` so the reason survives to the UI), the swap external recipient, and the address book entry screen
- A token account is now rejected outright instead of being sent round the name resolver, which has nothing to find for a well-formed address
- New shared string `error_recipient_not_a_wallet_address`, translated into all 10 locales

It **blocks** rather than warns: a warning tapped through still loses the funds, and no sibling platform has shipped a reference behaviour to match yet.

## Scope boundary

Off-curve is not a general "dangerous recipient" test. The Token Program, ATA Program and System Program addresses are all **on**-curve, so the burn/program-address denylist (sdk#2182 item 2) is separate work and is not filed on Android yet.

## On device

A Kamino share mint — a program-derived address — pasted into Send on Solana. It is a well-formed
address that base58 validation accepts, and before this change it went straight through to the
amount step.

<img src="https://i.imgur.com/clq5ICE.png" width="320" alt="Send screen rejecting a program address with the not-a-wallet error" />

## Test plan

10 new tests; full suite green at **5329 tests, 0 failures**, lint clean.

- `SolanaProgramDerivedAddressTest` — the three ATAs it already pins are rejected; a real wallet and a program id are accepted; non-32-byte input is rejected; the Kamino share mints are rejected, documenting why the guard cannot live in `isValid`
- `ChainAccountAddressRepositoryRecipientTest` — the ordering: chain validation reported as itself, the curve rule applied after it and only to Solana
- `AddressManagerTest` — a token account sets `NotAWalletAddress`, resolves nothing, emits no validation and never reaches the resolver; a wallet address after it clears the error
- `SwapFormViewModelTest` — the external recipient gets the specific message, not the generic one

The two behaviour tests were confirmed to fail when the guard and the reject branch are reverted.

Manual, on a vault with a Solana account: pasting `FGETo8T8wMcN2wCjav8VK6eh3dLk63evNDPxzLSJra8B` as a recipient in Send, in the swap external-recipient field and in the address book is refused with the new message, while `9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM` is accepted as before. Custom-token search for the Kamino share mint above still resolves — that is the regression this shape exists to avoid. EVM, Bitcoin and XRP sends are untouched.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recipient address validation during sends, swaps, and address entry.
  - Displays distinct errors for addresses invalid on the selected chain and valid-format addresses that are not wallet addresses.
  - Prevents token accounts or program addresses from being treated as wallet recipients.
  - Prevents outdated validation results from affecting updated recipient addresses.
  - Supports recovery when users replace an invalid recipient with a valid wallet address.

- **Localization**
  - Added translations for the new non-wallet recipient error in supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->