### PR TITLE
feat(qbtc): let the claim banner be closed, behind real glass

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
@@ -27,6 +27,8 @@ import com.vultisig.wallet.data.repositories.BalanceRepository
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.ChainDashboardBottomBarVisibilityRepository
 import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
+import com.vultisig.wallet.data.repositories.PromoBanner
+import com.vultisig.wallet.data.repositories.PromoBannerDismissalRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DiscoverTokenUseCase
@@ -106,6 +108,7 @@ constructor(
     private val vaultRepository: VaultRepository,
     private val requestResultRepository: RequestResultRepository,
     private val balanceRepository: BalanceRepository,
+    private val promoBannerDismissalRepository: PromoBannerDismissalRepository,
 ) : ViewModel() {
     private val tokens = MutableStateFlow(emptyList<Coin>())
 
@@ -116,6 +119,7 @@ constructor(
     val uiState = MutableStateFlow(ChainTokensUiModel())
 
     private var loadDataJob: Job? = null
+    private var qbtcBannerJob: Job? = null
 
     private fun updateBalanceVisibility() {
         viewModelScope.safeLaunch {
@@ -186,13 +190,31 @@ constructor(
         val vault = currentVault
         val hasMldsaKey = vault != null && vault.hasValidMldsaKey()
         val canGenerateMldsaKey = vault != null && vault.libType == SigningLibType.DKLS
-        uiState.update {
-            it.copy(
-                showQbtcClaimBanner =
-                    chain == Chain.Bitcoin && (hasMldsaKey || canGenerateMldsaKey),
-                showClaimQbtcButton = chain == Chain.Qbtc && hasMldsaKey,
-            )
+        val isEligible = chain == Chain.Bitcoin && (hasMldsaKey || canGenerateMldsaKey)
+
+        uiState.update { it.copy(showClaimQbtcButton = chain == Chain.Qbtc && hasMldsaKey) }
+
+        qbtcBannerJob?.cancel()
+        if (!isEligible) {
+            uiState.update { it.copy(showQbtcClaimBanner = false) }
+            return
         }
+
+        // Collected rather than read once so closing the banner hides it on the spot: the
+        // dismissal is a stored timestamp, and writing it re-emits here.
+        qbtcBannerJob =
+            viewModelScope.safeLaunch {
+                promoBannerDismissalRepository.isDismissed(PromoBanner.ClaimQbtc).collect {
+                    isDismissed ->
+                    uiState.update { it.copy(showQbtcClaimBanner = !isDismissed) }
+                }
+            }
+    }
+
+    // Global dismissal under the banner's own policy — permanent, so the card does not come back
+    // once closed. The claim itself stays reachable from the QBTC chain screen.
+    fun dismissQbtcClaimBanner() {
+        viewModelScope.safeLaunch { promoBannerDismissalRepository.dismiss(PromoBanner.ClaimQbtc) }
     }
 
     fun buy() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
@@ -214,6 +214,9 @@ constructor(
     // Global dismissal under the banner's own policy — permanent, so the card does not come back
     // once closed. The claim itself stays reachable from the QBTC chain screen.
     fun dismissQbtcClaimBanner() {
+        // Hidden here rather than left to the dismissal collector, so the card goes on the tap
+        // instead of a disk write later; the stored dismissal then re-emits the same false.
+        uiState.update { it.copy(showQbtcClaimBanner = false) }
         viewModelScope.safeLaunch { promoBannerDismissalRepository.dismiss(PromoBanner.ClaimQbtc) }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/ClaimQbtcPromoBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/ClaimQbtcPromoBanner.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.ui.screens.qbtc
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,128 +14,255 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.components.UiIcon
+import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.theme.Theme
 
+/** Height of the Figma reference frame (361x156), which the coin geometry below is measured in. */
+private val BannerHeight = 156.dp
+
+private val GlassCloseSize = 40.dp
+private val GlassCloseInset = 9.dp
+private val GlassCloseBlur = 20.dp
+private val GlassCloseIconSize = 12.dp
+
 @Composable
-internal fun ClaimQbtcPromoBanner(onClaim: () -> Unit, modifier: Modifier = Modifier) {
+internal fun ClaimQbtcPromoBanner(
+    onClaim: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val glow = Theme.v2.colors.primary.accent2
+    val scrim = Theme.v2.colors.backgrounds.background
+    val shine = Theme.v2.colors.neutrals.n50
+    val backdrop = rememberGraphicsLayer()
+    val frost = rememberGraphicsLayer()
+
     Box(
         contentAlignment = Alignment.Center,
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(156.dp)
+                .height(BannerHeight)
                 .clip(Theme.v2.radius.xl)
                 .background(Theme.v2.colors.backgrounds.surface2)
                 .drawBehind {
+                    val centerX = size.width / 2f
+                    val centerY = size.height / 2f
+
+                    // The card's depth, in the order Figma stacks it: a faint disc wider than the
+                    // card, a dark navy disc that sinks its middle, and the brand glow on top.
+                    drawCircle(
+                        color = shine.copy(alpha = 0.014f),
+                        radius = 209.dp.toPx(),
+                        center = Offset(centerX, centerY),
+                    )
+                    drawCircle(
+                        color = scrim.copy(alpha = 0.7f),
+                        radius = 147.dp.toPx(),
+                        center = Offset(centerX, centerY),
+                    )
+                    drawCircle(
+                        color = shine.copy(alpha = 0.07f),
+                        radius = 146.dp.toPx(),
+                        center = Offset(centerX, centerY),
+                        style = Stroke(width = 2.dp.toPx()),
+                    )
                     drawRect(
                         brush =
                             Brush.radialGradient(
-                                0f to QbtcBannerGlow.copy(alpha = 0.3f),
-                                0.45f to QbtcBannerGlow.copy(alpha = 0.1f),
-                                1f to Color.Transparent,
-                                center = Offset(size.width / 2f, size.height / 2f + 30.dp.toPx()),
-                                radius = size.maxDimension * 0.4f,
+                                0f to glow.copy(alpha = 0.7f),
+                                1f to scrim.copy(alpha = 0f),
+                                center = Offset(centerX, 115.dp.toPx()),
+                                radius = 175.dp.toPx(),
                             )
                     )
-                },
+                }
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.border.light,
+                    shape = Theme.v2.radius.xl,
+                ),
     ) {
-        QbtcCoinDecorations()
-
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-            modifier = Modifier.padding(24.dp),
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier.matchParentSize().drawWithContent {
+                    backdrop.record { this@drawWithContent.drawContent() }
+                    drawLayer(backdrop)
+                },
         ) {
+            QbtcCoinDecorations()
+
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+                modifier = Modifier.fillMaxWidth().padding(24.dp),
             ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    Text(
+                        text = stringResource(R.string.qbtc_claim_banner_subtitle),
+                        style = Theme.brockmann.supplementary.caption,
+                        color = Theme.v2.colors.text.tertiary,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = stringResource(R.string.qbtc_claim_banner_title),
+                        style = Theme.brockmann.headings.title2,
+                        color = Theme.v2.colors.text.primary,
+                        textAlign = TextAlign.Center,
+                    )
+                }
                 Text(
-                    text = stringResource(R.string.qbtc_claim_banner_subtitle),
+                    text = stringResource(R.string.qbtc_claim_banner_cta),
                     style = Theme.brockmann.supplementary.caption,
-                    color = Theme.v2.colors.text.tertiary,
-                    textAlign = TextAlign.Center,
-                )
-                Text(
-                    text = stringResource(R.string.qbtc_claim_banner_title),
-                    style = Theme.brockmann.headings.title2,
-                    color = Theme.v2.colors.text.primary,
-                    textAlign = TextAlign.Center,
+                    color = Theme.v2.colors.text.button.primary,
+                    modifier =
+                        Modifier.clip(Theme.v2.radius.pill)
+                            .background(Theme.v2.colors.buttons.ctaPrimary)
+                            .clickable(onClick = onClaim)
+                            .padding(horizontal = 16.dp, vertical = 8.dp),
                 )
             }
-            Text(
-                text = stringResource(R.string.qbtc_claim_banner_cta),
-                style = Theme.brockmann.button.semibold.medium,
-                color = Theme.v2.colors.text.primary,
-                modifier =
-                    Modifier.clip(Theme.v2.radius.pill)
-                        .background(Theme.v2.colors.buttons.ctaPrimary)
-                        .clickable(onClick = onClaim)
-                        .padding(horizontal = 24.dp, vertical = 12.dp),
+        }
+
+        Box(
+            modifier =
+                Modifier.matchParentSize().drawBehind {
+                    drawGlassCloseBackdrop(backdrop = backdrop, frost = frost, tint = shine)
+                }
+        )
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier =
+                Modifier.align(Alignment.TopEnd)
+                    .padding(all = GlassCloseInset)
+                    .size(GlassCloseSize)
+                    .clip(CircleShape)
+                    .clickOnce(onClick = onDismiss),
+        ) {
+            UiIcon(
+                drawableResId = R.drawable.glass,
+                tint = Theme.v2.colors.neutrals.n100,
+                size = GlassCloseIconSize,
             )
         }
     }
 }
 
+/**
+ * Frosts the card under the close control: what the banner drew is re-drawn blurred and clipped to
+ * the control's circle, so the coin behind it reads as glass rather than as a bare icon.
+ *
+ * [backdrop] holds the card's own drawing, recorded a moment earlier in the same frame; [frost]
+ * carries the blur, since a render effect belongs to a layer rather than to a draw call. The blur
+ * needs API 31 — below it the layer draws unblurred, leaving the control as it was before.
+ */
+private fun DrawScope.drawGlassCloseBackdrop(
+    backdrop: GraphicsLayer,
+    frost: GraphicsLayer,
+    tint: Color,
+) {
+    val blurRadius = GlassCloseBlur.toPx()
+    frost.renderEffect = BlurEffect(radiusX = blurRadius, radiusY = blurRadius)
+    frost.record { drawLayer(backdrop) }
+
+    val radius = GlassCloseSize.toPx() / 2f
+    val center =
+        Offset(
+            x = size.width - GlassCloseInset.toPx() - radius,
+            y = GlassCloseInset.toPx() + radius,
+        )
+
+    clipPath(Path().apply { addOval(Rect(center = center, radius = radius)) }) {
+        drawLayer(frost)
+        drawCircle(color = tint.copy(alpha = 0.01f), radius = radius, center = center)
+    }
+}
+
+/**
+ * The scattered coin stacks, placed from the Figma frame: left-hand coins keep their distance from
+ * the leading edge and right-hand ones from the trailing edge, so the arrangement survives a card
+ * wider or narrower than the 361 dp reference.
+ *
+ * Each coin is sized unrotated — [rotate] spins it about its centre without changing the space it
+ * takes — so these are Figma's inner sizes, not its rotated bounding boxes.
+ */
 @Composable
 private fun QbtcCoinDecorations() {
     Box(modifier = Modifier.fillMaxSize()) {
         QbtcCoin(
-            width = 40.dp,
-            height = 45.dp,
-            rotation = -26.5f,
-            alignment = Alignment.CenterStart,
-            offsetX = 7.dp,
-            offsetY = (-55).dp,
+            width = 37.3.dp,
+            height = 41.7.dp,
+            rotation = -26.62f,
+            alignment = Alignment.TopStart,
+            offsetX = 5.4.dp,
+            offsetY = 5.2.dp,
         )
         QbtcCoin(
-            width = 90.dp,
-            height = 100.dp,
-            rotation = 13f,
-            alignment = Alignment.CenterStart,
-            offsetX = (-30).dp,
+            width = 80.dp,
+            height = 90.dp,
+            rotation = 13.22f,
+            alignment = Alignment.TopStart,
+            offsetX = (-28.8).dp,
+            offsetY = 43.dp,
+        )
+        QbtcCoin(
+            width = 44.1.dp,
+            height = 49.2.dp,
+            rotation = 8.42f,
+            alignment = Alignment.TopStart,
+            offsetX = 1.4.dp,
+            offsetY = 124.dp,
+        )
+        QbtcCoin(
+            width = 86.8.dp,
+            height = 97.8.dp,
+            rotation = 0f,
+            alignment = Alignment.TopEnd,
+            offsetX = 13.8.dp,
             offsetY = 11.dp,
         )
         QbtcCoin(
-            width = 50.dp,
-            height = 55.dp,
-            rotation = 8.5f,
-            alignment = Alignment.CenterStart,
-            offsetX = 10.dp,
-            offsetY = 72.dp,
-        )
-        QbtcCoin(
-            width = 87.dp,
-            height = 98.dp,
-            rotation = 0f,
-            alignment = Alignment.CenterEnd,
-            offsetX = 17.dp,
-            offsetY = (-50).dp,
-        )
-        QbtcCoin(
-            width = 50.dp,
-            height = 55.dp,
+            width = 43.dp,
+            height = 48.dp,
             rotation = -6.84f,
-            alignment = Alignment.CenterEnd,
-            offsetX = (-10).dp,
-            offsetY = 45.dp,
+            alignment = Alignment.TopEnd,
+            offsetX = (-27.3).dp,
+            offsetY = 106.4.dp,
         )
     }
 }
@@ -192,4 +320,8 @@ internal fun ClaimQbtcBottomCta(onClaim: () -> Unit, modifier: Modifier = Modifi
     }
 }
 
-private val QbtcBannerGlow = Color(0xFF0538C7)
+@Preview
+@Composable
+private fun ClaimQbtcPromoBannerPreview() {
+    ClaimQbtcPromoBanner(onClaim = {}, onDismiss = {}, modifier = Modifier.padding(16.dp))
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/ClaimQbtcPromoBanner.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/qbtc/ClaimQbtcPromoBanner.kt
@@ -38,6 +38,10 @@ import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -54,6 +58,15 @@ private val GlassCloseSize = 40.dp
 private val GlassCloseInset = 9.dp
 private val GlassCloseBlur = 20.dp
 private val GlassCloseIconSize = 12.dp
+
+private val ContentPadding = 24.dp
+
+/**
+ * Kept clear of the close control on both sides, so the subtitle stays centred on the card: it is
+ * the one line drawn level with the control, and a long translation would otherwise run under the
+ * frost disc.
+ */
+private val SubtitleGutter = GlassCloseInset + GlassCloseSize - ContentPadding
 
 @Composable
 internal fun ClaimQbtcPromoBanner(
@@ -126,7 +139,7 @@ internal fun ClaimQbtcPromoBanner(
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(16.dp),
-                modifier = Modifier.fillMaxWidth().padding(24.dp),
+                modifier = Modifier.fillMaxWidth().padding(ContentPadding),
             ) {
                 Column(
                     horizontalAlignment = Alignment.CenterHorizontally,
@@ -137,6 +150,7 @@ internal fun ClaimQbtcPromoBanner(
                         style = Theme.brockmann.supplementary.caption,
                         color = Theme.v2.colors.text.tertiary,
                         textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(horizontal = SubtitleGutter),
                     )
                     Text(
                         text = stringResource(R.string.qbtc_claim_banner_title),
@@ -165,6 +179,8 @@ internal fun ClaimQbtcPromoBanner(
                 }
         )
 
+        // The icon carries no description of its own, so the control announces once, as a button.
+        val dismissLabel = stringResource(R.string.close_sheet_content_description)
         Box(
             contentAlignment = Alignment.Center,
             modifier =
@@ -172,7 +188,11 @@ internal fun ClaimQbtcPromoBanner(
                     .padding(all = GlassCloseInset)
                     .size(GlassCloseSize)
                     .clip(CircleShape)
-                    .clickOnce(onClick = onDismiss),
+                    .clickOnce(onClick = onDismiss)
+                    .semantics {
+                        role = Role.Button
+                        contentDescription = dismissLabel
+                    },
         ) {
             UiIcon(
                 drawableResId = R.drawable.glass,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
@@ -87,6 +87,7 @@ internal fun ChainTokensScreen(
         onHideSearchBar = viewModel::hideSearchBar,
         onShowSearchBar = viewModel::showSearchBar,
         onClaimQbtc = viewModel::onClaimQbtc,
+        onDismissQbtcBanner = viewModel::dismissQbtcClaimBanner,
     )
 }
 
@@ -107,6 +108,7 @@ internal fun ChainTokensScreen(
     onSelectTokens: () -> Unit,
     onTokenClick: (ChainTokenUiModel) -> Unit,
     onClaimQbtc: () -> Unit = {},
+    onDismissQbtcBanner: () -> Unit = {},
 ) {
     val snackbarState = rememberVsSnackbarState()
     val uriHandler = VsUriHandler()
@@ -307,6 +309,7 @@ internal fun ChainTokensScreen(
                     if (uiModel.showQbtcClaimBanner) {
                         ClaimQbtcPromoBanner(
                             onClaim = onClaimQbtc,
+                            onDismiss = onDismissQbtcBanner,
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                         )
                     }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ChainTokensViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ChainTokensViewModelTest.kt
@@ -2,11 +2,17 @@
 
 package com.vultisig.wallet.ui.models
 
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SigningLibType
+import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.BalanceRepository
 import com.vultisig.wallet.data.repositories.BalanceVisibilityRepository
 import com.vultisig.wallet.data.repositories.ChainDashboardBottomBarVisibilityRepository
+import com.vultisig.wallet.data.repositories.DismissPolicy
 import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
+import com.vultisig.wallet.data.repositories.PromoBanner
+import com.vultisig.wallet.data.repositories.PromoBannerDismissalRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.DiscoverTokenUseCase
@@ -14,11 +20,17 @@ import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -41,6 +53,7 @@ internal class ChainTokensViewModelTest {
     private lateinit var vaultRepository: VaultRepository
     private lateinit var requestResultRepository: RequestResultRepository
     private lateinit var balanceRepository: BalanceRepository
+    private lateinit var promoBannerDismissalRepository: FakePromoBannerDismissalRepository
 
     @BeforeEach
     fun setUp() {
@@ -56,6 +69,7 @@ internal class ChainTokensViewModelTest {
         vaultRepository = mockk(relaxed = true)
         requestResultRepository = mockk(relaxed = true)
         balanceRepository = mockk(relaxed = true)
+        promoBannerDismissalRepository = FakePromoBannerDismissalRepository()
     }
 
     @AfterEach
@@ -76,6 +90,7 @@ internal class ChainTokensViewModelTest {
             vaultRepository = vaultRepository,
             requestResultRepository = requestResultRepository,
             balanceRepository = balanceRepository,
+            promoBannerDismissalRepository = promoBannerDismissalRepository,
         )
 
     @Test
@@ -115,5 +130,59 @@ internal class ChainTokensViewModelTest {
 
         vm.hideSearchBar()
         assertFalse(vm.uiState.value.isSearchMode)
+    }
+
+    @Test
+    fun `the qbtc claim banner shows on bitcoin for a vault that can claim`() {
+        val vm = createEligibleViewModel()
+
+        assertTrue(vm.uiState.value.showQbtcClaimBanner)
+    }
+
+    @Test
+    fun `closing the qbtc claim banner hides it straight away`() {
+        val vm = createEligibleViewModel()
+
+        vm.dismissQbtcClaimBanner()
+
+        assertFalse(vm.uiState.value.showQbtcClaimBanner)
+    }
+
+    @Test
+    fun `a qbtc claim banner closed earlier does not come back`() {
+        promoBannerDismissalRepository.setDismissed(PromoBanner.ClaimQbtc)
+
+        val vm = createEligibleViewModel()
+
+        assertFalse(vm.uiState.value.showQbtcClaimBanner)
+    }
+
+    /** A view model on the Bitcoin screen of a DKLS vault — the state that surfaces the banner. */
+    private fun createEligibleViewModel(): ChainTokensViewModel {
+        // A relaxed mock answers this Unit-returning function type with an Object, which the call
+        // site then fails to cast.
+        every { discoverTokenUseCase(any(), any()) } returns Unit
+        coEvery { vaultRepository.get(VAULT_ID) } returns
+            Vault(id = VAULT_ID, name = "vault", libType = SigningLibType.DKLS)
+
+        return createViewModel().apply { initData(vaultId = VAULT_ID, chainId = Chain.Bitcoin.raw) }
+    }
+
+    /**
+     * Dismissals held in memory, so a write is observed by an in-flight read as it is in DataStore.
+     */
+    private class FakePromoBannerDismissalRepository : PromoBannerDismissalRepository {
+        private val dismissed = MutableStateFlow(emptySet<PromoBanner>())
+
+        fun setDismissed(banner: PromoBanner) = dismissed.update { it + banner }
+
+        override fun isDismissed(banner: PromoBanner, policy: DismissPolicy): Flow<Boolean> =
+            dismissed.map { banner in it }
+
+        override suspend fun dismiss(banner: PromoBanner) = setDismissed(banner)
+    }
+
+    private companion object {
+        const val VAULT_ID = "vault-id"
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/ChainTokensViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/ChainTokensViewModelTest.kt
@@ -20,13 +20,13 @@ import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.map
@@ -99,7 +99,7 @@ internal class ChainTokensViewModelTest {
 
         vm.showSearchBar()
 
-        assertTrue(vm.uiState.value.isSearchMode)
+        vm.uiState.value.isSearchMode shouldBe true
     }
 
     @Test
@@ -109,34 +109,34 @@ internal class ChainTokensViewModelTest {
 
         vm.hideSearchBar()
 
-        assertFalse(vm.uiState.value.isSearchMode)
+        vm.uiState.value.isSearchMode shouldBe false
     }
 
     @Test
     fun `isSearchMode is false by default`() {
         val vm = createViewModel()
 
-        assertFalse(vm.uiState.value.isSearchMode)
+        vm.uiState.value.isSearchMode shouldBe false
     }
 
     @Test
     fun `showSearchBar then hideSearchBar toggles state correctly`() {
         val vm = createViewModel()
 
-        assertFalse(vm.uiState.value.isSearchMode)
+        vm.uiState.value.isSearchMode shouldBe false
 
         vm.showSearchBar()
-        assertTrue(vm.uiState.value.isSearchMode)
+        vm.uiState.value.isSearchMode shouldBe true
 
         vm.hideSearchBar()
-        assertFalse(vm.uiState.value.isSearchMode)
+        vm.uiState.value.isSearchMode shouldBe false
     }
 
     @Test
     fun `the qbtc claim banner shows on bitcoin for a vault that can claim`() {
         val vm = createEligibleViewModel()
 
-        assertTrue(vm.uiState.value.showQbtcClaimBanner)
+        vm.uiState.value.showQbtcClaimBanner shouldBe true
     }
 
     @Test
@@ -145,7 +145,17 @@ internal class ChainTokensViewModelTest {
 
         vm.dismissQbtcClaimBanner()
 
-        assertFalse(vm.uiState.value.showQbtcClaimBanner)
+        vm.uiState.value.showQbtcClaimBanner shouldBe false
+    }
+
+    @Test
+    fun `the qbtc claim banner goes before the dismissal reaches disk`() {
+        promoBannerDismissalRepository.holdDismissal()
+        val vm = createEligibleViewModel()
+
+        vm.dismissQbtcClaimBanner()
+
+        vm.uiState.value.showQbtcClaimBanner shouldBe false
     }
 
     @Test
@@ -154,7 +164,7 @@ internal class ChainTokensViewModelTest {
 
         val vm = createEligibleViewModel()
 
-        assertFalse(vm.uiState.value.showQbtcClaimBanner)
+        vm.uiState.value.showQbtcClaimBanner shouldBe false
     }
 
     /** A view model on the Bitcoin screen of a DKLS vault — the state that surfaces the banner. */
@@ -173,13 +183,22 @@ internal class ChainTokensViewModelTest {
      */
     private class FakePromoBannerDismissalRepository : PromoBannerDismissalRepository {
         private val dismissed = MutableStateFlow(emptySet<PromoBanner>())
+        private var dismissalLands = true
 
         fun setDismissed(banner: PromoBanner) = dismissed.update { it + banner }
+
+        /** Stands in for a write that has not reached disk, so nothing is read back from it. */
+        fun holdDismissal() {
+            dismissalLands = false
+        }
 
         override fun isDismissed(banner: PromoBanner, policy: DismissPolicy): Flow<Boolean> =
             dismissed.map { banner in it }
 
-        override suspend fun dismiss(banner: PromoBanner) = setDismissed(banner)
+        override suspend fun dismiss(banner: PromoBanner) {
+            if (!dismissalLands) awaitCancellation()
+            setDismissed(banner)
+        }
     }
 
     private companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepository.kt
@@ -33,6 +33,9 @@ enum class PromoBanner(val id: String, val dismissPolicy: DismissPolicy) {
     UpgradeVaultDkls(id = "upgrade_vault_dkls", dismissPolicy = DismissPolicy.Ttl(15.days)),
     BuyVultSwap(id = "buy_vult_swap", dismissPolicy = DismissPolicy.Ttl(7.days)),
     FollowXVultisig(id = "follow_x_vultisig", dismissPolicy = DismissPolicy.Ttl(15.days)),
+    // A campaign, not a standing promo: the claim entry point also lives on the QBTC chain screen,
+    // so a closed banner has nothing to come back for.
+    ClaimQbtc(id = "claim_qbtc", dismissPolicy = DismissPolicy.Permanent),
 }
 
 interface PromoBannerDismissalRepository {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/PromoBannerDismissalRepositoryTest.kt
@@ -92,6 +92,15 @@ internal class PromoBannerDismissalRepositoryTest {
         repo.isDismissed(PromoBanner.FollowXVultisig).first() shouldBe false
     }
 
+    @Test
+    fun `closing the QBTC claim banner keeps it closed for good`() = runTest {
+        repo.dismiss(PromoBanner.ClaimQbtc)
+
+        now += 3650.days.inWholeMilliseconds
+
+        repo.isDismissed(PromoBanner.ClaimQbtc).first() shouldBe true
+    }
+
     private fun ttlOf(banner: PromoBanner): Long {
         val policy = banner.dismissPolicy
         check(policy is DismissPolicy.Ttl) { "Expected a TTL policy for $banner" }


### PR DESCRIPTION
Closes #5682

## Why

The QBTC claim banner had no way out. It shows on the Bitcoin chain screen for any vault that holds — or can generate — an MLDSA key, and nothing ever hides it: claiming does not clear it either, so a user who is never going to claim carries the card for good.

## What

**Dismissable.** The × goes through the per-banner dismiss policy from #5669 rather than a one-off flag, assigned `Permanent`. This is a campaign, and the claim keeps its own entry point on the QBTC chain screen, so a closed card has nothing to come back for. `ChainTokensViewModel` collects the dismissal instead of reading it once, so the tap hides the card on the spot; the collector hangs off `viewModelScope` rather than the load job, so a pull-to-refresh does not silently kill it.

**Real glass.** The control is Figma's *Glass close*, and the glass is the point of it: the card records what it drew into a `GraphicsLayer`, re-draws that layer blurred, and clips it to the control's circle — so the coin behind reads as frosted rather than as a bare icon on gold. The blur lives on a second layer because a render effect belongs to a layer, not to a draw call. It needs API 31; below that the layer draws unblurred and the control looks exactly as it did before this PR, so the fallback is the old behaviour rather than a broken one.

**Geometry that had drifted from the node.** Every rotated coin was sized to Figma's *bounding box* instead of the unrotated image — `rotate()` spins about the centre without changing layout size — so all four were 7–16% oversized, and the large right-hand coin sat 32dp too high. The background is now the three discs Figma stacks (faint white, navy scrim, brand glow) instead of one weak gradient, and the CTA is the Button/XS it was drawn as (12sp, 16/8) rather than 14sp semibold at 24/12.

Design: https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=79216-74490

## Screenshot

![qbtc claim banner with the glass close](https://i.imgur.com/WXEdSxP.png)

## Not reproduced from the node

- The CTA's inset bevel shadows — there is no inner-shadow modifier in the app, and the button never had them.
- The label uses `supplementary.caption`, which matches Button/XS on size, weight and line height but carries 0.12sp tracking; the theme has no 12sp button token.

## Test plan

- `ChainTokensViewModelTest` — banner shows when the vault can claim, hides the moment it is closed, stays hidden on a later visit. The two behavioural ones were checked to fail with the gate reverted.
- `PromoBannerDismissalRepositoryTest` — the QBTC dismissal never lapses, while the TTL banners still do.
- `:app:testDebugUnitTest` 2204 tests, `:data:testDebugUnitTest` 3167 tests, both green.
- Rendered on an emulator (API 36) via `PreviewActivity → btc_detail_claim`; screenshot above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a refreshed QBTC claim promotional banner with updated visuals and a dismiss control.
  - QBTC eligibility now determines whether the banner appears.
  - Added support for permanently dismissing the banner.

- **Bug Fixes**
  - Prevented previously dismissed QBTC banners from reappearing.
  - Improved banner state handling when switching between eligible and ineligible Bitcoin paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->