### PR TITLE
chore(build): fix Gradle deprecation warnings

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ lottieCompose = "6.7.1"
 minSdk = "26"
 
 accompanistPermissions = "0.37.0"
-agp = "8.9.2"
+agp = "8.12.2"
 apache-compress = "1.27.1"
 apache-compress-xz = "1.10"
 barcodeScanning = "17.3.0"


### PR DESCRIPTION
## Summary
- bump Android Gradle Plugin from 8.9.2 to 8.12.2
- clears the Gradle null-attribute lookup deprecation emitted by Android lint model tasks
- keeps the project on the Gradle 8-compatible AGP line ahead of a future Gradle 9 upgrade

Fixes #5650

## Verification
- `./gradlew lintDebug --warning-mode all --rerun-tasks`
- `./gradlew assembleDebug testDebugUnitTest --warning-mode all --rerun-tasks`
- `./gradlew app:connectedDebugAndroidTest --warning-mode all` built without Gradle deprecation warnings, but failed on existing emulator UI test failures on Pixel 8 - 17 with `NoSuchMethodException: android.hardware.input.InputManager.getInstance`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android build tooling to a newer version.
  * Improves compatibility with current Android development requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->