### PR TITLE
fix(token detail): fit five actions instead of clipping the fifth

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -374,6 +374,7 @@ class PreviewActivity : ComponentActivity() {
                     "asset_action_button" -> AssetActionButtonPreview()
                     "token_detail_sheet_loading" -> TokenDetailSheetLoadingPreview()
                     "token_detail_sheet_full" -> TokenDetailSheetFullPreview()
+                    "token_detail_sheet_actions" -> TokenDetailSheetFullPreview(allActions = true)
                     "camera_button" -> CameraButton(onClick = {})
                     "banner" -> BannerPreview()
                     "send_tx_done" -> SendTxDonePreview()
@@ -3666,7 +3667,7 @@ private const val CHART_POINT_COUNT = 48
  * that actually exercises the partial rest position, the drag up to full, and the faded cut edge.
  */
 @Composable
-private fun TokenDetailSheetFullPreview() {
+private fun TokenDetailSheetFullPreview(allActions: Boolean = false) {
     val points =
         List(CHART_POINT_COUNT) { index ->
             val price = 73.5 + sin(index / 5.0) * 6.0 + index * 0.12
@@ -3695,6 +3696,8 @@ private fun TokenDetailSheetFullPreview() {
                     ),
                 canSwap = true,
                 canBuy = true,
+                canDeposit = allActions,
+                chainAddress = if (allActions) "9ceRgz57Jj1kmDBQtBWJyeSRhSpxvzWLPQb1LzGxKPWa" else "",
                 chart =
                     ChartUiModel(points = points, isPositive = true, changePercentText = "+4.21%"),
                 marketStats =

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/TokenDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.vultisig.wallet.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -47,7 +46,8 @@ import com.vultisig.wallet.ui.models.TokenDetailViewModel
 import com.vultisig.wallet.ui.models.TokenInfoUiModel
 import com.vultisig.wallet.ui.screens.v2.chaintokens.components.ChainLogo
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
-import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionButton
+import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionItem
+import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionRow
 import com.vultisig.wallet.ui.screens.v2.home.components.assetActionButtonHeight
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.VsUriHandler
@@ -181,47 +181,38 @@ internal fun TokenDetailsContent(
 
             UiSpacer(size = 32.dp)
 
-            Row(
-                horizontalArrangement =
-                    Arrangement.spacedBy(space = 20.dp, alignment = Alignment.CenterHorizontally),
+            AssetActionRow(
+                actions =
+                    buildList {
+                        if (uiModel.canSwap) {
+                            add(AssetActionItem(action = AssetAction.SWAP, onClick = onSwap))
+                        }
+
+                        add(AssetActionItem(action = AssetAction.SEND, onClick = onSend))
+
+                        if (uiModel.canBuy) {
+                            add(AssetActionItem(action = AssetAction.BUY, onClick = onBuy))
+                        }
+
+                        if (uiModel.canDeposit) {
+                            add(
+                                AssetActionItem(action = AssetAction.FUNCTIONS, onClick = onDeposit)
+                            )
+                        }
+
+                        // Gated on the address for the same reason every flag above is gated on
+                        // the account: until one resolves there is nothing to put in a QR code,
+                        // and an action that is tappable but does nothing is worse than one that
+                        // has not appeared yet.
+                        if (uiModel.chainAddress.isNotEmpty()) {
+                            add(AssetActionItem(action = AssetAction.RECEIVE, onClick = onReceive))
+                        }
+                    },
                 // Send routes from this screen's own arguments and is always available; every
                 // other child appears only once the account resolves, so the reserved height keeps
                 // the row from growing as they arrive.
                 modifier = Modifier.fillMaxWidth().heightIn(min = assetActionButtonHeight),
-            ) {
-                if (uiModel.canSwap) {
-                    AssetActionButton(
-                        action = AssetAction.SWAP,
-                        isSelected = true,
-                        onClick = onSwap,
-                    )
-                }
-
-                AssetActionButton(action = AssetAction.SEND, isSelected = false, onClick = onSend)
-
-                if (uiModel.canBuy) {
-                    AssetActionButton(action = AssetAction.BUY, isSelected = false, onClick = onBuy)
-                }
-
-                if (uiModel.canDeposit) {
-                    AssetActionButton(
-                        action = AssetAction.FUNCTIONS,
-                        isSelected = false,
-                        onClick = onDeposit,
-                    )
-                }
-
-                // Gated on the address for the same reason every flag above is gated on the
-                // account: until one resolves there is nothing to put in a QR code, and an action
-                // that is tappable but does nothing is worse than one that has not appeared yet.
-                if (uiModel.chainAddress.isNotEmpty()) {
-                    AssetActionButton(
-                        action = AssetAction.RECEIVE,
-                        isSelected = false,
-                        onClick = onReceive,
-                    )
-                }
-            }
+            )
         }
 
         UiSpacer(size = 40.dp)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
@@ -55,7 +55,8 @@ import com.vultisig.wallet.ui.screens.v2.chaintokens.components.ChainAccount
 import com.vultisig.wallet.ui.screens.v2.chaintokens.components.ChainLogo
 import com.vultisig.wallet.ui.screens.v2.chaintokens.components.ChainTokensTabMenuAndSearchBar
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
-import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionButton
+import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionItem
+import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionRow
 import com.vultisig.wallet.ui.screens.v2.home.components.CopiableAddress
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.KeyboardAware
@@ -205,48 +206,33 @@ internal fun ChainTokensScreen(
 
                 UiSpacer(size = 32.dp)
 
-                Row(
+                AssetActionRow(
+                    actions =
+                        buildList {
+                            if (uiModel.canSwap) {
+                                add(AssetActionItem(action = AssetAction.SWAP, onClick = onSwap))
+                            }
+
+                            add(AssetActionItem(action = AssetAction.SEND, onClick = onSend))
+
+                            if (uiModel.canBuy) {
+                                add(AssetActionItem(action = AssetAction.BUY, onClick = onBuy))
+                            }
+
+                            if (uiModel.canDeposit) {
+                                add(
+                                    AssetActionItem(
+                                        action = AssetAction.FUNCTIONS,
+                                        onClick = onDeposit,
+                                    )
+                                )
+                            }
+
+                            add(AssetActionItem(action = AssetAction.RECEIVE, onClick = onReceive))
+                        },
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement =
-                        Arrangement.spacedBy(12.dp, alignment = Alignment.CenterHorizontally),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    if (uiModel.canSwap) {
-                        AssetActionButton(
-                            action = AssetAction.SWAP,
-                            isSelected = true,
-                            onClick = onSwap,
-                        )
-                    }
-
-                    AssetActionButton(
-                        action = AssetAction.SEND,
-                        isSelected = false,
-                        onClick = onSend,
-                    )
-
-                    if (uiModel.canBuy) {
-                        AssetActionButton(
-                            action = AssetAction.BUY,
-                            isSelected = false,
-                            onClick = onBuy,
-                        )
-                    }
-
-                    if (uiModel.canDeposit) {
-                        AssetActionButton(
-                            action = AssetAction.FUNCTIONS,
-                            isSelected = false,
-                            onClick = onDeposit,
-                        )
-                    }
-
-                    AssetActionButton(
-                        action = AssetAction.RECEIVE,
-                        isSelected = false,
-                        onClick = onReceive,
-                    )
-                }
+                    maxSpacing = 12.dp,
+                )
 
                 UiSpacer(size = 10.dp)
                 uiModel.tronResourceStats?.let { resourceUsage ->

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionButton.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionButton.kt
@@ -1,5 +1,7 @@
 package com.vultisig.wallet.ui.screens.v2.home.components
 
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
@@ -12,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -21,12 +24,15 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.theme.Theme
 
-enum class AssetAction {
-    SWAP,
-    BUY,
-    SEND,
-    RECEIVE,
-    FUNCTIONS,
+enum class AssetAction(
+    @DrawableRes internal val iconRes: Int,
+    @StringRes internal val titleRes: Int,
+) {
+    SWAP(R.drawable.swap_v2, R.string.transaction_type_button_swap),
+    BUY(R.drawable.buy, R.string.transaction_type_button_buy),
+    SEND(R.drawable.send, R.string.transaction_type_button_send),
+    RECEIVE(R.drawable.receive, R.string.transaction_type_button_receive),
+    FUNCTIONS(R.drawable.functions, R.string.transaction_type_button_functions),
 }
 
 /**
@@ -37,11 +43,13 @@ enum class AssetAction {
 internal val assetActionButtonHeight: Dp
     @Composable
     get() =
-        IconBoxSize +
+        AssetActionIconBoxSize +
             IconLabelSpacing +
             with(LocalDensity.current) { Theme.brockmann.supplementary.caption.lineHeight.toDp() }
 
-private val IconBoxSize = 52.dp
+/** Side of the icon box when the row has the width to give every button its full size. */
+internal val AssetActionIconBoxSize = 52.dp
+
 private val IconLabelSpacing = 8.dp
 
 @Composable
@@ -53,6 +61,7 @@ fun AssetActionButton(
             AssetAction.SWAP -> true
             else -> false
         },
+    iconBoxSize: Dp = AssetActionIconBoxSize,
     onClick: () -> Unit = {},
 ) {
 
@@ -60,23 +69,13 @@ fun AssetActionButton(
         if (isSelected) Theme.v2.colors.buttons.ctaPrimary
         else Theme.v2.colors.backgrounds.tertiary_2
 
-    val (logo, title) =
-        when (action) {
-            AssetAction.SWAP -> R.drawable.swap_v2 to R.string.transaction_type_button_swap
-            AssetAction.BUY -> R.drawable.buy to R.string.transaction_type_button_buy
-            AssetAction.SEND -> R.drawable.send to R.string.transaction_type_button_send
-            AssetAction.RECEIVE -> R.drawable.receive to R.string.transaction_type_button_receive
-            AssetAction.FUNCTIONS ->
-                R.drawable.functions to R.string.transaction_type_button_functions
-        }
-
     Column(
         modifier = modifier.clickOnce(onClick = onClick),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Box(
             modifier =
-                Modifier.size(size = IconBoxSize)
+                Modifier.size(size = iconBoxSize)
                     .clip(shape = Theme.v2.radius.lg)
                     .border(
                         width = 1.dp,
@@ -86,15 +85,21 @@ fun AssetActionButton(
                     .background(backgroundColor),
             contentAlignment = Alignment.Center,
         ) {
-            UiIcon(drawableResId = logo, size = 20.dp, tint = Theme.v2.colors.text.primary)
+            UiIcon(
+                drawableResId = action.iconRes,
+                size = 20.dp,
+                tint = Theme.v2.colors.text.primary,
+            )
         }
 
         UiSpacer(IconLabelSpacing)
 
         Text(
-            text = stringResource(title),
+            text = stringResource(action.titleRes),
             color = Theme.v2.colors.text.secondary,
             style = Theme.brockmann.supplementary.caption,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionRow.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionRow.kt
@@ -1,0 +1,113 @@
+package com.vultisig.wallet.ui.screens.v2.home.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.ui.theme.Theme
+
+internal data class AssetActionItem(
+    val action: AssetAction,
+    val isSelected: Boolean = action == AssetAction.SWAP,
+    val onClick: () -> Unit,
+)
+
+/** Tightest gap the row falls back to before it starts taking width off the buttons. */
+internal val AssetActionRowMinSpacing = 8.dp
+
+/** Gap the row uses whenever the buttons leave that much room. */
+internal val AssetActionRowMaxSpacing = 20.dp
+
+/**
+ * Row of [AssetActionButton]s that always fits the width it is given.
+ *
+ * The gap closes first, from [maxSpacing] down to [AssetActionRowMinSpacing]. Only once that is
+ * spent do the buttons themselves give way, and then all of them equally — with five actions the
+ * last one used to be the only one squeezed, which clipped it off the sheet and broke its label
+ * across three lines.
+ */
+@Composable
+internal fun AssetActionRow(
+    actions: List<AssetActionItem>,
+    modifier: Modifier = Modifier,
+    maxSpacing: Dp = AssetActionRowMaxSpacing,
+) {
+    val labelStyle = Theme.brockmann.supplementary.caption
+    val labels = actions.map { stringResource(it.action.titleRes) }
+    val textMeasurer = rememberTextMeasurer()
+    val density = LocalDensity.current
+
+    // A label is free to be wider than its icon box — "Intercambiar" is, in Spanish — so the
+    // natural width of a button is whichever of the two is wider.
+    val naturalWidths =
+        remember(labels, labelStyle, density, textMeasurer) {
+            labels.map { label ->
+                val labelWidth =
+                    with(density) { textMeasurer.measure(label, labelStyle).size.width.toDp() }
+                maxOf(AssetActionIconBoxSize, labelWidth)
+            }
+        }
+
+    BoxWithConstraints(modifier = modifier) {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = maxWidth,
+                naturalWidths = naturalWidths,
+                maxSpacing = maxSpacing,
+            )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement =
+                Arrangement.spacedBy(layout.spacing, alignment = Alignment.CenterHorizontally),
+        ) {
+            actions.forEach { item ->
+                val buttonWidth = layout.buttonWidth
+                AssetActionButton(
+                    modifier = if (buttonWidth == null) Modifier else Modifier.width(buttonWidth),
+                    action = item.action,
+                    isSelected = item.isSelected,
+                    iconBoxSize =
+                        if (buttonWidth == null) AssetActionIconBoxSize
+                        else minOf(AssetActionIconBoxSize, buttonWidth),
+                    onClick = item.onClick,
+                )
+            }
+        }
+    }
+}
+
+/** @param buttonWidth width every button is held to, or null to let each keep its natural width. */
+internal data class AssetActionRowLayout(val spacing: Dp, val buttonWidth: Dp?)
+
+internal fun calculateAssetActionRowLayout(
+    availableWidth: Dp,
+    naturalWidths: List<Dp>,
+    minSpacing: Dp = AssetActionRowMinSpacing,
+    maxSpacing: Dp = AssetActionRowMaxSpacing,
+): AssetActionRowLayout {
+    val gaps = naturalWidths.size - 1
+    if (gaps <= 0) return AssetActionRowLayout(spacing = 0.dp, buttonWidth = null)
+
+    val freeSpace = availableWidth - naturalWidths.fold(0.dp) { total, width -> total + width }
+    val spacingFromFreeSpace = freeSpace / gaps
+    if (spacingFromFreeSpace >= minSpacing) {
+        return AssetActionRowLayout(
+            spacing = minOf(spacingFromFreeSpace, maxSpacing),
+            buttonWidth = null,
+        )
+    }
+
+    val sharedWidth = (availableWidth - minSpacing * gaps) / naturalWidths.size
+    return AssetActionRowLayout(spacing = minSpacing, buttonWidth = maxOf(sharedWidth, 0.dp))
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionRowLayoutTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/home/components/AssetActionRowLayoutTest.kt
@@ -1,0 +1,139 @@
+package com.vultisig.wallet.ui.screens.v2.home.components
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class AssetActionRowLayoutTest {
+
+    // A 360dp phone less the 24dp content padding the token detail sheet applies on both sides.
+    private val phoneWidth = 312.dp
+
+    // Icon box wins over every English label except "Function".
+    private val fiveEnglishButtons = listOf(52.dp, 52.dp, 52.dp, 56.dp, 52.dp)
+
+    // "Intercambiar" / "Funciones" are far wider than the icon box.
+    private val fiveSpanishButtons = listOf(84.dp, 52.dp, 52.dp, 63.dp, 52.dp)
+
+    @Test
+    fun `four buttons with room to spare keep their width and the widest gap`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = phoneWidth,
+                naturalWidths = listOf(52.dp, 52.dp, 52.dp, 52.dp),
+            )
+
+        assertEquals(AssetActionRowMaxSpacing, layout.spacing)
+        assertNull(layout.buttonWidth)
+    }
+
+    @Test
+    fun `five buttons close the gap instead of shrinking`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = phoneWidth,
+                naturalWidths = fiveEnglishButtons,
+            )
+
+        // 312 - 264 = 48 spread over four gaps.
+        assertEquals(12.dp, layout.spacing)
+        assertNull(layout.buttonWidth)
+    }
+
+    @Test
+    fun `five buttons never fall below the tightest gap`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = phoneWidth,
+                naturalWidths = fiveSpanishButtons,
+            )
+
+        assertEquals(AssetActionRowMinSpacing, layout.spacing)
+    }
+
+    @Test
+    fun `labels too wide for the row shrink every button by the same amount`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = phoneWidth,
+                naturalWidths = fiveSpanishButtons,
+            )
+
+        // (312 - 4 * 8) / 5 — one width for all five, not four full ones and a clipped fifth.
+        assertEquals(56.dp, layout.buttonWidth)
+    }
+
+    @Test
+    fun `a shrunk row fits the width it was given`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = phoneWidth,
+                naturalWidths = fiveSpanishButtons,
+            )
+
+        val buttonWidth = requireNotNull(layout.buttonWidth)
+        val used =
+            buttonWidth * fiveSpanishButtons.size + layout.spacing * (fiveSpanishButtons.size - 1)
+        assertTrue(used <= phoneWidth, "row of $used does not fit $phoneWidth")
+    }
+
+    @Test
+    fun `a single action has no gap to size`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = phoneWidth,
+                naturalWidths = listOf(52.dp),
+            )
+
+        assertEquals(0.dp, layout.spacing)
+        assertNull(layout.buttonWidth)
+    }
+
+    @Test
+    fun `an empty row is not laid out`() {
+        val layout =
+            calculateAssetActionRowLayout(availableWidth = phoneWidth, naturalWidths = emptyList())
+
+        assertEquals(0.dp, layout.spacing)
+        assertNull(layout.buttonWidth)
+    }
+
+    @Test
+    fun `a row narrower than its gaps never asks for a negative width`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = 16.dp,
+                naturalWidths = fiveEnglishButtons,
+            )
+
+        assertEquals(0.dp, layout.buttonWidth)
+    }
+
+    @Test
+    fun `an unbounded row keeps its natural widths`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = Dp.Infinity,
+                naturalWidths = fiveEnglishButtons,
+            )
+
+        assertEquals(AssetActionRowMaxSpacing, layout.spacing)
+        assertNull(layout.buttonWidth)
+    }
+
+    @Test
+    fun `the caller can hold the gap below the default maximum`() {
+        val layout =
+            calculateAssetActionRowLayout(
+                availableWidth = phoneWidth,
+                naturalWidths = listOf(52.dp, 52.dp, 52.dp, 52.dp),
+                maxSpacing = 12.dp,
+            )
+
+        assertEquals(12.dp, layout.spacing)
+        assertNull(layout.buttonWidth)
+    }
+}


### PR DESCRIPTION
## Problem

With all five actions visible the token detail row asked for `5 × 52 + 4 × 20 = 340dp` of icons alone, plus 24dp of content padding each side. On a 360dp phone that leaves 312dp, so **Receive** was pushed off the sheet edge and its label broke across three lines.

## Fix

The gap closes before anything else does. `AssetActionRow` measures each button's natural width — the icon box, or the label when the label is wider — and spends the leftover space on the gaps, from the caller's maximum down to an 8dp floor. Only once that floor is spent do the buttons themselves give way, and then **all of them equally**, with the icon box sized from the shared width, so the fifth is never the only one squeezed.

That is iOS's design (`CoinActionsView.swift` computes the same clamped spacing around a fixed 52pt icon), not the `weight(1f)` the issue suggests: weighted children fill the row, which would spread the four- and three-button rows that are correct today. **Up to four buttons the row resolves to natural widths at the full gap, so those cases are unchanged.**

`ChainTokensScreen` uses the same row, holding its gap at its current 12dp, since the same five actions can appear there. Home `TxButtons` is untouched — it is capped at four.

## Locales are the binding constraint, not English

Labels measured out of `brockmann_bold.ttf` at 12sp, against 312dp of content width:

| Locale | Natural sum | Outcome |
|---|---|---|
| en, pt | 260dp | 13dp gap, natural widths, nothing truncated |
| de, nl | 273–278dp | 8.5–9.8dp gap, natural widths |
| es, ru | 292dp / 395dp | cannot fit at any gap → 56dp per button, icons still 52dp, labels ellipsize |

Russian `Отправить` alone is 101.5dp, so its five labels can never all be shown in full. Ellipsis at a row that fits is the degradation; today it overflows the screen instead. A 320dp phone puts English into that branch too, at 48dp buttons.

## Before / After

Captured on the Small_Phone AVD (720×1280 @320dpi = exactly 360dp wide). Medium_Phone is 411dp and does not reproduce the bug.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/JH3V6Rw.png) | ![after](https://i.imgur.com/J4fkD82.png) |

Three-action sheet on the same build, to show the unchanged case:

<img src="https://i.imgur.com/YVILlhO.png" width="300">

## Test plan

- `AssetActionRowLayoutTest` — 10 tests over the pure layout function: the four-button row keeps the full gap, the five-button row closes the gap instead of shrinking, the gap never drops below the floor, a row too narrow for its labels shrinks every button by the same amount and still fits, and a degenerate row never asks for a negative width.
- `:app:testDebugUnitTest` — 2277 tests, 0 failures.
- `:app:lintDebug`, `:app:compileDebugAndroidTestKotlin`, `ktfmtFormat`.
- On device, at 360dp: token detail with Swap / Send / Buy / Function / Receive, and the same five on the chain screen.

Closes #5778


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive action row for token and chain asset screens.
  * Action buttons now adapt their widths and spacing to available space.
  * Added support for displaying all available token actions in previews.

* **Improvements**
  * Long action labels are truncated cleanly to remain on one line.
  * Available actions remain dynamically tailored, including send, receive, swap, buy, and deposit.

* **Tests**
  * Added coverage for action-row sizing, spacing, narrow layouts, and empty or single-action states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->