### PR TITLE
fix(home): don't flash "No chains enabled" before accounts load

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -95,6 +95,10 @@ internal data class VaultAccountsUiModel(
     val isBalanceValueVisible: Boolean = true,
     val accounts: List<AccountUiModel> = emptyList(),
     val defiAccounts: List<AccountUiModel> = emptyList(),
+    // Set once the corresponding flow has emitted, so an empty list can be read as "no chains
+    // enabled" rather than "not loaded yet".
+    val hasLoadedAccounts: Boolean = false,
+    val hasLoadedDeFiAccounts: Boolean = false,
     val searchTextFieldState: TextFieldState = TextFieldState(),
     // Per-banner visibility, each gated on a global dismissal whose lifetime is the banner's own
     // policy (#5064). The upgrade banner additionally requires the vault to be GG20
@@ -116,6 +120,14 @@ internal data class VaultAccountsUiModel(
                 accounts
             } else {
                 defiAccounts
+            }
+
+    val areAccountsLoaded: Boolean
+        get() =
+            if (cryptoConnectionType == CryptoConnectionType.Wallet) {
+                hasLoadedAccounts
+            } else {
+                hasLoadedDeFiAccounts
             }
 }
 
@@ -278,6 +290,8 @@ constructor(
                 it.copy(
                     accounts = emptyList(),
                     defiAccounts = emptyList(),
+                    hasLoadedAccounts = false,
+                    hasLoadedDeFiAccounts = false,
                     totalFiatValue = null,
                     totalDeFiValue = null,
                     // Upgrade banner is vault-scoped (GG20-only); clear it eagerly so the previous
@@ -695,11 +709,19 @@ constructor(
 
         uiState.update { state ->
             if (!isDefi) {
-                state.copy(totalFiatValue = totalFiatValue, accounts = accountsUiModel)
+                state.copy(
+                    totalFiatValue = totalFiatValue,
+                    accounts = accountsUiModel,
+                    hasLoadedAccounts = true,
+                )
             } else {
                 // An empty merged list (e.g. every DeFi chain deselected) yields a null total here,
                 // clearing the header instead of stranding a stale figure over zero rows (#4768).
-                state.copy(totalDeFiValue = totalFiatValue, defiAccounts = accountsUiModel)
+                state.copy(
+                    totalDeFiValue = totalFiatValue,
+                    defiAccounts = accountsUiModel,
+                    hasLoadedDeFiAccounts = true,
+                )
             }
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
@@ -337,10 +337,15 @@ internal fun VaultAccountsScreen(
 
                     item {
                         TopShineContainer(modifier = Modifier.padding(horizontal = 16.dp)) {
-                            if (isShowingSearchResult.value && state.noChainFound) {
-                                NoChainFound(onChooseChains = onChooseChains)
-                            } else {
-                                if (state.getAccounts.isEmpty()) {
+                            when {
+                                isShowingSearchResult.value && state.noChainFound ->
+                                    NoChainFound(onChooseChains = onChooseChains)
+
+                                // Only once the accounts flow has emitted does an empty list mean
+                                // the user disabled every chain; before that it just means the
+                                // addresses are still being derived, which on a cold start with
+                                // many chains takes seconds.
+                                state.areAccountsLoaded && state.getAccounts.isEmpty() ->
                                     NotEnabledContainer(
                                         title =
                                             stringResource(R.string.home_page_no_chains_enabled),
@@ -352,7 +357,8 @@ internal fun VaultAccountsScreen(
                                         // steps down rather than matching it.
                                         radius = Theme.v2.radius.md,
                                     )
-                                } else {
+
+                                else ->
                                     AccountList(
                                         onAccountClick = onAccountClick,
                                         snackbarState = snackbarState,
@@ -360,7 +366,6 @@ internal fun VaultAccountsScreen(
                                         accounts = state.getAccounts,
                                         showAddress = isWallet,
                                     )
-                                }
                             }
                         }
                     }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/VaultAccountsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/VaultAccountsViewModelTest.kt
@@ -15,6 +15,7 @@ import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultDataStoreRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.HasCircleAccountUseCase
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -266,6 +267,81 @@ internal class VaultAccountsViewModelTest {
         viewModel.uiState.value.showBackupWarning shouldBe false
     }
 
+    @Test
+    fun `an empty list is not the no-chains-enabled state until the accounts flow emits`() =
+        runTest {
+            val balances = Channel<AddressBalancesUpdate>(Channel.UNLIMITED)
+            every { accountsRepository.loadAddressBalances(VAULT_ID) } returns
+                balances.consumeAsFlow()
+            val viewModel = viewModel()
+            advanceUntilIdle()
+
+            // Deriving the addresses and reading their cached balances takes seconds on a cold
+            // start
+            // with many chains; until that first emission lands, an empty list says nothing about
+            // which chains the user enabled.
+            viewModel.uiState.value.getAccounts.shouldBeEmpty()
+            viewModel.uiState.value.areAccountsLoaded shouldBe false
+
+            balances.send(AddressBalancesUpdate(addresses = emptyList(), isComplete = false))
+            advanceUntilIdle()
+
+            // The cached snapshot is the first emission, so the guard lifts without waiting on the
+            // network — a vault that really has every chain disabled still reads as such.
+            viewModel.uiState.value.getAccounts.shouldBeEmpty()
+            viewModel.uiState.value.areAccountsLoaded shouldBe true
+        }
+
+    @Test
+    fun `switching vaults re-arms the guard until the next vault's accounts land`() = runTest {
+        val vaultIds = MutableSharedFlow<String?>(replay = 1)
+        vaultIds.emit(VAULT_ID)
+        every { lastOpenedVaultRepository.lastOpenedVaultId } returns vaultIds
+        every { accountsRepository.loadAddressBalances(VAULT_ID) } returns
+            flowOf(AddressBalancesUpdate(addresses = emptyList(), isComplete = true))
+        every { accountsRepository.loadAddressBalances(OTHER_VAULT_ID) } returns
+            Channel<AddressBalancesUpdate>(Channel.UNLIMITED).consumeAsFlow()
+        coEvery { vaultRepository.get(OTHER_VAULT_ID) } returns VAULT.copy(id = OTHER_VAULT_ID)
+        coEvery { accountsRepository.loadDeFiAddresses(OTHER_VAULT_ID, any()) } returns
+            flowOf(emptyList())
+        every { defaultDeFiChainsRepository.getDefaultChains(OTHER_VAULT_ID) } returns
+            flowOf(emptySet())
+        coEvery { balanceVisibilityRepository.getVisibility(OTHER_VAULT_ID) } returns true
+        coEvery { vaultDataStoreRepository.readBackupStatus(OTHER_VAULT_ID) } returns flowOf(true)
+        val viewModel = viewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.value.areAccountsLoaded shouldBe true
+
+        vaultIds.emit(OTHER_VAULT_ID)
+        advanceUntilIdle()
+
+        // The previous vault's rows are dropped on the switch, so the empty list left behind is
+        // once again "not loaded yet" rather than "this vault has no chains".
+        viewModel.uiState.value.areAccountsLoaded shouldBe false
+    }
+
+    @Test
+    fun `the DeFi tab waits on its own flow rather than the wallet one`() = runTest {
+        connectionType.value = CryptoConnectionType.Defi
+        val deFiAddresses = Channel<List<Address>>(Channel.UNLIMITED)
+        coEvery { accountsRepository.loadDeFiAddresses(VAULT_ID, any()) } returns
+            deFiAddresses.consumeAsFlow()
+        // The wallet list is loaded either way, and on this tab it says nothing about whether the
+        // positions the user is looking at have arrived.
+        every { accountsRepository.loadAddressBalances(VAULT_ID) } returns
+            flowOf(AddressBalancesUpdate(addresses = emptyList(), isComplete = true))
+        val viewModel = viewModel()
+        advanceUntilIdle()
+
+        viewModel.uiState.value.areAccountsLoaded shouldBe false
+
+        deFiAddresses.send(emptyList())
+        advanceUntilIdle()
+
+        viewModel.uiState.value.areAccountsLoaded shouldBe true
+    }
+
     private fun viewModel() =
         VaultAccountsViewModel(
             savedStateHandle = SavedStateHandle(),
@@ -295,6 +371,7 @@ internal class VaultAccountsViewModelTest {
 
     private companion object {
         const val VAULT_ID = "vault-id"
+        const val OTHER_VAULT_ID = "other-vault-id"
 
         // Mirrors DEFI_REFRESH_THROTTLE, which is private to the ViewModel.
         val THROTTLE_WINDOW = 15.seconds


### PR DESCRIPTION
Closes #5710

## Summary

The home list rendered the **"No chains enabled — You've disabled all chains"** empty state on `state.getAccounts.isEmpty()` with no loading guard. That predicate is also true before the accounts flow has emitted anything, so on a cold start — where deriving addresses for a dozen chains and reading their cached balances takes seconds — every launch flashed the empty state over an intact portfolio. Switching vaults did the same, since `loadData` clears the list first.

Telling a self-custody user their chains are gone, on every launch, is the wrong copy to guess with.

## Changes

- `VaultAccountsUiModel` tracks whether each list's flow has emitted (`hasLoadedAccounts` / `hasLoadedDeFiAccounts`), exposed through an `areAccountsLoaded` getter that mirrors the existing `getAccounts` wallet/DeFi switch.
- The flag is set in `updateUiStateFromList` — the single funnel both tabs go through. It fires on the cached-DB emission, which lands before any network work, so a vault that really does have every chain disabled still shows the message promptly rather than waiting on a fetch.
- Cleared on vault switch alongside the lists it describes, so the guard re-arms.
- `VaultAccountsScreen` only renders the empty state once the flag is set; until then the list renders empty. Deliberately *not* reset on the chain-picker reload, so disabling every chain there still reads correctly.

## Notes

The last touch on this block was the ktfmt sweep (#3265) — the missing guard has been there since the v2 home screen landed and simply got more visible as the chain count grew, rather than being introduced by #5622 as the issue supposed.

If `loadAddressBalances` ever fails outright, its `catch` completes without emitting and the list stays empty instead of showing the wrong copy forever. A real error state there is worth a separate ticket.

## Test plan

Three regression tests added to `VaultAccountsViewModelTest`:

- an empty list is not the no-chains-enabled state until the accounts flow emits, and flips as soon as it does
- switching vaults re-arms the guard until the next vault's accounts land
- the DeFi tab waits on its own flow rather than on the wallet one

`./gradlew :app:testDebugUnitTest --tests "*VaultAccountsViewModelTest"` — 13 + 31 tests, 0 skipped, 0 failures. ktfmt applied.

Manual: cold-launch a multi-chain vault; the chain card stays empty until the rows land, with no "No chains enabled" flash. Then disable every chain from the picker and confirm the message still appears.