### PR TITLE
refactor: declare kotlinx-serialization-json explicitly

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,7 +76,8 @@ dependencies {
 
     // kotlinx
     implementation(libs.kotlinx.coroutines.core)
-    implementation(libs.kotlinx.serialization)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.serialization.protobuf)
     implementation(libs.kotlinx.datetime)
 
     // androidx

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -105,7 +105,8 @@ dependencies {
     implementation(libs.ktor.client.serialization.kotlinx)
 
     // serialization
-    implementation(libs.kotlinx.serialization)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.kotlinx.serialization.protobuf)
 
     // crypto
     implementation(libs.wallet.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,7 +87,8 @@ apache-compress = { module = "org.apache.commons:commons-compress", version.ref 
 apache-compress-xz = { module = "org.tukaani:xz", version.ref = "apache-compress-xz" }
 
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
-kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }


### PR DESCRIPTION
## Summary
- `kotlinx-serialization` catalog alias actually resolved to `kotlinx-serialization-protobuf`; `kotlinx-serialization-json` (used by 73 files vs. 11 for protobuf) was only pulled in transitively via Ktor, with its version pinned as a side effect of the protobuf artifact's BOM alignment
- Split the alias into two explicit ones (`kotlinx-serialization-json`, `kotlinx-serialization-protobuf`), both on the existing `serialization = "1.8.0"` version ref
- Updated `app/build.gradle.kts` and `data/build.gradle.kts` call sites accordingly
- No source changes; resolved versions unchanged at 1.8.0 (confirmed via `:data:dependencies --configuration debugRuntimeClasspath`)

## Issue
Closes #5750

## Test Plan
- [x] `./gradlew lint`
- [x] `./gradlew :app:compileDebugKotlin :data:compileDebugKotlin`
- [x] Diffed resolved `debugRuntimeClasspath` before/after — `kotlinx-serialization-json` and `-protobuf` both still resolve to 1.8.0

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated serialization libraries to use separate JSON and Protobuf components.
  * Applied the updated serialization configuration across the application and data modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->