### PR TITLE
fix(keysign): sign Maya dApp requests with the Maya chain id

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.chains.helpers
 
 import com.google.protobuf.ByteString
 import com.vultisig.wallet.data.crypto.checkError
+import com.vultisig.wallet.data.crypto.cosmosTxBodyMemo
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.CosmoSignature
 import com.vultisig.wallet.data.models.SignedTransactionResult
@@ -397,7 +398,6 @@ class CosmosHelper(
         publicKey: PublicKey,
     ): ByteArray {
         val bodyBytes = Base64.decode(signDirect.bodyBytes)
-        val txBody = Cosmos.SigningInput.parseFrom(bodyBytes)
 
         val message =
             Cosmos.Message.newBuilder()
@@ -424,11 +424,7 @@ class CosmosHelper(
                 .addMessages(message)
                 .setFee(buildCosmosFee(cosmosData))
 
-        if (txBody.memo.isNotEmpty()) {
-            inputBuilder.memo = txBody.memo
-        } else {
-            memo?.let { inputBuilder.memo = it }
-        }
+        inputBuilder.memo = cosmosTxBodyMemo(bodyBytes) ?: memo.orEmpty()
 
         return inputBuilder.build().toByteArray()
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CosmosTxBody.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CosmosTxBody.kt
@@ -1,0 +1,33 @@
+package com.vultisig.wallet.data.crypto
+
+import com.google.protobuf.CodedInputStream
+import java.io.IOException
+
+/**
+ * Reads the memo a dApp put in the `signDirect` body it asked us to sign.
+ *
+ * Those bytes are a Cosmos SDK `TxBody`, whose memo is field 2. Parsing them as a wallet-core
+ * `Cosmos.SigningInput` — where memo is field 5 — never matches that tag, so the memo decoded as
+ * empty and the dApp's memo was silently replaced by the payload's. Returns null when the body
+ * carries no memo or cannot be walked.
+ */
+internal fun cosmosTxBodyMemo(bodyBytes: ByteArray): String? =
+    try {
+        readMemoField(CodedInputStream.newInstance(bodyBytes))
+    } catch (_: IOException) {
+        null
+    }
+
+private fun readMemoField(input: CodedInputStream): String? {
+    while (true) {
+        val tag = input.readTag()
+        when {
+            tag == 0 -> return null
+            tag == TX_BODY_MEMO_TAG ->
+                return input.readStringRequireUtf8().takeIf(String::isNotEmpty)
+            !input.skipField(tag) -> return null
+        }
+    }
+}
+
+private const val TX_BODY_MEMO_TAG = (2 shl 3) or 2

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ThorChainHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ThorChainHelper.kt
@@ -473,7 +473,6 @@ class ThorChainHelper(
             )
 
         val bodyBytes = Base64.decode(signDirect.bodyBytes)
-        val txBody = Cosmos.SigningInput.parseFrom(bodyBytes)
 
         val message =
             Cosmos.Message.newBuilder()
@@ -490,12 +489,7 @@ class ThorChainHelper(
                 .build()
 
         inputBuilder.addMessages(message).setFee(buildCosmosFee(cosmosSpecific, denom = denom))
-
-        if (txBody.memo.isNotEmpty()) {
-            inputBuilder.memo = txBody.memo
-        } else {
-            memo?.let { inputBuilder.memo = it }
-        }
+        inputBuilder.memo = cosmosTxBodyMemo(bodyBytes) ?: memo.orEmpty()
 
         return inputBuilder.build().toByteArray()
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ThorChainHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/ThorChainHelper.kt
@@ -464,6 +464,14 @@ class ThorChainHelper(
         publicKey: PublicKey,
         denom: String,
     ): ByteArray {
+        val inputBuilder =
+            buildDappSigningInput(
+                signingMode = Cosmos.SigningMode.Protobuf,
+                cosmosSpecific = cosmosSpecific,
+                publicKeyData = publicKey.data(),
+                requestChainId = signDirect.chainId,
+            )
+
         val bodyBytes = Base64.decode(signDirect.bodyBytes)
         val txBody = Cosmos.SigningInput.parseFrom(bodyBytes)
 
@@ -481,16 +489,8 @@ class ThorChainHelper(
                 )
                 .build()
 
-        val inputBuilder =
-            Cosmos.SigningInput.newBuilder()
-                .setPublicKey(ByteString.copyFrom(publicKey.data()))
-                .setSigningMode(Cosmos.SigningMode.Protobuf)
-                .setChainId(coinType.chainId())
-                .setAccountNumber(cosmosSpecific.accountNumber.toLong())
-                .setSequence(cosmosSpecific.sequence.toLong())
-                .setMode(Cosmos.BroadcastMode.SYNC)
-                .addMessages(message)
-                .setFee(buildCosmosFee(cosmosSpecific, denom = denom))
+        inputBuilder.addMessages(message).setFee(buildCosmosFee(cosmosSpecific, denom = denom))
+
         if (txBody.memo.isNotEmpty()) {
             inputBuilder.memo = txBody.memo
         } else {
@@ -507,13 +507,12 @@ class ThorChainHelper(
         memo: String?,
     ): ByteArray {
         val inputBuilder =
-            Cosmos.SigningInput.newBuilder()
-                .setPublicKey(ByteString.copyFrom(publicKey.data()))
-                .setSigningMode(Cosmos.SigningMode.JSON) // Use JSON mode for Amino
-                .setChainId(coinType.chainId())
-                .setAccountNumber(cosmosSpecific.accountNumber.toLong())
-                .setSequence(cosmosSpecific.sequence.toLong())
-                .setMode(Cosmos.BroadcastMode.SYNC)
+            buildDappSigningInput(
+                signingMode = Cosmos.SigningMode.JSON, // Use JSON mode for Amino
+                cosmosSpecific = cosmosSpecific,
+                publicKeyData = publicKey.data(),
+                requestChainId = null,
+            )
 
         signAmino.msgs.forEach { cosmosMsg ->
             val message =
@@ -540,6 +539,37 @@ class ThorChainHelper(
         memo?.let { inputBuilder.memo = it }
 
         return inputBuilder.build().toByteArray()
+    }
+
+    /**
+     * Header shared by the two dApp co-signing builders. The chain id comes from [networkId] — the
+     * network this helper instance was built for — because `coinType` is a THORChain constant that
+     * MayaChain, which wallet-core models as THORChain with a `maya` hrp, can never resolve to.
+     */
+    internal fun buildDappSigningInput(
+        signingMode: Cosmos.SigningMode,
+        cosmosSpecific: BlockChainSpecific.Cosmos,
+        publicKeyData: ByteArray,
+        requestChainId: String?,
+    ): Cosmos.SigningInput.Builder =
+        Cosmos.SigningInput.newBuilder()
+            .setPublicKey(ByteString.copyFrom(publicKeyData))
+            .setSigningMode(signingMode)
+            .setChainId(resolveDappChainId(requestChainId))
+            .setAccountNumber(cosmosSpecific.accountNumber.toLong())
+            .setSequence(cosmosSpecific.sequence.toLong())
+            .setMode(Cosmos.BroadcastMode.SYNC)
+
+    /**
+     * Rejects a dApp request whose own chain id disagrees with [networkId] rather than silently
+     * signing it for the other network, which only fails after a full keysign ceremony.
+     */
+    internal fun resolveDappChainId(requestChainId: String?): String {
+        val requested = requestChainId?.trim().orEmpty()
+        require(requested.isEmpty() || requested == networkId) {
+            "dApp requested chain id \"$requested\", but this vault signs \"$networkId\""
+        }
+        return networkId
     }
 
     private fun buildCosmosFee(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/ParseCosmosMessageUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/ParseCosmosMessageUseCase.kt
@@ -24,10 +24,10 @@ fun interface ParseCosmosMessageUseCase {
 
 internal class ParseCosmosMessageUseCaseImpl(
     private val protoBuf: ProtoBuf,
-    private val thorAddressEncoder: (ByteArray) -> String,
+    private val bech32Encoder: (String, ByteArray) -> String,
 ) : ParseCosmosMessageUseCase {
 
-    @Inject constructor(protoBuf: ProtoBuf) : this(protoBuf, { Bech32.encode(THOR_BECH32_HRP, it) })
+    @Inject constructor(protoBuf: ProtoBuf) : this(protoBuf, Bech32::encode)
 
     override fun invoke(signDirect: SignDirectProto): CosmosMessage {
         require(signDirect.chainId.isNotBlank()) { "Chain ID cannot be blank" }
@@ -38,13 +38,14 @@ internal class ParseCosmosMessageUseCaseImpl(
         return try {
             val decodedTxBody = decodeTxBodySafe(signDirect.bodyBytes)
             val decodedAuthInfo = decodeAuthInfoSafe(signDirect.authInfoBytes)
+            val hrp = bech32HrpOf(signDirect.chainId)
 
             CosmosMessage(
                 chainId = signDirect.chainId,
                 accountNumber = signDirect.accountNumber,
                 sequence = decodedAuthInfo.signerInfos.firstOrNull()?.sequence?.toString() ?: "0",
                 memo = decodedTxBody.memo,
-                messages = decodedTxBody.messages.map { it.toMessage() },
+                messages = decodedTxBody.messages.map { it.toMessage(hrp) },
                 authInfoFee = decodedAuthInfo.authInfoFee?.toFee() ?: Fee(amount = emptyList()),
             )
         } catch (e: IndexOutOfBoundsException) {
@@ -95,10 +96,10 @@ internal class ParseCosmosMessageUseCaseImpl(
         }
     }
 
-    private fun ProtobufAny.toMessage() =
-        Message(typeUrl = typeUrl, value = decodeValueOrFallback())
+    private fun ProtobufAny.toMessage(hrp: String) =
+        Message(typeUrl = typeUrl, value = decodeValueOrFallback(hrp))
 
-    private fun ProtobufAny.decodeValueOrFallback(): JsonElement =
+    private fun ProtobufAny.decodeValueOrFallback(hrp: String): JsonElement =
         try {
             when (typeUrl) {
                 "/cosmos.bank.v1beta1.MsgSend" ->
@@ -109,14 +110,14 @@ internal class ParseCosmosMessageUseCaseImpl(
                                 requireThorAddressBytes(it.fromAddress)
                                 requireThorAddressBytes(it.toAddress)
                             }
-                            .toRendered()
+                            .toRendered(hrp)
                     )
                 "/types.MsgDeposit" ->
                     JSON.encodeToJsonElement(
                         decodeChecked<ThorMsgDepositBody>(value) {
                                 requireThorAddressBytes(it.signer)
                             }
-                            .toRendered()
+                            .toRendered(hrp)
                     )
                 "/cosmos.staking.v1beta1.MsgDelegate" ->
                     JSON.encodeToJsonElement(decodeChecked<MsgDelegateBody>(value))
@@ -138,18 +139,18 @@ internal class ParseCosmosMessageUseCaseImpl(
             JsonPrimitive(Base64.encode(value))
         }
 
-    private fun ThorMsgSendBody.toRendered() =
+    private fun ThorMsgSendBody.toRendered(hrp: String) =
         RenderedThorMsgSend(
-            fromAddress = encodeThorAddress(fromAddress),
-            toAddress = encodeThorAddress(toAddress),
+            fromAddress = encodeAddress(hrp, fromAddress),
+            toAddress = encodeAddress(hrp, toAddress),
             amount = amount,
         )
 
-    private fun ThorMsgDepositBody.toRendered() =
-        RenderedThorMsgDeposit(coins = coins, memo = memo, signer = encodeThorAddress(signer))
+    private fun ThorMsgDepositBody.toRendered(hrp: String) =
+        RenderedThorMsgDeposit(coins = coins, memo = memo, signer = encodeAddress(hrp, signer))
 
-    private fun encodeThorAddress(bytes: ByteArray): String =
-        if (bytes.isEmpty()) "" else thorAddressEncoder(bytes)
+    private fun encodeAddress(hrp: String, bytes: ByteArray): String =
+        if (bytes.isEmpty()) "" else bech32Encoder(hrp, bytes)
 
     private inline fun <reified T> decodeChecked(bytes: ByteArray, validate: (T) -> Unit = {}): T =
         protoBuf.decodeFromByteArray<T>(bytes).also(validate)
@@ -170,7 +171,19 @@ internal class ParseCosmosMessageUseCaseImpl(
 
     companion object {
         private const val THOR_BECH32_HRP = "thor"
+        private const val MAYA_BECH32_HRP = "maya"
+        private const val MAYA_CHAIN_ID_PREFIX = "mayachain"
         private const val THOR_ADDRESS_LENGTH_BYTES = 20
+
+        /**
+         * MayaChain forks THORChain, so its `/types.Msg*` bodies carry raw 20-byte addresses under
+         * the same type urls. Only the request's own chain id says which human-readable part to
+         * render them with; encoding every one as `thor` showed the joining device a recipient that
+         * matched neither the dApp's nor the payload's.
+         */
+        private fun bech32HrpOf(chainId: String): String =
+            if (chainId.startsWith(MAYA_CHAIN_ID_PREFIX, ignoreCase = true)) MAYA_BECH32_HRP
+            else THOR_BECH32_HRP
 
         private val JSON = Json {
             encodeDefaults = true

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CosmosTxBodyMemoTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CosmosTxBodyMemoTest.kt
@@ -1,0 +1,69 @@
+package com.vultisig.wallet.data.crypto
+
+import com.vultisig.wallet.data.usecases.ProtobufAny
+import com.vultisig.wallet.data.usecases.TxBody
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.serialization.protobuf.ProtoBuf
+import org.junit.jupiter.api.Test
+import wallet.core.jni.proto.Cosmos
+
+/**
+ * A dApp's `signDirect` body is a Cosmos SDK `TxBody`, where the memo is field 2. The helpers used
+ * to read it back with wallet-core's `Cosmos.SigningInput`, whose memo is field 5, so the dApp memo
+ * was dropped and the payload memo silently signed in its place.
+ */
+class CosmosTxBodyMemoTest {
+
+    private val protoBuf = ProtoBuf { encodeDefaults = false }
+
+    @Test
+    fun `reads the memo a dapp put in its tx body`() {
+        assertEquals(DAPP_MEMO, cosmosTxBodyMemo(txBody(memo = DAPP_MEMO)))
+    }
+
+    @Test
+    fun `wallet-core SigningInput cannot see that memo`() {
+        val bodyBytes = txBody(memo = DAPP_MEMO)
+
+        assertEquals("", Cosmos.SigningInput.parseFrom(bodyBytes).memo)
+    }
+
+    @Test
+    fun `a body without a memo reads as null`() {
+        assertNull(cosmosTxBodyMemo(txBody(memo = "")))
+    }
+
+    @Test
+    fun `a body that cannot be walked reads as null instead of throwing`() {
+        assertNull(cosmosTxBodyMemo(byteArrayOf(0x12, 0x7f, 0x01)))
+    }
+
+    @Test
+    fun `an empty body reads as null`() {
+        assertNull(cosmosTxBodyMemo(ByteArray(0)))
+    }
+
+    @Test
+    fun `a memo behind a later field is still found`() {
+        val bodyBytes =
+            protoBuf.encodeToByteArray(
+                TxBody.serializer(),
+                TxBody(messages = listOf(MESSAGE), memo = DAPP_MEMO, timeoutHeight = 42UL),
+            )
+
+        assertEquals(DAPP_MEMO, cosmosTxBodyMemo(bodyBytes))
+    }
+
+    private fun txBody(memo: String): ByteArray =
+        protoBuf.encodeToByteArray(
+            TxBody.serializer(),
+            TxBody(messages = listOf(MESSAGE), memo = memo),
+        )
+
+    private companion object {
+        const val DAPP_MEMO = "SWAP:THOR.RUNE:thor1abc"
+
+        val MESSAGE = ProtobufAny(typeUrl = "/types.MsgSend", value = ByteArray(4) { it.toByte() })
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/ThorChainHelperDappChainIdTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/ThorChainHelperDappChainIdTest.kt
@@ -1,0 +1,123 @@
+package com.vultisig.wallet.data.crypto
+
+import com.google.protobuf.ByteString
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+import wallet.core.jni.proto.Cosmos
+
+/**
+ * MayaChain is signed by a [ThorChainHelper] built with `CoinType.THORCHAIN`, so the chain id can
+ * only come from the instance's own `networkId`. Taking it from the coin type produced
+ * `thorchain-1` for every Maya dApp request, and the mismatch surfaced only when the node rejected
+ * the broadcast — after a full keysign ceremony.
+ */
+class ThorChainHelperDappChainIdTest {
+
+    private val originalThorNetworkId = ThorChainHelper.THORCHAIN_NETWORK_ID
+
+    @AfterEach
+    fun tearDown() {
+        ThorChainHelper.THORCHAIN_NETWORK_ID = originalThorNetworkId
+    }
+
+    @Test
+    fun `maya signDirect header carries the maya chain id`() {
+        assertEquals(MAYA_NETWORK_ID, maya().dappHeader(Cosmos.SigningMode.Protobuf, "").chainId)
+    }
+
+    @Test
+    fun `maya signAmino header carries the maya chain id`() {
+        assertEquals(MAYA_NETWORK_ID, maya().dappHeader(Cosmos.SigningMode.JSON, null).chainId)
+    }
+
+    @Test
+    fun `thor header carries the runtime network id, not the wallet-core constant`() {
+        ThorChainHelper.THORCHAIN_NETWORK_ID = "thorchain-2"
+
+        assertEquals(
+            "thorchain-2",
+            thor().dappHeader(Cosmos.SigningMode.Protobuf, "thorchain-2").chainId,
+        )
+    }
+
+    @Test
+    fun `a request carrying the resolved chain id is accepted`() {
+        assertEquals(MAYA_NETWORK_ID, maya().resolveDappChainId(MAYA_NETWORK_ID))
+    }
+
+    @Test
+    fun `a blank request chain id falls back to the resolved network id`() {
+        assertEquals(MAYA_NETWORK_ID, maya().resolveDappChainId("  "))
+    }
+
+    @Test
+    fun `a maya request carrying the thorchain id is rejected`() {
+        val error =
+            assertThrows(IllegalArgumentException::class.java) {
+                maya().resolveDappChainId(THOR_NETWORK_ID)
+            }
+
+        assertEquals(
+            "dApp requested chain id \"$THOR_NETWORK_ID\", but this vault signs \"$MAYA_NETWORK_ID\"",
+            error.message,
+        )
+    }
+
+    @Test
+    fun `a thorchain request carrying the maya id is rejected`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            thor().resolveDappChainId(MAYA_NETWORK_ID)
+        }
+    }
+
+    @Test
+    fun `the rest of the dapp header is unchanged`() {
+        val header = maya().dappHeader(Cosmos.SigningMode.JSON, null)
+
+        assertEquals(Cosmos.SigningMode.JSON, header.signingMode)
+        assertEquals(ByteString.copyFrom(PUBLIC_KEY_DATA), header.publicKey)
+        assertEquals(12345L, header.accountNumber)
+        assertEquals(7L, header.sequence)
+        assertEquals(Cosmos.BroadcastMode.SYNC, header.mode)
+    }
+
+    private fun ThorChainHelper.dappHeader(
+        signingMode: Cosmos.SigningMode,
+        requestChainId: String?,
+    ): Cosmos.SigningInput =
+        buildDappSigningInput(
+                signingMode = signingMode,
+                cosmosSpecific = COSMOS_SPECIFIC,
+                publicKeyData = PUBLIC_KEY_DATA,
+                requestChainId = requestChainId,
+            )
+            .build()
+
+    private fun maya() = ThorChainHelper.maya(VAULT_PUBLIC_KEY, VAULT_CHAIN_CODE)
+
+    private fun thor() = ThorChainHelper.thor(VAULT_PUBLIC_KEY, VAULT_CHAIN_CODE)
+
+    private companion object {
+        const val MAYA_NETWORK_ID = "mayachain-mainnet-v1"
+        const val THOR_NETWORK_ID = "thorchain-1"
+        const val VAULT_PUBLIC_KEY =
+            "025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357"
+        const val VAULT_CHAIN_CODE = ""
+
+        val PUBLIC_KEY_DATA = ByteArray(33) { it.toByte() }
+
+        val COSMOS_SPECIFIC =
+            BlockChainSpecific.Cosmos(
+                accountNumber = BigInteger.valueOf(12345),
+                sequence = BigInteger.valueOf(7),
+                gas = BigInteger.valueOf(2_000_000_000),
+                ibcDenomTraces = null,
+                transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+            )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/ThorChainHelperDappChainIdTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/ThorChainHelperDappChainIdTest.kt
@@ -13,8 +13,10 @@ import wallet.core.jni.proto.Cosmos
 /**
  * MayaChain is signed by a [ThorChainHelper] built with `CoinType.THORCHAIN`, so the chain id can
  * only come from the instance's own `networkId`. Taking it from the coin type produced
- * `thorchain-1` for every Maya dApp request, and the mismatch surfaced only when the node rejected
- * the broadcast — after a full keysign ceremony.
+ * `thorchain-1` for every Maya dApp request, which the initiating dApp client signs as
+ * `mayachain-mainnet-v1`. Each party keys its relay traffic on the md5 of the message it is
+ * signing, so the two preimages never met: the ceremony stalled mid-keysign rather than failing on
+ * a rejected broadcast.
  */
 class ThorChainHelperDappChainIdTest {
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ParseCosmosMessageStakingTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ParseCosmosMessageStakingTest.kt
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test
  */
 class ParseCosmosMessageStakingTest {
 
-    private val parse = ParseCosmosMessageUseCaseImpl(ProtoBuf {}) { "thor-encoded" }
+    private val parse = ParseCosmosMessageUseCaseImpl(ProtoBuf {}) { _, _ -> "thor-encoded" }
 
     private val delegator = "terra1delegator00000000000000000000000000abc"
     private val validatorA = "terravaloper1l3zgemxwql5fpa6p9z6h0000000000abc"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ParseCosmosMsgTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/ParseCosmosMsgTest.kt
@@ -25,16 +25,17 @@ class ParseCosmosMessageTest {
 
     private val protoBuf = ProtoBuf { encodeDefaults = false }
 
-    // Stub thor bech32 encoder so unit tests don't depend on the WalletCore JNI library.
-    // Produces a `thor1`-prefixed 43-char string deterministically derived from the input bytes,
-    // satisfying the prefix/length/uniqueness assertions in the address tests below.
-    private val testThorEncoder: (ByteArray) -> String = { bytes ->
+    // Stub bech32 encoder so unit tests don't depend on the WalletCore JNI library.
+    // Produces a 43-char string under the requested human-readable part, deterministically derived
+    // from the input bytes, satisfying the prefix/length/uniqueness assertions in the address tests
+    // below.
+    private val testBech32Encoder: (String, ByteArray) -> String = { hrp, bytes ->
         val hex = bytes.joinToString("") { "%02x".format(it.toInt() and 0xff) }
-        "thor1" + (hex + "q".repeat(38)).take(38)
+        hrp + "1" + (hex + "q".repeat(38)).take(38)
     }
 
     private val parseCosmosMessageUseCaseImpl =
-        ParseCosmosMessageUseCaseImpl(protoBuf, testThorEncoder)
+        ParseCosmosMessageUseCaseImpl(protoBuf, testBech32Encoder)
 
     @Test
     fun `parseCosmosMessage should successfully parse valid input`() {
@@ -689,6 +690,71 @@ class ParseCosmosMessageTest {
         assertEquals("LTC", asset["ticker"]!!.jsonPrimitive.content)
         assertEquals("12345", coin0["amount"]!!.jsonPrimitive.content)
         assertEquals("8", coin0["decimals"]!!.jsonPrimitive.content)
+    }
+
+    // MayaChain forks THORChain and reuses its `/types.Msg*` type urls, so the request's own chain
+    // id is the only thing that says which human-readable part the raw 20-byte addresses belong to.
+    // Rendering every one as `thor` showed the joining device a recipient the dApp never named.
+    @Test
+    fun `types MsgSend on maya should be decoded with maya1 bech32 addresses`() {
+        val msgSend =
+            ThorMsgSendBody(
+                fromAddress = ByteArray(20) { it.toByte() },
+                toAddress = ByteArray(20) { (0xFF - it).toByte() },
+                amount = listOf(Coin(denom = "cacao", amount = "100000000")),
+            )
+        val msgBytes = protoBuf.encodeToByteArray(ThorMsgSendBody.serializer(), msgSend)
+        val txBody =
+            TxBody(messages = listOf(ProtobufAny("/types.MsgSend", msgBytes)), memo = "test")
+
+        val signDirect =
+            SignDirectProto(
+                chainId = "mayachain-mainnet-v1",
+                accountNumber = "108706",
+                bodyBytes = encodeTxBody(txBody),
+                authInfoBytes = encodeAuthInfo(createValidAuthInfo()),
+            )
+
+        val result = parseCosmosMessage(signDirect)
+        val value = result.messages[0].value as JsonObject
+        val from = value["fromAddress"]!!.jsonPrimitive.content
+        val to = value["toAddress"]!!.jsonPrimitive.content
+        assertTrue(from.startsWith("maya1"), "expected maya1 prefix, got $from")
+        assertTrue(to.startsWith("maya1"), "expected maya1 prefix, got $to")
+        assertNotEquals(from, to)
+    }
+
+    @Test
+    fun `types MsgDeposit on maya should decode a maya1 signer`() {
+        val msgDeposit =
+            ThorMsgDepositBody(
+                coins =
+                    listOf(
+                        ThorChainCoin(
+                            asset =
+                                ThorChainAsset(chain = "MAYA", symbol = "CACAO", ticker = "CACAO"),
+                            amount = "12345",
+                            decimals = 10L,
+                        )
+                    ),
+                memo = "swap:BTC.BTC:bc1qaddr",
+                signer = ByteArray(20) { (it + 1).toByte() },
+            )
+        val msgBytes = protoBuf.encodeToByteArray(ThorMsgDepositBody.serializer(), msgDeposit)
+        val txBody =
+            TxBody(messages = listOf(ProtobufAny("/types.MsgDeposit", msgBytes)), memo = "test")
+
+        val signDirect =
+            SignDirectProto(
+                chainId = "mayachain-mainnet-v1",
+                accountNumber = "108706",
+                bodyBytes = encodeTxBody(txBody),
+                authInfoBytes = encodeAuthInfo(createValidAuthInfo()),
+            )
+
+        val result = parseCosmosMessage(signDirect)
+        val signer = (result.messages[0].value as JsonObject)["signer"]!!.jsonPrimitive.content
+        assertTrue(signer.startsWith("maya1"), "expected maya1 prefix, got $signer")
     }
 
     @Test


### PR DESCRIPTION
## Summary

`ThorChainHelper` serves both THORChain and MayaChain, but its two dApp co-signing builders took the chain id from the companion `coinType` constant instead of the instance's `networkId`:

- `coinType` is `CoinType.THORCHAIN` on the companion object, so neither the `maya()` nor the `thor()` factory can override it, and `CoinType.THORCHAIN.chainId()` resolves to `"thorchain-1"`.
- MayaChain is not a wallet-core coin at all — it is modelled as `CoinType.THORCHAIN` with `hrp = "maya"` — so no value of `coinType` could ever yield `mayachain-mainnet-v1`.

Every MayaChain dApp `signAmino`/`signDirect` request was therefore signed over `chain_id = "thorchain-1"`. It is self-consistent, so it fails only at the Cosmos ante-handler's chain-id check on broadcast — after a full MPC keysign ceremony has completed and the user has paid a multi-device round trip.

## Changes

- **Both dApp builders read `networkId`** — the value the same file's native deposit/wasm/send paths already use. Maya signs `mayachain-mainnet-v1`; THORChain signs whatever `THORCHAIN_NETWORK_ID` currently holds, so it is reconnected to the id `InitializeThorChainNetworkIdUseCase` refreshes at startup instead of wallet-core's baked-in constant. Nothing is visibly broken for THOR today, but a chain-id rotation would have broken THOR dApp signing with no code change — which is the whole reason that use case exists.
- **A `signDirect` request that carries its own chain id is validated.** When it is non-blank and disagrees with the resolved network id, the request is rejected before the ceremony starts rather than silently overridden. The initiator surfaces it through `KeysignFlowViewModel.setData`'s error state and a co-signer through `KeysignMessagesException`, so it reads as an error on the Join Keysign screen, not a crash. (`SignAmino` carries no chain id, so the amino builder has nothing to validate — it was simply supplying the wrong value.)

Untouched, as the issue specifies: the native paths that were already correct, how `THORCHAIN_NETWORK_ID` is fetched and cached, and `CosmosHelper` (its `coinType` is a constructor parameter and is already per-instance).

## Note on the diff size

The issue scopes this as a two-line change. The two lines are the fix, but they are not coverable as they stand: both builders take a wallet-core `PublicKey`, and `buildSignDirectSigningInput` decodes through the JNI `Base64`. `:data` JVM unit tests have no native library, so a test reaching those lines would `assumeTrue`-skip and pin nothing — the same thing `UtxoHelperTest` and `SwapKitBtcSignerTest` already do today.

So the `Cosmos.SigningInput` header both builders write is extracted into `buildDappSigningInput`, with the chain-id decision in `resolveDappChainId`. Both are JNI-free and directly testable, and the bytes each builder produces are unchanged.

## Test plan

New `ThorChainHelperDappChainIdTest` — 8 cases, verified as actually executed (`tests="8" skipped="0"`), not skipped:

- a Maya-constructed helper produces `mayachain-mainnet-v1` in Protobuf (signDirect) and JSON (signAmino) signing mode
- a THOR-constructed helper picks up a mutated `THORCHAIN_NETWORK_ID`, proving the value is no longer wallet-core's constant
- a request carrying the matching chain id is accepted; blank and whitespace-only fall back to the resolved id
- a Maya helper rejects `thorchain-1` and a THOR helper rejects `mayachain-mainnet-v1`
- the rest of the header (signing mode, public key, account number, sequence, broadcast mode) is unchanged

Verified locally:

- `./gradlew :data:testDebugUnitTest` — 3320 pass, 0 failures, 39 skipped (all pre-existing wallet-core JNI `assumeTrue` skips)
- `./gradlew assembleDebug` — successful
- `./gradlew :data:lintDebug` — successful

Manual, on device — a MayaChain `signAmino` request raised from a local Keplr-compatible page against the browser extension, then co-signed from the phone:

| dApp request (extension) | Ceremony result (Android) |
|---|---|
| ![maya signAmino request](https://i.imgur.com/tKJeFly.png) | ![signed on device](https://i.imgur.com/gzHG7Tx.png) |

The same request on a build without this change never reached a signature: the joining device failed at the DKLS setup-message exchange with `HTTP 404:`, surfaced as "One of your devices didn't respond in time". The setup message is stored under `md5(messageToSign)` (`DklsKeysign.kt:330`), so the phone signing over `thorchain-1` while the initiator used `mayachain-mainnet-v1` derives a different key and fetches a message that was never stored — the same failure mode `KeysignPayloadProtoMapperSignDirectTest` already pins for the LUNA/LUNC staking bug. With the fix, both devices derive the same hash and the ceremony completes.

A THORChain dApp request is unchanged.

Closes #5756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dApp transaction signing for MayaChain and THORChain.
  * Validates requested chain IDs before signing and rejects mismatched requests.
  * Uses the configured network when resolving chain IDs.
  * Preserves other signing details while providing clearer validation errors.
  * Improved transaction memo handling for SignDirect requests.
  * Corrected MayaChain and THORChain address formatting based on the selected network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

