### PR TITLE
Require strong biometrics for auth

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -133,7 +133,7 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-api-29-v2
+          key: avd-api-30-v2
 
       # Clean only when cache did not restore
       - name: Clean old AVD on cache miss
@@ -147,7 +147,7 @@ jobs:
           TRUSTWALLET_PAT: ${{ secrets.TRUSTWALLET_PAT }}
           TRUSTWALLET_USER: ${{ secrets.TRUSTWALLET_USER }}
         with:
-          api-level: 29
+          api-level: 30
           target: default
           arch: x86_64
           profile: Nexus 5

--- a/app/src/main/java/com/vultisig/wallet/ui/components/BiometryAuthPrompt.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/BiometryAuthPrompt.kt
@@ -3,7 +3,6 @@ package com.vultisig.wallet.ui.components
 import android.content.Context
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_STRONG
-import androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK
 import androidx.biometric.BiometricManager.Authenticators.DEVICE_CREDENTIAL
 import androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS
 import androidx.biometric.BiometricPrompt
@@ -38,7 +37,7 @@ import com.vultisig.wallet.ui.utils.closestActivityOrNull
 import timber.log.Timber
 
 private val allowedAuthenticatorTypes
-    get() = BIOMETRIC_STRONG or BIOMETRIC_WEAK or DEVICE_CREDENTIAL
+    get() = BIOMETRIC_STRONG or DEVICE_CREDENTIAL
 
 @Composable
 internal fun BiometryAuthScreen() {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ browser = "1.8.0"
 compileSdk = "36"
 ktorClientMock = "3.0.3"
 lottieCompose = "6.7.1"
-minSdk = "26"
+minSdk = "30"
 
 accompanistPermissions = "0.37.0"
 agp = "8.12.2"


### PR DESCRIPTION
## Summary
- bump minSdk from 26 to 30
- require BIOMETRIC_STRONG or DEVICE_CREDENTIAL for biometric auth
- remove BIOMETRIC_WEAK from the shared biometric authenticator policy

Fixes #5752

## Tests
- ./gradlew test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Biometric authentication now supports only strong biometric methods with device credentials.
  - Weak biometric authentication methods are no longer accepted, helping ensure stronger protection for wallet access.

- **Compatibility**
  - The minimum supported Android version is now Android 11 (API 30).
  - Devices running older Android versions are no longer supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->