### PR TITLE
chore(deps): bump okhttp, commons-compress, zxing, protobuf plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,6 +134,7 @@ dependencies {
     implementation(libs.apache.compress)
     implementation(libs.apache.compress.xz)
     implementation(libs.mlkit.barcode)
+    implementation(platform(libs.okhttp.bom))
     implementation(libs.okhttp)
     implementation(libs.timber)
     implementation(libs.spark.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,14 +7,14 @@ minSdk = "26"
 
 accompanistPermissions = "0.37.0"
 agp = "8.12.2"
-apache-compress = "1.27.1"
+apache-compress = "1.28.0"
 apache-compress-xz = "1.10"
 barcodeScanning = "17.3.0"
 bcprovJdk18on = "1.79"
 biometric = "1.1.0"
 camera = "1.4.2"
 coil = "2.7.0"
-core = "3.5.3"
+core = "3.5.4"
 coreKtx = "1.17.0"
 work = "2.10.1"
 coreSplashscreen = "1.0.1"
@@ -37,7 +37,7 @@ dagger = "2.56.1"
 hilt = "1.2.0"
 lifecycleViewmodelComposeVersion = "2.8.7"
 navigationCompose = "2.8.9"
-okhttp = "4.12.0"
+okhttp = "5.4.0"
 room = "2.7.1"
 sparkCore = "2.9.4"
 annotation = "1.9.1"
@@ -46,7 +46,7 @@ timber = "5.0.1"
 ksp = "2.1.20-2.0.1"
 appcompat = "1.7.0"
 serialization = "1.8.0"
-protobuf = "0.9.4"
+protobuf = "0.10.0"
 rive = "11.1.1"
 update = "2.1.0"
 review = "2.0.2"
@@ -120,6 +120,7 @@ ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktorCli
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelComposeVersion" }
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version.ref = "lottieCompose" }
 mlkit-barcode = { module = "com.google.mlkit:barcode-scanning", version.ref = "barcodeScanning" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 spark-core = { module = "com.sparkjava:spark-core", version.ref = "sparkCore" }
 androidx-annotation = { group = "androidx.annotation", name = "annotation", version.ref = "annotation" }


### PR DESCRIPTION
## Summary

Closes #5720

Moves four dependencies in `gradle/libs.versions.toml` to their current Maven Central releases, with one exception explained below.

| Dependency | Before | After |
|---|---|---|
| `com.squareup.okhttp3:okhttp` | 4.12.0 | **5.4.0** (ticket asked for 5.5.0 — see below) |
| `org.apache.commons:commons-compress` | 1.27.1 | 1.28.0 |
| `com.google.zxing:core` | 3.5.3 | 3.5.4 |
| `com.google.protobuf` gradle plugin | 0.9.4 | 0.10.0 |

## Why okhttp stops at 5.4.0

`com.squareup.okhttp3:okhttp` is a KMP artifact; on Android it resolves to `okhttp-android`, whose `aar-metadata.properties` declares a `minCompileSdk` that has moved twice in the last two releases:

| okhttp | `minCompileSdk` |
|---|---|
| 5.0.0 – 5.3.2 | 1 |
| 5.4.0 | 36 |
| 5.5.0 | **37** |

This project is `compileSdk = 36` on AGP 8.12.2, whose own maximum recommended compileSdk is 36. 5.5.0 therefore fails `:app:checkDebugAarMetadata` outright:

```
Dependency 'com.squareup.okhttp3:okhttp-android:5.5.0' requires libraries and
applications that depend on it to compile against version 37 or later of the
Android APIs. :app is currently compiled against android-36.
```

Reaching 5.5.0 means an AGP major bump first, which is its own change rather than part of a dependency chore. 5.4.0 is the newest release that fits today.

To re-check this ceiling on a future bump:

```
unzip -p okhttp-android-<version>.aar META-INF/com/android/build/gradle/aar-metadata.properties
```

## The okhttp BOM

`ktor-client-okhttp:3.0.3` depends on `okhttp-sse` at a version of its own, which does not follow the `okhttp` version ref. Raising okhttp alone left a 4.12.0 SSE module sitting on a 5.x core:

```
+--- io.ktor:ktor-client-okhttp:3.0.3
|         +--- com.squareup.okhttp3:okhttp-sse:4.12.0
|         +--- com.squareup.okhttp3:okhttp:4.12.0 -> 5.4.0
```

Adding `okhttp-bom` to the catalog under the same `version.ref` and declaring `implementation(platform(libs.okhttp.bom))` in `:app` aligns the whole family at 5.4.0. `:data` has no okhttp siblings on its classpath, so it needs no BOM.

## Test plan

| Check | Result |
|---|---|
| `./gradlew assembleDebug` | pass |
| `./gradlew testDebugUnitTest` | pass — 5,425 tests, 0 failures (`:app` 2241, `:data` 3184) |
| `./gradlew lint` | pass (`abortOnError = true`; nothing new past the baselines) |
| `./gradlew :app:connectedDebugAndroidTest` | pass — 78 tests on an API 36 emulator, 0 failed, 4 skipped (the pre-existing `@Ignore`s tracked by #5732) |

Nothing in the suite exercises the real okhttp transport — `NetworkErrorHandlingTest` short-circuits inside its interceptor and `:data` tests use `ktor-client-mock` — so the risky half of a major okhttp bump is uncovered by CI. Verified separately with throwaway tests, run on the emulator and then deleted:

- Live TLS JSON-RPC POST to `https://api.vultisig.com/eth/` through `HttpClient(OkHttp)` with the app's own engine config (`connectTimeout`/`readTimeout`/`writeTimeout`/`retryOnConnectionFailure`) — returned `{"jsonrpc":"2.0","id":1,"result":"0x18a6262"}`. That is Ktor 3.0.3 driving OkHttp 5.4.0 over a real connection.
- commons-compress 1.28.0 XZ round-trip, the peer-discovery QR path — 4120 B compressed to 116 B and restored byte-identical.
- zxing 3.5.4 `MultiFormatWriter` QR encode.

**Not verified:** the ticket's "verify keygen/keysign flows" and "test all transaction types". Those need a real vault and a second signing device, and the keygen instrumented tests that would cover part of it are the `@Ignore`d ones. The live JSON-RPC round-trip is the closest available proxy, since every one of those flows rides the same Ktor + OkHttp client.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated networking, compression, barcode-scanning, and build tooling dependencies.
  * Added centralized dependency management for the networking library to improve version consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->