### PR TITLE
Migrate Coil image loading to Coil 3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,6 +141,7 @@ dependencies {
     implementation(libs.wallet.core)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.coil)
+    implementation(libs.coil.network.okhttp)
     implementation(libs.coil.svg)
     implementation(libs.play.update)
     implementation(libs.play.review)

--- a/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
+++ b/app/src/main/java/com/vultisig/wallet/app/VoltixApplication.kt
@@ -1,15 +1,16 @@
 package com.vultisig.wallet.app
 
 import android.app.Application
-import coil.ImageLoader
-import coil.ImageLoaderFactory
-import coil.decode.SvgDecoder
+import android.content.Context
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.svg.SvgDecoder
 import com.vultisig.wallet.BuildConfig
 import com.vultisig.wallet.data.utils.SharedPrefsMasterKeyInitializer
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 
-internal open class VsBaseApplication : Application(), ImageLoaderFactory {
+internal open class VsBaseApplication : Application(), SingletonImageLoader.Factory {
     override fun onCreate() {
         super.onCreate()
         WalletCoreLoader
@@ -24,8 +25,8 @@ internal open class VsBaseApplication : Application(), ImageLoaderFactory {
 
     // Coin logos (e.g. Sui on-chain metadata icons) are sometimes served as SVG, which the
     // platform ImageDecoder rejects with "Failed to create image decoder ... unimplemented".
-    override fun newImageLoader(): ImageLoader =
-        ImageLoader.Builder(this).components { add(SvgDecoder.Factory()) }.build()
+    override fun newImageLoader(context: Context): ImageLoader =
+        ImageLoader.Builder(context).components { add(SvgDecoder.Factory()) }.build()
 }
 
 @HiltAndroidApp internal class VultisigApplication : VsBaseApplication()

--- a/app/src/main/java/com/vultisig/wallet/ui/components/TokenLogo.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/TokenLogo.kt
@@ -12,8 +12,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
-import coil.compose.SubcomposeAsyncImage
-import coil.request.ImageRequest
+import coil3.compose.SubcomposeAsyncImage
+import coil3.network.NetworkHeaders
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -41,7 +43,7 @@ internal fun TokenLogo(
         if (logo is String && logo.contains("ipfs.io", ignoreCase = true)) {
             ImageRequest.Builder(context)
                 .data(logo)
-                .addHeader(USER_AGENT, DEFAULT_USER_AGENT)
+                .httpHeaders(NetworkHeaders.Builder().set(USER_AGENT, DEFAULT_USER_AGENT).build())
                 .build()
         } else {
             logo

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/ChainSelectionItem.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/ChainSelectionItem.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.compose.SubcomposeAsyncImage
+import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.ImageModel

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosUnbondingDelegation

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImage
+import coil3.compose.AsyncImage
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.ui.components.UiAlertDialog

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/referral/ReferralViewScreen.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
-import coil.compose.SubcomposeAsyncImage
+import coil3.compose.SubcomposeAsyncImage
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiIcon

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/sharelink/ShareBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/settings/bottomsheets/sharelink/ShareBottomSheet.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.rememberAsyncImagePainter
+import coil3.compose.rememberAsyncImagePainter
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.components.CopyIcon
 import com.vultisig.wallet.ui.components.UiSpacer

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainLogo.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/components/ChainLogo.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import coil.compose.SubcomposeAsyncImage
+import coil3.compose.SubcomposeAsyncImage
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.ui.theme.Theme
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
@@ -22,8 +22,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.compose.SubcomposeAsyncImage
+import coil3.compose.AsyncImage
+import coil3.compose.SubcomposeAsyncImage
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.ui.components.UiHorizontalDivider

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ barcodeScanning = "17.3.0"
 bcprovJdk18on = "1.79"
 biometric = "1.1.0"
 camera = "1.4.2"
-coil = "2.7.0"
+coil = "3.2.0"
 core = "3.5.4"
 coreKtx = "1.17.0"
 work = "2.10.1"
@@ -113,8 +113,9 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 androidx-test-core-ktx = { group = "androidx.test", name = "core-ktx", version.ref = "coreKtxVersion" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version = "1.7.0" }
 androidx-test-rules = { group = "androidx.test", name = "rules", version = "1.7.0" }
-coil = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
-coil-svg = { module = "io.coil-kt:coil-svg", version.ref = "coil" }
+coil = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp", version.ref = "coil" }
+coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 
 ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktorClientMock" }
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelComposeVersion" }


### PR DESCRIPTION
## Summary
- migrate Coil dependencies from io.coil-kt 2.x to io.coil-kt.coil3 3.2.0
- add the explicit Coil 3 OkHttp network engine dependency
- update Coil imports, singleton image loader registration, SVG decoder setup, and IPFS request headers for Coil 3 APIs

## Notes
- Chose coil-network-okhttp because the app already uses OkHttp, making it the lowest-risk/drop-in network engine for this migration.
- Kept Coil at 3.2.0 per issue #5751. Newer Coil versions currently require a larger compileSdk/AGP upgrade than this issue targets.
- SvgDecoder.Factory() remains registered on the singleton ImageLoader.

## Testing
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:dependencyInsight --dependency io.coil-kt.coil3 --configuration debugRuntimeClasspath
- ./gradlew test
- ./gradlew :app:assembleDebug

## Manual follow-up
- Device check recommended for remote token images and SVG-logo token rendering.

Closes #5751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image loading reliability across token logos, chain icons, staking screens, referral views, sharing, and DeFi components.
  * Added support for loading images over OkHttp, including IPFS image requests.
* **Refactor**
  * Updated the app’s image-loading system to the latest Coil implementation without changing the existing user interface or image behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->