### PR TITLE
fix(send): show memo for token signers that carry it

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
@@ -15,10 +15,10 @@ import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenId
-import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.VaultId
+import com.vultisig.wallet.data.models.carriesMemo
 import com.vultisig.wallet.data.models.isRippleIssuedToken
 import com.vultisig.wallet.data.models.settings.AppCurrency
 import com.vultisig.wallet.data.repositories.AccountsRepository
@@ -311,6 +311,7 @@ internal class SendFormGraph(
             accounts = accounts,
             selectedToken = selectedToken,
             addressFieldState = addressFieldState,
+            memoFieldState = memoFieldState,
             uiState = uiState,
             isSwitchingAccounts = isSwitchingAccounts,
             defiTypeProvider = defiTypeProvider,
@@ -520,13 +521,10 @@ internal class SendFormGraph(
                 val address = token.address
                 // The tag belongs to the destination account, not the asset.
                 val isDestinationTag = token.chain == Chain.Ripple
-                val hasMemo =
-                    (token.isNativeToken || token.chain.standard == TokenStandard.COSMOS) &&
-                        token.chain != Chain.Sui
+                val hasMemo = token.carriesMemo
 
-                // Issued currencies hide the memo field but submit still reads it, so text typed
-                // for another coin would be signed. TON jettons, SPL and TRC20 hide the field
-                // too, but keep signing their memo.
+                // Issued currencies use the destination-tag field, while submit still reads the
+                // memo text; clear anything typed for a previous asset before it can leak through.
                 if (token.isRippleIssuedToken) {
                     memoFieldState.clearText()
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/TokenNetworkSelectionDelegate.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/TokenNetworkSelectionDelegate.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.models.ChainId
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenId
 import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.carriesMemo
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.TokenRepository
@@ -70,6 +71,7 @@ internal class TokenNetworkSelectionDelegate(
     private val accounts: StateFlow<List<Account>>,
     private val selectedToken: MutableStateFlow<Coin?>,
     private val addressFieldState: TextFieldState,
+    private val memoFieldState: TextFieldState,
     private val uiState: MutableStateFlow<SendFormUiModel>,
     private val isSwitchingAccounts: MutableStateFlow<Boolean>,
     private val defiTypeProvider: () -> DeFiNavActions?,
@@ -260,6 +262,9 @@ internal class TokenNetworkSelectionDelegate(
         // autocompound toggle hits this same race that setTronResourceType already preempts).
         amountFractionManager.cancel()
         amountManager.resetUserInputCache()
+        if (!token.carriesMemo) {
+            memoFieldState.setTextAndPlaceCursorAtEnd("")
+        }
         selectedToken.value = token
     }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelInitTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelInitTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -142,6 +143,48 @@ internal class SendFormViewModelInitTest {
     }
 
     @Test
+    fun `memo is visible for a TON jetton`() = runTest {
+        val vm = buildViewModelWithPreselectedToken(Coins.Ton.USDT)
+
+        assertTrue(vm.uiState.value.hasMemo)
+    }
+
+    @Test
+    fun `memo is visible for an SPL token`() = runTest {
+        val vm = buildViewModelWithPreselectedToken(Coins.Solana.USDC)
+
+        assertTrue(vm.uiState.value.hasMemo)
+    }
+
+    @Test
+    fun `memo is visible for a TRC20 token`() = runTest {
+        val vm = buildViewModelWithPreselectedToken(Coins.Tron.USDT)
+
+        assertTrue(vm.uiState.value.hasMemo)
+    }
+
+    @Test
+    fun `memo is hidden for an ERC20 token`() = runTest {
+        val vm = buildViewModelWithPreselectedToken(Coins.Ethereum.USDC)
+
+        assertFalse(vm.uiState.value.hasMemo)
+    }
+
+    @Test
+    fun `memo is hidden for an XRPL issued currency`() = runTest {
+        val vm = buildViewModelWithPreselectedToken(Coins.Ripple.RLUSD)
+
+        assertFalse(vm.uiState.value.hasMemo)
+    }
+
+    @Test
+    fun `memo is hidden for Sui`() = runTest {
+        val vm = buildViewModelWithPreselectedToken(Coins.Sui.SUI)
+
+        assertFalse(vm.uiState.value.hasMemo)
+    }
+
+    @Test
     fun `preSelectedTokenId without address expands the Address section`() = runTest {
         every { savedStateHandle.toRoute<Route.Send>() } returns
             Route.Send(vaultId = VAULT_ID, tokenId = "RUNE-thorchain")
@@ -235,10 +278,9 @@ internal class SendFormViewModelInitTest {
         assertEquals("", vm.slippageFieldState.text.toString())
     }
 
-    // Regression: the memo clear added for XRPL issued currencies must not reach a TON jetton. A
-    // jetton hides the memo field too, but TonHelper signs `payload.memo` as the transfer comment,
-    // and a `vultisig://send?...&memo=` deep link is the only way to supply one — wiping it makes
-    // an exchange deposit arrive without its comment.
+    // Regression: the memo clear added for XRPL issued currencies must not reach a TON jetton.
+    // TonHelper signs `payload.memo` as the transfer comment, so wiping it makes an exchange
+    // deposit arrive without its comment.
     @Test
     fun `a deep-linked memo survives on a TON jetton`() = runTest {
         every { savedStateHandle.toRoute<Route.Send>() } returns
@@ -283,11 +325,8 @@ internal class SendFormViewModelInitTest {
 
     private val jettonAccount =
         account(
-            Coins.Ton.TON.copy(
-                ticker = "USDT",
+            Coins.Ton.USDT.copy(
                 address = TON_ADDRESS,
-                contractAddress = "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs",
-                isNativeToken = false,
             )
         )
 
@@ -338,8 +377,27 @@ internal class SendFormViewModelInitTest {
         )
     }
 
+    private fun TestScope.buildViewModelWithPreselectedToken(coin: Coin): SendFormViewModel {
+        val token = coin.copy(address = ADDRESS)
+        coEvery { accountsRepository.loadAddresses(VAULT_ID) } returns
+            flowOf(
+                listOf(
+                    Address(
+                        chain = token.chain,
+                        address = ADDRESS,
+                        accounts = listOf(account(token)),
+                    )
+                )
+            )
+        every { savedStateHandle.toRoute<Route.Send>() } returns
+            Route.Send(vaultId = VAULT_ID, tokenId = token.id)
+
+        return buildViewModel().also { advanceUntilIdle() }
+    }
+
     private companion object {
         const val VAULT_ID = "vault-1"
+        const val ADDRESS = "address-1"
 
         // A chain id old deep links still carry after the entry was removed from [Chain].
         const val RETIRED_CHAIN_ID = "Kujira"

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/TokenNetworkSelectionDelegateMemoTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/TokenNetworkSelectionDelegateMemoTest.kt
@@ -1,0 +1,62 @@
+@file:OptIn(ExperimentalCoroutinesApi::class, ExperimentalStdlibApi::class)
+
+package com.vultisig.wallet.ui.models.send
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+internal class TokenNetworkSelectionDelegateMemoTest {
+
+    private val selectedToken = MutableStateFlow<Coin?>(Coins.Ethereum.ETH)
+    private val memoFieldState = TextFieldState()
+
+    @Test
+    fun `selecting a token whose signer drops memos clears the memo`() = runTest {
+        memoFieldState.setTextAndPlaceCursorAtEnd("exchange memo")
+
+        delegate().selectToken(Coins.Ethereum.USDC)
+
+        assertEquals("", memoFieldState.text.toString())
+    }
+
+    @Test
+    fun `selecting a token whose signer carries memos keeps the memo`() = runTest {
+        memoFieldState.setTextAndPlaceCursorAtEnd("exchange memo")
+
+        delegate().selectToken(Coins.Ton.USDT)
+
+        assertEquals("exchange memo", memoFieldState.text.toString())
+    }
+
+    private fun delegate(): TokenNetworkSelectionDelegate =
+        TokenNetworkSelectionDelegate(
+            scope = mockk(relaxed = true),
+            navigator = mockk(relaxed = true),
+            requestResultRepository = mockk(relaxed = true),
+            tokenRepository = mockk(relaxed = true),
+            vaultRepository = mockk(relaxed = true),
+            chainAccountAddressRepository = mockk(relaxed = true),
+            tokenPreselectionService = mockk(relaxed = true),
+            accountsLoader = mockk(relaxed = true),
+            amountFractionManager = mockk(relaxed = true),
+            amountManager = mockk(relaxed = true),
+            vaultIdProvider = { null },
+            accounts = MutableStateFlow(emptyList<Account>()),
+            selectedToken = selectedToken,
+            addressFieldState = TextFieldState(),
+            memoFieldState = memoFieldState,
+            uiState = MutableStateFlow(SendFormUiModel()),
+            isSwitchingAccounts = MutableStateFlow(false),
+            defiTypeProvider = { null },
+            expandSection = {},
+        )
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
@@ -90,6 +90,19 @@ val Coin.isLpToken: Boolean
             else -> false
         }
 
+/**
+ * True when the transaction builder for this exact coin carries
+ * [com.vultisig.wallet.data.models.payload.KeysignPayload.memo] into the signed transaction.
+ */
+val Coin.carriesMemo: Boolean
+    get() =
+        chain != Chain.Sui &&
+            (isNativeToken ||
+                chain.standard == TokenStandard.COSMOS ||
+                chain == Chain.Ton ||
+                chain == Chain.Solana ||
+                chain == Chain.Tron)
+
 /** Returns true if this coin's chain allows zero-gas transactions. */
 fun Coin.allowZeroGas(): Boolean {
     return this.chain == Chain.Polkadot || this.chain == Chain.Bittensor || this.chain == Chain.Tron


### PR DESCRIPTION
## Summary
- add a coin-level memo capability that follows signer behavior instead of native-token status
- show the send memo field for TON jettons, SPL tokens, and TRC20 tokens while keeping ERC-20, XRPL issued currencies, and Sui hidden
- clear stale memo text when switching to a coin whose signer cannot carry it

Fixes #5763

## Tests
- ./gradlew :app:testDebugUnitTest
- ./gradlew assembleDebug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Memo fields now appear only for assets and networks that support memo values.
  * Switching to an asset that does not support memos automatically clears any previously entered memo.
  * Memo values are preserved when switching between assets that support them.

* **Tests**
  * Added coverage for memo behavior across multiple supported asset types and networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->