### PR TITLE
fix(tron): reject a failed balance read and a reverted fee estimate

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/TronApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/TronApi.kt
@@ -39,6 +39,10 @@ interface TronApi {
 
     suspend fun getSpecific(): TronSpecificBlockJson
 
+    /**
+     * Simulates a TRC-20 transfer to size its energy cost. Throws when the node answers with a
+     * failed or reverted simulation, so a caller never turns one into a `fee_limit`.
+     */
     suspend fun getTriggerConstantContractFee(
         ownerAddressBase58: String,
         contractAddressBase58: String,
@@ -107,13 +111,29 @@ internal class TronApiImpl @Inject constructor(private val httpClient: HttpClien
             put("visible", true)
         }
 
-        return httpClient
-            .post(tronGrid) {
-                url { path("tron", "walletsolidity", "triggerconstantcontract") }
-                setBody(body)
-                accept(ContentType.Application.Json)
-            }
-            .bodyOrThrow<TronTriggerConstantContractJson>()
+        val response =
+            httpClient
+                .post(tronGrid) {
+                    // Full node (`wallet`), not `walletsolidity`: the solidified node lags the head
+                    // by ~60s, so a just-funded or just-approved account is simulated against stale
+                    // state. iOS and the SDK both simulate on the full node.
+                    url { path("tron", "wallet", "triggerconstantcontract") }
+                    setBody(body)
+                    accept(ContentType.Application.Json)
+                }
+                .bodyOrThrow<TronTriggerConstantContractJson>()
+
+        // A 200 does not mean the transfer would land. A revert is returned as an ordinary response
+        // whose energy figures are far below the real cost, and consuming one produces a signed
+        // fee_limit that guarantees OUT_OF_ENERGY at broadcast.
+        check(response.isSuccessfulSimulation()) {
+            "Tron fee simulation failed: ${response.simulationFailureReason()}"
+        }
+        check(response.energyUsed + response.energyPenalty > 0L) {
+            "Tron fee simulation returned a non-positive energy estimate"
+        }
+
+        return response
     }
 
     override suspend fun getChainParameters(): TronChainParametersJson {
@@ -122,24 +142,24 @@ internal class TronApiImpl @Inject constructor(private val httpClient: HttpClien
             .bodyOrThrow<TronChainParametersJson>()
     }
 
+    /**
+     * A failed read throws instead of reading as zero. This balance feeds both the portfolio and
+     * the TRC-20 fee simulation, so swallowing an RPC failure would show real funds as empty and
+     * simulate the transfer at amount 0 — a different shape from the send that actually gets
+     * signed. Only an account the node does not know reads zero.
+     */
     override suspend fun getBalance(coin: Coin): BigInteger {
-        try {
-            val response = httpClient.get("$tronGrid/v1/accounts/${coin.address}")
-            val content = response.bodyOrThrow<TronBalanceResponseJson>()
-            val account = content.tronBalanceResponseData.firstOrNull() ?: return BigInteger.ZERO
+        val response = httpClient.get("$tronGrid/v1/accounts/${coin.address}")
+        val content = response.bodyOrThrow<TronBalanceResponseJson>()
+        val account = content.tronBalanceResponseData.firstOrNull() ?: return BigInteger.ZERO
 
-            return if (coin.isNativeToken) {
-                account.balance
-            } else {
-                account.trc20
-                    .asSequence()
-                    .mapNotNull { it[coin.contractAddress]?.toBigIntegerOrNull() }
-                    .firstOrNull() ?: BigInteger.ZERO
-            }
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e(e, "error getting tron balance")
-            return BigInteger.ZERO
+        return if (coin.isNativeToken) {
+            account.balance
+        } else {
+            account.trc20
+                .asSequence()
+                .mapNotNull { it[coin.contractAddress]?.toBigIntegerOrNull() }
+                .firstOrNull() ?: BigInteger.ZERO
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
@@ -50,7 +50,8 @@ data class TronTriggerConstantContractJson(
     @SerialName("energy_penalty") val energyPenalty: Long = 0L,
     @SerialName("transaction") val transaction: Transaction,
 ) {
-    @Serializable data class Result(val result: Boolean = false, val message: String = "")
+    @Serializable
+    data class Result(val result: Boolean = false, val code: String = "", val message: String = "")
 
     @Serializable data class RetItem(val ret: String? = null)
 
@@ -60,9 +61,23 @@ data class TronTriggerConstantContractJson(
         @SerialName("raw_data_hex") val rawDataHex: String = "",
     )
 
+    /**
+     * A reverted simulation can come back as `result.result = true` alongside a `code` or a
+     * `message` such as `REVERT opcode executed`, carrying an energy figure far below what the real
+     * transfer costs. Rejecting on either keeps a doomed estimate out of the signed `fee_limit`.
+     */
     fun isSuccessfulSimulation(): Boolean {
-        return result?.result == true && transaction.ret?.all { it.ret != "FAILED" } != false
+        return result?.result == true &&
+            result.code.isEmpty() &&
+            result.message.isEmpty() &&
+            transaction.ret?.all { it.ret != "FAILED" } != false
     }
+
+    /** Why the simulation was rejected, for the error the caller surfaces. */
+    fun simulationFailureReason(): String =
+        result?.message?.takeIf(String::isNotEmpty)
+            ?: result?.code?.takeIf(String::isNotEmpty)
+            ?: "node reported an unsuccessful simulation"
 }
 
 @Serializable

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/TronApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/TronApiBodyReadTest.kt
@@ -4,6 +4,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.testutils.MockHttpClient
 import com.vultisig.wallet.data.utils.BigIntegerSerializerImpl
+import com.vultisig.wallet.data.utils.NetworkException
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -12,6 +13,7 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import java.math.BigInteger
+import java.net.UnknownHostException
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
@@ -19,6 +21,7 @@ import kotlinx.serialization.modules.contextual
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 /**
  * Characterization tests for [TronApiImpl] methods that call `response.body<T>()`. They pin the
@@ -28,7 +31,8 @@ import org.junit.jupiter.api.Test
  * Methods covered:
  * - [TronApi.broadcastTransaction] — `body<TronBroadcastTxResponseJson>()` (null code + dup code)
  * - [TronApi.getSpecific] — `body<TronSpecificBlockJson>()`
- * - [TronApi.getBalance] — `body<TronBalanceResponseJson>()` (native, TRC-20, empty)
+ * - [TronApi.getBalance] — `body<TronBalanceResponseJson>()` (native, TRC-20, empty), plus the
+ *   failure path: a read that fails must throw rather than report real funds as zero.
  * - [TronApi.getTsStatus] — `body<TronTransactionStatusResponse?>()` (present / absent txId)
  */
 class TronApiBodyReadTest {
@@ -232,6 +236,42 @@ class TronApiBodyReadTest {
 
         assertEquals(BigInteger.ZERO, result)
     }
+
+    @Test
+    fun `getBalance throws on a transport failure instead of reading zero`() {
+        val api =
+            TronApiImpl(httpClient = MockHttpClient.throwingIOException(UnknownHostException()))
+
+        val error = assertThrows<NetworkException> { runBlocking { api.getBalance(nativeCoin()) } }
+
+        assertEquals(0, error.httpStatusCode)
+    }
+
+    @Test
+    fun `getBalance throws on an HTTP error instead of reading zero`() {
+        val api =
+            TronApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWith(HttpStatusCode.BadGateway, "upstream down")
+            )
+
+        val error = assertThrows<NetworkException> { runBlocking { api.getBalance(nativeCoin()) } }
+
+        assertEquals(HttpStatusCode.BadGateway.value, error.httpStatusCode)
+    }
+
+    private fun nativeCoin() =
+        Coin(
+            chain = Chain.Tron,
+            ticker = "TRX",
+            logo = "",
+            address = "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = true,
+        )
 
     // -------------------------------------------------------------------------
     // getTsStatus — body<TronTransactionStatusResponse?>()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/TronApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/TronApiBodyReadTest.kt
@@ -24,16 +24,17 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
 /**
- * Characterization tests for [TronApiImpl] methods that call `response.body<T>()`. They pin the
- * success-path (HTTP 200) behavior so it is preserved when the call sites are migrated to
- * `bodyOrThrow<T>()`.
+ * Characterization tests for [TronApiImpl] methods that deserialize a response body. Every call
+ * site reads through `bodyOrThrow<T>()`; these pin the success-path (HTTP 200) behavior that the
+ * migration off the raw `body<T>()` had to preserve.
  *
  * Methods covered:
- * - [TronApi.broadcastTransaction] — `body<TronBroadcastTxResponseJson>()` (null code + dup code)
- * - [TronApi.getSpecific] — `body<TronSpecificBlockJson>()`
- * - [TronApi.getBalance] — `body<TronBalanceResponseJson>()` (native, TRC-20, empty), plus the
- *   failure path: a read that fails must throw rather than report real funds as zero.
- * - [TronApi.getTsStatus] — `body<TronTransactionStatusResponse?>()` (present / absent txId)
+ * - [TronApi.broadcastTransaction] — `bodyOrThrow<TronBroadcastTxResponseJson>()` (null code + dup
+ *   code)
+ * - [TronApi.getSpecific] — `bodyOrThrow<TronSpecificBlockJson>()`
+ * - [TronApi.getBalance] — `bodyOrThrow<TronBalanceResponseJson>()` (native, TRC-20, empty), plus
+ *   the failure path: a read that fails must throw rather than report real funds as zero.
+ * - [TronApi.getTsStatus] — `bodyOrThrow<TronTransactionStatusResponse?>()` (present / absent txId)
  */
 class TronApiBodyReadTest {
 
@@ -68,7 +69,7 @@ class TronApiBodyReadTest {
     }
 
     // -------------------------------------------------------------------------
-    // broadcastTransaction — body<TronBroadcastTxResponseJson>()
+    // broadcastTransaction — bodyOrThrow<TronBroadcastTxResponseJson>()
     // -------------------------------------------------------------------------
 
     @Test
@@ -106,7 +107,7 @@ class TronApiBodyReadTest {
     }
 
     // -------------------------------------------------------------------------
-    // getSpecific — body<TronSpecificBlockJson>()
+    // getSpecific — bodyOrThrow<TronSpecificBlockJson>()
     // -------------------------------------------------------------------------
 
     @Test
@@ -137,7 +138,7 @@ class TronApiBodyReadTest {
     }
 
     // -------------------------------------------------------------------------
-    // getBalance — body<TronBalanceResponseJson>()
+    // getBalance — bodyOrThrow<TronBalanceResponseJson>()
     // -------------------------------------------------------------------------
 
     @Test
@@ -274,7 +275,7 @@ class TronApiBodyReadTest {
         )
 
     // -------------------------------------------------------------------------
-    // getTsStatus — body<TronTransactionStatusResponse?>()
+    // getTsStatus — bodyOrThrow<TronTransactionStatusResponse?>()
     // -------------------------------------------------------------------------
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/TronApiFeeSimulationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/TronApiFeeSimulationTest.kt
@@ -1,0 +1,154 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * `triggerconstantcontract` answers a doomed transfer with an ordinary HTTP 200 whose energy
+ * figures are far below what the real send costs, so consuming one produces a signed `fee_limit`
+ * that guarantees OUT_OF_ENERGY at broadcast. These tests pin the rejection of such a response and
+ * the node the simulation runs against.
+ */
+class TronApiFeeSimulationTest {
+
+    private fun newApi(
+        body: String,
+        capture: MockHttpClient.RequestCapture = MockHttpClient.RequestCapture(),
+    ): TronApi =
+        TronApiImpl(httpClient = MockHttpClient.capturingRequest(HttpStatusCode.OK, body, capture))
+
+    private suspend fun TronApi.simulate() =
+        getTriggerConstantContractFee(
+            ownerAddressBase58 = OWNER,
+            contractAddressBase58 = CONTRACT,
+            recipientAddressHex = RECIPIENT_HEX,
+            functionSelector = TronApiImpl.TRANSFER_FUNCTION_SELECTOR,
+            amount = BigInteger.valueOf(1_000_000L),
+        )
+
+    @Test
+    fun `a clean simulation returns its energy figures`() = runBlocking {
+        val api = newApi(simulationBody(result = "true", energyUsed = 31_895, energyPenalty = 0))
+
+        val result = api.simulate()
+
+        assertEquals(31_895L, result.energyUsed)
+        assertEquals(0L, result.energyPenalty)
+    }
+
+    @Test
+    fun `a revert carrying result true is rejected`() {
+        // The shape TronGrid actually returns for a doomed transfer: the call itself succeeded, so
+        // `result` is true, and only the message says the contract reverted.
+        val api =
+            newApi(
+                simulationBody(
+                    result = "true",
+                    energyUsed = 1_080,
+                    energyPenalty = 0,
+                    message = "REVERT opcode executed",
+                )
+            )
+
+        val error = assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+
+        assertTrue(error.message.orEmpty().contains("REVERT opcode executed"))
+    }
+
+    @Test
+    fun `a simulation carrying an error code is rejected`() {
+        val api =
+            newApi(
+                simulationBody(
+                    result = "true",
+                    energyUsed = 1_080,
+                    energyPenalty = 0,
+                    code = "CONTRACT_VALIDATE_ERROR",
+                )
+            )
+
+        val error = assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+
+        assertTrue(error.message.orEmpty().contains("CONTRACT_VALIDATE_ERROR"))
+    }
+
+    @Test
+    fun `a simulation reporting result false is rejected`() {
+        val api = newApi(simulationBody(result = "false", energyUsed = 31_895, energyPenalty = 0))
+
+        assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+    }
+
+    @Test
+    fun `a FAILED transaction ret is rejected`() {
+        val api =
+            newApi(
+                simulationBody(
+                    result = "true",
+                    energyUsed = 31_895,
+                    energyPenalty = 0,
+                    ret = "FAILED",
+                )
+            )
+
+        assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+    }
+
+    @Test
+    fun `a non-positive energy estimate is rejected`() {
+        // Zero energy would serialize as feeLimit = 0, which cannot pay for any TRC-20 transfer.
+        val api = newApi(simulationBody(result = "true", energyUsed = 0, energyPenalty = 0))
+
+        assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+    }
+
+    @Test
+    fun `the simulation runs on the full node, not the solidified one`() {
+        // walletsolidity lags the head by ~60s, so a just-funded account simulates against state
+        // that does not have its balance yet.
+        val capture = MockHttpClient.RequestCapture()
+        val api =
+            newApi(simulationBody(result = "true", energyUsed = 31_895, energyPenalty = 0), capture)
+
+        runBlocking { api.simulate() }
+
+        assertEquals("/tron/wallet/triggerconstantcontract", capture.lastPath)
+    }
+
+    private fun simulationBody(
+        result: String,
+        energyUsed: Int,
+        energyPenalty: Int,
+        code: String? = null,
+        message: String? = null,
+        ret: String? = null,
+    ): String {
+        val codeField = code?.let { ""","code": "$it"""" }.orEmpty()
+        val messageField = message?.let { ""","message": "$it"""" }.orEmpty()
+        val retItem = ret?.let { """{ "ret": "$it" }""" } ?: "{}"
+        return """
+            {
+              "result": { "result": $result$codeField$messageField },
+              "energy_used": $energyUsed,
+              "energy_penalty": $energyPenalty,
+              "transaction": {
+                "ret": [$retItem],
+                "raw_data_hex": "0a02b1f7"
+              }
+            }
+            """
+            .trimIndent()
+    }
+
+    private companion object {
+        const val OWNER = "T9yD14Nj9j7xAB4dbGeiX9h8unkKHxuWwb"
+        const val CONTRACT = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+        const val RECIPIENT_HEX = "0x41e552f6487585c2b58bc2c9bb4492bc1f17132cd0"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/TronApiFeeSimulationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/TronApiFeeSimulationTest.kt
@@ -3,11 +3,11 @@ package com.vultisig.wallet.data.api
 import com.vultisig.wallet.data.testutils.MockHttpClient
 import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
-import kotlinx.coroutines.runBlocking
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 /**
  * `triggerconstantcontract` answers a doomed transfer with an ordinary HTTP 200 whose energy
@@ -33,7 +33,7 @@ class TronApiFeeSimulationTest {
         )
 
     @Test
-    fun `a clean simulation returns its energy figures`() = runBlocking {
+    fun `a clean simulation returns its energy figures`() = runTest {
         val api = newApi(simulationBody(result = "true", energyUsed = 31_895, energyPenalty = 0))
 
         val result = api.simulate()
@@ -43,7 +43,7 @@ class TronApiFeeSimulationTest {
     }
 
     @Test
-    fun `a revert carrying result true is rejected`() {
+    fun `a revert carrying result true is rejected`() = runTest {
         // The shape TronGrid actually returns for a doomed transfer: the call itself succeeded, so
         // `result` is true, and only the message says the contract reverted.
         val api =
@@ -56,13 +56,13 @@ class TronApiFeeSimulationTest {
                 )
             )
 
-        val error = assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+        val error = assertFailsWith<IllegalStateException> { api.simulate() }
 
         assertTrue(error.message.orEmpty().contains("REVERT opcode executed"))
     }
 
     @Test
-    fun `a simulation carrying an error code is rejected`() {
+    fun `a simulation carrying an error code is rejected`() = runTest {
         val api =
             newApi(
                 simulationBody(
@@ -73,20 +73,20 @@ class TronApiFeeSimulationTest {
                 )
             )
 
-        val error = assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+        val error = assertFailsWith<IllegalStateException> { api.simulate() }
 
         assertTrue(error.message.orEmpty().contains("CONTRACT_VALIDATE_ERROR"))
     }
 
     @Test
-    fun `a simulation reporting result false is rejected`() {
+    fun `a simulation reporting result false is rejected`() = runTest {
         val api = newApi(simulationBody(result = "false", energyUsed = 31_895, energyPenalty = 0))
 
-        assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+        assertFailsWith<IllegalStateException> { api.simulate() }
     }
 
     @Test
-    fun `a FAILED transaction ret is rejected`() {
+    fun `a FAILED transaction ret is rejected`() = runTest {
         val api =
             newApi(
                 simulationBody(
@@ -97,26 +97,26 @@ class TronApiFeeSimulationTest {
                 )
             )
 
-        assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+        assertFailsWith<IllegalStateException> { api.simulate() }
     }
 
     @Test
-    fun `a non-positive energy estimate is rejected`() {
+    fun `a non-positive energy estimate is rejected`() = runTest {
         // Zero energy would serialize as feeLimit = 0, which cannot pay for any TRC-20 transfer.
         val api = newApi(simulationBody(result = "true", energyUsed = 0, energyPenalty = 0))
 
-        assertThrows<IllegalStateException> { runBlocking { api.simulate() } }
+        assertFailsWith<IllegalStateException> { api.simulate() }
     }
 
     @Test
-    fun `the simulation runs on the full node, not the solidified one`() {
+    fun `the simulation runs on the full node, not the solidified one`() = runTest {
         // walletsolidity lags the head by ~60s, so a just-funded account simulates against state
         // that does not have its balance yet.
         val capture = MockHttpClient.RequestCapture()
         val api =
             newApi(simulationBody(result = "true", energyUsed = 31_895, energyPenalty = 0), capture)
 
-        runBlocking { api.simulate() }
+        api.simulate()
 
         assertEquals("/tron/wallet/triggerconstantcontract", capture.lastPath)
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
@@ -90,8 +90,13 @@ object MockHttpClient {
         var lastBody: String = ""
             private set
 
-        internal fun record(body: String) {
+        /** Encoded path of the most recent request, for asserting which node endpoint was hit. */
+        var lastPath: String = ""
+            private set
+
+        internal fun record(body: String, path: String) {
             lastBody = body
+            lastPath = path
             bodies += body
         }
     }
@@ -109,7 +114,10 @@ object MockHttpClient {
     ): HttpClient =
         HttpClient(
             MockEngine { request ->
-                capture.record(request.body.toByteArray().decodeToString())
+                capture.record(
+                    body = request.body.toByteArray().decodeToString(),
+                    path = request.url.encodedPath,
+                )
                 respond(content = body, status = status, headers = JSON_HEADERS)
             }
         ) {
@@ -132,7 +140,10 @@ object MockHttpClient {
         var index = 0
         return HttpClient(
             MockEngine { request ->
-                capture.record(request.body.toByteArray().decodeToString())
+                capture.record(
+                    body = request.body.toByteArray().decodeToString(),
+                    path = request.url.encodedPath,
+                )
                 val (status, body) = responses[minOf(index++, responses.size - 1)]
                 respond(content = body, status = status, headers = JSON_HEADERS)
             }


### PR DESCRIPTION
## Summary

Two Tron defects that end in the same place: a number that is not a real estimate reaching the signed transaction.

**`getBalance` reported every failure as zero (#5766).** `TronApi.getBalance` caught all exceptions and returned `BigInteger.ZERO`, so a proxy hiccup rendered real funds as empty *and* handed `0` to the TRC-20 fee simulation as the transfer amount — a shape that simulates differently from the send that actually gets signed. It throws now, which is the contract every other chain already follows and which `BalanceRepository.getBalanceOrNull` already documented in its own comment ("every other chain surfaces a failed read as an exception"). Only an account the node does not know reads `0`.

**A reverted simulation was consumed as a valid estimate (#5767).** `triggerconstantcontract` answers a doomed transfer with an ordinary HTTP 200 whose energy figures are far below the real cost. A live revert arrives as `result.result = true` *alongside* a `REVERT opcode executed` message, so checking the boolean alone was never sufficient. The estimate is now rejected on a non-empty `code` or `message`, a `FAILED` ret, or non-positive energy — the last of which would serialize as `fee_limit = 0` and guarantee `OUT_OF_ENERGY` at broadcast.

**The simulation ran on the solidified node (#5767).** `walletsolidity` lags the head by ~60s, so it answered for a just-funded account against stale state. Moved to the full node, matching iOS (`TronAPI.swift:55`) and the SDK.

## Why the check lives in the API method

#5767 reports that neither caller inspected the result. That is half right, and the half it misses is the one that matters: `TronFeeService` did check `result.result` via `isSuccessfulSimulation()` but never looked at `message`, while `BlockChainSpecificRepository` — the caller that produces the **signed** `fee_limit` — inspected nothing at all. Validating inside `getTriggerConstantContractFee` covers both by construction rather than leaving two call sites to drift apart again. `TronFeeService` keeps its own check as defence, since the interface cannot express the guarantee.

## Reference

The issue cites the SDK, and the SDK is stricter than iOS here. `vultisig-sdk` `packages/core/mpc/keysign/chainSpecific/resolvers/tron/fee.ts:71-96` rejects on `!result || result.result !== true || result.code || result.message`, and separately on `totalEnergy <= 0`. iOS `TronService.swift:231` checks only the boolean, so porting iOS would not have fixed the reported bug.

## Test plan

- `./gradlew :data:testDebugUnitTest` — green. 7 new tests in `TronApiFeeSimulationTest` (clean estimate, revert carrying `result: true`, error code, `result: false`, `FAILED` ret, zero energy, full-node path) and 2 in `TronApiBodyReadTest` (transport failure, HTTP 502).
- `./gradlew :app:testDebugUnitTest` — green
- `./gradlew assembleDebug` — green
- `./gradlew :data:lintDebug` — green

### Live mainnet TRC-20 send

[`03ecc1c74b2f82623915a8bdc332a44ea85e8f615ab1059201aeac50a65f93e6`](https://tronscan.org/#/transaction/03ecc1c74b2f82623915a8bdc332a44ea85e8f615ab1059201aeac50a65f93e6) — 0.1 USDT, `receipt.result: SUCCESS`.

| | |
|---|---|
| Bandwidth | `net_usage: 345` — free from the daily quota, no bandwidth fee |
| Energy | `energy_usage_total: 64,285`, of which `energy_penalty_total: 49,635` |
| Fee | `6,427,600` sun = 6.4276 TRX, all energy burn at the current `getEnergyFee = 100` sun |

The signed `fee_limit` was `(energy_used + energy_penalty) × 1.3 × 100` = 8,357,050 sun ≈ 8.36 TRX against a 6.43 TRX actual burn, so the estimate covered execution with headroom and no `OUT_OF_ENERGY`. Worth noting from these numbers that the penalty was 49,635 of the 64,285 — sized off `energy_used` alone the limit would have been ~1.9 TRX against a 6.43 TRX burn. The code already summed both; what is new is that the sum can no longer be zero.

This run exercises the node change and confirms the new checks do not reject a healthy simulation. The two failure paths — a reverted estimate and a failed balance read — are covered by the unit tests, since neither is reachable by hand.

## Note for review

The rejection throws `IllegalStateException("Tron fee simulation failed: REVERT opcode executed")`. Failing loudly beats signing a doomed transaction, but that string is developer-facing and I have not traced what the Send screen renders for it. Happy to add a localized string if the message surfaces to the user.

Closes #5766
Closes #5767


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TRON fee estimation by validating transfer simulations and rejecting failed or invalid energy estimates.
  * Preserved balance lookup errors instead of incorrectly reporting them as zero.
  * Improved error details for unsuccessful simulations.

* **Tests**
  * Added coverage for failed simulations, network errors, HTTP failures, invalid estimates, and endpoint routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->