### PR TITLE
fix(navigation): redact route debug logs

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/NavController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/NavController.kt
@@ -14,7 +14,11 @@ internal fun NavController.route(route: String, opts: NavigationOptions? = null)
         try {
             navigate(route) { buildOptions(this, opts) }
         } catch (e: Exception) {
-            Timber.e(e, "Navigation failed for route: ${route.toNavigationLogName()}")
+            Timber.e(
+                "Navigation failed for route: %s (%s)",
+                route.toNavigationLogName(),
+                e::class.simpleName,
+            )
         }
     }
 }
@@ -27,7 +31,11 @@ internal fun NavController.route(route: NavigateAction<Any>) {
     try {
         navigate(dst) { buildOptions(this, opts) }
     } catch (e: Exception) {
-        Timber.e(e, "Navigation failed for route: ${dst.toNavigationLogName()}")
+        Timber.e(
+            "Navigation failed for route: %s (%s)",
+            dst.toNavigationLogName(),
+            e::class.simpleName,
+        )
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/NavController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/NavController.kt
@@ -6,7 +6,7 @@ import androidx.navigation.NavOptionsBuilder
 import timber.log.Timber
 
 internal fun NavController.route(route: String, opts: NavigationOptions? = null) {
-    Timber.d("route($route, $opts)")
+    Timber.d("route(${route.toNavigationLogName()}, $opts)")
 
     if (route == Destination.Back.route) {
         popBackStack()
@@ -14,7 +14,7 @@ internal fun NavController.route(route: String, opts: NavigationOptions? = null)
         try {
             navigate(route) { buildOptions(this, opts) }
         } catch (e: Exception) {
-            Timber.e(e, "Navigation failed for route: $route")
+            Timber.e(e, "Navigation failed for route: ${route.toNavigationLogName()}")
         }
     }
 }
@@ -27,7 +27,7 @@ internal fun NavController.route(route: NavigateAction<Any>) {
     try {
         navigate(dst) { buildOptions(this, opts) }
     } catch (e: Exception) {
-        Timber.e(e, "Navigation failed for route: $dst")
+        Timber.e(e, "Navigation failed for route: ${dst.toNavigationLogName()}")
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigator.kt
@@ -23,7 +23,10 @@ internal interface Navigator<Dest> {
     suspend fun navigate(dst: Dest, opts: NavigationOptions)
 }
 
-internal data class NavigateAction<Dst>(val dst: Dst, val opts: NavigationOptions? = null)
+internal data class NavigateAction<Dst>(val dst: Dst, val opts: NavigationOptions? = null) {
+
+    override fun toString(): String = "NavigateAction(dst=${dst.toNavigationLogName()}, opts=$opts)"
+}
 
 internal data class NavigationOptions(
     val popUpTo: String? = null,
@@ -47,15 +50,22 @@ internal class NavigatorImpl<Dst> @Inject constructor() : Navigator<Dst> {
     }
 
     override suspend fun navigate(destination: Dst) {
-        Timber.d("navigate($destination)")
+        Timber.d("navigate(${destination.toNavigationLogName()})")
         this.destination.emit(NavigateAction(destination))
     }
 
     override suspend fun navigate(dst: Dst, opts: NavigationOptions) {
-        Timber.d("navigate($dst, $opts)")
+        Timber.d("navigate(${dst.toNavigationLogName()}, $opts)")
         this.destination.emit(NavigateAction(dst, opts))
     }
 }
+
+internal fun Any?.toNavigationLogName(): String =
+    when (this) {
+        null -> "null"
+        is String -> "String"
+        else -> javaClass.name
+    }
 
 internal suspend fun Navigator<Destination>.back() {
     navigate(Destination.Back)

--- a/app/src/test/java/com/vultisig/wallet/ui/navigation/NavigateActionTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/navigation/NavigateActionTest.kt
@@ -1,0 +1,27 @@
+package com.vultisig.wallet.ui.navigation
+
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class NavigateActionTest {
+
+    @Test
+    fun `toString does not include keysign password`() {
+        val password = "super-secret-password"
+        val action =
+            NavigateAction(
+                Route.Keysign.Keysign(
+                    transactionId = "transaction-id",
+                    password = password,
+                    txType = Route.Keysign.Keysign.TxType.Swap,
+                )
+            )
+
+        val logText = action.toString()
+
+        assertFalse(logText.contains(password))
+        assertFalse(logText.contains("password="))
+        assertTrue(logText.contains(Route.Keysign.Keysign::class.java.name))
+    }
+}


### PR DESCRIPTION
## Summary
- Log only route type names from navigation debug/error logs instead of full route objects
- Override NavigateAction.toString() so password-carrying routes cannot leak through debug logging
- Add a regression test for Route.Keysign.Keysign password redaction

Fixes #5712

## Tests
- ./gradlew :app:testDebugUnitTest --tests com.vultisig.wallet.ui.navigation.NavigateActionTest
- ./gradlew :app:ktfmtCheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation logs with clearer, destination-specific names for successful and failed navigation attempts.
  * Prevented sensitive Keysign passwords from appearing in navigation action details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->