### PR TITLE
feat(referral): let Edit change the payout asset, not just the expiry

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/referral/EditVaultReferralViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/referral/EditVaultReferralViewModel.kt
@@ -10,13 +10,21 @@ import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.models.cosmos.NativeTxFeeRune
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.GasFeeParams
+import com.vultisig.wallet.data.models.ThorChainPoolCoin
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.repositories.RequestResultRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.EnableTokenUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCaseImpl
 import com.vultisig.wallet.data.utils.decimals
 import com.vultisig.wallet.data.utils.symbol
@@ -49,6 +57,8 @@ internal data class EditVaultReferralUiState(
     val referralCostFiatFormatted: String = "",
     val referralExpiration: String = "",
     val costFeesTokenAmount: String = "",
+    val payoutAsset: PayoutAssetUiModel? = null,
+    val isSaveEnabled: Boolean = false,
     val error: ReferralError? = null,
 )
 
@@ -63,6 +73,10 @@ constructor(
     private val accountsRepository: AccountsRepository,
     private val transactionRepository: DepositTransactionRepository,
     private val thorChainApi: ThorChainApi,
+    private val requestResultRepository: RequestResultRepository,
+    private val vaultRepository: VaultRepository,
+    private val chainAccountAddressRepository: ChainAccountAddressRepository,
+    private val enableToken: EnableTokenUseCase,
 ) : ViewModel() {
 
     private val args = savedStateHandle.toRoute<Route.ReferralVaultEdition>()
@@ -75,6 +89,11 @@ constructor(
     val state = MutableStateFlow(EditVaultReferralUiState())
     private var address: Address? = null
 
+    /** The asset the THORName is registered with today; null while unknown or when it has none. */
+    private var initialPayoutAsset: ThorChainPoolCoin? = null
+    private var selectedPayoutAsset: ThorChainPoolCoin? = null
+    private var hasPickedPayoutAsset = false
+
     init {
         loadAddress()
         initData()
@@ -85,7 +104,9 @@ constructor(
         viewModelScope.launch {
             referralTextFieldState.setTextAndPlaceCursorAtEnd(vaultReferralCode)
 
-            state.update { it.copy(referralExpiration = vaultReferralExpiration) }
+            state.update {
+                it.copy(referralExpiration = vaultReferralExpiration, payoutAsset = RUNE_PAYOUT)
+            }
 
             try {
                 nativeRuneFees =
@@ -95,6 +116,39 @@ constructor(
                 Timber.w(e, "Falling back to default referral fees")
                 nativeRuneFees = null
             }
+        }
+
+        loadPayoutAsset()
+    }
+
+    /**
+     * Reads the payout asset the THORName already carries so the picker opens on it and an edit
+     * that only extends the expiry keeps it, rather than silently re-registering the name without
+     * one.
+     */
+    private fun loadPayoutAsset() {
+        viewModelScope.launch {
+            val preferredAsset =
+                try {
+                    withContext(Dispatchers.IO) {
+                            thorChainApi.getReferralCodeInfo(vaultReferralCode)
+                        }
+                        .preferredAsset
+                } catch (t: Throwable) {
+                    if (t is kotlinx.coroutines.CancellationException) throw t
+                    Timber.w(t, "Failed to load the referral's payout asset")
+                    return@launch
+                }
+
+            val asset = ThorChainPoolCoin.from(preferredAsset) ?: return@launch
+            initialPayoutAsset = asset
+            // A pick made while this was in flight is the newer intent, and stands.
+            if (hasPickedPayoutAsset) {
+                state.update { it.copy(isSaveEnabled = isSaveEnabled(it.referralCounter)) }
+                return@launch
+            }
+            selectedPayoutAsset = asset
+            state.update { it.copy(payoutAsset = asset.toUiModel()) }
         }
     }
 
@@ -111,7 +165,11 @@ constructor(
             val newCounter = (stateValue.referralCounter + yearsDelta.toInt()).coerceAtLeast(0)
 
             state.update {
-                it.copy(referralCounter = newCounter, referralExpiration = newExpiration)
+                it.copy(
+                    referralCounter = newCounter,
+                    referralExpiration = newExpiration,
+                    isSaveEnabled = isSaveEnabled(newCounter),
+                )
             }
         } catch (t: Throwable) {
             Timber.e(t, "Failed to parse date")
@@ -131,6 +189,38 @@ constructor(
             calculateFees()
         }
     }
+
+    fun onSelectPayoutAsset() {
+        viewModelScope.launch {
+            val requestId = UUID.randomUUID().toString()
+            navigator.route(
+                Route.ReferralPayoutAsset(
+                    requestId = requestId,
+                    selectedAsset = selectedPayoutAsset?.asset,
+                )
+            )
+
+            val asset =
+                requestResultRepository.request<ThorChainPoolCoin>(requestId) ?: return@launch
+
+            selectedPayoutAsset = asset
+            hasPickedPayoutAsset = true
+            state.update {
+                it.copy(
+                    payoutAsset = asset.toUiModel(),
+                    isSaveEnabled = isSaveEnabled(it.referralCounter),
+                )
+            }
+        }
+    }
+
+    /**
+     * Save covers two independent edits: buying more years, and switching the payout asset. Either
+     * alone is a valid transaction, so an unchanged asset with no added year is the only state that
+     * has nothing to sign.
+     */
+    private fun isSaveEnabled(counter: Int): Boolean =
+        counter > 0 || selectedPayoutAsset?.asset != initialPayoutAsset?.asset
 
     private fun calculateFees() {
         viewModelScope.launch {
@@ -183,7 +273,14 @@ constructor(
                 }
 
                 val address = account.token.address
-                val memo = "~:${vaultReferralCode.uppercase()}:THOR:$address:$address"
+                val payoutAsset = selectedPayoutAsset
+                val memo =
+                    buildEditReferralMemo(
+                        referralCode = vaultReferralCode,
+                        thorAddress = address,
+                        payoutAsset = payoutAsset,
+                        payoutAssetAddress = payoutAsset?.let { payoutAddress(it.coin) },
+                    )
                 val gasFees =
                     TokenValue(
                         value = gasFeeValue,
@@ -235,6 +332,32 @@ constructor(
         }
     }
 
+    /**
+     * This vault's address on the payout asset's chain — the alias THORChain pays the asset out to.
+     * The token is enabled alongside it, so the payouts land somewhere the vault actually shows.
+     */
+    private suspend fun payoutAddress(coin: Coin): String {
+        val vault = vaultRepository.get(vaultId) ?: error("Can't load vault")
+        val address =
+            withContext(Dispatchers.IO) {
+                chainAccountAddressRepository.getAddress(coin, vault).first
+            }
+        enablePayoutToken(coin, vault)
+        return address
+    }
+
+    private suspend fun enablePayoutToken(coin: Coin, vault: Vault) {
+        if (vault.coins.any { it.id == coin.id }) return
+        try {
+            enableToken(vaultId, coin)
+        } catch (t: Throwable) {
+            if (t is kotlinx.coroutines.CancellationException) throw t
+            // Only costs the user the token's row in the vault — the memo, and with it the
+            // payout itself, is unaffected.
+            Timber.w(t, "Failed to add the payout asset to the vault")
+        }
+    }
+
     private fun loadAddress() {
         viewModelScope.launch {
             try {
@@ -264,5 +387,24 @@ constructor(
 
     fun onDismissError() {
         viewModelScope.launch { state.update { it.copy(error = null) } }
+    }
+
+    private fun ThorChainPoolCoin.toUiModel(): PayoutAssetUiModel =
+        PayoutAssetUiModel(
+            asset = asset,
+            logo = getCoinLogo(coin.logo),
+            ticker = coin.ticker,
+            chain = coin.chain.raw,
+        )
+
+    private companion object {
+        /** What a THORName pays out in until an asset is chosen. */
+        val RUNE_PAYOUT =
+            PayoutAssetUiModel(
+                asset = "",
+                logo = getCoinLogo(Coins.ThorChain.RUNE.logo),
+                ticker = Coins.ThorChain.RUNE.ticker,
+                chain = Chain.ThorChain.raw,
+            )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/referral/EditVaultReferralViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/referral/EditVaultReferralViewModel.kt
@@ -27,6 +27,7 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
 import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCaseImpl
 import com.vultisig.wallet.data.utils.decimals
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.data.utils.symbol
 import com.vultisig.wallet.data.utils.toValue
 import com.vultisig.wallet.ui.models.referral.CreateReferralViewModel.Companion.BLOCKS_PER_YEAR
@@ -127,25 +128,19 @@ constructor(
      * one.
      */
     private fun loadPayoutAsset() {
-        viewModelScope.launch {
+        viewModelScope.safeLaunch(
+            onError = { Timber.w(it, "Failed to load the referral's payout asset") }
+        ) {
             val preferredAsset =
-                try {
-                    withContext(Dispatchers.IO) {
-                            thorChainApi.getReferralCodeInfo(vaultReferralCode)
-                        }
-                        .preferredAsset
-                } catch (t: Throwable) {
-                    if (t is kotlinx.coroutines.CancellationException) throw t
-                    Timber.w(t, "Failed to load the referral's payout asset")
-                    return@launch
-                }
+                withContext(Dispatchers.IO) { thorChainApi.getReferralCodeInfo(vaultReferralCode) }
+                    .preferredAsset
 
-            val asset = ThorChainPoolCoin.from(preferredAsset) ?: return@launch
+            val asset = ThorChainPoolCoin.from(preferredAsset) ?: return@safeLaunch
             initialPayoutAsset = asset
             // A pick made while this was in flight is the newer intent, and stands.
             if (hasPickedPayoutAsset) {
                 state.update { it.copy(isSaveEnabled = isSaveEnabled(it.referralCounter)) }
-                return@launch
+                return@safeLaunch
             }
             selectedPayoutAsset = asset
             state.update { it.copy(payoutAsset = asset.toUiModel()) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModel.kt
@@ -1,0 +1,110 @@
+package com.vultisig.wallet.ui.models.referral
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.ImageModel
+import com.vultisig.wallet.data.models.ThorChainPoolCoin
+import com.vultisig.wallet.data.models.getCoinLogo
+import com.vultisig.wallet.data.repositories.RequestResultRepository
+import com.vultisig.wallet.data.usecases.GetThorChainPoolAssetsUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.utils.textAsFlow
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+internal data class PayoutAssetUiModel(
+    val asset: String,
+    val logo: ImageModel,
+    val ticker: String,
+    val chain: String,
+    val isSelected: Boolean = false,
+)
+
+internal data class ReferralPayoutAssetUiState(
+    val assets: List<PayoutAssetUiModel> = emptyList(),
+    val isLoading: Boolean = true,
+)
+
+@HiltViewModel
+internal class ReferralPayoutAssetViewModel
+@Inject
+constructor(
+    savedStateHandle: SavedStateHandle,
+    private val navigator: Navigator<Destination>,
+    private val requestResultRepository: RequestResultRepository,
+    private val getThorChainPoolAssets: GetThorChainPoolAssetsUseCase,
+) : ViewModel() {
+
+    private val args = savedStateHandle.toRoute<Route.ReferralPayoutAsset>()
+
+    private var assets: List<ThorChainPoolCoin> = emptyList()
+
+    val searchFieldState = TextFieldState()
+    val state = MutableStateFlow(ReferralPayoutAssetUiState())
+
+    init {
+        loadAssets()
+        observeSearch()
+    }
+
+    private fun loadAssets() {
+        viewModelScope.launch {
+            try {
+                assets = getThorChainPoolAssets()
+            } catch (t: Throwable) {
+                if (t is kotlinx.coroutines.CancellationException) throw t
+                Timber.e(t, "Failed to load THORChain pool assets")
+                assets = emptyList()
+            }
+            state.update {
+                it.copy(isLoading = false, assets = filterAssets(searchFieldState.text.toString()))
+            }
+        }
+    }
+
+    private fun observeSearch() {
+        viewModelScope.launch {
+            searchFieldState.textAsFlow().collectLatest { query ->
+                state.update { it.copy(assets = filterAssets(query.toString())) }
+            }
+        }
+    }
+
+    private fun filterAssets(query: String): List<PayoutAssetUiModel> =
+        assets
+            .filter { query.isBlank() || it.coin.ticker.contains(query.trim(), ignoreCase = true) }
+            .map {
+                PayoutAssetUiModel(
+                    asset = it.asset,
+                    logo = getCoinLogo(it.coin.logo),
+                    ticker = it.coin.ticker,
+                    chain = it.coin.chain.raw,
+                    isSelected = it.asset.equals(args.selectedAsset, ignoreCase = true),
+                )
+            }
+
+    fun onAssetClick(asset: PayoutAssetUiModel) {
+        viewModelScope.launch {
+            val selected = assets.firstOrNull { it.asset == asset.asset } ?: return@launch
+            requestResultRepository.respond(args.requestId, selected)
+            navigator.navigate(Destination.Back)
+        }
+    }
+
+    fun back() {
+        viewModelScope.launch {
+            requestResultRepository.respond(args.requestId, null)
+            navigator.navigate(Destination.Back)
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModel.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.ui.models.referral
 
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -10,6 +11,7 @@ import com.vultisig.wallet.data.models.ThorChainPoolCoin
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.usecases.GetThorChainPoolAssetsUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -22,6 +24,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+@Immutable
 internal data class PayoutAssetUiModel(
     val asset: String,
     val logo: ImageModel,
@@ -30,9 +33,11 @@ internal data class PayoutAssetUiModel(
     val isSelected: Boolean = false,
 )
 
+@Immutable
 internal data class ReferralPayoutAssetUiState(
     val assets: List<PayoutAssetUiModel> = emptyList(),
     val isLoading: Boolean = true,
+    val isError: Boolean = false,
 )
 
 @HiltViewModel
@@ -58,14 +63,15 @@ constructor(
     }
 
     private fun loadAssets() {
-        viewModelScope.launch {
-            try {
-                assets = getThorChainPoolAssets()
-            } catch (t: Throwable) {
-                if (t is kotlinx.coroutines.CancellationException) throw t
+        viewModelScope.safeLaunch(
+            onError = { t ->
                 Timber.e(t, "Failed to load THORChain pool assets")
                 assets = emptyList()
+                // Told apart from an empty pool list, which reads as "no such asset" instead.
+                state.update { it.copy(isLoading = false, isError = true, assets = emptyList()) }
             }
+        ) {
+            assets = getThorChainPoolAssets()
             state.update {
                 it.copy(isLoading = false, assets = filterAssets(searchFieldState.text.toString()))
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralUtils.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralUtils.kt
@@ -1,6 +1,8 @@
 package com.vultisig.wallet.ui.models.referral
 
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.ThorChainPoolCoin
+import com.vultisig.wallet.data.models.swapAssetName
 import com.vultisig.wallet.ui.models.referral.ReferralViewModel.Companion.MAX_LENGTH_REFERRAL_CODE
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
@@ -24,4 +26,29 @@ internal fun validateReferralCode(code: String): UiText? {
 
 internal fun validateMaxReferral(code: String): UiText? {
     return validateMaxLength(code)
+}
+
+/**
+ * Builds the THORName memo a referral edit is signed with:
+ * `~:NAME:CHAIN:ADDRESS:OWNER:PREFERRED_ASSET`, where thornode reads the chain/address pair as the
+ * alias to register and the last field as the payout asset.
+ *
+ * With a payout asset the alias is registered on *that* asset's chain, pointing at this vault's
+ * address there — a preferred asset is only paid out to the alias its own chain carries, so setting
+ * the asset without the matching alias would leave the payout nowhere to land. Without one the memo
+ * keeps registering the THOR alias, which is all a plain expiry extension needs.
+ */
+internal fun buildEditReferralMemo(
+    referralCode: String,
+    thorAddress: String,
+    payoutAsset: ThorChainPoolCoin?,
+    payoutAssetAddress: String?,
+): String {
+    val code = referralCode.uppercase()
+    return if (payoutAsset != null && !payoutAssetAddress.isNullOrBlank()) {
+        "~:$code:${payoutAsset.coin.chain.swapAssetName()}:$payoutAssetAddress:$thorAddress:" +
+            payoutAsset.asset
+    } else {
+        "~:$code:THOR:$thorAddress:$thorAddress"
+    }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralViewModel.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.ui.navigation.Route
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -42,6 +43,8 @@ constructor(
 
     val state = MutableStateFlow<ReferralUiState>(ReferralUiState.Loading)
     private var remoteReferral: String? = null
+    private var retryCount = 0
+    private val maxRetries = 3
 
     init {
         loadStatus()
@@ -69,6 +72,30 @@ constructor(
                         state.value = ReferralUiState.Unavailable
                         return@safeLaunch
                     }
+
+                    // Retry if address is not yet loaded
+                    if (coin.address.isBlank()) {
+                        if (retryCount < maxRetries) {
+                            retryCount++
+                            Timber.d(
+                                "Coin address not ready, retrying in 500ms (attempt %d/%d)",
+                                retryCount,
+                                maxRetries,
+                            )
+                            viewModelScope.launch {
+                                delay(500)
+                                loadStatus()
+                            }
+                        } else {
+                            Timber.d(
+                                "Coin address never became available after %d retries",
+                                maxRetries,
+                            )
+                            state.value = ReferralUiState.Unavailable
+                        }
+                        return@safeLaunch
+                    }
+
                     withContext(Dispatchers.IO) {
                         thorChainApi.getReferralCodesByAddress(coin.address)
                     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/referral/ViewReferralViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/referral/ViewReferralViewModel.kt
@@ -179,12 +179,23 @@ constructor(
                 onLoadReferralCodeInfo()
             } else {
                 try {
+                    val coin =
+                        withContext(Dispatchers.IO) {
+                            vaultRepository.get(vaultId)?.coins?.find {
+                                it.chain.id == Chain.ThorChain.id && it.isNativeToken
+                            }
+                        } ?: error("Coin not found")
+
+                    // Skip if address is not ready
+                    if (coin.address.isBlank()) {
+                        Timber.d("Coin address not ready for vault %s", vaultId)
+                        this@ViewReferralViewModel.vaultReferralCode = ""
+                        onLoadReferralCodeInfo()
+                        return@launch
+                    }
+
                     val remoteReferral =
                         withContext(Dispatchers.IO) {
-                                val coin =
-                                    vaultRepository.get(vaultId)?.coins?.find {
-                                        it.chain.id == Chain.ThorChain.id && it.isNativeToken
-                                    } ?: error("Coin not found")
                                 thorChainApi.getReferralCodesByAddress(coin.address)
                             }
                             .firstOrNull()

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/NavGraph.kt
@@ -104,6 +104,7 @@ import com.vultisig.wallet.ui.screens.referral.ReferralCreateScreen
 import com.vultisig.wallet.ui.screens.referral.ReferralEditExternalScreen
 import com.vultisig.wallet.ui.screens.referral.ReferralEditVaultScreen
 import com.vultisig.wallet.ui.screens.referral.ReferralOnboardingScreen
+import com.vultisig.wallet.ui.screens.referral.ReferralPayoutAssetScreen
 import com.vultisig.wallet.ui.screens.referral.ReferralScreen
 import com.vultisig.wallet.ui.screens.referral.ReferralVaultListScreen
 import com.vultisig.wallet.ui.screens.referral.ReferralViewScreen
@@ -445,6 +446,8 @@ internal fun SetupNavGraph(navController: NavHostController, startDestination: A
         }
 
         composable<Route.ReferralCreation> { ReferralCreateScreen(navController = navController) }
+
+        dialog<Route.ReferralPayoutAsset> { ReferralPayoutAssetScreen() }
 
         composable(
             route = Destination.ReferralView.STATIC_ROUTE,

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
@@ -613,6 +613,13 @@ internal sealed class Route {
 
     @Serializable data class ReferralCreation(val vaultId: String)
 
+    /**
+     * Payout-asset picker for a referral. [selectedAsset] is the THORChain pool asset id currently
+     * chosen, so the list can mark it; the pick is returned through [requestId].
+     */
+    @Serializable
+    data class ReferralPayoutAsset(val requestId: String, val selectedAsset: String? = null)
+
     @Serializable data class ReferralExternalEdition(val vaultId: String)
 
     @Serializable data class ReferralListVault(val vaultId: String)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralEditVaultScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralEditVaultScreen.kt
@@ -3,6 +3,8 @@ package com.vultisig.wallet.ui.screens.referral
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,15 +12,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -29,6 +34,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.TokenLogo
 import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiGradientDivider
 import com.vultisig.wallet.ui.components.UiSpacer
@@ -40,6 +46,7 @@ import com.vultisig.wallet.ui.components.inputs.VsTextInputFieldInnerState
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.referral.EditVaultReferralUiState
 import com.vultisig.wallet.ui.models.referral.EditVaultReferralViewModel
+import com.vultisig.wallet.ui.models.referral.PayoutAssetUiModel
 import com.vultisig.wallet.ui.models.referral.ReferralError
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -59,6 +66,7 @@ internal fun ReferralEditVaultScreen(
         referralTextFieldState = model.referralTextFieldState,
         onDecrementCounter = model::onDecrementCounter,
         onIncrementCounter = model::onIncrementCounter,
+        onSelectPayoutAsset = model::onSelectPayoutAsset,
         onDismissError = model::onDismissError,
         onCopyReferralCode = {
             val clip = ClipData.newPlainText("ReferralCode", it)
@@ -75,6 +83,7 @@ private fun ReferralEditVaultScreen(
     onSavedReferral: () -> Unit,
     onIncrementCounter: () -> Unit,
     onDecrementCounter: () -> Unit,
+    onSelectPayoutAsset: () -> Unit,
     onDismissError: () -> Unit,
     referralTextFieldState: TextFieldState,
 ) {
@@ -175,6 +184,25 @@ private fun ReferralEditVaultScreen(
 
                 UiSpacer(16.dp)
 
+                Text(
+                    text = stringResource(R.string.referral_choose_payout_asset),
+                    style = Theme.brockmann.body.s.medium,
+                    color = Theme.v2.colors.text.primary,
+                )
+
+                UiSpacer(8.dp)
+
+                PayoutAssetSelection(asset = state.payoutAsset, onClick = onSelectPayoutAsset)
+
+                UiSpacer(16.dp)
+
+                UiGradientDivider(
+                    initialColor = Theme.v2.colors.backgrounds.primary,
+                    endColor = Theme.v2.colors.backgrounds.primary,
+                )
+
+                UiSpacer(16.dp)
+
                 EstimatedNetworkFee(
                     title = stringResource(R.string.referral_create_cost),
                     tokenGas = state.referralCostAmountFormatted,
@@ -188,7 +216,7 @@ private fun ReferralEditVaultScreen(
                 modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp).fillMaxWidth(),
                 variant = VsButtonVariant.Primary,
                 state =
-                    if (state.referralCounter != 0) {
+                    if (state.isSaveEnabled) {
                         VsButtonState.Enabled
                     } else {
                         VsButtonState.Disabled
@@ -197,6 +225,47 @@ private fun ReferralEditVaultScreen(
             )
         },
     )
+}
+
+@Composable
+private fun PayoutAssetSelection(asset: PayoutAssetUiModel?, onClick: () -> Unit) {
+    Row(
+        modifier =
+            Modifier.fillMaxWidth()
+                .background(
+                    color = Theme.v2.colors.backgrounds.secondary,
+                    shape = Theme.v2.radius.md,
+                )
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (asset != null) {
+            TokenLogo(
+                errorLogoModifier = Modifier.size(32.dp).background(Theme.v2.colors.neutrals.n100),
+                logo = asset.logo,
+                title = asset.ticker,
+                modifier = Modifier.size(32.dp),
+            )
+
+            UiSpacer(8.dp)
+
+            Text(
+                text = asset.ticker,
+                style = Theme.brockmann.body.m.medium,
+                color = Theme.v2.colors.text.primary,
+            )
+        }
+
+        UiSpacer(1f)
+
+        Icon(
+            painter = painterResource(id = R.drawable.ic_caret_right),
+            contentDescription = null,
+            tint = Theme.v2.colors.text.primary,
+            modifier = Modifier.size(24.dp),
+        )
+    }
 }
 
 @Preview(showBackground = true)
@@ -211,6 +280,14 @@ private fun ReferralEditVaultScreenPreview() {
                 referralExpiration = "December 31, 2025",
                 referralCostAmountFormatted = "0.02 RUNE",
                 referralCostFiatFormatted = "$1.50",
+                payoutAsset =
+                    PayoutAssetUiModel(
+                        asset = "THOR.RUNE",
+                        logo = "rune",
+                        ticker = "RUNE",
+                        chain = "THORChain",
+                    ),
+                isSaveEnabled = true,
                 error = null,
             ),
         onBackPressed = {},
@@ -218,6 +295,7 @@ private fun ReferralEditVaultScreenPreview() {
         onSavedReferral = {},
         onIncrementCounter = {},
         onDecrementCounter = {},
+        onSelectPayoutAsset = {},
         onDismissError = {},
         referralTextFieldState = referralTextFieldState,
     )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralPayoutAssetScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralPayoutAssetScreen.kt
@@ -88,6 +88,10 @@ private fun ReferralPayoutAssetScreen(
                     ) {
                         VsCircularLoading(modifier = Modifier.size(32.dp))
                     }
+                state.isError ->
+                    Column(modifier = Modifier.padding(all = 16.dp)) {
+                        NoFoundContent(message = stringResource(R.string.error_loading_information))
+                    }
                 assets.isEmpty() ->
                     Column(modifier = Modifier.padding(all = 16.dp)) {
                         NoFoundContent(message = stringResource(R.string.select_asset_no_result))

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralPayoutAssetScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralPayoutAssetScreen.kt
@@ -1,0 +1,203 @@
+package com.vultisig.wallet.ui.screens.referral
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.TokenLogo
+import com.vultisig.wallet.ui.components.UiGradientDivider
+import com.vultisig.wallet.ui.components.VsCircularLoading
+import com.vultisig.wallet.ui.components.bottomsheet.VsModalBottomSheet
+import com.vultisig.wallet.ui.components.inputs.VsSearchTextField
+import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
+import com.vultisig.wallet.ui.components.v2.tokenitem.NoFoundContent
+import com.vultisig.wallet.ui.models.referral.PayoutAssetUiModel
+import com.vultisig.wallet.ui.models.referral.ReferralPayoutAssetUiState
+import com.vultisig.wallet.ui.models.referral.ReferralPayoutAssetViewModel
+import com.vultisig.wallet.ui.theme.Theme
+
+@Composable
+internal fun ReferralPayoutAssetScreen(model: ReferralPayoutAssetViewModel = hiltViewModel()) {
+    val state by model.state.collectAsStateWithLifecycle()
+
+    VsModalBottomSheet(
+        onDismissRequest = model::back,
+        content = {
+            ReferralPayoutAssetScreen(
+                state = state,
+                searchFieldState = model.searchFieldState,
+                onAssetClick = model::onAssetClick,
+            )
+        },
+    )
+}
+
+@Composable
+private fun ReferralPayoutAssetScreen(
+    state: ReferralPayoutAssetUiState,
+    searchFieldState: TextFieldState,
+    onAssetClick: (PayoutAssetUiModel) -> Unit,
+) {
+    V2Scaffold(
+        applyScaffoldPaddings = true,
+        applyDefaultPaddings = false,
+        topBar = {
+            Column {
+                Text(
+                    text = stringResource(R.string.select_asset_title),
+                    style = Theme.brockmann.body.l.medium,
+                    color = Theme.v2.colors.text.primary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth().padding(all = 16.dp),
+                )
+
+                VsSearchTextField(fieldState = searchFieldState)
+            }
+        },
+        content = {
+            val assets = state.assets
+            when {
+                state.isLoading ->
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.fillMaxWidth().padding(all = 32.dp),
+                    ) {
+                        VsCircularLoading(modifier = Modifier.size(32.dp))
+                    }
+                assets.isEmpty() ->
+                    Column(modifier = Modifier.padding(all = 16.dp)) {
+                        NoFoundContent(message = stringResource(R.string.select_asset_no_result))
+                    }
+                else ->
+                    LazyColumn(contentPadding = PaddingValues(all = 16.dp)) {
+                        itemsIndexed(assets, key = { _, item -> item.asset }) { index, item ->
+                            val isFirst = index == 0
+                            val isLast = index == assets.size - 1
+                            val rounding = 12.dp
+
+                            PayoutAssetItem(
+                                asset = item,
+                                modifier =
+                                    Modifier.clickable(onClick = { onAssetClick(item) })
+                                        .background(
+                                            color = Theme.v2.colors.backgrounds.secondary,
+                                            shape =
+                                                RoundedCornerShape(
+                                                    topStart = if (isFirst) rounding else 0.dp,
+                                                    topEnd = if (isFirst) rounding else 0.dp,
+                                                    bottomStart = if (isLast) rounding else 0.dp,
+                                                    bottomEnd = if (isLast) rounding else 0.dp,
+                                                ),
+                                        ),
+                            )
+
+                            if (!isLast) {
+                                UiGradientDivider(
+                                    initialColor = Theme.v2.colors.backgrounds.secondary,
+                                    endColor = Theme.v2.colors.backgrounds.secondary,
+                                )
+                            }
+                        }
+                    }
+            }
+        },
+    )
+}
+
+@Composable
+private fun PayoutAssetItem(asset: PayoutAssetUiModel, modifier: Modifier = Modifier) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+    ) {
+        TokenLogo(
+            errorLogoModifier = Modifier.size(32.dp).background(Theme.v2.colors.neutrals.n100),
+            logo = asset.logo,
+            title = asset.ticker,
+            modifier = Modifier.size(32.dp),
+        )
+
+        Text(
+            text = asset.ticker,
+            style = Theme.brockmann.supplementary.footnote,
+            color = Theme.v2.colors.text.primary,
+            modifier = Modifier.weight(1f),
+        )
+
+        Text(
+            text = asset.chain,
+            style = Theme.brockmann.supplementary.caption,
+            color = Theme.v2.colors.text.secondary,
+            modifier =
+                Modifier.border(
+                        width = 1.dp,
+                        color = Theme.v2.colors.border.light,
+                        shape = Theme.v2.radius.pill,
+                    )
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+        )
+
+        if (asset.isSelected) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic_check),
+                contentDescription = null,
+                tint = Theme.v2.colors.alerts.success,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ReferralPayoutAssetScreenPreview() {
+    ReferralPayoutAssetScreen(
+        state =
+            ReferralPayoutAssetUiState(
+                isLoading = false,
+                assets =
+                    listOf(
+                        PayoutAssetUiModel(
+                            asset = "BTC.BTC",
+                            logo = "btc",
+                            ticker = "BTC",
+                            chain = "Bitcoin",
+                        ),
+                        PayoutAssetUiModel(
+                            asset = "ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48",
+                            logo = "usdc",
+                            ticker = "USDC",
+                            chain = "Ethereum",
+                            isSelected = true,
+                        ),
+                    ),
+            ),
+        searchFieldState = TextFieldState(),
+        onAssetClick = {},
+    )
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -627,6 +627,7 @@
     <string name="referral_create_search">Suche</string>
     <string name="referral_create_expiration_date">Ablaufdatum</string>
     <string name="referral_create_set_expiration_years">Ablauf festlegen (in Jahren)</string>
+    <string name="referral_choose_payout_asset">Auszahlungs-Asset wählen</string>
     <string name="referral_create_registration_fees">Registrierungsgebühren</string>
     <string name="referral_create_cost">Kosten</string>
     <string name="referral_create_fees_error">Gebühren konnten nicht geladen werden. Bitte versuchen Sie es erneut.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -627,6 +627,7 @@
     <string name="referral_create_search">Buscar</string>
     <string name="referral_create_expiration_date">Fecha de vencimiento</string>
     <string name="referral_create_set_expiration_years">Establecer vencimiento (en años)</string>
+    <string name="referral_choose_payout_asset">Elegir activo de pago</string>
     <string name="referral_create_registration_fees">Tarifas de registro</string>
     <string name="referral_create_cost">Costo</string>
     <string name="referral_create_fees_error">Error al cargar las tarifas. Inténtelo de nuevo.</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -628,6 +628,7 @@
     <string name="referral_create_search">Traži</string>
     <string name="referral_create_expiration_date">Datum isteka</string>
     <string name="referral_create_set_expiration_years">Postavi istek (u godinama)</string>
+    <string name="referral_choose_payout_asset">Odaberi isplatni token</string>
     <string name="referral_create_registration_fees">Naknade za registraciju</string>
     <string name="referral_create_cost">Trošak</string>
     <string name="referral_create_fees_error">Učitavanje naknada nije uspjelo. Pokušajte ponovo.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -627,6 +627,7 @@
     <string name="referral_create_search">Cerca</string>
     <string name="referral_create_expiration_date">Data di scadenza</string>
     <string name="referral_create_set_expiration_years">Imposta scadenza (in anni)</string>
+    <string name="referral_choose_payout_asset">Scegli asset di pagamento</string>
     <string name="referral_create_registration_fees">Commissioni di registrazione</string>
     <string name="referral_create_cost">Costo</string>
     <string name="referral_create_fees_error">Impossibile caricare le commissioni. Riprova.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -927,6 +927,7 @@
     <string name="referral_create_search">검색</string>
     <string name="referral_create_expiration_date">만료 날짜</string>
     <string name="referral_create_set_expiration_years">만료 기간 설정 (년 단위)</string>
+    <string name="referral_choose_payout_asset">지급 자산 선택</string>
     <string name="referral_create_registration_fees">등록 수수료</string>
     <string name="referral_create_cost">비용</string>
     <string name="referral_create_fees_error">수수료를 불러오지 못했습니다. 다시 시도해 주세요.</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -624,6 +624,7 @@
     <string name="referral_create_search">Zoeken</string>
     <string name="referral_create_expiration_date">Vervaldatum</string>
     <string name="referral_create_set_expiration_years">Vervaldatum instellen (in jaren)</string>
+    <string name="referral_choose_payout_asset">Kies uitbetalingsasset</string>
     <string name="referral_create_registration_fees">Registratiekosten</string>
     <string name="referral_create_cost">Kosten</string>
     <string name="referral_create_fees_error">Laden van vergoedingen mislukt. Probeer het opnieuw.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -625,6 +625,7 @@
     <string name="referral_create_search">Pesquisar</string>
     <string name="referral_create_expiration_date">Data de expiração</string>
     <string name="referral_create_set_expiration_years">Definir expiração (em anos)</string>
+    <string name="referral_choose_payout_asset">Escolher ativo de pagamento</string>
     <string name="referral_create_registration_fees">Taxas de registro</string>
     <string name="referral_create_cost">Custo</string>
     <string name="referral_create_fees_error">Falha ao carregar taxas. Tente novamente.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -626,6 +626,7 @@
     <string name="referral_create_search">Поиск</string>
     <string name="referral_create_expiration_date">Дата истечения</string>
     <string name="referral_create_set_expiration_years">Установить срок действия (в годах)</string>
+    <string name="referral_choose_payout_asset">Выбрать актив для выплат</string>
     <string name="referral_create_registration_fees">Регистрационные сборы</string>
     <string name="referral_create_cost">Стоимость</string>
     <string name="referral_create_fees_error">Не удалось загрузить комиссии. Попробуйте ещё раз.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -871,6 +871,7 @@
     <string name="referral_create_search">搜索</string>
     <string name="referral_create_expiration_date">到期日期</string>
     <string name="referral_create_set_expiration_years">设置到期（年）</string>
+    <string name="referral_choose_payout_asset">选择支付资产</string>
     <string name="referral_create_registration_fees">注册费</string>
     <string name="referral_create_cost">成本</string>
     <string name="referral_create_fees_error">加载费用失败，请重试。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -940,6 +940,7 @@
     <string name="referral_create_search">Search</string>
     <string name="referral_create_expiration_date">Expiration date</string>
     <string name="referral_create_set_expiration_years">Set Expiration (in years)</string>
+    <string name="referral_choose_payout_asset">Choose payout asset</string>
     <string name="referral_create_registration_fees">Registration Fees</string>
     <string name="referral_create_cost">Cost</string>
     <string name="referral_create_fees_error">Failed to load fees. Please try again.</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/referral/EditReferralMemoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/referral/EditReferralMemoTest.kt
@@ -1,0 +1,84 @@
+package com.vultisig.wallet.ui.models.referral
+
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.ThorChainPoolCoin
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the THORName memo a referral edit signs (issue #5684).
+ *
+ * Thornode reads it positionally — `~:name:chain:address:owner:preferred_asset` — so a shifted or
+ * dropped field silently registers the wrong thing: an alias on the wrong chain, or an ownership
+ * transfer. Matches iOS `ReferralCodeMemoFactory.createEdit`.
+ */
+internal class EditReferralMemoTest {
+
+    private val thorAddress = "thor1qzr6dfsxw8fjc9pj39cj7cxwlm8v49g0v5f9tw"
+
+    @Test
+    fun `extending the expiry alone re-registers only the THOR alias`() {
+        val memo =
+            buildEditReferralMemo(
+                referralCode = "vult",
+                thorAddress = thorAddress,
+                payoutAsset = null,
+                payoutAssetAddress = null,
+            )
+
+        assertEquals("~:VULT:THOR:$thorAddress:$thorAddress", memo)
+    }
+
+    @Test
+    fun `a payout asset registers its own chain's alias and the asset`() {
+        val ethAddress = "0x1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f00"
+        val asset =
+            ThorChainPoolCoin(
+                asset = "ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48",
+                coin = Coins.Ethereum.USDC,
+            )
+
+        val memo =
+            buildEditReferralMemo(
+                referralCode = "vult",
+                thorAddress = thorAddress,
+                payoutAsset = asset,
+                payoutAssetAddress = ethAddress,
+            )
+
+        assertEquals(
+            "~:VULT:ETH:$ethAddress:$thorAddress:ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48",
+            memo,
+        )
+    }
+
+    @Test
+    fun `the asset id is carried verbatim, only the code is uppercased`() {
+        val asset = ThorChainPoolCoin(asset = "THOR.TCY", coin = Coins.ThorChain.TCY)
+
+        val memo =
+            buildEditReferralMemo(
+                referralCode = "vUlT",
+                thorAddress = thorAddress,
+                payoutAsset = asset,
+                payoutAssetAddress = thorAddress,
+            )
+
+        assertEquals("~:VULT:THOR:$thorAddress:$thorAddress:THOR.TCY", memo)
+    }
+
+    @Test
+    fun `an asset with no derivable address falls back to the alias-only memo`() {
+        val asset = ThorChainPoolCoin(asset = "BTC.BTC", coin = Coins.Bitcoin.BTC)
+
+        val memo =
+            buildEditReferralMemo(
+                referralCode = "vult",
+                thorAddress = thorAddress,
+                payoutAsset = asset,
+                payoutAssetAddress = null,
+            )
+
+        assertEquals("~:VULT:THOR:$thorAddress:$thorAddress", memo)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/referral/EditVaultReferralViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/referral/EditVaultReferralViewModelTest.kt
@@ -1,0 +1,282 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.referral
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.cosmos.NativeTxFeeRune
+import com.vultisig.wallet.data.api.models.thorchain.ThorOwnerData
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.ThorChainPoolCoin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.AccountsRepository
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.DepositTransactionRepository
+import com.vultisig.wallet.data.repositories.RequestResultRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.EnableTokenUseCase
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCaseImpl
+import com.vultisig.wallet.data.utils.decimals
+import com.vultisig.wallet.data.utils.symbol
+import com.vultisig.wallet.data.utils.toValue
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import wallet.core.jni.CoinType
+
+/**
+ * Covers the payout-asset half of the referral edit (issue #5684): switching the asset is an edit
+ * of its own — it enables Save with no year added — and it has to reach the memo as an alias on the
+ * asset's own chain.
+ */
+internal class EditVaultReferralViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var blockChainSpecificRepository: BlockChainSpecificRepository
+    private lateinit var gasFeeToEstimate: GasFeeToEstimatedFeeUseCaseImpl
+    private lateinit var accountsRepository: AccountsRepository
+    private lateinit var transactionRepository: DepositTransactionRepository
+    private lateinit var thorChainApi: ThorChainApi
+    private lateinit var requestResultRepository: RequestResultRepository
+    private lateinit var vaultRepository: VaultRepository
+    private lateinit var chainAccountAddressRepository: ChainAccountAddressRepository
+    private lateinit var enableToken: EnableTokenUseCase
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        // Every network read in this ViewModel is wrapped in `withContext(Dispatchers.IO)`, which
+        // would otherwise hop to a real thread pool the test scheduler cannot wait on.
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns testDispatcher
+        // The RUNE amounts the screen formats read their ticker and precision from WalletCore,
+        // whose native library a JVM test has no way to load.
+        mockkStatic(COIN_TYPE_EXTENSIONS)
+        every { CoinType.THORCHAIN.symbol } returns "RUNE"
+        every { CoinType.THORCHAIN.decimals } returns 8
+        every { CoinType.THORCHAIN.toValue(any<BigInteger>()) } returns BigDecimal.ZERO
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+        every { any<SavedStateHandle>().toRoute<Route.ReferralVaultEdition>() } returns
+            Route.ReferralVaultEdition(
+                vaultId = VAULT_ID,
+                code = REFERRAL_CODE,
+                expiration = "1 January 2027",
+            )
+
+        navigator = mockk(relaxed = true)
+        blockChainSpecificRepository = mockk(relaxed = true)
+        gasFeeToEstimate = mockk(relaxed = true)
+        accountsRepository = mockk(relaxed = true)
+        transactionRepository = mockk(relaxed = true)
+        thorChainApi = mockk(relaxed = true)
+        requestResultRepository = mockk(relaxed = true)
+        vaultRepository = mockk(relaxed = true)
+        chainAccountAddressRepository = mockk(relaxed = true)
+        enableToken = mockk(relaxed = true)
+
+        every { accountsRepository.loadAddress(VAULT_ID, Chain.ThorChain) } returns
+            flowOf(thorAddress())
+        coEvery { thorChainApi.getTHORChainReferralFees() } returns
+            NativeTxFeeRune(
+                value = "2000000",
+                registerFeeRune = "1000000000",
+                feePerBlock = "20",
+                runePriceInTor = null,
+            )
+        coEvery { thorChainApi.getReferralCodeInfo(REFERRAL_CODE) } returns thorName(NO_ASSET)
+        coEvery { vaultRepository.get(VAULT_ID) } returns Vault(id = VAULT_ID, name = "Test Vault")
+        coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), any<Vault>()) } returns
+            Pair(ETH_ADDRESS, "derivedPubKey")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        unmockkStatic(COIN_TYPE_EXTENSIONS)
+        unmockkStatic(Dispatchers::class)
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `save stays disabled while nothing has been edited`() =
+        runTest(testDispatcher) {
+            val model = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(model.state.value.isSaveEnabled)
+        }
+
+    @Test
+    fun `changing only the payout asset enables save`() =
+        runTest(testDispatcher) {
+            coEvery { requestResultRepository.request<ThorChainPoolCoin>(any()) } returns usdc()
+
+            val model = createViewModel()
+            advanceUntilIdle()
+            model.onSelectPayoutAsset()
+            advanceUntilIdle()
+
+            assertEquals(0, model.state.value.referralCounter)
+            assertTrue(model.state.value.isSaveEnabled)
+            assertEquals("USDC", model.state.value.payoutAsset?.ticker)
+        }
+
+    @Test
+    fun `re-picking the asset the name already carries leaves nothing to save`() =
+        runTest(testDispatcher) {
+            coEvery { thorChainApi.getReferralCodeInfo(REFERRAL_CODE) } returns thorName(USDC_ASSET)
+            coEvery { requestResultRepository.request<ThorChainPoolCoin>(any()) } returns usdc()
+
+            val model = createViewModel()
+            advanceUntilIdle()
+            model.onSelectPayoutAsset()
+            advanceUntilIdle()
+
+            assertFalse(model.state.value.isSaveEnabled)
+        }
+
+    @Test
+    fun `the name's current payout asset is shown and kept through a year-only edit`() =
+        runTest(testDispatcher) {
+            coEvery { thorChainApi.getReferralCodeInfo(REFERRAL_CODE) } returns thorName(USDC_ASSET)
+
+            val model = createViewModel()
+            advanceUntilIdle()
+            assertEquals("USDC", model.state.value.payoutAsset?.ticker)
+
+            model.onIncrementCounter()
+            advanceUntilIdle()
+            model.onSavedReferral()
+            advanceUntilIdle()
+
+            assertEquals(
+                "~:$REFERRAL_CODE:ETH:$ETH_ADDRESS:$THOR_ADDRESS:$USDC_ASSET",
+                capturedMemo(),
+            )
+        }
+
+    @Test
+    fun `a chosen payout asset registers its chain's alias and is added to the vault`() =
+        runTest(testDispatcher) {
+            coEvery { requestResultRepository.request<ThorChainPoolCoin>(any()) } returns usdc()
+
+            val model = createViewModel()
+            advanceUntilIdle()
+            model.onSelectPayoutAsset()
+            advanceUntilIdle()
+            model.onSavedReferral()
+            advanceUntilIdle()
+
+            assertEquals(
+                "~:$REFERRAL_CODE:ETH:$ETH_ADDRESS:$THOR_ADDRESS:$USDC_ASSET",
+                capturedMemo(),
+            )
+            coVerify { enableToken(VAULT_ID, Coins.Ethereum.USDC) }
+        }
+
+    @Test
+    fun `an unchanged payout asset keeps the plain renewal memo`() =
+        runTest(testDispatcher) {
+            val model = createViewModel()
+            advanceUntilIdle()
+            model.onIncrementCounter()
+            advanceUntilIdle()
+            model.onSavedReferral()
+            advanceUntilIdle()
+
+            assertEquals("~:$REFERRAL_CODE:THOR:$THOR_ADDRESS:$THOR_ADDRESS", capturedMemo())
+        }
+
+    private fun capturedMemo(): String {
+        val tx = slot<DepositTransaction>()
+        coVerify { transactionRepository.addTransaction(capture(tx)) }
+        return tx.captured.memo
+    }
+
+    private fun createViewModel() =
+        EditVaultReferralViewModel(
+            savedStateHandle = SavedStateHandle(),
+            navigator = navigator,
+            blockChainSpecificRepository = blockChainSpecificRepository,
+            gasFeeToEstimate = gasFeeToEstimate,
+            accountsRepository = accountsRepository,
+            transactionRepository = transactionRepository,
+            thorChainApi = thorChainApi,
+            requestResultRepository = requestResultRepository,
+            vaultRepository = vaultRepository,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            enableToken = enableToken,
+        )
+
+    private fun usdc() = ThorChainPoolCoin(asset = USDC_ASSET, coin = Coins.Ethereum.USDC)
+
+    private fun thorName(preferredAsset: String) =
+        ThorOwnerData(
+            name = REFERRAL_CODE,
+            expireBlockHeight = 20_000_000L,
+            owner = THOR_ADDRESS,
+            preferredAsset = preferredAsset,
+            preferredAssetSwapThresholdRune = "0",
+            affiliateCollectorRune = "0",
+        )
+
+    private fun thorAddress(): Address {
+        val rune = Coins.ThorChain.RUNE.copy(address = THOR_ADDRESS)
+        return Address(
+            chain = Chain.ThorChain,
+            address = THOR_ADDRESS,
+            accounts =
+                listOf(
+                    Account(
+                        token = rune,
+                        tokenValue = TokenValue(BigInteger("100000000000"), rune),
+                        fiatValue = null,
+                        price = null,
+                    )
+                ),
+        )
+    }
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
+        const val REFERRAL_CODE = "VULT"
+        const val THOR_ADDRESS = "thor1qzr6dfsxw8fjc9pj39cj7cxwlm8v49g0v5f9tw"
+        const val ETH_ADDRESS = "0x1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f00"
+        const val USDC_ASSET = "ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48"
+        const val NO_ASSET = "."
+        const val COIN_TYPE_EXTENSIONS = "com.vultisig.wallet.data.utils.CoinTypeKt"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModelTest.kt
@@ -1,0 +1,156 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.referral
+
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.ThorChainPoolCoin
+import com.vultisig.wallet.data.repositories.RequestResultRepository
+import com.vultisig.wallet.data.usecases.GetThorChainPoolAssetsUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/** The payout-asset picker behind the referral edit (issue #5684). */
+internal class ReferralPayoutAssetViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private lateinit var navigator: Navigator<Destination>
+    private lateinit var requestResultRepository: RequestResultRepository
+    private lateinit var getThorChainPoolAssets: GetThorChainPoolAssetsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+        givenRoute(selectedAsset = null)
+
+        navigator = mockk(relaxed = true)
+        requestResultRepository = mockk(relaxed = true)
+        getThorChainPoolAssets = mockk()
+        coEvery { getThorChainPoolAssets() } returns listOf(btc(), usdc())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `lists the available pool assets once loaded`() =
+        runTest(testDispatcher) {
+            val model = createViewModel()
+            advanceUntilIdle()
+
+            assertEquals(listOf("BTC", "USDC"), model.state.value.assets.map { it.ticker })
+            assertEquals(false, model.state.value.isLoading)
+        }
+
+    @Test
+    fun `an empty list is shown rather than a spinner when the pools cannot be read`() =
+        runTest(testDispatcher) {
+            coEvery { getThorChainPoolAssets() } throws IllegalStateException("offline")
+
+            val model = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(model.state.value.assets.isEmpty())
+            assertEquals(false, model.state.value.isLoading)
+        }
+
+    @Test
+    fun `search narrows the list by ticker`() =
+        runTest(testDispatcher) {
+            val model = createViewModel()
+            advanceUntilIdle()
+
+            model.searchFieldState.setTextAndPlaceCursorAtEnd("usd")
+            // Nothing composes in a JVM test, so the snapshot the edit lands in has to be
+            // published by hand before `snapshotFlow` sees it.
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            assertEquals(listOf("USDC"), model.state.value.assets.map { it.ticker })
+        }
+
+    @Test
+    fun `marks the asset the caller opened the picker on`() =
+        runTest(testDispatcher) {
+            givenRoute(selectedAsset = USDC_ASSET)
+
+            val model = createViewModel()
+            advanceUntilIdle()
+
+            assertEquals(listOf(false, true), model.state.value.assets.map { it.isSelected })
+        }
+
+    @Test
+    fun `a pick is returned to the caller`() =
+        runTest(testDispatcher) {
+            val model = createViewModel()
+            advanceUntilIdle()
+
+            model.onAssetClick(model.state.value.assets.first { it.ticker == "USDC" })
+            advanceUntilIdle()
+
+            coVerify { requestResultRepository.respond(REQUEST_ID, usdc()) }
+            coVerify { navigator.navigate(Destination.Back) }
+        }
+
+    @Test
+    fun `dismissing releases the caller with no pick`() =
+        runTest(testDispatcher) {
+            val model = createViewModel()
+            advanceUntilIdle()
+
+            model.back()
+            advanceUntilIdle()
+
+            coVerify { requestResultRepository.respond(REQUEST_ID, null) }
+        }
+
+    private fun givenRoute(selectedAsset: String?) {
+        every { any<SavedStateHandle>().toRoute<Route.ReferralPayoutAsset>() } returns
+            Route.ReferralPayoutAsset(requestId = REQUEST_ID, selectedAsset = selectedAsset)
+    }
+
+    private fun createViewModel() =
+        ReferralPayoutAssetViewModel(
+            savedStateHandle = SavedStateHandle(),
+            navigator = navigator,
+            requestResultRepository = requestResultRepository,
+            getThorChainPoolAssets = getThorChainPoolAssets,
+        )
+
+    private fun btc() = ThorChainPoolCoin(asset = "BTC.BTC", coin = Coins.Bitcoin.BTC)
+
+    private fun usdc() = ThorChainPoolCoin(asset = USDC_ASSET, coin = Coins.Ethereum.USDC)
+
+    private companion object {
+        const val REQUEST_ID = "request-id"
+        const val USDC_ASSET = "ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModelTest.kt
@@ -67,10 +67,11 @@ internal class ReferralPayoutAssetViewModelTest {
 
             assertEquals(listOf("BTC", "USDC"), model.state.value.assets.map { it.ticker })
             assertEquals(false, model.state.value.isLoading)
+            assertEquals(false, model.state.value.isError)
         }
 
     @Test
-    fun `an empty list is shown rather than a spinner when the pools cannot be read`() =
+    fun `a failed read is reported as an error rather than as an empty pool list`() =
         runTest(testDispatcher) {
             coEvery { getThorChainPoolAssets() } throws IllegalStateException("offline")
 
@@ -79,6 +80,7 @@ internal class ReferralPayoutAssetViewModelTest {
 
             assertTrue(model.state.value.assets.isEmpty())
             assertEquals(false, model.state.value.isLoading)
+            assertEquals(true, model.state.value.isError)
         }
 
     @Test

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorChainPoolJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/ThorChainPoolJson.kt
@@ -19,4 +19,7 @@ data class ThorChainPoolJson(
     // lookup, without asking thornode about all ~100 of them.
     @SerialName("pending_inbound_rune") val pendingInboundRune: String = "0",
     @SerialName("pending_inbound_asset") val pendingInboundAsset: String = "0",
+    // The asset's own precision, only present when it differs from the 8 decimals THORChain
+    // accounts in (e.g. 6 for ETH.USDC). Absent for most pools.
+    @SerialName("decimals") val decimals: Int? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/ThorChainPoolCoin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/ThorChainPoolCoin.kt
@@ -1,0 +1,83 @@
+package com.vultisig.wallet.data.models
+
+/**
+ * A THORChain pool asset: the wire string thornode identifies it by (`BTC.BTC`,
+ * `ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48`) together with the wallet [Coin] it
+ * resolves to.
+ *
+ * Both halves are needed: [asset] is what a THORName memo carries verbatim — thornode matches it
+ * against its own pool table, so it must survive the round-trip unaltered — while [coin] is what
+ * the UI renders and what the vault enables so payouts in it become visible.
+ */
+data class ThorChainPoolCoin(val asset: String, val coin: Coin) {
+
+    companion object {
+        /** THORChain accounts in 8 decimals; used when a pool reports no precision of its own. */
+        private const val DEFAULT_DECIMALS = 8
+
+        /**
+         * Resolves a pool asset id into a [ThorChainPoolCoin], or null when the app has no chain
+         * for it (thornode lists pools this wallet cannot hold, e.g. a chain it doesn't support
+         * yet).
+         *
+         * [decimals] comes from the pool entry, which only reports it when the asset's precision
+         * differs from THORChain's own; it is used solely for assets missing from [Coins].
+         */
+        fun from(asset: String, decimals: Int? = null): ThorChainPoolCoin? {
+            val chainCode = asset.substringBefore('.', missingDelimiterValue = "")
+            if (chainCode.isEmpty()) return null
+
+            val tail = asset.substringAfter('.', missingDelimiterValue = "")
+            val ticker: String
+            val contractAddress: String
+            when {
+                tail.isEmpty() -> {
+                    ticker = chainCode
+                    contractAddress = ""
+                }
+                tail.contains('-') -> {
+                    ticker = tail.substringBefore('-')
+                    contractAddress = tail.substringAfter('-')
+                }
+                else -> {
+                    ticker = tail
+                    // THORChain's own non-native assets are denominated by their lowercased
+                    // ticker (`THOR.TCY` is held as `tcy`), every other chain identifies a token
+                    // by contract address, which a dash-less pool id does not carry.
+                    contractAddress =
+                        if (chainCode.equals(THORCHAIN_CODE, ignoreCase = true)) tail.lowercase()
+                        else ""
+                }
+            }
+            if (ticker.isEmpty()) return null
+
+            val chain =
+                Chain.entries.firstOrNull {
+                    it.swapAssetName().equals(chainCode, ignoreCase = true)
+                } ?: return null
+
+            val known = Coins.coins[chain].orEmpty()
+            val coin =
+                known.firstOrNull {
+                    contractAddress.isNotEmpty() &&
+                        it.contractAddress.equals(contractAddress, ignoreCase = true)
+                }
+                    ?: known.firstOrNull { it.ticker.equals(ticker, ignoreCase = true) }
+                    ?: Coin(
+                        chain = chain,
+                        ticker = ticker.uppercase(),
+                        logo = ticker.lowercase(),
+                        address = "",
+                        decimal = decimals ?: DEFAULT_DECIMALS,
+                        hexPublicKey = "",
+                        priceProviderID = "",
+                        contractAddress = contractAddress,
+                        isNativeToken = contractAddress.isEmpty(),
+                    )
+
+            return ThorChainPoolCoin(asset = asset, coin = coin)
+        }
+
+        private const val THORCHAIN_CODE = "THOR"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/ThorChainPoolCoin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/ThorChainPoolCoin.kt
@@ -57,12 +57,20 @@ data class ThorChainPoolCoin(val asset: String, val coin: Coin) {
                 } ?: return null
 
             val known = Coins.coins[chain].orEmpty()
+            // A pool id that spells out a contract address names one exact token, so a registry
+            // coin sharing only the ticker is a different token: enabling it would put the wrong
+            // contract and precision in the vault. The THORChain denom above is a guess made from
+            // the ticker rather than something the pool id carries, so it keeps the fallback.
+            val isTickerFallbackSound =
+                contractAddress.isEmpty() || chainCode.equals(THORCHAIN_CODE, ignoreCase = true)
             val coin =
                 known.firstOrNull {
                     contractAddress.isNotEmpty() &&
                         it.contractAddress.equals(contractAddress, ignoreCase = true)
                 }
-                    ?: known.firstOrNull { it.ticker.equals(ticker, ignoreCase = true) }
+                    ?: known.firstOrNull {
+                        isTickerFallbackSound && it.ticker.equals(ticker, ignoreCase = true)
+                    }
                     ?: Coin(
                         chain = chain,
                         ticker = ticker.uppercase(),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -274,6 +274,12 @@ internal interface DataUsecasesModule {
 
     @Binds
     @Singleton
+    fun bindGetThorChainPoolAssetsUseCase(
+        impl: GetThorChainPoolAssetsUseCaseImpl
+    ): GetThorChainPoolAssetsUseCase
+
+    @Binds
+    @Singleton
     fun bindThorChainLpPreflightUseCase(
         impl: ThorChainLpPreflightUseCaseImpl
     ): ThorChainLpPreflightUseCase

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainPoolAssetsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GetThorChainPoolAssetsUseCase.kt
@@ -1,0 +1,32 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.models.ThorChainPoolCoin
+import javax.inject.Inject
+
+/** Pool status thornode reports for a pool that can be traded — and set as a preferred asset. */
+private const val STATUS_AVAILABLE = "available"
+
+interface GetThorChainPoolAssetsUseCase {
+    /**
+     * The assets of every available THORChain pool, resolved to wallet coins and ordered by ticker.
+     *
+     * Staged and suspended pools are dropped: thornode rejects a THORName preferred asset whose
+     * pool is not available, so offering one could only produce a transaction that fails on chain.
+     */
+    suspend operator fun invoke(): List<ThorChainPoolCoin>
+}
+
+internal class GetThorChainPoolAssetsUseCaseImpl
+@Inject
+constructor(private val thorChainApi: ThorChainApi) : GetThorChainPoolAssetsUseCase {
+
+    override suspend fun invoke(): List<ThorChainPoolCoin> =
+        thorChainApi
+            .getPools()
+            .asSequence()
+            .filter { it.status.equals(STATUS_AVAILABLE, ignoreCase = true) }
+            .mapNotNull { ThorChainPoolCoin.from(asset = it.asset, decimals = it.decimals) }
+            .sortedBy { it.coin.ticker }
+            .toList()
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/ThorChainPoolCoinTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/ThorChainPoolCoinTest.kt
@@ -56,6 +56,18 @@ class ThorChainPoolCoinTest {
     }
 
     @Test
+    fun `keeps a pool's own contract rather than a registry coin sharing the ticker`() {
+        // Same ticker as the registry's USDC, a different token: resolving to the registry coin
+        // would enable the wrong contract in the vault.
+        val resolved =
+            ThorChainPoolCoin.from("ETH.USDC-0X0000000000000000000000000000000000000001", 6)
+
+        assertEquals("USDC", resolved?.coin?.ticker)
+        assertEquals("0X0000000000000000000000000000000000000001", resolved?.coin?.contractAddress)
+        assertEquals(6, resolved?.coin?.decimal)
+    }
+
+    @Test
     fun `synthesizes a coin for an asset missing from the registry`() {
         val resolved = ThorChainPoolCoin.from("AVAX.SOL-0XFE6B19286885A4F7F55ADAD09C3CD1F906D2478F")
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/ThorChainPoolCoinTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/ThorChainPoolCoinTest.kt
@@ -1,0 +1,88 @@
+package com.vultisig.wallet.data.models
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the pool-asset → [Coin] resolution behind the referral payout-asset picker (issue #5684).
+ *
+ * The asset id itself must survive unaltered: it is what the THORName memo carries, and thornode
+ * matches it verbatim against its own pool table.
+ */
+class ThorChainPoolCoinTest {
+
+    @Test
+    fun `resolves a native pool asset to its registry coin`() {
+        val resolved = ThorChainPoolCoin.from("BTC.BTC")
+
+        assertEquals("BTC.BTC", resolved?.asset)
+        assertEquals(Chain.Bitcoin, resolved?.coin?.chain)
+        assertEquals("BTC", resolved?.coin?.ticker)
+        assertTrue(resolved?.coin?.isNativeToken == true)
+    }
+
+    @Test
+    fun `resolves a contract-qualified pool asset to the matching registry coin`() {
+        val resolved =
+            ThorChainPoolCoin.from("ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48", 6)
+
+        assertEquals("ETH.USDC-0XA0B86991C6218B36C1D19D4A2E9EB0CE3606EB48", resolved?.asset)
+        assertEquals(Chain.Ethereum, resolved?.coin?.chain)
+        assertEquals("USDC", resolved?.coin?.ticker)
+        assertEquals(
+            Coins.Ethereum.USDC.contractAddress.lowercase(),
+            resolved?.coin?.contractAddress?.lowercase(),
+        )
+    }
+
+    @Test
+    fun `resolves a THORChain asset by its lowercased denom`() {
+        val resolved = ThorChainPoolCoin.from("THOR.TCY", 8)
+
+        assertEquals(Chain.ThorChain, resolved?.coin?.chain)
+        assertEquals("TCY", resolved?.coin?.ticker)
+        assertEquals("tcy", resolved?.coin?.contractAddress)
+    }
+
+    @Test
+    fun `falls back to the ticker when the denom is not the registry's`() {
+        // THOR.RUJI is held as `x/ruji`, which the pool id does not spell out.
+        val resolved = ThorChainPoolCoin.from("THOR.RUJI", 8)
+
+        assertEquals("RUJI", resolved?.coin?.ticker)
+        assertEquals("x/ruji", resolved?.coin?.contractAddress)
+    }
+
+    @Test
+    fun `synthesizes a coin for an asset missing from the registry`() {
+        val resolved = ThorChainPoolCoin.from("AVAX.SOL-0XFE6B19286885A4F7F55ADAD09C3CD1F906D2478F")
+
+        assertEquals(Chain.Avalanche, resolved?.coin?.chain)
+        assertEquals("SOL", resolved?.coin?.ticker)
+        assertEquals("0XFE6B19286885A4F7F55ADAD09C3CD1F906D2478F", resolved?.coin?.contractAddress)
+        assertEquals(false, resolved?.coin?.isNativeToken)
+        // No precision reported by the pool, so THORChain's own 8 decimals stand in.
+        assertEquals(8, resolved?.coin?.decimal)
+    }
+
+    @Test
+    fun `takes the pool's decimals for a synthesized coin`() {
+        val resolved =
+            ThorChainPoolCoin.from("BASE.VVV-0XACFE6019ED1A7DC6F7B508C02D1B04EC88CC21BF", 6)
+
+        assertEquals(6, resolved?.coin?.decimal)
+    }
+
+    @Test
+    fun `returns null for the sentinel a nameless preferred asset uses`() {
+        assertNull(ThorChainPoolCoin.from("."))
+        assertNull(ThorChainPoolCoin.from(""))
+    }
+
+    @Test
+    fun `returns null for a chain the wallet does not hold`() {
+        assertNull(ThorChainPoolCoin.from("ALEO.ALEO"))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/GetThorChainPoolAssetsUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/GetThorChainPoolAssetsUseCaseTest.kt
@@ -1,0 +1,48 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.models.thorchain.ThorChainPoolJson
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * The payout-asset list behind the referral edit (issue #5684). Thornode refuses a THORName whose
+ * preferred asset is not an available pool, so a staged or suspended pool must never be offered.
+ */
+class GetThorChainPoolAssetsUseCaseTest {
+
+    private val thorChainApi = mockk<ThorChainApi>()
+    private val useCase = GetThorChainPoolAssetsUseCaseImpl(thorChainApi)
+
+    @Test
+    fun `offers available pools only, ordered by ticker`() = runTest {
+        coEvery { thorChainApi.getPools() } returns
+            listOf(
+                pool("ETH.ETH", "Available"),
+                pool("ETH.DPI-0X1494CA1F11D487C2BBE4543E90080AEBA4BA3C2B", "Staged"),
+                pool("BTC.BTC", "Available"),
+                pool("LTC.LTC", "Suspended"),
+            )
+
+        val assets = useCase()
+
+        assertEquals(listOf("BTC.BTC", "ETH.ETH"), assets.map { it.asset })
+    }
+
+    @Test
+    fun `drops pools on chains the wallet cannot hold`() = runTest {
+        coEvery { thorChainApi.getPools() } returns
+            listOf(pool("BTC.BTC", "Available"), pool("ALEO.ALEO", "Available"))
+
+        val assets = useCase()
+
+        assertEquals(listOf("BTC.BTC"), assets.map { it.asset })
+    }
+
+    private fun pool(asset: String, status: String) =
+        ThorChainPoolJson(asset = asset, assetTorPrice = BigInteger.ZERO, status = status)
+}


### PR DESCRIPTION
Transaction hash 
https://runescan.io/tx/512D4D2D9D31A80DC1D691BB95277A4597989ABD2E075F781A08FDA68C90CAB3

## Summary

Referral → Edit could only extend the expiry, so a user who wanted their affiliate rewards paid in a different asset had no way to say so. That is the answer support ticket #1567 got on Aug 11 ("Edit allows me to add years only, not change preferred asset"), and it has been open since. iOS (`EditReferralDetailsViewModel`) and desktop both ship the control.

- **Choose payout asset** row on the Edit screen, opening on the asset the THORName already carries (RUNE when it has none)
- Picker sheet listing the **available** THORChain pool assets, searchable, with the current one ticked
- Save enables on an asset change alone — no year purchase required
- The chosen token is added to the vault, so the payouts are visible when they land (iOS `addCoinIfNeeded` parity)

## The memo

The siblings disagree on the memo, and only one of them can actually be paid:

| | memo |
|---|---|
| desktop `buildSetPreferredAssetMemo` | `~:CODE:THOR:thor:thor:ASSET` |
| iOS `ReferralCodeMemoFactory.createEdit` | `~:CODE:<assetChain>:<addrOnThatChain>:<thor>:<ASSET>` |

This follows iOS, checked against thornode rather than taken on faith. `handler_manage_thorname.go` applies `tn.SetAlias(msg.Chain, msg.Address)`, and a preferred asset is paid out to the alias of *that asset's* chain — so desktop's form can set an asset with no alias to deliver it to, while iOS's registers both in one message.

Two more behaviours come from the same handler:

- validation requires the pool to exist **and be `Available`**, so staged/suspended pools are filtered out of the picker instead of being offered and rejected on chain
- the expiry branch is guarded by `!msg.Coin.Amount.IsZero()`, so an asset-only edit signs a 0 RUNE deposit — matching iOS

## Notes

- `ThorChainPoolCoin` is named around the `ThorChainAsset` (protobuf DTO) and `ThorChainPoolAsset` (`ui.models.defi`) types that already exist.
- Translations for the one new string are lifted from iOS's own `choosePayoutAsset` for de/es/hr/it/ko/pt/zh; nl and ru are written here, since iOS ships neither.
- Out of scope: the create-referral flow still has no picker (iOS has one), and there is no "clear back to RUNE" affordance — thornode accepts RUNE as a clear sentinel, but iOS offers no such control either.
- No before/after screenshots, per the standing instruction on this repo to keep screenshots to debugging.

## Test plan

- [x] 26 new unit tests: memo shape (4), edit ViewModel behaviour (6), picker ViewModel (6), pool→coin resolution (8), pool filtering (2)
- [x] Full `:app` and `:data` unit test suites
- [x] `./gradlew assembleDebug`, `./gradlew :app:lintDebug`
- [ ] On device: Settings → Referral Code → My Referral → Edit referral → pick a payout asset with the year counter at 0 → Save enables, verify screen shows `~:CODE:ETH:<eth addr>:<thor addr>:ETH.USDC-0X…` with a 0 RUNE amount
- [ ] On device: re-enter Edit and add a year without touching the asset → memo keeps the asset already set

Closes #5684


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added referral payout-asset selection with search, chain labels, logos, and selected-state indicators.
- Existing payout assets are preserved, with RUNE selected by default when none is configured.
- Referral updates include the selected payout asset and automatically enable required vault tokens.
- Added loading, empty, and error states for asset selection.

## Bug Fixes
- Improved referral status loading with retry handling when wallet addresses are temporarily unavailable.

## Localization
- Added payout-asset selection translations across supported languages.

## Tests
- Added coverage for asset selection, memo generation, persistence, filtering, and asset resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->