### PR TITLE
fix(qr): dedupe QR encoder, remove ZXing from app module

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,7 +138,6 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.timber)
     implementation(libs.spark.core)
-    implementation(libs.core.zxing)
     implementation(libs.wallet.core)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.coil)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/peer/PeerDiscoveryScreen.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.screens.peer
 
-import android.graphics.Bitmap
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.RepeatMode
@@ -70,11 +69,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import app.rive.Fit
 import app.rive.ViewModelSource
 import app.rive.rememberViewModelInstance
-import com.google.zxing.BarcodeFormat
-import com.google.zxing.EncodeHintType
-import com.google.zxing.qrcode.QRCodeWriter
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.common.Utils
+import com.vultisig.wallet.data.usecases.GenerateQrBitmapImpl
 import com.vultisig.wallet.data.usecases.tss.ParticipantName
 import com.vultisig.wallet.ui.components.KeepScreenOn
 import com.vultisig.wallet.ui.components.ShowQrHelperBottomSheet
@@ -861,28 +858,13 @@ private fun Error(state: ErrorUiModel, onTryAgainClick: () -> Unit) {
 }
 
 /**
- * Builds a real QR painter so the static @Preview renders the framed card with actual content. In
- * production the QR comes from a Hilt-provided generator backed by an Android context, which the
- * preview renderer does not have — so the bitmap is encoded inline here with the same quiet-zone
- * margin used by the app.
+ * Builds a real QR painter so the static @Preview renders the framed card with actual content,
+ * using the same generator production code paths inject via Hilt.
  */
 @Composable
 private fun rememberPreviewQr(content: String): BitmapPainter =
     remember(content) {
-        val matrix =
-            QRCodeWriter()
-                .encode(content, BarcodeFormat.QR_CODE, 0, 0, mapOf(EncodeHintType.MARGIN to 4))
-        val bitmap = Bitmap.createBitmap(matrix.width, matrix.height, Bitmap.Config.ARGB_8888)
-        for (x in 0 until matrix.width) {
-            for (y in 0 until matrix.height) {
-                bitmap.setPixel(
-                    x,
-                    y,
-                    if (matrix.get(x, y)) android.graphics.Color.WHITE
-                    else android.graphics.Color.TRANSPARENT,
-                )
-            }
-        }
+        val bitmap = GenerateQrBitmapImpl()(content, Color.White, Color.Transparent, null)
         BitmapPainter(bitmap.asImageBitmap(), filterQuality = FilterQuality.None)
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GenerateQrBitmap.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/GenerateQrBitmap.kt
@@ -21,7 +21,7 @@ private const val QR_CODE_QUIET_ZONE = 4
 
 interface GenerateQrBitmap : (String, Color, Color, Bitmap?) -> Bitmap
 
-internal class GenerateQrBitmapImpl @Inject constructor() : GenerateQrBitmap {
+class GenerateQrBitmapImpl @Inject constructor() : GenerateQrBitmap {
     override fun invoke(
         qrCodeContent: String,
         mainColor: Color,


### PR DESCRIPTION
## Summary
- `rememberPreviewQr` in `PeerDiscoveryScreen.kt` reimplemented ZXing encoding inline (~20 lines), the only reason `app` needed `implementation(libs.core.zxing)` at all
- The stated reason (Hilt generator needs an Android `Context` the preview doesn't have) was inaccurate — `GenerateQrBitmapImpl` has a no-arg constructor and takes no `Context`, it was just `internal` to the `data` module
- Made `GenerateQrBitmapImpl` public, rewired the preview to call it directly, and dropped the now-unused ZXing import/dependency from `app`

## Issue
Closes #5741

## Test Plan
- [x] `./gradlew lint`
- [x] `./gradlew :app:compileDebugKotlin :data:compileDebugKotlin`

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * QR code previews now use the same generation flow as production QR codes.
  * Removed redundant QR-generation dependencies while preserving configured QR colors and behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->