### PR TITLE
chore: bump version to 1.0.118

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.vultisig.wallet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = 36
-        versionCode = 117
-        versionName = "1.0.117"
+        versionCode = 118
+        versionName = "1.0.118"
 
         testInstrumentationRunner = "com.vultisig.wallet.util.HiltTestRunner"
 


### PR DESCRIPTION
Bump versionCode to 118 / versionName to 1.0.118 for release v1.0.118.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android app version to 1.0.118 (build 118).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->