### PR TITLE
fix: resolve debug unit test compile warnings

### DIFF
--- a/app/src/test/java/com/vultisig/wallet/data/keygen/ReshareRoutingServerMatchTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/ReshareRoutingServerMatchTest.kt
@@ -29,27 +29,27 @@ class ReshareRoutingServerMatchTest {
     // -- Wire-string pin: production constants must match the server contract verbatim --
 
     @Test
-    fun `ROOT_ECDSA_MESSAGE_ID is exactly "p-ecdsa" — wire contract with server`() {
+    fun `ROOT_ECDSA_MESSAGE_ID is exactly p_ecdsa wire contract with server`() {
         assertEquals("p-ecdsa", ROOT_ECDSA_MESSAGE_ID)
     }
 
     @Test
-    fun `ROOT_EDDSA_MESSAGE_ID is exactly "p-eddsa" — wire contract with server`() {
+    fun `ROOT_EDDSA_MESSAGE_ID is exactly p_eddsa wire contract with server`() {
         assertEquals("p-eddsa", ROOT_EDDSA_MESSAGE_ID)
     }
 
     @Test
-    fun `ROOT_MLDSA_EXCHANGE_MESSAGE_ID is exactly "p-mldsa"`() {
+    fun `ROOT_MLDSA_EXCHANGE_MESSAGE_ID is exactly p_mldsa`() {
         assertEquals("p-mldsa", ROOT_MLDSA_EXCHANGE_MESSAGE_ID)
     }
 
     @Test
-    fun `ROOT_MLDSA_SETUP_MESSAGE_ID is exactly "p-mldsa-setup"`() {
+    fun `ROOT_MLDSA_SETUP_MESSAGE_ID is exactly p_mldsa_setup`() {
         assertEquals("p-mldsa-setup", ROOT_MLDSA_SETUP_MESSAGE_ID)
     }
 
     @Test
-    fun `ROOT_EDDSA_KEY_IMPORT_MESSAGE_ID is exactly "eddsa_key_import"`() {
+    fun `ROOT_EDDSA_KEY_IMPORT_MESSAGE_ID is exactly eddsa_key_import`() {
         assertEquals("eddsa_key_import", ROOT_EDDSA_KEY_IMPORT_MESSAGE_ID)
     }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/qbtc/QbtcClaimViewModelTest.kt
@@ -1,4 +1,4 @@
-@file:OptIn(ExperimentalCoroutinesApi::class)
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalSerializationApi::class)
 
 package com.vultisig.wallet.ui.models.qbtc
 
@@ -46,6 +46,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.protobuf.ProtoBuf
 import org.junit.jupiter.api.AfterEach

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapKitErrorMappingTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapKitErrorMappingTest.kt
@@ -91,7 +91,7 @@ internal class SwapKitErrorMappingTest {
     }
 
     @Test
-    fun `QuoteDeviation routes through FormattedText so 5%% unescapes to 5%`() {
+    fun `QuoteDeviation routes through FormattedText so escaped percent unescapes`() {
         // The empty args list is intentional — FormattedText runs String.format which collapses
         // the resource's `%%` escape back to a literal `%`. A StringResource here would render
         // `5%%` verbatim because it skips String.format entirely.


### PR DESCRIPTION
## Summary
- rename warning-producing test display names to avoid Windows-sensitive characters
- add the missing ExperimentalSerializationApi opt-in for the qBTC claim ViewModel test

Fixes #5731

## Test
- ./gradlew :app:compileDebugUnitTestKotlin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Clarified test names for routing message identifiers and escaped percentage formatting.
  - Enabled experimental serialization APIs required by a test.
  - No changes to production behavior or test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->