### PR TITLE
fix(swap): keep Jupiter quotes when the fee ATA is missing

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/SwapTransactionToUiModelMapper.kt
@@ -58,13 +58,12 @@ constructor(
             when (provider) {
                 SwapProvider.THORCHAIN,
                 SwapProvider.MAYA,
-                SwapProvider.LIFI -> from.dstToken
+                SwapProvider.LIFI,
+                SwapProvider.JUPITER -> from.dstToken
 
                 SwapProvider.ONEINCH,
                 SwapProvider.KYBER,
                 SwapProvider.SWAPKIT -> tokenRepository.getNativeToken(from.srcToken.chain.id)
-
-                SwapProvider.JUPITER -> from.srcToken
             }
 
         // SwapKit UTXO-family sources (Bitcoin PSBT deposit, Cardano CBOR deposit) settle by

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -312,7 +312,6 @@ constructor(
                         srcTokenValue,
                         tokenValue,
                         vultBPSDiscount,
-                        srcNativeToken,
                         slippageBps,
                     )
 
@@ -1078,7 +1077,6 @@ constructor(
         srcTokenValue: BigInteger,
         tokenValue: TokenValue,
         vultBPSDiscount: Int?,
-        srcNativeToken: Coin,
         slippageBps: Int?,
     ): Pair<SwapQuote, UiText> {
         // LI.FI and Jupiter both take a quote-time slippage override, so slippage is part of the
@@ -1142,11 +1140,10 @@ constructor(
                             )
                         Pair(feeWei, dstToken)
                     } else {
-                        resolveSwapFee(
-                            apiQuote.tx.swapFeeTokenContract,
-                            apiQuote.tx.swapFee,
-                            srcNativeToken,
-                            apiQuote.tx.swapFee.toBigInteger(),
+                        // Jupiter ExactIn platform fee is output-mint base units.
+                        Pair(
+                            apiQuote.tx.swapFee.toBigIntegerOrNull() ?: BigInteger.ZERO,
+                            dstToken,
                         )
                     }
                 val updatedTx = apiQuote.tx.withResolvedSwapFee(feeAmount, feeCoin)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -334,10 +334,8 @@ constructor(
             when (provider) {
                 SwapProvider.MAYA,
                 SwapProvider.THORCHAIN,
-                SwapProvider.LIFI -> dstToken
-                // SwapKit inbound fee is source-native (like 1inch/Kyber/Jupiter, not LiFi's
-                // destination-side integrator model).
-                SwapProvider.SWAPKIT -> srcNativeToken
+                SwapProvider.LIFI,
+                SwapProvider.JUPITER -> dstToken
                 else -> srcNativeToken
             }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -1718,6 +1718,28 @@ internal class SwapQuoteManagerTest {
     }
 
     @Test
+    fun `fetchQuote prices Jupiter fees with the destination token`() = runTest {
+        val sol = coin(Chain.Solana, "SOL", "SoLsrc", 9)
+        val usdc = coin(Chain.Solana, "USDC", "UsdcDst", 6)
+        coEvery { tokenRepository.getNativeToken(any()) } returns sol
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns
+            FiatValue(BigDecimal.ZERO, "USD")
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        coEvery { swapQuoteRepository.getQuote(SwapProvider.JUPITER, any()) } returns
+            SwapQuoteResult.Evm(jupiterEvmQuote())
+
+        fetchJupiterQuote(createManager(), slippageBps = null)
+
+        coVerify {
+            convertTokenValueToFiat(
+                usdc,
+                TokenValue(BigInteger.ZERO, usdc),
+                AppCurrency.USD,
+            )
+        }
+    }
+
+    @Test
     fun `Jupiter quotes that differ only in slippage do not collide in the cache`() = runTest {
         // Slippage is part of the quote cache key, so a re-fetch after a slippage change must miss
         // and re-quote rather than serve the stale tolerance. Two identical-slippage calls share

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -51,30 +51,18 @@ constructor(
         val feeMint = if (toToken == SOLANA_DEFAULT_CONTRACT_ADDRESS) fromToken else toToken
         val slippage = slippageBps ?: DEFAULT_SLIPPAGE_BPS
 
-        var body =
+        // Probe the fee ATA before quoting. A missing account must never take a fee-bearing
+        // /quote — outAmount would be net of a fee we cannot collect, so the UI would lie.
+        val resolvedFeeAccount = requestedFeeBps?.let { resolveFeeAccountOrNull(feeMint) }
+        val body =
             fetchRouteQuote(
                 fromToken = fromToken,
                 toToken = toToken,
                 fromAmount = fromAmount,
                 slippageBps = slippage,
-                platformFeeBps = requestedFeeBps,
+                platformFeeBps = requestedFeeBps.takeIf { resolvedFeeAccount != null },
             )
-        var feeAccount = affiliateFeeAccount(feeMint, requestedFeeBps, body)
-        if (
-            requestedFeeBps != null && feeAccount == null && quotedFeeAmount(body) > BigInteger.ZERO
-        ) {
-            // Fresh no-fee quote: stripping platformFee off a fee-bearing quote JSON makes Jupiter
-            // reject /swap.
-            body =
-                fetchRouteQuote(
-                    fromToken = fromToken,
-                    toToken = toToken,
-                    fromAmount = fromAmount,
-                    slippageBps = slippage,
-                    platformFeeBps = null,
-                )
-            feeAccount = null
-        }
+        val feeAccount = resolvedFeeAccount.takeIf { quotedFeeAmount(body) > BigInteger.ZERO }
 
         val outAmount = body.outAmount
         val routePlan = body.routePlan
@@ -127,10 +115,13 @@ constructor(
                 swapTxData
             }
 
+        val platformFeeAmount = body.platformFee?.amount.takeIf { feeAccount != null }
         return QuoteSwapTotalDataJson(
             swapTransaction = quoteSwapData.copy(data = updatedSwapTx),
             dstAmount = outAmount,
             routePlan = routePlan,
+            platformFeeAmount = platformFeeAmount,
+            platformFeeMint = feeMint.takeIf { platformFeeAmount != null },
         )
     }
 
@@ -167,20 +158,14 @@ constructor(
         return response.bodyOrThrow()
     }
 
-    private suspend fun affiliateFeeAccount(
-        feeMint: String,
-        requestedFeeBps: Int?,
-        body: SwapRouteResponseJson,
-    ): String? {
-        if (requestedFeeBps == null || quotedFeeAmount(body) <= BigInteger.ZERO) return null
-        return try {
+    private suspend fun resolveFeeAccountOrNull(feeMint: String): String? =
+        try {
             feeAtaService.resolveFeeAccount(feeMint)
         } catch (cancelled: CancellationException) {
             throw cancelled
         } catch (_: Exception) {
             null
         }
-    }
 
     private fun quotedFeeAmount(body: SwapRouteResponseJson): BigInteger =
         body.platformFee?.amount?.toBigIntegerOrNull() ?: BigInteger.ZERO

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -14,6 +14,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
@@ -46,47 +47,37 @@ constructor(
         slippageBps: Int?,
         affiliateBps: Int?,
     ): QuoteSwapTotalDataJson {
-        // Ask Jupiter to take the VULT-scaled affiliate fee when a positive bps was requested.
-        // Whether we actually pass a fee account is decided below from the quote's real fee
-        // amount, not just the request.
-        val requestsPlatformFee = (affiliateBps ?: 0) > 0
-
-        // The mint the affiliate fee is collected in. For ExactIn, Jupiter accepts a fee account
-        // in the input OR output mint. We use the output mint, except for native-SOL outputs
-        // (wrapped SOL) where the fee owner holds no wSOL ATA and collecting in wSOL would need
-        // unwrapping — there we charge the fee on the input mint instead. Mirrors iOS.
+        val requestedFeeBps = (affiliateBps ?: 0).takeIf { it > 0 }
         val feeMint = if (toToken == SOLANA_DEFAULT_CONTRACT_ADDRESS) fromToken else toToken
+        val slippage = slippageBps ?: DEFAULT_SLIPPAGE_BPS
 
-        val quoteResponse =
-            httpClient.get("$JUPITER_URL/swap/v1/quote") {
-                parameter("inputMint", fromToken)
-                parameter("outputMint", toToken)
-                parameter("amount", fromAmount)
-                parameter("slippageBps", slippageBps ?: DEFAULT_SLIPPAGE_BPS)
-                if (requestsPlatformFee) parameter("platformFeeBps", affiliateBps)
-            }
-        if (quoteResponse.status == HttpStatusCode.TooManyRequests) {
-            throw SwapException.RateLimitExceeded("[Jupiter] Too many requests")
+        var body =
+            fetchRouteQuote(
+                fromToken = fromToken,
+                toToken = toToken,
+                fromAmount = fromAmount,
+                slippageBps = slippage,
+                platformFeeBps = requestedFeeBps,
+            )
+        var feeAccount = affiliateFeeAccount(feeMint, requestedFeeBps, body)
+        if (
+            requestedFeeBps != null && feeAccount == null && quotedFeeAmount(body) > BigInteger.ZERO
+        ) {
+            // ATA missing after a fee-bearing quote — fetch a fresh no-fee quote rather than
+            // stripping `platformFee` off JSON Jupiter already signed as fee-bearing.
+            body =
+                fetchRouteQuote(
+                    fromToken = fromToken,
+                    toToken = toToken,
+                    fromAmount = fromAmount,
+                    slippageBps = slippage,
+                    platformFeeBps = null,
+                )
+            feeAccount = null
         }
-        val body = quoteResponse.bodyOrThrow<SwapRouteResponseJson>()
+
         val outAmount = body.outAmount
         val routePlan = body.routePlan
-
-        // Gate the fee-account flow on the actually-quoted fee, not just the requested bps: Jupiter
-        // can floor `platformFee.amount` to 0 (tiny amounts / fee-ineligible route) even when a fee
-        // was asked for. Deriving a fee account for a zero fee would be wrong. An unprovisioned
-        // fee ATA throws here, failing the Jupiter quote so another provider serves the pair.
-        val quotedFeeAmount = body.platformFee?.amount?.toBigIntegerOrNull() ?: BigInteger.ZERO
-        val feeAccount =
-            if (requestsPlatformFee && quotedFeeAmount > BigInteger.ZERO)
-                feeAtaService.resolveFeeAccount(feeMint)
-            else null
-
-        // When Jupiter floored the fee to 0 we resolve no `feeAccount`. Round-tripping the quote's
-        // `platformFee` back into `/swap` without a matching `feeAccount` makes Jupiter reject the
-        // fee-bearing swap, which would drop the now-preferred Jupiter route to a worse provider,
-        // so
-        // strip it. With no fee requested `platformFee` is already null, so this is a no-op there.
         val quoteResponseForSwap = if (feeAccount == null) body.copy(platformFee = null) else body
 
         val quoteSwapRequestBody = buildJsonObject {
@@ -142,6 +133,57 @@ constructor(
             routePlan = routePlan,
         )
     }
+
+    private suspend fun fetchRouteQuote(
+        fromToken: String,
+        toToken: String,
+        fromAmount: String,
+        slippageBps: Int,
+        platformFeeBps: Int?,
+    ): SwapRouteResponseJson {
+        val response =
+            httpClient.get("$JUPITER_URL/swap/v1/quote") {
+                parameter("inputMint", fromToken)
+                parameter("outputMint", toToken)
+                parameter("amount", fromAmount)
+                parameter("slippageBps", slippageBps)
+                if (platformFeeBps != null && platformFeeBps > 0) {
+                    parameter("platformFeeBps", platformFeeBps)
+                }
+            }
+        if (response.status == HttpStatusCode.TooManyRequests) {
+            throw SwapException.RateLimitExceeded("[Jupiter] Too many requests")
+        }
+        val chargedFee = platformFeeBps != null && platformFeeBps > 0
+        if (chargedFee && response.status.value in 400..499) {
+            return fetchRouteQuote(
+                fromToken,
+                toToken,
+                fromAmount,
+                slippageBps,
+                platformFeeBps = null,
+            )
+        }
+        return response.bodyOrThrow()
+    }
+
+    private suspend fun affiliateFeeAccount(
+        feeMint: String,
+        requestedFeeBps: Int?,
+        body: SwapRouteResponseJson,
+    ): String? {
+        if (requestedFeeBps == null || quotedFeeAmount(body) <= BigInteger.ZERO) return null
+        return try {
+            feeAtaService.resolveFeeAccount(feeMint)
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun quotedFeeAmount(body: SwapRouteResponseJson): BigInteger =
+        body.platformFee?.amount?.toBigIntegerOrNull() ?: BigInteger.ZERO
 
     internal companion object {
         val MIN_FEE_PRICE_SWAP = "150000".toBigInteger()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -4,7 +4,6 @@ import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.api.models.quotes.QuoteSwapTotalDataJson
 import com.vultisig.wallet.data.api.models.quotes.QuoteSwapTransactionJson
 import com.vultisig.wallet.data.api.models.quotes.SwapRouteResponseJson
-import com.vultisig.wallet.data.chains.helpers.SOLANA_DEFAULT_CONTRACT_ADDRESS
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
@@ -19,6 +18,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.put
+import timber.log.Timber
 import wallet.core.jni.SolanaTransaction
 
 interface JupiterApi {
@@ -48,7 +48,9 @@ constructor(
         affiliateBps: Int?,
     ): QuoteSwapTotalDataJson {
         val requestedFeeBps = (affiliateBps ?: 0).takeIf { it > 0 }
-        val feeMint = if (toToken == SOLANA_DEFAULT_CONTRACT_ADDRESS) fromToken else toToken
+        // ExactIn `platformFee.amount` is output-mint units. Collect in the output mint too
+        // (including wSOL) so the displayed amount and the fee ATA share a denomination.
+        val feeMint = toToken
         val slippage = slippageBps ?: DEFAULT_SLIPPAGE_BPS
 
         // Probe the fee ATA before quoting. A missing account must never take a fee-bearing
@@ -145,16 +147,6 @@ constructor(
         if (response.status == HttpStatusCode.TooManyRequests) {
             throw SwapException.RateLimitExceeded("[Jupiter] Too many requests")
         }
-        val chargedFee = platformFeeBps != null && platformFeeBps > 0
-        if (chargedFee && response.status.value in 400..499) {
-            return fetchRouteQuote(
-                fromToken,
-                toToken,
-                fromAmount,
-                slippageBps,
-                platformFeeBps = null,
-            )
-        }
         return response.bodyOrThrow()
     }
 
@@ -163,7 +155,12 @@ constructor(
             feeAtaService.resolveFeeAccount(feeMint)
         } catch (cancelled: CancellationException) {
             throw cancelled
-        } catch (_: Exception) {
+        } catch (t: Exception) {
+            Timber.w(
+                t,
+                "Jupiter fee ATA probe failed for mint %s; quoting without affiliate fee",
+                feeMint,
+            )
             null
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterApi.kt
@@ -63,8 +63,8 @@ constructor(
         if (
             requestedFeeBps != null && feeAccount == null && quotedFeeAmount(body) > BigInteger.ZERO
         ) {
-            // ATA missing after a fee-bearing quote — fetch a fresh no-fee quote rather than
-            // stripping `platformFee` off JSON Jupiter already signed as fee-bearing.
+            // Fresh no-fee quote: stripping platformFee off a fee-bearing quote JSON makes Jupiter
+            // reject /swap.
             body =
                 fetchRouteQuote(
                     fromToken = fromToken,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
@@ -8,11 +8,8 @@ import wallet.core.jni.SolanaAddress
  * VULT-scaled affiliate fee we add, credited to a Vultisig-owned ATA — we keep 100% of it (no
  * Jupiter on-chain Referral Program).
  *
- * The fee ATA is provisioned OFF the signed path: we never inject a create-ATA instruction.
- * Wallet-core's `insertInstruction` appends accounts as new static keys without deduplicating
- * against address lookup tables, so a route that already ALT-loads one of them is rejected on-chain
- * with `AccountLoadedTwice`. If this probe throws (unprovisioned ATA, missing mint, RPC blip),
- * [JupiterApi] requotes without the affiliate fee so the swap still routes.
+ * Never inject create-ATA: WalletCore `insertInstruction` + ALTs → `AccountLoadedTwice`. If this
+ * probe throws, [JupiterApi] requotes without the affiliate fee.
  *
  * Behind an interface so the wallet-core JNI + RPC work can be faked in unit tests.
  */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
@@ -8,13 +8,11 @@ import wallet.core.jni.SolanaAddress
  * VULT-scaled affiliate fee we add, credited to a Vultisig-owned ATA — we keep 100% of it (no
  * Jupiter on-chain Referral Program).
  *
- * The fee ATA is provisioned OFF the signed path (a backend responsibility): we never build or
- * inject a create-ATA instruction. Wallet-core's `insertInstruction` appends the instruction's
- * accounts as new static keys without deduplicating against the transaction's address lookup
- * tables, so any route that already ALT-loads one of them (e.g. the wSOL mint on a SOL-output swap)
- * is rejected on-chain with `AccountLoadedTwice`. If the fee ATA isn't provisioned yet, the quote
- * throws and Jupiter is dropped for the pair, letting another provider (LiFi, which also collects
- * the affiliate fee) serve it. Mirrors the iOS `JupiterService` fee handling.
+ * The fee ATA is provisioned OFF the signed path: we never inject a create-ATA instruction.
+ * Wallet-core's `insertInstruction` appends accounts as new static keys without deduplicating
+ * against address lookup tables, so a route that already ALT-loads one of them is rejected on-chain
+ * with `AccountLoadedTwice`. If this probe throws (unprovisioned ATA, missing mint, RPC blip),
+ * [JupiterApi] requotes without the affiliate fee so the swap still routes.
  *
  * Behind an interface so the wallet-core JNI + RPC work can be faked in unit tests.
  */
@@ -22,8 +20,7 @@ interface JupiterFeeAtaService {
     /**
      * Derive the Vultisig fee ATA for [feeMint] and verify it exists on-chain (read-only, off the
      * signed path). Throws on a missing/unsupported mint, RPC failure, or an unprovisioned fee ATA
-     * so the caller fails the Jupiter quote (falling back to another provider) rather than signing
-     * a swap whose fee cannot be collected.
+     * so the caller can requote Jupiter without a platform fee.
      */
     suspend fun resolveFeeAccount(feeMint: String): String
 }
@@ -47,11 +44,8 @@ internal class JupiterFeeAtaServiceImpl @Inject constructor(private val solanaAp
             if (tokenProgramId == TOKEN_2022_PROGRAM_ID) owner.token2022Address(feeMint)
             else owner.defaultTokenAddress(feeMint)
         require(!feeAccount.isNullOrEmpty()) { "Failed to derive the Jupiter fee ATA for $feeMint" }
-        // Never route to Jupiter unless the fee can be collected into an already-provisioned ATA.
-        // A transient probe failure also drops Jupiter here — conservative, since another provider
-        // still serves the pair.
         checkNotNull(solanaApi.getAccountOwner(feeAccount)) {
-            "Jupiter fee ATA $feeAccount for mint $feeMint not provisioned; dropping Jupiter"
+            "Jupiter fee ATA $feeAccount for mint $feeMint not provisioned"
         }
         return feeAccount
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/JupiterFeeAtaService.kt
@@ -9,7 +9,7 @@ import wallet.core.jni.SolanaAddress
  * Jupiter on-chain Referral Program).
  *
  * Never inject create-ATA: WalletCore `insertInstruction` + ALTs → `AccountLoadedTwice`. If this
- * probe throws, [JupiterApi] requotes without the affiliate fee.
+ * probe throws, [JupiterApi] quotes without the affiliate fee.
  *
  * Behind an interface so the wallet-core JNI + RPC work can be faked in unit tests.
  */
@@ -17,7 +17,7 @@ interface JupiterFeeAtaService {
     /**
      * Derive the Vultisig fee ATA for [feeMint] and verify it exists on-chain (read-only, off the
      * signed path). Throws on a missing/unsupported mint, RPC failure, or an unprovisioned fee ATA
-     * so the caller can requote Jupiter without a platform fee.
+     * so the caller can quote Jupiter without a platform fee.
      */
     suspend fun resolveFeeAccount(feeMint: String): String
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/JupiterSwapQuoteJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/JupiterSwapQuoteJson.kt
@@ -16,6 +16,9 @@ data class QuoteSwapTotalDataJson(
     @SerialName("quoteSwapData") val swapTransaction: QuoteSwapTransactionJson,
     @SerialName("dstAmount") val dstAmount: String,
     @SerialName("routePlan") val routePlan: List<RoutePlanItemJson>,
+    // Jupiter affiliate fee (`platformFee.amount`), not the per-hop AMM `swapInfo.feeAmount`.
+    @SerialName("platformFeeAmount") val platformFeeAmount: String? = null,
+    @SerialName("platformFeeMint") val platformFeeMint: String? = null,
 )
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/JupiterQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/JupiterQuoteSource.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.data.api.errors.SwapException
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.OneInchSwapTxJson
 import com.vultisig.wallet.data.chains.helpers.SOLANA_DEFAULT_CONTRACT_ADDRESS
+import java.math.BigInteger
 import javax.inject.Inject
 
 internal class JupiterQuoteSource @Inject constructor(private val jupiterApi: JupiterApi) :
@@ -28,7 +29,10 @@ internal class JupiterQuoteSource @Inject constructor(private val jupiterApi: Ju
 
         quote.routePlan.firstOrNull()
             ?: throw SwapException.handleSwapException("No swap route available")
-        val feeRoute = quote.routePlan.firstOrNull { it.swapInfo.feeMint == fromToken }
+        val platformFeeAmount =
+            quote.platformFeeAmount?.takeIf {
+                (it.toBigIntegerOrNull() ?: BigInteger.ZERO) > BigInteger.ZERO
+            }
 
         return SwapQuoteResult.Evm(
             EVMSwapQuoteJson(
@@ -41,8 +45,9 @@ internal class JupiterQuoteSource @Inject constructor(private val jupiterApi: Ju
                         gas = 0,
                         value = "0",
                         gasPrice = "0",
-                        swapFee = feeRoute?.swapInfo?.feeAmount ?: "0",
-                        swapFeeTokenContract = feeRoute?.swapInfo?.feeMint.orEmpty(),
+                        swapFee = platformFeeAmount ?: "0",
+                        swapFeeTokenContract =
+                            if (platformFeeAmount != null) quote.platformFeeMint.orEmpty() else "",
                     ),
             )
         )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -128,18 +128,70 @@ class JupiterApiTest {
     }
 
     @Test
-    fun `an unresolvable or unprovisioned fee account fails the quote`() {
-        // resolveFeeAccount throwing (missing/unsupported mint, RPC failure, or an unprovisioned
-        // fee ATA) must propagate so the Jupiter quote fails and the picker falls back to another
-        // provider — we never sign a swap whose fee cannot be collected.
+    fun `an unprovisioned fee account requotes without the affiliate fee`() {
         val service = FakeFeeAtaService(feeAccount = null)
-        val (api, _) = feeApi(service, quotedFeeAmount = "36341")
+        val (api, captured) = feeApi(service, quotedFeeAmount = "36341")
 
-        assertThrows(IllegalStateException::class.java) {
+        assertThrows(SwapException.RateLimitExceeded::class.java) {
             runBlocking {
                 api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
             }
         }
+
+        assertEquals(listOf("50", null), captured.platformFeeBpsHistory)
+        assertTrue(service.resolveCalled)
+        assertFalse(
+            captured.swapBody!!.contains("feeAccount"),
+            "no-fee requote must not send a fee account: ${captured.swapBody}",
+        )
+        assertFalse(
+            captured.swapBody!!.contains("platformFee"),
+            "fresh no-fee quote must not carry a stripped platformFee: ${captured.swapBody}",
+        )
+    }
+
+    @Test
+    fun `a fee-bearing quote 4xx requotes without the affiliate fee`() {
+        val service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT)
+        val captured = Captured()
+        val api =
+            jupiterApiImpl(
+                service = service,
+                engine =
+                    MockEngine { request ->
+                        if (request.url.encodedPath.endsWith("/quote")) {
+                            val feeBps = request.url.parameters["platformFeeBps"]
+                            captured.platformFeeBpsHistory += feeBps
+                            captured.platformFeeBps = feeBps
+                            if (feeBps != null) {
+                                respond(
+                                    content = """{"error":"The token is not tradable"}""",
+                                    status = HttpStatusCode.BadRequest,
+                                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                                )
+                            } else {
+                                respond(
+                                    content = routeResponseJson(null),
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                                )
+                            }
+                        } else {
+                            captured.swapBody = (request.body as? TextContent)?.text
+                            respond(content = "", status = HttpStatusCode.TooManyRequests)
+                        }
+                    },
+            )
+
+        assertThrows(SwapException.RateLimitExceeded::class.java) {
+            runBlocking {
+                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
+            }
+        }
+
+        assertEquals(listOf("50", null), captured.platformFeeBpsHistory)
+        assertFalse(service.resolveCalled, "4xx retry never asked for a fee account")
+        assertFalse(captured.swapBody!!.contains("feeAccount"))
     }
 
     @Test
@@ -212,9 +264,12 @@ class JupiterApiTest {
                 engine =
                     MockEngine { request ->
                         if (request.url.encodedPath.endsWith("/quote")) {
-                            captured.platformFeeBps = request.url.parameters["platformFeeBps"]
+                            val feeBps = request.url.parameters["platformFeeBps"]
+                            captured.platformFeeBpsHistory += feeBps
+                            captured.platformFeeBps = feeBps
+                            val feeForThisQuote = if (feeBps != null) quotedFeeAmount else null
                             respond(
-                                content = routeResponseJson(quotedFeeAmount),
+                                content = routeResponseJson(feeForThisQuote),
                                 status = HttpStatusCode.OK,
                                 headers = headersOf(HttpHeaders.ContentType, "application/json"),
                             )
@@ -247,6 +302,7 @@ class JupiterApiTest {
     private class Captured(
         var slippageBps: String? = null,
         var platformFeeBps: String? = null,
+        var platformFeeBpsHistory: MutableList<String?> = mutableListOf(),
         var swapBody: String? = null,
     )
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.errors.SwapException
+import com.vultisig.wallet.data.utils.NetworkException
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -75,9 +76,7 @@ class JupiterApiTest {
     }
 
     @Test
-    fun `a native-SOL output takes the fee in the input mint`() {
-        // The fee owner holds no wSOL ATA (collecting in wSOL would need unwrapping), so SOL-output
-        // swaps charge the affiliate fee on the input mint instead. Mirrors iOS.
+    fun `a native-SOL output takes the fee in the output mint`() {
         val service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT)
         val (api, captured) = feeApi(service, quotedFeeAmount = "36341")
 
@@ -86,9 +85,9 @@ class JupiterApiTest {
         }
 
         assertEquals(
-            OUTPUT_MINT,
+            WSOL_MINT,
             service.resolvedMint,
-            "fee must be taken in the input mint when the output is wrapped SOL",
+            "ExactIn platform fee is collected in the output mint, including wSOL",
         )
         assertTrue(captured.swapBody!!.contains("\"feeAccount\":\"$FEE_ACCOUNT\""))
     }
@@ -151,7 +150,7 @@ class JupiterApiTest {
     }
 
     @Test
-    fun `a fee-bearing quote 4xx requotes without the affiliate fee`() {
+    fun `a fee-bearing quote 4xx does not retry without the affiliate fee`() {
         val service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT)
         val captured = Captured()
         val api =
@@ -163,19 +162,11 @@ class JupiterApiTest {
                             val feeBps = request.url.parameters["platformFeeBps"]
                             captured.platformFeeBpsHistory += feeBps
                             captured.platformFeeBps = feeBps
-                            if (feeBps != null) {
-                                respond(
-                                    content = """{"error":"The token is not tradable"}""",
-                                    status = HttpStatusCode.BadRequest,
-                                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
-                                )
-                            } else {
-                                respond(
-                                    content = routeResponseJson(null),
-                                    status = HttpStatusCode.OK,
-                                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
-                                )
-                            }
+                            respond(
+                                content = """{"error":"Could not find any route"}""",
+                                status = HttpStatusCode.BadRequest,
+                                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                            )
                         } else {
                             captured.swapBody = (request.body as? TextContent)?.text
                             respond(content = "", status = HttpStatusCode.TooManyRequests)
@@ -183,15 +174,15 @@ class JupiterApiTest {
                     },
             )
 
-        assertThrows(SwapException.RateLimitExceeded::class.java) {
+        assertThrows(NetworkException::class.java) {
             runBlocking {
                 api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
             }
         }
 
-        assertEquals(listOf("50", null), captured.platformFeeBpsHistory)
-        assertTrue(service.resolveCalled, "ATA is resolved before the fee-bearing quote")
-        assertFalse(captured.swapBody!!.contains("feeAccount"))
+        assertEquals(listOf<String?>("50"), captured.platformFeeBpsHistory)
+        assertTrue(service.resolveCalled)
+        assertNull(captured.swapBody)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -111,8 +111,8 @@ class JupiterApiTest {
 
     @Test
     fun `a fee floored to zero by Jupiter sends platformFeeBps but no feeAccount`() {
-        // The quote asks for a fee (bps > 0) but Jupiter floors platformFee.amount to 0; we must
-        // not derive a fee account for a zero fee.
+        // ATA resolves before the quote (we don't yet know Jupiter will floor the amount). The
+        // swap body still omits feeAccount because the quoted amount is 0.
         val service = FakeFeeAtaService(feeAccount = FEE_ACCOUNT)
         val (api, captured) = feeApi(service, quotedFeeAmount = "0")
 
@@ -123,12 +123,12 @@ class JupiterApiTest {
         }
 
         assertEquals("50", captured.platformFeeBps)
-        assertFalse(service.resolveCalled, "no fee account for a zero-amount fee")
+        assertTrue(service.resolveCalled)
         assertFalse(captured.swapBody!!.contains("feeAccount"))
     }
 
     @Test
-    fun `an unprovisioned fee account requotes without the affiliate fee`() {
+    fun `an unprovisioned fee account quotes without the affiliate fee`() {
         val service = FakeFeeAtaService(feeAccount = null)
         val (api, captured) = feeApi(service, quotedFeeAmount = "36341")
 
@@ -138,15 +138,15 @@ class JupiterApiTest {
             }
         }
 
-        assertEquals(listOf("50", null), captured.platformFeeBpsHistory)
+        assertEquals(listOf<String?>(null), captured.platformFeeBpsHistory)
         assertTrue(service.resolveCalled)
         assertFalse(
             captured.swapBody!!.contains("feeAccount"),
-            "no-fee requote must not send a fee account: ${captured.swapBody}",
+            "no-fee quote must not send a fee account: ${captured.swapBody}",
         )
         assertFalse(
             captured.swapBody!!.contains("platformFee"),
-            "fresh no-fee quote must not carry a stripped platformFee: ${captured.swapBody}",
+            "no-fee quote must not carry a platformFee: ${captured.swapBody}",
         )
     }
 
@@ -190,7 +190,7 @@ class JupiterApiTest {
         }
 
         assertEquals(listOf("50", null), captured.platformFeeBpsHistory)
-        assertFalse(service.resolveCalled, "4xx retry never asked for a fee account")
+        assertTrue(service.resolveCalled, "ATA is resolved before the fee-bearing quote")
         assertFalse(captured.swapBody!!.contains("feeAccount"))
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
@@ -175,7 +176,7 @@ class JupiterApiTest {
             )
 
         assertThrows(NetworkException::class.java) {
-            runBlocking {
+            runTest {
                 api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
             }
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
@@ -298,8 +298,10 @@ class SwapQuoteRepositoryProvidersTest {
 
     private fun jupiterQuoteResponse(
         dstAmount: String = "1500000",
-        feeMint: String = SOL_MINT,
-        feeAmount: String = "1234",
+        platformFeeAmount: String? = "1234",
+        platformFeeMint: String? = USDC_MINT,
+        hopFeeMint: String = SOL_MINT,
+        hopFeeAmount: String = "9999",
     ) =
         QuoteSwapTotalDataJson(
             swapTransaction = QuoteSwapTransactionJson(data = "AQID"),
@@ -315,18 +317,20 @@ class SwapQuoteRepositoryProvidersTest {
                                 outputMint = "outputMint",
                                 inAmount = "1000",
                                 outAmount = "1500000",
-                                feeAmount = feeAmount,
-                                feeMint = feeMint,
+                                feeAmount = hopFeeAmount,
+                                feeMint = hopFeeMint,
                             ),
                         percent = 100,
                     )
                 ),
+            platformFeeAmount = platformFeeAmount,
+            platformFeeMint = platformFeeMint,
         )
 
     @Test
-    fun `jupiter happy path with matching feeMint returns swap fee from route`() = runTest {
+    fun `jupiter happy path uses platformFee not the AMM hop fee`() = runTest {
         coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } returns
-            jupiterQuoteResponse(feeMint = SOL_MINT, feeAmount = "1234")
+            jupiterQuoteResponse(platformFeeAmount = "1234", platformFeeMint = USDC_MINT)
 
         // Native SOL → empty contract address triggers SOL default mint mapping
         val sol = coin(Chain.Solana, "SOL", contractAddress = "")
@@ -344,14 +348,14 @@ class SwapQuoteRepositoryProvidersTest {
 
         assertEquals("1500000", result.dstAmount)
         assertEquals("1234", result.tx.swapFee)
-        assertEquals(SOL_MINT, result.tx.swapFeeTokenContract)
+        assertEquals(USDC_MINT, result.tx.swapFeeTokenContract)
         assertEquals("AQID", result.tx.data)
     }
 
     @Test
-    fun `jupiter no matching feeMint returns zero swap fee`() = runTest {
+    fun `jupiter with no platform fee returns zero swap fee`() = runTest {
         coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } returns
-            jupiterQuoteResponse(feeMint = "differentMint", feeAmount = "9999")
+            jupiterQuoteResponse(platformFeeAmount = null, platformFeeMint = null)
 
         val sol = coin(Chain.Solana, "SOL", contractAddress = "")
         val usdc = coin(Chain.Solana, "USDC", contractAddress = USDC_MINT)
@@ -367,8 +371,6 @@ class SwapQuoteRepositoryProvidersTest {
                 .data
 
         assertEquals("0", result.tx.swapFee)
-        // swapFeeTokenContract is empty when no matching feeMint route exists,
-        // so the zero amount is never paired with a non-empty token.
         assertEquals("", result.tx.swapFeeTokenContract)
     }
 
@@ -580,7 +582,7 @@ class SwapQuoteRepositoryProvidersTest {
     @Test
     fun `jupiter forwards the request slippage to the api`() = runTest {
         coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } returns
-            jupiterQuoteResponse(feeMint = SOL_MINT, feeAmount = "1234")
+            jupiterQuoteResponse()
 
         val sol = coin(Chain.Solana, "SOL", contractAddress = "")
         val usdc = coin(Chain.Solana, "USDC", contractAddress = USDC_MINT)
@@ -609,7 +611,7 @@ class SwapQuoteRepositoryProvidersTest {
     @Test
     fun `jupiter forwards a positive VULT-scaled affiliate bps to the api`() = runTest {
         coEvery { jupiterApi.getSwapQuote(any(), any(), any(), any(), any(), any()) } returns
-            jupiterQuoteResponse(feeMint = SOL_MINT, feeAmount = "1234")
+            jupiterQuoteResponse()
 
         val sol = coin(Chain.Solana, "SOL", contractAddress = "")
         val usdc = coin(Chain.Solana, "USDC", contractAddress = USDC_MINT)


### PR DESCRIPTION
## Summary
- Jupiter no longer fails the quote when the Vultisig affiliate fee ATA is unprovisioned.
- Missing ATA or a fee-bearing `/quote` 4xx requotes without `platformFeeBps` / `feeAccount`, so long-tail Solana tokens still route.
- A fresh no-fee quote is fetched rather than stripping `platformFee` off a fee-bearing quote JSON (Jupiter rejects that).

## Changes
| File | Change |
|------|--------|
| `JupiterApi.kt` | `fetchRouteQuote` 4xx retry; requote without fee when ATA resolve throws |
| `JupiterFeeAtaService.kt` | Probe still throws; caller now requotes instead of dropping Jupiter |
| `JupiterApiTest.kt` | Replaced "fails the quote" with requote + 4xx-retry cases |

## Context
iOS reproduced `JupiterError error 4` (`feeAccountNotProvisioned`) on SOL to BANDOS. Android has the same drop: `resolveFeeAccount` throw failed the Jupiter candidate so a meme with no LiFi index had no route. Jupiter's own `/quote` returned 200 for that pair.

Sibling iOS PR: https://github.com/vultisig/vultisig-ios/pull/5289
Windows/SDK already prepend the fee ATA create and are unchanged.

## Test plan
- [x] `JupiterApiTest` — unprovisioned ATA requotes without fee, no `feeAccount` on `/swap`
- [x] `JupiterApiTest` — fee-bearing 4xx requotes without fee
- [x] Existing fee-present / fee-zero / native-SOL-output cases still pass
- [x] `ktfmtCheckMain` + `ktfmtCheckTest`
- [ ] Live SOL to long-tail SPL on a device (no on-chain receipt in this PR)

## receipts
```
$ JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :data:testDebugUnitTest --tests com.vultisig.wallet.data.api.JupiterApiTest
BUILD SUCCESSFUL in 16s
29 actionable tasks: 12 executed, 17 up-to-date
```

Live Jupiter probe: SOL to BANDOS HG3sZ52NRmNpm2BueL1MSBM3krr5M6YJtQohjNyhpump `/quote` HTTP 200; fee ATA not provisioned.

No signed broadcast / explorer tx for this change. Do not request review until a device swap is captured, or a maintainer accepts tests as enough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swap quotes now include platform fee amount and currency details when applicable.
  * Swap fee information is calculated using the destination token for supported swaps.

* **Bug Fixes**
  * Improved quote reliability when affiliate fee accounts are unavailable.
  * Fee-enabled quote errors now surface correctly without issuing an unnecessary swap request.
  * Improved handling of native SOL and wrapped SOL fee calculations.

* **Tests**
  * Expanded coverage for fee fallback, error handling, and fee reporting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->