### PR TITLE
fix(tx-history): keep checking a pending row instead of asking once

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -356,7 +356,7 @@ constructor(
      * and a backgrounded one stops rather than polling from behind the home screen.
      */
     private fun observeInFlightRows() {
-        viewModelScope.launch {
+        viewModelScope.safeLaunch(onError = { t -> Timber.w(t, "In-flight polling stopped") }) {
             transactionHistoryRepository
                 .observeTransactions(
                     vaultId = vaultId,
@@ -542,9 +542,34 @@ constructor(
                         }
                 }
                 .collect { groups ->
-                    _uiState.update { it.copy(groups = groups, isLoading = false) }
+                    _uiState.update {
+                        it.copy(
+                            groups = groups,
+                            isLoading = false,
+                            selectedItem = it.selectedItem.reconciledWith(groups),
+                        )
+                    }
                 }
         }
+    }
+
+    /**
+     * Re-points an open detail sheet at the row this emission just carried.
+     *
+     * [TransactionHistoryUiState.selectedItem] is a snapshot taken when the sheet was presented, so
+     * nothing else reaches it: a sheet left open while the poll settles the transaction keeps
+     * reading "In progress" above a row that has already flipped to Confirmed behind it.
+     *
+     * A row that is no longer in the list — filtered out, or on a tab that does not carry it —
+     * keeps the snapshot rather than closing the sheet under the user.
+     */
+    private fun TransactionHistoryItemUiModel?.reconciledWith(
+        groups: List<TransactionHistoryGroupUiModel>
+    ): TransactionHistoryItemUiModel? {
+        val current = this ?: return null
+        return groups.firstNotNullOfOrNull { group ->
+            group.transactions.firstOrNull { it.id == current.id }
+        } ?: current
     }
 
     private fun TransactionHistoryItemUiModel.matchesAssetIds(assetIds: Set<String>): Boolean =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -9,6 +9,7 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
 import com.vultisig.wallet.data.db.models.TransactionStatus
+import com.vultisig.wallet.data.db.models.isInFlight
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.data.models.SendTransactionHistoryData
 import com.vultisig.wallet.data.models.SwapTransactionHistoryData
@@ -50,6 +51,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
@@ -209,12 +211,37 @@ constructor(
     private val _uiState = MutableStateFlow(TransactionHistoryUiState(chainName = chainId))
     val uiState: StateFlow<TransactionHistoryUiState> = _uiState.asStateFlow()
 
+    /**
+     * Screen visibility, driven by the composable's resume effect. A flow rather than a job handle
+     * so the poll loop below is started and stopped by the same collector that watches for
+     * in-flight rows, instead of two callbacks racing over a shared `Job?`.
+     */
+    private val isScreenVisible = MutableStateFlow(false)
+
     init {
         observeTransactions()
         observeLimitTabVisibility()
         observeAssetSearchItems()
         observeLimitOrders()
+        observeInFlightRows()
+    }
+
+    /**
+     * Re-checks settlement every time the screen comes back into view, and again on a timer while
+     * anything is still in flight.
+     *
+     * One poll at construction is not enough: the row the user is watching was broadcast seconds
+     * earlier, so that first check lands before the receipt exists and writes PENDING. With nothing
+     * scheduled behind it the row then stays at "In progress" indefinitely — the elapsed chip keeps
+     * ticking, which reads as live, while the status is frozen.
+     */
+    fun onScreenResumed() {
+        isScreenVisible.value = true
         refreshOnEnter()
+    }
+
+    fun onScreenPaused() {
+        isScreenVisible.value = false
     }
 
     fun selectTab(tab: TransactionHistoryTab) {
@@ -268,8 +295,19 @@ constructor(
         viewModelScope.launch { navigator.back() }
     }
 
+    /**
+     * Opening a row that is still in flight re-checks that one transaction: answering "in progress"
+     * to someone who just asked about this specific transaction, without having looked, is what the
+     * sweep's backoff would otherwise do. One status call is a fair price for a current answer.
+     */
     fun openDetail(item: TransactionHistoryItemUiModel) {
         _uiState.update { it.copy(selectedItem = item) }
+        if (!item.status.isInFlight()) return
+        viewModelScope.safeLaunch(
+            onError = { t -> Timber.w(t, "Detail-sheet status re-check failed") }
+        ) {
+            refreshPendingTransactions.refreshOne(item.chain, item.txHash)
+        }
     }
 
     fun dismissDetail() {
@@ -308,6 +346,35 @@ constructor(
             throw e
         } catch (e: Exception) {
             Timber.w(e, "Pull-to-refresh failed for %s", what)
+        }
+    }
+
+    /**
+     * Polls while the screen is in view AND at least one row is still in flight, so a transaction
+     * that settles under the user's eyes flips on its own rather than waiting for them to leave and
+     * come back or pull to refresh. Both halves matter: an idle history screen issues no requests,
+     * and a backgrounded one stops rather than polling from behind the home screen.
+     */
+    private fun observeInFlightRows() {
+        viewModelScope.launch {
+            transactionHistoryRepository
+                .observeTransactions(
+                    vaultId = vaultId,
+                    type = TransactionHistoryType.OVERVIEW,
+                    chain = chainId,
+                )
+                .map { rows -> rows.any { it.status.isInFlight } }
+                .combine(isScreenVisible) { hasInFlight, isVisible -> hasInFlight && isVisible }
+                .distinctUntilChanged()
+                .collectLatest { shouldPoll ->
+                    if (!shouldPoll) return@collectLatest
+                    while (true) {
+                        delay(IN_FLIGHT_POLL_INTERVAL)
+                        runCatchingRefresh("in-flight transactions") {
+                            refreshPendingTransactions(vaultId, chainId)
+                        }
+                    }
+                }
         }
     }
 
@@ -653,5 +720,26 @@ constructor(
          * network and no database.
          */
         val EXPIRY_TICK = 15.seconds
+
+        /**
+         * How often in-flight rows are re-checked while the screen is in view. A little over one
+         * Ethereum block, and well behind the 5s the done-screen poller uses for the same chain —
+         * this sweep covers every pending row at once and keeps running for as long as the user
+         * stays on the screen, where that one is scoped to a single transaction.
+         */
+        val IN_FLIGHT_POLL_INTERVAL = 15.seconds
     }
 }
+
+/**
+ * Whether the row is still awaiting settlement. `NotFound` already maps to
+ * [TransactionStatusUiModel.Pending] upstream, so indexer lag counts as in flight here too.
+ */
+private fun TransactionStatusUiModel.isInFlight(): Boolean =
+    when (this) {
+        TransactionStatusUiModel.Broadcasted,
+        TransactionStatusUiModel.Pending -> true
+        TransactionStatusUiModel.Confirmed,
+        is TransactionStatusUiModel.Failed,
+        is TransactionStatusUiModel.Refunded -> false
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionHistoryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionHistoryScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.TokenLogo
 import com.vultisig.wallet.ui.components.UiAlertDialog
@@ -76,6 +77,14 @@ import com.vultisig.wallet.ui.utils.asString
 internal fun TransactionHistoryScreen(viewModel: TransactionHistoryViewModel = hiltViewModel()) {
     val state by viewModel.uiState.collectAsState()
     val uriHandler = LocalUriHandler.current
+
+    // Settlement is re-checked on every return to the screen, not once at construction: the first
+    // check on a just-broadcast transaction lands before its receipt exists.
+    LifecycleResumeEffect(Unit) {
+        viewModel.onScreenResumed()
+        onPauseOrDispose { viewModel.onScreenPaused() }
+    }
+
     TransactionHistoryScreen(
         state = state,
         onBack = viewModel::back,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/transaction/TransactionHistoryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/transaction/TransactionHistoryViewModelTest.kt
@@ -7,10 +7,14 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.api.models.FeatureFlagJson
 import com.vultisig.wallet.data.db.models.PendingLimitOrderEntity
+import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
+import com.vultisig.wallet.data.db.models.TransactionStatus
+import com.vultisig.wallet.data.db.models.TransactionType as DbTransactionType
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.LimitOrderStatus
+import com.vultisig.wallet.data.models.SendTransactionHistoryData
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
@@ -261,19 +265,112 @@ internal class TransactionHistoryViewModelTest {
     }
 
     /**
-     * Verifies refresh() invokes refreshPendingTransactions(vaultId) on the use-case. The
-     * production code calls it once from `refreshOnEnter` in init and once from each explicit
-     * `refresh()`, so the assertion is `atLeast = 2` after one refresh call.
+     * Verifies refresh() invokes refreshPendingTransactions(vaultId) on the use-case. Construction
+     * alone no longer polls — the screen's resume effect owns that — so one explicit refresh is
+     * exactly one call.
      */
     @Test
     fun `refresh invokes refreshPendingTransactions`() {
         val vm = createViewModel()
-        testScope.runCurrent() // drain init's refreshOnEnter call
+        testScope.runCurrent()
 
         vm.refresh()
         testScope.runCurrent()
 
-        coVerify(atLeast = 2) { refreshPendingTransactions(VAULT_ID) }
+        coVerify(exactly = 1) { refreshPendingTransactions(VAULT_ID) }
+    }
+
+    /**
+     * The screen re-checks settlement on every return, not once at construction: a transaction
+     * broadcast seconds before the screen opened has no receipt yet at that first check, and
+     * nothing else would look again.
+     */
+    @Test
+    fun `onScreenResumed refreshes pending transactions`() {
+        val vm = createViewModel()
+        testScope.runCurrent()
+        coVerify(exactly = 0) { refreshPendingTransactions(VAULT_ID) }
+
+        vm.onScreenResumed()
+        testScope.runCurrent()
+
+        coVerify(exactly = 1) { refreshPendingTransactions(VAULT_ID) }
+    }
+
+    /** A row still in flight is re-checked while the user watches it, without any gesture. */
+    @Test
+    fun `in-flight rows are re-polled on a timer while the screen is visible`() {
+        every { transactionHistoryRepository.observeTransactions(any(), any(), any()) } returns
+            flowOf(listOf(inFlightEntity()))
+
+        val vm = createViewModel()
+        testScope.runCurrent()
+        vm.onScreenResumed()
+        testScope.runCurrent()
+
+        testScope.testScheduler.advanceTimeBy(POLL_INTERVAL_MS + 1)
+        testScope.runCurrent()
+
+        coVerify(exactly = 2) { refreshPendingTransactions(VAULT_ID) }
+    }
+
+    /** Leaving the screen stops the timer: a backgrounded history screen must not keep polling. */
+    @Test
+    fun `polling stops once the screen is no longer visible`() {
+        every { transactionHistoryRepository.observeTransactions(any(), any(), any()) } returns
+            flowOf(listOf(inFlightEntity()))
+
+        val vm = createViewModel()
+        testScope.runCurrent()
+        vm.onScreenResumed()
+        testScope.runCurrent()
+        vm.onScreenPaused()
+        testScope.runCurrent()
+
+        testScope.testScheduler.advanceTimeBy(POLL_INTERVAL_MS * 4)
+        testScope.runCurrent()
+
+        coVerify(exactly = 1) { refreshPendingTransactions(VAULT_ID) }
+    }
+
+    /** A settled row costs nothing: no timer starts when there is nothing left to settle. */
+    @Test
+    fun `no polling timer runs when every row has settled`() {
+        every { transactionHistoryRepository.observeTransactions(any(), any(), any()) } returns
+            flowOf(listOf(inFlightEntity().copy(status = TransactionStatus.CONFIRMED)))
+
+        val vm = createViewModel()
+        testScope.runCurrent()
+        vm.onScreenResumed()
+        testScope.runCurrent()
+
+        testScope.testScheduler.advanceTimeBy(POLL_INTERVAL_MS * 4)
+        testScope.runCurrent()
+
+        coVerify(exactly = 1) { refreshPendingTransactions(VAULT_ID) }
+    }
+
+    /** Opening a row that is still in flight asks the chain about that one transaction. */
+    @Test
+    fun `openDetail re-checks an in-flight row`() {
+        val vm = createViewModel()
+        val item = sendItem().copy(status = TransactionStatusUiModel.Broadcasted)
+
+        vm.openDetail(item)
+        testScope.runCurrent()
+
+        coVerify(exactly = 1) { refreshPendingTransactions.refreshOne("Ethereum", "0xabc") }
+    }
+
+    /** A settled row is already final — opening it must not spend a status call. */
+    @Test
+    fun `openDetail does not re-check a settled row`() {
+        val vm = createViewModel()
+
+        vm.openDetail(sendItem())
+        testScope.runCurrent()
+
+        coVerify(exactly = 0) { refreshPendingTransactions.refreshOne(any(), any()) }
     }
 
     /**
@@ -456,9 +553,36 @@ internal class TransactionHistoryViewModelTest {
             feeEstimate = null,
         )
 
+    private fun inFlightEntity() =
+        TransactionHistoryEntity(
+            id = "Ethereum:0xabc",
+            vaultId = VAULT_ID,
+            type = DbTransactionType.SEND,
+            status = TransactionStatus.BROADCASTED,
+            chain = "Ethereum",
+            timestamp = 0L,
+            txHash = "0xabc",
+            explorerUrl = "",
+            payload =
+                SendTransactionHistoryData(
+                    fromAddress = "0xFrom",
+                    toAddress = "0xTo",
+                    amount = "1.0",
+                    token = "ETH",
+                    tokenLogo = "",
+                    feeEstimate = "",
+                    memo = "",
+                    fiatValue = "",
+                ),
+            confirmedAt = null,
+            failureReason = null,
+            lastCheckedAt = null,
+        )
+
     private companion object {
         const val VAULT_ID = "vault-1"
         const val ORDER_HASH = "HASH"
         const val CANCEL_TX_ID = "cancel-tx"
+        const val POLL_INTERVAL_MS = 15_000L
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/transaction/TransactionHistoryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/transaction/TransactionHistoryViewModelTest.kt
@@ -54,6 +54,7 @@ import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -371,6 +372,47 @@ internal class TransactionHistoryViewModelTest {
         testScope.runCurrent()
 
         coVerify(exactly = 0) { refreshPendingTransactions.refreshOne(any(), any()) }
+    }
+
+    /**
+     * The sheet is handed a snapshot, so without reconciliation it keeps reading "In progress"
+     * above a row that has already settled behind it — the exact thing this screen polls for.
+     */
+    @Test
+    fun `an open detail sheet follows the row it is showing`() {
+        val rows = MutableStateFlow(listOf(inFlightEntity()))
+        every { transactionHistoryRepository.observeTransactions(any(), any(), any()) } returns rows
+
+        val vm = createViewModel()
+        testScope.runCurrent()
+        vm.openDetail(vm.uiState.value.groups.first().transactions.first())
+        testScope.runCurrent()
+        vm.uiState.value.selectedItem?.status shouldBe TransactionStatusUiModel.Broadcasted
+
+        rows.value = listOf(inFlightEntity().copy(status = TransactionStatus.CONFIRMED))
+        testScope.runCurrent()
+
+        vm.uiState.value.selectedItem?.status shouldBe TransactionStatusUiModel.Confirmed
+    }
+
+    /**
+     * A row that leaves the list keeps its sheet: closing it would yank it out from under a read.
+     */
+    @Test
+    fun `a detail sheet stays open when its row leaves the list`() {
+        val rows = MutableStateFlow(listOf(inFlightEntity()))
+        every { transactionHistoryRepository.observeTransactions(any(), any(), any()) } returns rows
+
+        val vm = createViewModel()
+        testScope.runCurrent()
+        vm.openDetail(vm.uiState.value.groups.first().transactions.first())
+        testScope.runCurrent()
+
+        rows.value = emptyList()
+        testScope.runCurrent()
+
+        vm.uiState.value.selectedItem.shouldNotBeNull().status shouldBe
+            TransactionStatusUiModel.Broadcasted
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TransactionEntity.kt
@@ -76,3 +76,21 @@ data class TransactionHistoryEntity(
      */
     @ColumnInfo("broadcastBlockNumber") val broadcastBlockNumber: Long? = null,
 )
+
+/**
+ * Whether the row is still awaiting settlement and stays pollable.
+ *
+ * Mirrors the `status IN (...)` guards in [com.vultisig.wallet.data.db.dao.TransactionHistoryDao]:
+ * `NotFound` is transient indexer lag, not a verdict. Exhaustive on purpose — a new status has to
+ * declare which side it falls on rather than defaulting to terminal and going unpolled forever.
+ */
+val TransactionStatus.isInFlight: Boolean
+    get() =
+        when (this) {
+            TransactionStatus.BROADCASTED,
+            TransactionStatus.PENDING,
+            TransactionStatus.NotFound -> true
+            TransactionStatus.CONFIRMED,
+            TransactionStatus.FAILED,
+            TransactionStatus.REFUNDED -> false
+        }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCase.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.usecases
 import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.api.txstatus.SwapKitTrackingService
 import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
+import com.vultisig.wallet.data.db.models.isInFlight
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapTransactionHistoryData
@@ -25,6 +26,15 @@ interface RefreshPendingTransactionsUseCase {
      * when the user is viewing a single-chain history.
      */
     suspend operator fun invoke(vaultId: String, chain: String? = null)
+
+    /**
+     * Re-check one transaction by [chain] and [txHash], ignoring the [invoke] sweep's backoff.
+     *
+     * For the case where the user asks about a specific row (opening its detail sheet): a single
+     * status call is cheap, and answering "still in progress" without having looked is the defect
+     * this exists to avoid. A row that already settled, or that no longer exists, is a no-op.
+     */
+    suspend fun refreshOne(chain: String, txHash: String)
 }
 
 class RefreshPendingTransactionsUseCaseImpl
@@ -45,6 +55,15 @@ constructor(
                 .filter { it.shouldPollNow() }
                 .map { tx -> async { refreshTransaction(tx) } }
                 .awaitAll()
+        }
+    }
+
+    override suspend fun refreshOne(chain: String, txHash: String) {
+        withContext(dispatcher) {
+            val tx =
+                transactionHistoryRepository.getTransaction(chain, txHash) ?: return@withContext
+            if (!tx.status.isInFlight) return@withContext
+            refreshTransaction(tx)
         }
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCaseRefreshOneTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/RefreshPendingTransactionsUseCaseRefreshOneTest.kt
@@ -1,0 +1,135 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.txstatus.SwapKitTrackingService
+import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
+import com.vultisig.wallet.data.db.models.TransactionStatus
+import com.vultisig.wallet.data.db.models.TransactionType
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.SendTransactionHistoryData
+import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusRepository
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins `refreshOne` — the single-transaction re-check behind the history detail sheet.
+ *
+ * It exists because the sweep is paced for unattended polling: opening one row is an explicit
+ * question about one transaction, and answering it from a row the app has not looked at since the
+ * broadcast is the whole defect. So this path skips the backoff, and skips nothing else.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class RefreshPendingTransactionsUseCaseRefreshOneTest {
+
+    private val historyRepository: TransactionHistoryRepository = mockk(relaxed = true)
+    private val statusRepository: TransactionStatusRepository = mockk()
+    private val trackingService: SwapKitTrackingService = mockk()
+
+    private fun useCase(): RefreshPendingTransactionsUseCase =
+        RefreshPendingTransactionsUseCaseImpl(
+            transactionHistoryRepository = historyRepository,
+            transactionStatusRepository = statusRepository,
+            swapKitTrackingService = trackingService,
+            dispatcher = UnconfinedTestDispatcher(),
+        )
+
+    @Test
+    fun `refreshOne checks the chain and persists the result`() = runTest {
+        coEvery { historyRepository.getTransaction(CHAIN, TX_HASH) } returns entity()
+        coEvery { statusRepository.checkTransactionStatus(TX_HASH, Chain.Ethereum) } returns
+            TransactionResult.Confirmed
+        coEvery { historyRepository.updateTransactionStatus(any(), any(), any()) } just Runs
+
+        useCase().refreshOne(CHAIN, TX_HASH)
+
+        coVerify(exactly = 1) { statusRepository.checkTransactionStatus(TX_HASH, Chain.Ethereum) }
+        coVerify(exactly = 1) {
+            historyRepository.updateTransactionStatus(CHAIN, TX_HASH, TransactionResult.Confirmed)
+        }
+    }
+
+    @Test
+    fun `refreshOne leaves a settled row alone`() = runTest {
+        coEvery { historyRepository.getTransaction(CHAIN, TX_HASH) } returns
+            entity(status = TransactionStatus.CONFIRMED)
+
+        useCase().refreshOne(CHAIN, TX_HASH)
+
+        coVerify(exactly = 0) { statusRepository.checkTransactionStatus(any(), any()) }
+        coVerify(exactly = 0) { historyRepository.updateTransactionStatus(any(), any(), any()) }
+    }
+
+    @Test
+    fun `refreshOne is a no-op when the row is gone`() = runTest {
+        coEvery { historyRepository.getTransaction(CHAIN, TX_HASH) } returns null
+
+        useCase().refreshOne(CHAIN, TX_HASH)
+
+        coVerify(exactly = 0) { statusRepository.checkTransactionStatus(any(), any()) }
+    }
+
+    /**
+     * The contrast that gives `refreshOne` its reason to exist: the same row, backed off far enough
+     * that the sweep skips it, is still checked when the user opens it.
+     */
+    @Test
+    fun `refreshOne ignores the backoff that makes the sweep skip the same row`() = runTest {
+        val backedOff = entity(retryCount = 5, lastCheckedAt = System.currentTimeMillis())
+        coEvery { historyRepository.getPendingTransactions(VAULT) } returns listOf(backedOff)
+        coEvery { historyRepository.getTransaction(CHAIN, TX_HASH) } returns backedOff
+        coEvery { statusRepository.checkTransactionStatus(TX_HASH, Chain.Ethereum) } returns
+            TransactionResult.Confirmed
+        coEvery { historyRepository.updateTransactionStatus(any(), any(), any()) } just Runs
+
+        useCase().invoke(VAULT)
+        coVerify(exactly = 0) { statusRepository.checkTransactionStatus(any(), any()) }
+
+        useCase().refreshOne(CHAIN, TX_HASH)
+        coVerify(exactly = 1) { statusRepository.checkTransactionStatus(TX_HASH, Chain.Ethereum) }
+    }
+
+    private fun entity(
+        status: TransactionStatus = TransactionStatus.BROADCASTED,
+        retryCount: Int = 0,
+        lastCheckedAt: Long? = null,
+    ) =
+        TransactionHistoryEntity(
+            id = "$CHAIN:$TX_HASH",
+            vaultId = VAULT,
+            type = TransactionType.SEND,
+            status = status,
+            chain = CHAIN,
+            timestamp = 0L,
+            txHash = TX_HASH,
+            explorerUrl = "",
+            payload =
+                SendTransactionHistoryData(
+                    fromAddress = "",
+                    toAddress = "",
+                    amount = "",
+                    token = "",
+                    tokenLogo = "",
+                    feeEstimate = "",
+                    memo = "",
+                    fiatValue = "",
+                ),
+            confirmedAt = null,
+            failureReason = null,
+            lastCheckedAt = lastCheckedAt,
+            retryCount = retryCount,
+        )
+
+    private companion object {
+        const val VAULT = "vault-id"
+        const val CHAIN = "Ethereum"
+        const val TX_HASH = "0xhash"
+    }
+}


### PR DESCRIPTION
## Problem

A mined ETH send stayed listed as "In progress" for 49+ minutes after its receipt succeeded — `0x9530f403…`, block 25839408, `status=0x1`.

The issue's stated cause ("there is no re-check when History is opened") turned out not to be the defect. `TransactionHistoryViewModel.refreshOnEnter()` has polled from `init` since #3233, and the receipt query itself is fine — querying the app's own default endpoint (`CustomRpcDefaultEndpoint.evmUrl(Chain.Ethereum)`) with that hash returns `status:"0x1"` and every field `EvmRpcResponseJson<EvmTxStatusJson>` requires, so `EvmStatusProvider` would have returned `Confirmed`.

The defect is the cadence. That check ran **exactly once, at ViewModel construction**. On a row broadcast seconds earlier it lands before the receipt exists, writes PENDING, and nothing is scheduled behind it. Meanwhile `InProgressPill` re-renders its elapsed label every second, so a frozen row reads as live.

## Changes

- `refreshOnEnter()` moves out of `init` into `onScreenResumed()`, driven by a `LifecycleResumeEffect` — every return to the screen re-queries, not just the first construction.
- `observeInFlightRows()` polls on a 15s timer, gated on *screen visible* **and** *any row still in flight*, combined into a single collector. An idle history screen issues no requests; a backgrounded one stops rather than polling from behind the home screen. Visibility is a `StateFlow` rather than a `Job?` field, so the resume and pause callbacks share no mutable handle.
- New `RefreshPendingTransactionsUseCase.refreshOne(chain, txHash)` behind `openDetail`, so opening a pending row asks the chain about that one transaction. It deliberately skips the sweep's exponential backoff: the backoff paces unattended polling, and someone opening a specific row is asking a direct question about it. Settled and missing rows are no-ops.
- `TransactionStatus.isInFlight`, exhaustive over the enum so a future status has to declare which side it falls on rather than defaulting to terminal and going unpolled forever.

## Not in scope

`TransactionHistoryDao.getAllPendingTransactions()` and its repository wrapper have zero callers — dead code. So nothing settles a pending row while the user sits on Home or a chain screen. The issue's "Expected" names only History and the row; a background poller carries its own battery and multi-vault questions and belongs in a separate change. Happy to file it.

## Tests

11 new unit tests, no device needed.

**`RefreshPendingTransactionsUseCaseRefreshOneTest`** (4) — checks the chain and persists the result; leaves a settled row alone; no-op when the row is gone; and the contrast case that gives the method its reason to exist: the same backed-off row that `invoke()` skips is still checked by `refreshOne`.

**`TransactionHistoryViewModelTest`** (7 new) — `onScreenResumed` refreshes; the timer fires while visible; the timer stops on pause; no timer runs when every row has settled; both `openDetail` branches. The existing `refresh invokes refreshPendingTransactions` moves from `atLeast = 2` to `exactly = 1` now that construction alone no longer polls.

Full suites green — app 2247 tests, data 3188, 0 failures, 0 errors (XML reports confirm the new cases ran rather than being silently skipped). `:app:lintDebug` clean. ktfmt applied.

## Manual check

Ethereum → Send a small amount to your own address → tap Done immediately → open History (Overview) and stay on it. The row flips to Successful on its own within ~15s of the transaction being mined, with no pull-to-refresh. Backgrounding the app with History open and returning also settles it, as does tapping the pending row to open its detail sheet. A failed transaction must still land on Failed and stay there.

Closes #5729

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transaction history now refreshes active transactions while the screen is open.
  * Returning to the screen triggers a refresh.
  * Opening an active transaction triggers an immediate status update.
  * Pending transactions affected by temporary indexer delays continue to be tracked.
  * Open transaction details stay synchronized with refreshed status updates.

* **Bug Fixes**
  * Settled transactions are no longer repeatedly refreshed.
  * Individual transaction refreshes now bypass periodic refresh delays.
  * Temporary refresh failures no longer stop ongoing status updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->