### PR TITLE
fix(ton): drop IGNORE_ACTION_PHASE_ERRORS, sign explicit MAX amount

### DIFF
--- a/app/src/androidTest/assets/ton.json
+++ b/app/src/androidTest/assets/ton.json
@@ -29,7 +29,7 @@
       "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
       "lib_type": "DKLS"
     },
-    "expected_image_hash": ["aefa16a3825645bcfcf305be112bc2da400d213cb8c20d87e0e43d4eb214a5f8"]
+    "expected_image_hash": ["db6bfdb5473ece22c91a7a497c83e8a5d9009a03ad820f46839472c89f9f9235"]
   },
   {
     "name": "Send USDT TON",
@@ -63,7 +63,7 @@
       "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
       "lib_type": "DKLS"
     },
-    "expected_image_hash": ["44cbfbae7924a26eec5e6338370ff5d1dbde3fe63f67b1e8937cff1fc28aa2f3"]
+    "expected_image_hash": ["145673a02a4f1b091d6f9a34bf84490309ce6ef70ae9a2c2de0e5d9c1299cca9"]
   },
   {
     "name": "TON Stake with memo",
@@ -95,6 +95,6 @@
       "vault_public_key_ecdsa": "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b",
       "lib_type": "DKLS"
     },
-    "expected_image_hash": ["299ecf1da0682c338130b7f3f890484100e41c8f0d2b024b1fd0214df6e310dd"]
+    "expected_image_hash": ["f132a896ec6ea24c25309f2c220da4efcbd99c210323e266a8dafa8c5e290b78"]
   }
 ]

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -209,6 +209,85 @@ class ChainHelpersTest {
     }
 
     /**
+     * Every app-built TON transfer carries mode PAY_FEES_SEPARATELY and nothing else - in
+     * particular not IGNORE_ACTION_PHASE_ERRORS, which lets a transfer the wallet contract cannot
+     * pay for be skipped while the transaction still lands un-aborted (seqno consumed, no funds
+     * moved). The mode is part of the signed body, so a co-signer that derives a different one
+     * computes a different pre-image hash and never finishes keysign. Mirrors iOS
+     * `TonSendTransactionTests.testNativeSingleTransferUsesPayFeesSeparately`.
+     */
+    @Test
+    fun tonSendModeIsPayFeesSeparatelyOnEveryBuilder() {
+        val payFeesSeparately = TheOpenNetwork.SendMode.PAY_FEES_SEPARATELY_VALUE
+
+        loadTransactionData(TON_JSON_FILE).forEach { transaction ->
+            val inputData =
+                TonHelper.getPreSignedInputData(
+                    transaction.keysignPayload.toInternalKeySignPayload()
+                )
+            val signingInput = TheOpenNetwork.SigningInput.parseFrom(inputData)
+
+            signingInput.messagesList.forEach { message ->
+                assertEquals(transaction.name, payFeesSeparately, message.mode)
+            }
+        }
+    }
+
+    /**
+     * A MAX send signs the explicit amount the user was shown (balance - fee), not amount 0 with
+     * ATTACH_ALL_CONTRACT_BALANCE - a mode-128 sweep would move the whole balance including the
+     * reserve, so the displayed and sent amounts diverge. Mirrors iOS
+     * `TonSendTransactionTests.testNativeMaxSignsExplicitAmountNotSweep`.
+     */
+    @Test
+    fun tonMaxSendSignsExplicitAmountNotSweep() {
+        val amount = 950_000_000L
+        val coin =
+            Coin(
+                chain = "Ton",
+                ticker = "TON",
+                address = "UQCc9iCgP_b5RMJcFE5XD8zStfjtNHLhDWfUqC5m1SjSer95",
+                decimals = 9,
+                priceProviderId = "the-open-network",
+                isNativeToken = true,
+                hexPublicKey = HEX_PUBLIC_KEY_EDDSA,
+                logo = "ton",
+            )
+        val payload =
+            KeysignPayload(
+                    coin = coin,
+                    toAddress = "UQDmLe6ticcY_uLZsfurdYONshNuCn8IS81KcJ8p6M6ISMcB",
+                    toAmount = amount.toString(),
+                    blockchainSpecific =
+                        BlockchainSpecific(
+                            tonSpecific =
+                                TonSpecific(
+                                    sendMaxAmount = true,
+                                    sequenceNumber = 0L,
+                                    expireAt = 1753579977L,
+                                    bounceable = false,
+                                )
+                        ),
+                    vaultPublicKeyEcdsa = HEX_PUBLIC_KEY,
+                    libType = "DKLS",
+                )
+                .toInternalKeySignPayload()
+
+        val signingInput =
+            TheOpenNetwork.SigningInput.parseFrom(TonHelper.getPreSignedInputData(payload))
+
+        assertEquals(1, signingInput.messagesCount)
+        assertEquals(
+            BigInteger.valueOf(amount),
+            BigInteger(1, signingInput.getMessages(0).amount.toByteArray()),
+        )
+        assertEquals(
+            TheOpenNetwork.SendMode.PAY_FEES_SEPARATELY_VALUE,
+            signingInput.getMessages(0).mode,
+        )
+    }
+
+    /**
      * Regression: verifies that per-message `payload` and `stateInit` fields are threaded into the
      * WalletCore SigningInput, and that multi-message signing emits one Transfer per TonMessage in
      * order. Mirrors iOS `TonSendTransactionTests.testTonConnectThreadsStateInitAndCustomPayload`.
@@ -272,6 +351,9 @@ class ChainHelpersTest {
         val signingInput = TheOpenNetwork.SigningInput.parseFrom(inputData)
 
         assertEquals(2, signingInput.messagesCount)
+        signingInput.messagesList.forEach { message ->
+            assertEquals(TheOpenNetwork.SendMode.PAY_FEES_SEPARATELY_VALUE, message.mode)
+        }
         assertEquals(stateInit, signingInput.getMessages(0).stateInit)
         assertEquals(customPayload, signingInput.getMessages(0).customPayload)
         assertEquals("", signingInput.getMessages(1).stateInit)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApiDto.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApiDto.kt
@@ -214,10 +214,10 @@ data class TonTransactionDescriptionJson(
 
 /**
  * Action phase of a TON transaction — where the wallet contract actually emits its outgoing
- * transfer message(s). Because every Vultisig TON send is signed with `IGNORE_ACTION_PHASE_ERRORS`,
- * an action that can't be carried out (e.g. insufficient balance for value+fees) is silently
- * skipped instead of aborting the transaction, so these fields — not `aborted` — are what reveal a
- * transfer that never moved any funds.
+ * transfer message(s). When a send is signed with `IGNORE_ACTION_PHASE_ERRORS`, an action that
+ * can't be carried out (e.g. insufficient balance for value+fees) is silently skipped instead of
+ * aborting the transaction, so these fields — not `aborted` — are what reveal a transfer that never
+ * moved any funds.
  */
 @Serializable
 data class TonActionPhaseJson(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProvider.kt
@@ -46,11 +46,12 @@ private fun TonComputePhaseJson?.hasFailed(): Boolean =
     this?.exitCode?.let { it != 0 && it != 1 } == true
 
 /**
- * The action phase is where the wallet emits its outgoing transfer(s). Since every Vultisig TON
- * send is signed with `IGNORE_ACTION_PHASE_ERRORS`, a transfer that can't be paid for is silently
- * skipped rather than aborting the transaction — the wallet tx lands un-aborted with the seqno
- * consumed but no funds moved. Treat a skipped / unfunded / unsuccessful action phase as a failure
- * so the user isn't shown a false "Confirmed".
+ * The action phase is where the wallet emits its outgoing transfer(s). A send signed with
+ * `IGNORE_ACTION_PHASE_ERRORS` skips a transfer it can't pay for rather than aborting — the wallet
+ * tx lands un-aborted with the seqno consumed but no funds moved. Vultisig no longer sets that flag
+ * (see [com.vultisig.wallet.data.crypto.TonHelper]), but this status path still reads transactions
+ * it did not sign: older sends, and sends built by peers or other clients. Treat a skipped /
+ * unfunded / unsuccessful action phase as a failure so the user isn't shown a false "Confirmed".
  */
 private fun TonActionPhaseJson?.hasFailed(): Boolean {
     if (this == null) return false

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/TonHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/TonHelper.kt
@@ -83,7 +83,6 @@ object TonHelper {
     ): TheOpenNetwork.Transfer {
         val toAddress = AnyAddress(msg.to, CoinType.TON)
         val amount = msg.amount.toLongOrNull() ?: 0L
-        val mode = calculateSendMode(sendMaxAmount = false)
         // Apply the wallet-level bounceable flag from tonSpecific to every TonConnect message,
         // matching the initiating device (browser extension / desktop) which builds the setup
         // message that all co-signers must reproduce. It does NOT derive bounceability per-address
@@ -96,7 +95,7 @@ object TonHelper {
         return TheOpenNetwork.Transfer.newBuilder()
             .setDest(toAddress.description())
             .setAmount(ByteString.copyFrom(amount.toHexString().toHexByteArray()))
-            .setMode(mode)
+            .setMode(SEND_MODE)
             .setBounceable(bounceable)
             .apply {
                 msg.payload?.takeIf { it.isNotEmpty() }?.let { setCustomPayload(it) }
@@ -110,9 +109,10 @@ object TonHelper {
         tonSpecific: BlockChainSpecific.Ton,
     ): TheOpenNetwork.Transfer {
         val toAddress = AnyAddress(payload.toAddress, CoinType.TON)
-        val amount = if (tonSpecific.sendMaxAmount) 0L else payload.toAmount.toLong()
-
-        val mode = calculateSendMode(tonSpecific.sendMaxAmount)
+        // Sign the explicit amount even for MAX, never an ATTACH_ALL_CONTRACT_BALANCE sweep: the
+        // displayed MAX (balance - fee) must equal what is signed, and that reserved fee doubles as
+        // the account's storage reserve. Matches iOS Ton.buildTransfers.
+        val amount = payload.toAmount.toLong()
 
         // Nominator-pool deposits/withdrawals MUST be sent bounceable so a message the pool
         // rejects (e.g. an uninitialized or mis-funded pool) bounces back instead of being
@@ -124,7 +124,7 @@ object TonHelper {
         return TheOpenNetwork.Transfer.newBuilder()
             .setDest(toAddress.description())
             .setAmount(ByteString.copyFrom(amount.toHexString().toHexByteArray()))
-            .setMode(mode)
+            .setMode(SEND_MODE)
             .setBounceable(bounceable)
             .apply { payload.memo?.let { setComment(it) } }
             .build()
@@ -153,32 +153,16 @@ object TonHelper {
                 )
                 .build()
 
-        val mode =
-            TheOpenNetwork.SendMode.PAY_FEES_SEPARATELY_VALUE or
-                TheOpenNetwork.SendMode.IGNORE_ACTION_PHASE_ERRORS_VALUE
-
         return TheOpenNetwork.Transfer.newBuilder()
             .setAmount(
                 ByteString.copyFrom(RECOMMENDED_JETTONS_AMOUNT.toHexString().toHexByteArray())
             )
             .setComment(payload.memo.orEmpty())
             .setBounceable(true) // Jettons always bounceable
-            .setMode(mode)
+            .setMode(SEND_MODE)
             .setDest(tonSpecific.jettonAddress) // Will be set to origin Jetton address
             .setJettonTransfer(jettonTransfer)
             .build()
-    }
-
-    private fun calculateSendMode(sendMaxAmount: Boolean): Int {
-        val baseMode =
-            if (sendMaxAmount) {
-                TheOpenNetwork.SendMode.ATTACH_ALL_CONTRACT_BALANCE.number
-            } else {
-                TheOpenNetwork.SendMode.PAY_FEES_SEPARATELY_VALUE
-            }
-
-        // Always include IGNORE_ACTION_PHASE_ERRORS to prevent retry loops
-        return baseMode or TheOpenNetwork.SendMode.IGNORE_ACTION_PHASE_ERRORS_VALUE
     }
 
     fun getPreSignedImageHash(payload: KeysignPayload): List<String> {
@@ -264,6 +248,15 @@ object TonHelper {
     }
 
     val RECOMMENDED_JETTONS_AMOUNT = CoinType.TON.toUnit("0.08".toBigDecimal()).toLong()
+
+    /**
+     * Every app-built transfer - native, jetton and TonConnect alike - pays fees separately and
+     * nothing more. `IGNORE_ACTION_PHASE_ERRORS` is deliberately absent: with it set, a transfer
+     * the wallet contract cannot pay for is skipped while the transaction still lands un-aborted,
+     * so the seqno is consumed and no funds move. The mode is part of the signed message body, so
+     * every co-signer must derive the same one.
+     */
+    private const val SEND_MODE = TheOpenNetwork.SendMode.PAY_FEES_SEPARATELY_VALUE
 
     private const val MAX_TON_MESSAGES = 4
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/TonStatusProviderTest.kt
@@ -118,8 +118,9 @@ class TonStatusProviderTest {
 
     @Test
     fun `action phase out of funds returns Failed even when not aborted`() = runTest {
-        // The core bug: IGNORE_ACTION_PHASE_ERRORS leaves the tx un-aborted while the
-        // transfer action is silently skipped for lack of funds — no funds actually moved.
+        // A send signed with IGNORE_ACTION_PHASE_ERRORS lands un-aborted while the transfer
+        // action is silently skipped for lack of funds — no funds actually moved. Vultisig no
+        // longer signs that way, but peers and older sends still do.
         coEvery { tonApi.getTsStatus(any()) } returns
             statusWith(
                 TonTransactionDescriptionJson(


### PR DESCRIPTION
Closes #5685

## Summary

- **Drops `IGNORE_ACTION_PHASE_ERRORS` from all three TON builders** — native, jetton and TonConnect. With the flag set, a transfer the wallet contract can't pay for is skipped while the transaction still lands un-aborted: seqno consumed, no funds moved. #5263 taught the status side to detect exactly that, so the app was reporting a failure it had itself asked the contract to ignore.
- **MAX now signs the explicit amount** instead of `amount=0` + `ATTACH_ALL_CONTRACT_BALANCE`. The form displayed `balance − fee` but signed a full sweep, so ~0.045 TON more left the wallet than the user approved. The reserved fee now doubles as the account's storage reserve.
- `calculateSendMode` is gone; a single `SEND_MODE` constant feeds all three builders, which also folds in the jetton path that had been hardcoding its own mode.
- `sendMaxAmount` stays in the payload but no longer affects signing — same as iOS, whose `buildTransfers` destructures it away.
- Reworded the three comments asserting "every Vultisig TON send is signed with `IGNORE_ACTION_PHASE_ERRORS`", which is no longer true. The status-side checks stay — this path still reads transactions the app didn't sign: older sends, and sends built by peers or other clients.

## Cross-platform coordination

Both changes alter the signed bytes, and every co-signer recomputes the signing hash from the payload, so this only works if the platforms move together:

- **iOS already shipped this** in vultisig-ios#5259 (merged 2026-08-24). Android↔iOS TON co-signing is therefore broken *today* — this PR repairs it.
- **Windows / extension still diverge** until vultisig-sdk#2181 (S1 item 1) lands and the `@vultisig/core-chain` pin moves off 2.39.0. Same window iOS is already sitting in.

One note for the issue as written: the "keep it only if a dApp explicitly requests it" clause isn't implementable — `TonMessage` in commondata carries only `to` / `amount` / `payload` / `state_init`, no send mode, and iOS hardcodes pay-fees-separately for TonConnect too.

## Goldens

The Android and iOS `ton.json` fixtures are content-identical, and their pre-change hashes agreed byte for byte. So the re-recorded hashes here are **copied from the iOS commit** rather than freshly generated — `sendTONTest` passing is a byte-level check that the two platforms still produce the same signing hash, not just similar-looking code.

## On-chain verification

A MAX send from a build carrying this change, on mainnet: [`be28ed84…04970`](https://tonviewer.com/transaction/be28ed84d0e339659b08e6bc4756618ffa4c19940572cd661d3d7cf596804970) (wallet v4, seqno 41, 2026-08-26 13:03 UTC, `success: true`).

The decoded signed body carries **`mode: 1`** — pay-fees-separately alone. No `+2` (`IGNORE_ACTION_PHASE_ERRORS`) and no `128` (`ATTACH_ALL_CONTRACT_BALANCE`), which is the whole change visible in the bytes the network actually accepted.

The amounts confirm the MAX half:

| | nanoton | TON |
|---|---|---|
| Balance before | 8 775 999 527 | 8.775999527 |
| Signed amount (`grams`) | 8 725 999 527 | 8.725999527 |
| Fee actually charged | 458 683 | 0.000458683 |
| **Balance after** | **49 541 317** | **0.049541317** |

The signed amount is `balance − 0.05 TON` to the nanoton — the displayed MAX, sent verbatim rather than swept. The wallet kept **0.049541317 TON**; under the old mode-128 sweep it would have been left at ≈0, with ~0.0495 TON more leaving than the form showed. Real fees came to 0.00046 TON, so the 0.05 reserve is comfortable.

## Test plan

- [x] `sendTONTest` green against iOS's re-recorded hashes (native, jetton, memo/stake vectors)
- [x] New `tonSendModeIsPayFeesSeparatelyOnEveryBuilder` — sweeps every fixture, asserts mode 1 on each message
- [x] New `tonMaxSendSignsExplicitAmountNotSweep` — `sendMaxAmount=true` signs the explicit amount with mode 1
- [x] Existing TonConnect tests green, now also asserting the bare mode
- [x] 50 `:data` JVM TON tests green, 0 failures
- [x] Mainnet MAX send signs the displayed amount with mode 1 and leaves the reserve behind — see On-chain verification above
- [x] Mainnet native send completes keysign, broadcasts and confirms
- [ ] Mainnet jetton + TonConnect sends complete keysign and arrive
- [ ] TON send co-signed with an iOS build carrying vultisig-ios#5259

