### PR TITLE
fix(balance): preserve cached balances on failed reads

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/BlockChairApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/BlockChairApi.kt
@@ -71,7 +71,7 @@ constructor(
         }
 
     override suspend fun getAddressInfo(chain: Chain, address: String): BlockChairInfo? {
-        try {
+        return try {
             val response =
                 httpClient.get(
                     "$BASE_URL/${getChainName(chain)}/dashboards/address/${address}?state=latest"
@@ -80,14 +80,14 @@ constructor(
                 }
             val responseData = response.bodyOrThrow<BlockChairInfoJson>()
             Timber.d("response data: $responseData")
-            return responseData.data[address]?.copy(
+            responseData.data[address]?.copy(
                 currentBlockHeight = responseData.context?.state?.toLong()
             )
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e("fail to get address info from blockchair: ${e.message}")
+            Timber.e(e, "fail to get address info from blockchair")
+            throw e
         }
-        return null
     }
 
     override suspend fun getAllUtxos(chain: Chain, address: String): BlockChairInfo {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -72,7 +72,7 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e("Error in Cardano getBalance : ${e.message}")
-            BigInteger.ZERO
+            throw e
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -497,7 +497,7 @@ constructor(
                                         .getAddressInfo(coin.chain, address)
                                         ?.address
                                         ?.balance
-                                balance?.toBigInteger() ?: 0.toBigInteger()
+                                balance?.toBigInteger() ?: BigInteger.ZERO
                             }
 
                             Ethereum,
@@ -571,7 +571,8 @@ constructor(
 
                             Solana -> {
                                 if (coin.isNativeToken) {
-                                    solanaApi.getBalance(address)
+                                    solanaApi.getBalanceOrNull(address)
+                                        ?: error("Solana balance read failed for $address")
                                 } else {
                                     splTokenRepository.getBalance(coin)
                                         ?: splTokenRepository.getCachedBalance(coin)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/BlockChairApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/BlockChairApiBodyReadTest.kt
@@ -3,9 +3,11 @@ package com.vultisig.wallet.data.api
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.testutils.MockHttpClient
 import com.vultisig.wallet.data.utils.BigIntegerSerializerImpl
+import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.UTXOStatusResponseSerializerImpl
 import io.ktor.http.HttpStatusCode
 import java.math.BigInteger
+import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
@@ -96,6 +98,20 @@ class BlockChairApiBodyReadTest {
         val result = api.getAddressInfo(chain = Chain.Litecoin, address = "missingAddress")
 
         assertNull(result)
+    }
+
+    @Test
+    fun `getAddressInfo propagates an HTTP failure instead of swallowing it into null`() = runTest {
+        val api =
+            BlockChairApiImp(
+                json = json,
+                httpClient = MockHttpClient.respondingWith(HttpStatusCode.Forbidden, ""),
+                utxoStatusResponseSerializer = UTXOStatusResponseSerializerImpl(json),
+            )
+
+        assertFailsWith<NetworkException> {
+            api.getAddressInfo(chain = Chain.Litecoin, address = "missingAddress")
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryBalanceOrNullTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryBalanceOrNullTest.kt
@@ -21,6 +21,7 @@ import com.vultisig.wallet.data.blockchain.thorchain.ThorchainDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.ton.TonDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.tron.TronDeFiBalanceService
 import com.vultisig.wallet.data.db.dao.TokenValueDao
+import com.vultisig.wallet.data.db.models.TokenValueEntity
 import com.vultisig.wallet.data.models.Coins
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
@@ -29,6 +30,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import java.math.BigInteger
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -45,11 +47,14 @@ class BalanceRepositoryBalanceOrNullTest {
 
     private val solanaApi = mockk<SolanaApi>(relaxed = true)
     private val thorChainApi = mockk<ThorChainApi>(relaxed = true)
+    private val blockchairApi = mockk<BlockChairApi>(relaxed = true)
+    private val cardanoApi = mockk<CardanoApi>(relaxed = true)
+    private val tokenValueDao = mockk<TokenValueDao>(relaxed = true)
 
     private val repository =
         BalanceRepositoryImpl(
             thorChainApi = thorChainApi,
-            blockchairApi = mockk<BlockChairApi>(relaxed = true),
+            blockchairApi = blockchairApi,
             evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
             mayaChainApi = mockk<MayaChainApi>(relaxed = true),
             cosmosApiFactory = mockk<CosmosApiFactory>(relaxed = true),
@@ -64,8 +69,8 @@ class BalanceRepositoryBalanceOrNullTest {
             tonApi = mockk<TonApi>(relaxed = true),
             rippleApi = mockk<RippleApi>(relaxed = true),
             tronApi = mockk<TronApi>(relaxed = true),
-            cardanoApi = mockk<CardanoApi>(relaxed = true),
-            tokenValueDao = mockk<TokenValueDao>(relaxed = true),
+            cardanoApi = cardanoApi,
+            tokenValueDao = tokenValueDao,
             thorchainDeFiBalanceService = mockk<ThorchainDeFiBalanceService>(relaxed = true),
             circleDeFiBalanceService = mockk<CircleDeFiBalanceService>(relaxed = true),
             mayaDeFiBalanceService = mockk<MayaDeFiBalanceService>(relaxed = true),
@@ -109,6 +114,55 @@ class BalanceRepositoryBalanceOrNullTest {
         assertThrows<CancellationException> {
             repository.getBalanceOrNull(ADDRESS, Coins.ThorChain.RUNE)
         }
+    }
+
+    @Test
+    fun `a Blockchair balance failure propagates and is not persisted as zero`() = runTest {
+        coEvery { blockchairApi.getAddressInfo(Coins.Bitcoin.BTC.chain, ADDRESS) } throws
+            IllegalStateException("blockchair down")
+
+        assertThrows<IllegalStateException> {
+            repository.getTokenValue(ADDRESS, Coins.Bitcoin.BTC).first()
+        }
+
+        coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
+    }
+
+    @Test
+    fun `a Blockchair absent address response persists a genuine zero`() = runTest {
+        coEvery { blockchairApi.getAddressInfo(Coins.Bitcoin.BTC.chain, ADDRESS) } returns null
+
+        repository.getTokenValue(ADDRESS, Coins.Bitcoin.BTC).first().value shouldBe BigInteger.ZERO
+
+        coVerify(exactly = 1) {
+            tokenValueDao.insertTokenValue(
+                match<TokenValueEntity> { it.tokenValue == BigInteger.ZERO.toString() }
+            )
+        }
+    }
+
+    @Test
+    fun `a Cardano balance failure propagates and is not persisted as zero`() = runTest {
+        coEvery { cardanoApi.getBalance(Coins.Cardano.ADA) } throws
+            IllegalStateException("koios down")
+
+        assertThrows<IllegalStateException> {
+            repository.getTokenValue(ADDRESS, Coins.Cardano.ADA).first()
+        }
+
+        coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
+    }
+
+    @Test
+    fun `a Solana native balance failure propagates and is not persisted as zero`() = runTest {
+        coEvery { solanaApi.getBalanceOrNull(ADDRESS) } returns null
+
+        assertThrows<IllegalStateException> {
+            repository.getTokenValue(ADDRESS, Coins.Solana.SOL).first()
+        }
+
+        coVerify(exactly = 0) { solanaApi.getBalance(any()) }
+        coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
- propagate failed Blockchair and Cardano balance reads instead of turning them into zero
- use Solana's nullable balance read for native display balances so unknown values do not get persisted
- add coverage for failed reads not inserting token values, while preserving the genuine empty Blockchair address zero case

Fixes #5770

## Tests
- ./gradlew :data:testDebugUnitTest
- ./gradlew assembleDebug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Balance retrieval errors now surface correctly instead of being silently treated as zero or unavailable balances.
  * Network failures, including blocked address requests, are reported consistently.
  * Solana balance reads now distinguish between missing data and valid zero balances.
  * Prevented failed balance lookups from persisting incorrect zero values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->