### PR TITLE
Fix THORChain empty Midgard status fallback

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -1139,10 +1139,7 @@ constructor(
                         Pair(feeWei, dstToken)
                     } else {
                         // Jupiter ExactIn platform fee is output-mint base units.
-                        Pair(
-                            apiQuote.tx.swapFee.toBigIntegerOrNull() ?: BigInteger.ZERO,
-                            dstToken,
-                        )
+                        Pair(apiQuote.tx.swapFee.toBigIntegerOrNull() ?: BigInteger.ZERO, dstToken)
                     }
                 val updatedTx = apiQuote.tx.withResolvedSwapFee(feeAmount, feeCoin)
                 val tokenFees = TokenValue(value = feeAmount, token = feeCoin)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -1731,11 +1731,7 @@ internal class SwapQuoteManagerTest {
         fetchJupiterQuote(createManager(), slippageBps = null)
 
         coVerify {
-            convertTokenValueToFiat(
-                usdc,
-                TokenValue(BigInteger.ZERO, usdc),
-                AppCurrency.USD,
-            )
+            convertTokenValueToFiat(usdc, TokenValue(BigInteger.ZERO, usdc), AppCurrency.USD)
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cosmos/CosmosEnvelopedTxResponse.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cosmos/CosmosEnvelopedTxResponse.kt
@@ -5,7 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 internal data class CosmosEnvelopedTxResponse(
-    @SerialName("tx_response") val txResponse: TxResponseBody
+    @SerialName("tx_response") val txResponse: TxResponseBody,
+    @SerialName("tx") val tx: CosmosTx? = null,
 )
 
 @Serializable
@@ -13,4 +14,18 @@ internal data class TxResponseBody(
     @SerialName("code") val code: Int?,
     @SerialName("codespace") val codeSpace: String?,
     @SerialName("raw_log") val rawLog: String?,
+)
+
+@Serializable internal data class CosmosTx(@SerialName("body") val body: CosmosTxBody? = null)
+
+@Serializable
+internal data class CosmosTxBody(
+    @SerialName("memo") val memo: String? = null,
+    @SerialName("messages") val messages: List<CosmosTxMessage> = emptyList(),
+)
+
+@Serializable
+internal data class CosmosTxMessage(
+    @SerialName("@type") val type: String? = null,
+    @SerialName("memo") val memo: String? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.api.txstatus
 
 import com.vultisig.wallet.data.api.models.cosmos.CosmosEnvelopedTxResponse
+import com.vultisig.wallet.data.api.models.cosmos.CosmosTxBody
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TransactionStatusProvider
@@ -9,6 +10,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.http.HttpStatusCode
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.SerialName
@@ -41,13 +43,20 @@ import timber.log.Timber
  * plain native transfer (e.g. sending a secured asset) or a native deposit the node rejected during
  * execution never becomes an action, so `/v2/actions` returns an empty array for it. Treating that
  * as [TransactionResult.Pending] left such txs stuck "in progress" forever while the app kept
- * polling Midgard. When no action is found we therefore fall back to the native node's
+ * polling Midgard. When no action is found we therefore consult the native node's
  * `cosmos/tx/v1beta1/txs/{hash}` endpoint, which reports the committed tx's result code directly:
- * code 0 → [TransactionResult.Confirmed], non-zero → [TransactionResult.Failed] with the node's
- * `raw_log`, and 404/not-yet-committed → [TransactionResult.Pending] so polling continues.
+ * non-zero → [TransactionResult.Failed] with the node's `raw_log`, and 404/not-yet-committed →
+ * [TransactionResult.Pending] so polling continues. A successful native result is trusted
+ * immediately for memos Midgard does not index; for Midgard-indexed memos it is trusted only after
+ * repeated empty action responses, giving Midgard's action index time to surface refunds.
  */
-class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: HttpClient) :
-    TransactionStatusProvider {
+class ThorMayaChainStatusProvider
+internal constructor(
+    private val httpClient: HttpClient,
+    private val nowMillis: () -> Long,
+) : TransactionStatusProvider {
+
+    @Inject constructor(httpClient: HttpClient) : this(httpClient, System::currentTimeMillis)
 
     private val midgardUrls =
         mapOf(
@@ -61,12 +70,17 @@ class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: Ht
             Chain.MayaChain to MAYACHAIN_NATIVE_TX_URL,
         )
 
+    private val emptyActionStreaks = ConcurrentHashMap<EmptyActionKey, EmptyActionStreak>()
+
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult {
         val baseUrl = midgardUrls[chain] ?: return TransactionResult.Failed("Unknown chain")
         return try {
             val response: MidgardActionsResponse =
                 httpClient.get(baseUrl) { parameter(MIDGARD_TXID_PARAM, txHash) }.bodyOrThrow()
-            val action = response.actions.firstOrNull() ?: return checkNativeStatus(txHash, chain)
+            val action =
+                response.actions.firstOrNull()
+                    ?: return checkNativeStatusAfterEmptyAction(txHash, chain)
+            emptyActionStreaks.remove(EmptyActionKey(chain, txHash))
             mapAction(action)
         } catch (e: CancellationException) {
             throw e
@@ -77,20 +91,98 @@ class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: Ht
     }
 
     /**
-     * Resolve a native THORChain/MayaChain tx that Midgard doesn't index (plain transfers, rejected
-     * deposits) via the node's `cosmos/tx/v1beta1/txs/{hash}` endpoint. The node returns 404 until
-     * the tx is committed in a block, then a non-null result code (0 = success).
+     * Resolve the ambiguous "no Midgard action yet" case. Native failures are terminal, native 404
+     * stays pending, and native success is gated for memo types Midgard is expected to index.
      */
-    private suspend fun checkNativeStatus(txHash: String, chain: Chain): TransactionResult {
-        val nativeTxUrl = nativeTxUrls[chain] ?: return TransactionResult.Pending
-        val response = httpClient.get("$nativeTxUrl/$txHash")
-        if (response.status == HttpStatusCode.NotFound) return TransactionResult.Pending
-        val txResponse = response.bodyOrThrow<CosmosEnvelopedTxResponse>().txResponse
-        return when (txResponse.code) {
-            0 -> TransactionResult.Confirmed
-            null -> TransactionResult.Pending
-            else -> TransactionResult.Failed(nonBlankOr(txResponse.rawLog, DEFAULT_FAILED_REASON))
+    private suspend fun checkNativeStatusAfterEmptyAction(
+        txHash: String,
+        chain: Chain,
+    ): TransactionResult {
+        val key = EmptyActionKey(chain, txHash)
+
+        val nativeStatus = checkNativeStatus(txHash, chain)
+        if (nativeStatus.result != TransactionResult.Confirmed) {
+            if (nativeStatus.result is TransactionResult.Failed) {
+                emptyActionStreaks.remove(key)
+            }
+            return nativeStatus.result
         }
+
+        if (nativeStatus.hasMemo && !nativeStatus.memo.isMidgardIndexedMemo()) {
+            emptyActionStreaks.remove(key)
+            return TransactionResult.Confirmed
+        }
+
+        val streak =
+            emptyActionStreaks.compute(key) { _, current ->
+                val now = nowMillis()
+                current?.copy(count = current.count + 1, lastObservedAtMillis = now)
+                    ?: EmptyActionStreak(
+                        count = 1,
+                        firstObservedAtMillis = now,
+                        lastObservedAtMillis = now,
+                    )
+            } ?: EmptyActionStreak(
+                count = 0,
+                firstObservedAtMillis = nowMillis(),
+                lastObservedAtMillis = nowMillis(),
+            )
+
+        return if (
+            streak.count >= MIN_INDEXABLE_EMPTY_ACTION_POLLS &&
+                streak.lastObservedAtMillis - streak.firstObservedAtMillis >=
+                    MIN_INDEXABLE_EMPTY_ACTION_AGE_MS
+        ) {
+            emptyActionStreaks.remove(key)
+            TransactionResult.Confirmed
+        } else {
+            TransactionResult.Pending
+        }
+    }
+
+    private suspend fun checkNativeStatus(txHash: String, chain: Chain): NativeStatusResult {
+        val nativeTxUrl =
+            nativeTxUrls[chain]
+                ?: return NativeStatusResult(
+                    result = TransactionResult.Pending,
+                    memo = null,
+                    hasMemo = false,
+                )
+        val response = httpClient.get("$nativeTxUrl/$txHash")
+        if (response.status == HttpStatusCode.NotFound) {
+            return NativeStatusResult(
+                result = TransactionResult.Pending,
+                memo = null,
+                hasMemo = false,
+            )
+        }
+        val envelope = response.bodyOrThrow<CosmosEnvelopedTxResponse>()
+        val txResponse = envelope.txResponse
+        val result =
+            when (txResponse.code) {
+                0 -> TransactionResult.Confirmed
+                null -> TransactionResult.Pending
+                else ->
+                    TransactionResult.Failed(nonBlankOr(txResponse.rawLog, DEFAULT_FAILED_REASON))
+            }
+        val memo = envelope.tx?.body.extractMemo()
+        return NativeStatusResult(result = result, memo = memo.value, hasMemo = memo.isPresent)
+    }
+
+    private fun CosmosTxBody?.extractMemo(): NativeMemo {
+        if (this == null) return NativeMemo(value = null, isPresent = false)
+        val msgDepositMemo =
+            messages.firstNotNullOfOrNull { message ->
+                message.memo.takeIf { message.type == THOR_MSG_DEPOSIT_TYPE && !it.isNullOrBlank() }
+            }
+        if (msgDepositMemo != null) return NativeMemo(value = msgDepositMemo, isPresent = true)
+        return NativeMemo(value = memo, isPresent = memo != null)
+    }
+
+    private fun String?.isMidgardIndexedMemo(): Boolean {
+        val op = this?.trim()?.takeIf { it.isNotEmpty() }?.substringBefore(":")?.uppercase()
+            ?: return false
+        return op in MIDGARD_INDEXED_MEMO_OPS
     }
 
     private fun mapAction(action: MidgardAction): TransactionResult =
@@ -126,8 +218,50 @@ class ThorMayaChainStatusProvider @Inject constructor(private val httpClient: Ht
         const val ACTION_STATUS_SUCCESS = "success"
         const val DEFAULT_REFUND_REASON = "Transaction refunded"
         const val DEFAULT_FAILED_REASON = "Transaction failed"
+        const val MIN_INDEXABLE_EMPTY_ACTION_POLLS = 2
+        const val MIN_INDEXABLE_EMPTY_ACTION_AGE_MS = 15_000L
+        const val THOR_MSG_DEPOSIT_TYPE = "/types.MsgDeposit"
+        val MIDGARD_INDEXED_MEMO_OPS =
+            setOf(
+                "=",
+                "=<",
+                "SWAP",
+                "S",
+                "M=<",
+                "+",
+                "ADD",
+                "A",
+                "-",
+                "WITHDRAW",
+                "WD",
+                "$+",
+                "$-",
+                "LOAN+",
+                "LOAN-",
+                "BOND",
+                "UNBOND",
+                "LEAVE",
+                "POOL+",
+                "POOL-",
+            )
     }
 }
+
+private data class EmptyActionKey(val chain: Chain, val txHash: String)
+
+private data class EmptyActionStreak(
+    val count: Int,
+    val firstObservedAtMillis: Long,
+    val lastObservedAtMillis: Long,
+)
+
+private data class NativeStatusResult(
+    val result: TransactionResult,
+    val memo: String?,
+    val hasMemo: Boolean,
+)
+
+private data class NativeMemo(val value: String?, val isPresent: Boolean)
 
 @Serializable
 internal data class MidgardActionsResponse(val actions: List<MidgardAction> = emptyList())

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProvider.kt
@@ -51,10 +51,8 @@ import timber.log.Timber
  * repeated empty action responses, giving Midgard's action index time to surface refunds.
  */
 class ThorMayaChainStatusProvider
-internal constructor(
-    private val httpClient: HttpClient,
-    private val nowMillis: () -> Long,
-) : TransactionStatusProvider {
+internal constructor(private val httpClient: HttpClient, private val nowMillis: () -> Long) :
+    TransactionStatusProvider {
 
     @Inject constructor(httpClient: HttpClient) : this(httpClient, System::currentTimeMillis)
 
@@ -116,17 +114,15 @@ internal constructor(
         val streak =
             emptyActionStreaks.compute(key) { _, current ->
                 val now = nowMillis()
-                current?.copy(count = current.count + 1, lastObservedAtMillis = now)
+                val fresh =
+                    current?.takeIf { now - it.lastObservedAtMillis <= EMPTY_ACTION_STREAK_TTL_MS }
+                fresh?.copy(count = fresh.count + 1, lastObservedAtMillis = now)
                     ?: EmptyActionStreak(
                         count = 1,
                         firstObservedAtMillis = now,
                         lastObservedAtMillis = now,
                     )
-            } ?: EmptyActionStreak(
-                count = 0,
-                firstObservedAtMillis = nowMillis(),
-                lastObservedAtMillis = nowMillis(),
-            )
+            }!!
 
         return if (
             streak.count >= MIN_INDEXABLE_EMPTY_ACTION_POLLS &&
@@ -180,8 +176,9 @@ internal constructor(
     }
 
     private fun String?.isMidgardIndexedMemo(): Boolean {
-        val op = this?.trim()?.takeIf { it.isNotEmpty() }?.substringBefore(":")?.uppercase()
-            ?: return false
+        val op =
+            this?.trim()?.takeIf { it.isNotEmpty() }?.substringBefore(":")?.uppercase()
+                ?: return false
         return op in MIDGARD_INDEXED_MEMO_OPS
     }
 
@@ -220,6 +217,7 @@ internal constructor(
         const val DEFAULT_FAILED_REASON = "Transaction failed"
         const val MIN_INDEXABLE_EMPTY_ACTION_POLLS = 2
         const val MIN_INDEXABLE_EMPTY_ACTION_AGE_MS = 15_000L
+        const val EMPTY_ACTION_STREAK_TTL_MS = 5 * 60_000L
         const val THOR_MSG_DEPOSIT_TYPE = "/types.MsgDeposit"
         val MIDGARD_INDEXED_MEMO_OPS =
             setOf(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/txstatus/PollingTxStatusUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/txstatus/PollingTxStatusUseCase.kt
@@ -49,7 +49,8 @@ constructor(
 
                 when (result) {
                     is TransactionResult.Confirmed,
-                    is TransactionResult.Failed -> return@flow
+                    is TransactionResult.Failed,
+                    is TransactionResult.Refunded -> return@flow
                     else ->
                         delay(
                             backoffDelay(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/JupiterApiTest.kt
@@ -176,9 +176,7 @@ class JupiterApiTest {
             )
 
         assertThrows(NetworkException::class.java) {
-            runTest {
-                api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50)
-            }
+            runTest { api.getSwapQuote(QUOTE_AMOUNT, INPUT_MINT, OUTPUT_MINT, WALLET, null, 50) }
         }
 
         assertEquals(listOf<String?>("50"), captured.platformFeeBpsHistory)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProviderTest.kt
@@ -268,7 +268,10 @@ class ThorMayaChainStatusProviderTest {
     fun `no midgard action falls back to native node and maps code 0 to Confirmed`() = runTest {
         val nativeSuccess =
             """
-            { "tx_response": { "code": 0, "codespace": "", "raw_log": "" } }
+            {
+              "tx": { "body": { "memo": "" } },
+              "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
+            }
             """
                 .trimIndent()
         val client =
@@ -282,6 +285,184 @@ class ThorMayaChainStatusProviderTest {
 
         result shouldBe TransactionResult.Confirmed
     }
+
+    @Test
+    fun `indexable memo with first empty midgard action does not trust native code 0`() = runTest {
+        val nativeSuccess =
+            """
+            {
+              "tx": { "body": { "memo": "=:BTC.BTC:bc1destination" } },
+              "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
+            }
+            """
+                .trimIndent()
+        val refundAction =
+            """
+            { "actions": [ { "type": "refund", "status": "success",
+              "metadata": { "refund": { "reason": "slip limit exceeded" } } } ] }
+            """
+                .trimIndent()
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.OK to nativeSuccess,
+                HttpStatusCode.OK to refundAction,
+            )
+        val provider = ThorMayaChainStatusProvider(client)
+
+        provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+        provider.checkStatus("hash", Chain.ThorChain) shouldBe
+            TransactionResult.Refunded("slip limit exceeded")
+    }
+
+    @Test
+    fun `non-indexable memo with empty midgard action still trusts native code 0 immediately`() =
+        runTest {
+            val nativeSuccess =
+                """
+                {
+                  "tx": { "body": { "memo": "SECURE+:thor1destination" } },
+                  "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
+                }
+                """
+                    .trimIndent()
+            val client =
+                MockHttpClient.respondingWithSequence(
+                    HttpStatusCode.OK to """{ "actions": [] }""",
+                    HttpStatusCode.OK to nativeSuccess,
+                )
+            val provider = ThorMayaChainStatusProvider(client)
+
+            val result = provider.checkStatus("hash", Chain.ThorChain)
+
+            result shouldBe TransactionResult.Confirmed
+        }
+
+    @Test
+    fun `indexable memo with repeated empty midgard actions eventually trusts native code 0`() =
+        runTest {
+            var nowMillis = 0L
+            val nativeSuccess =
+                """
+                {
+                  "tx": { "body": { "memo": "+:ETH.ETH:0xdestination" } },
+                  "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
+                }
+                """
+                    .trimIndent()
+            val client =
+                MockHttpClient.respondingWithSequence(
+                    HttpStatusCode.OK to """{ "actions": [] }""",
+                    HttpStatusCode.OK to nativeSuccess,
+                    HttpStatusCode.OK to """{ "actions": [] }""",
+                    HttpStatusCode.OK to nativeSuccess,
+                )
+            val provider = ThorMayaChainStatusProvider(client) { nowMillis }
+
+            provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+            nowMillis = 15_000L
+            provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Confirmed
+        }
+
+    @Test
+    fun `indexable memo with repeated empty midgard actions too close together stays Pending`() =
+        runTest {
+            val nativeSuccess =
+                """
+                {
+                  "tx": { "body": { "memo": "=:BTC.BTC:bc1destination" } },
+                  "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
+                }
+                """
+                    .trimIndent()
+            val client =
+                MockHttpClient.respondingWithSequence(
+                    HttpStatusCode.OK to """{ "actions": [] }""",
+                    HttpStatusCode.OK to nativeSuccess,
+                    HttpStatusCode.OK to """{ "actions": [] }""",
+                    HttpStatusCode.OK to nativeSuccess,
+                )
+            val provider = ThorMayaChainStatusProvider(client) { 0L }
+
+            provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+            provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+        }
+
+    @Test
+    fun `indexable memo in MsgDeposit with empty body memo does not trust native code 0`() =
+        runTest {
+            val nativeSuccess =
+                """
+                {
+                  "tx": {
+                    "body": {
+                      "memo": "",
+                      "messages": [
+                        {
+                          "@type": "/types.MsgDeposit",
+                          "memo": "=:BTC.BTC:bc1destination"
+                        }
+                      ]
+                    }
+                  },
+                  "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
+                }
+                """
+                    .trimIndent()
+            val client =
+                MockHttpClient.respondingWithSequence(
+                    HttpStatusCode.OK to """{ "actions": [] }""",
+                    HttpStatusCode.OK to nativeSuccess,
+                )
+            val provider = ThorMayaChainStatusProvider(client)
+
+            val result = provider.checkStatus("hash", Chain.ThorChain)
+
+            result shouldBe TransactionResult.Pending
+        }
+
+    @Test
+    fun `missing native memo with empty midgard action does not trust native code 0`() = runTest {
+        val nativeSuccess =
+            """
+            { "tx_response": { "code": 0, "codespace": "", "raw_log": "" } }
+            """
+                .trimIndent()
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.OK to nativeSuccess,
+            )
+        val provider = ThorMayaChainStatusProvider(client)
+
+        val result = provider.checkStatus("hash", Chain.ThorChain)
+
+        result shouldBe TransactionResult.Pending
+    }
+
+    @Test
+    fun `indexable memo does not count empty midgard response when native node is not found`() =
+        runTest {
+        val nativeSuccess =
+            """
+            {
+              "tx": { "body": { "memo": "=:BTC.BTC:bc1destination" } },
+              "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
+            }
+            """
+                .trimIndent()
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.NotFound to "",
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.OK to nativeSuccess,
+            )
+        val provider = ThorMayaChainStatusProvider(client)
+
+        provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+        provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+        }
 
     @Test
     fun `no midgard action and native node 404 stays Pending`() = runTest {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/ThorMayaChainStatusProviderTest.kt
@@ -389,6 +389,34 @@ class ThorMayaChainStatusProviderTest {
         }
 
     @Test
+    fun `stale empty action streak does not carry over to a later polling session`() = runTest {
+        var nowMillis = 0L
+        val nativeSuccess =
+            """
+            {
+              "tx": { "body": { "memo": "+:ETH.ETH:0xdestination" } },
+              "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
+            }
+            """
+                .trimIndent()
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.OK to nativeSuccess,
+                HttpStatusCode.OK to """{ "actions": [] }""",
+                HttpStatusCode.OK to nativeSuccess,
+            )
+        val provider = ThorMayaChainStatusProvider(client) { nowMillis }
+
+        provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+
+        // A new polling session starts long after the streak's TTL — the stale count must not
+        // let this poll confirm immediately even though 15s+ has technically elapsed.
+        nowMillis = 10 * 60_000L
+        provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+    }
+
+    @Test
     fun `indexable memo in MsgDeposit with empty body memo does not trust native code 0`() =
         runTest {
             val nativeSuccess =
@@ -443,25 +471,25 @@ class ThorMayaChainStatusProviderTest {
     @Test
     fun `indexable memo does not count empty midgard response when native node is not found`() =
         runTest {
-        val nativeSuccess =
-            """
+            val nativeSuccess =
+                """
             {
               "tx": { "body": { "memo": "=:BTC.BTC:bc1destination" } },
               "tx_response": { "code": 0, "codespace": "", "raw_log": "" }
             }
             """
-                .trimIndent()
-        val client =
-            MockHttpClient.respondingWithSequence(
-                HttpStatusCode.OK to """{ "actions": [] }""",
-                HttpStatusCode.NotFound to "",
-                HttpStatusCode.OK to """{ "actions": [] }""",
-                HttpStatusCode.OK to nativeSuccess,
-            )
-        val provider = ThorMayaChainStatusProvider(client)
+                    .trimIndent()
+            val client =
+                MockHttpClient.respondingWithSequence(
+                    HttpStatusCode.OK to """{ "actions": [] }""",
+                    HttpStatusCode.NotFound to "",
+                    HttpStatusCode.OK to """{ "actions": [] }""",
+                    HttpStatusCode.OK to nativeSuccess,
+                )
+            val provider = ThorMayaChainStatusProvider(client)
 
-        provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
-        provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+            provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
+            provider.checkStatus("hash", Chain.ThorChain) shouldBe TransactionResult.Pending
         }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/txstatus/PollingTxStatusUseCaseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/txstatus/PollingTxStatusUseCaseTest.kt
@@ -57,6 +57,19 @@ class PollingTxStatusUseCaseTest {
         }
     }
 
+    private class AlwaysRefundedStatusRepository : TransactionStatusRepository {
+        var callCount = 0
+            private set
+
+        override suspend fun checkTransactionStatus(
+            txHash: String,
+            chain: Chain,
+        ): TransactionResult {
+            callCount++
+            return TransactionResult.Refunded("refunded")
+        }
+    }
+
     private class FakeTxStatusConfigurationProvider(private val config: TxStatusConfiguration) :
         TxStatusConfigurationProvider {
         override fun getConfigurationForChain(chain: Chain) = config
@@ -163,5 +176,23 @@ class PollingTxStatusUseCaseTest {
             elapsedMillis < 10_000,
             "expected timeout near maxWaitSeconds, but took ${elapsedMillis}ms",
         )
+    }
+
+    @Test
+    fun `invoke stops polling after refunded result`() = runBlocking {
+        val repository = AlwaysRefundedStatusRepository()
+        val useCase =
+            PollingTxStatusUseCaseImpl(
+                txStatusConfigurationProvider =
+                    FakeTxStatusConfigurationProvider(
+                        TxStatusConfiguration(pollIntervalSeconds = 30, maxWaitSeconds = 60)
+                    ),
+                transactionStatusRepository = repository,
+            )
+
+        val results = withTimeout(5_000) { useCase(Chain.ThorChain, "deadbeef").toList() }
+
+        assertEquals(listOf(TransactionResult.Refunded("refunded")), results)
+        assertEquals(1, repository.callCount)
     }
 }


### PR DESCRIPTION
## Summary
- Gate native-node success fallback for THORChain/Maya indexable memos until Midgard returns repeated empty action responses
- Decode native tx body memo so empty-action fallback can distinguish indexed memo types from plain/non-indexed transfers
- Treat Refunded as terminal in PollingTxStatusUseCase

## Tests
- ./gradlew :data:testDebugUnitTest --tests "*ThorMayaChainStatusProviderTest*"
- ./gradlew :data:testDebugUnitTest --tests "*PollingTxStatusUseCaseTest*"
- ./gradlew assembleDebug

Fixes #5758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction status handling for confirmed, failed, pending, and refunded transactions across THORChain and Maya.
  - Preserved transaction memos during status checks.
  - Prevented premature confirmation while transaction details are still being indexed.
  - Polling now stops correctly when a transaction is refunded.
  - Improved recognition of deposit-related transaction memos and delayed status responses.

- **Tests**
  - Added coverage for delayed confirmations, native success handling, memo processing, and refunded transaction polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->