### PR TITLE
fix(ui): align select chain footer

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/components/VsCenterHighlightCarousel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VsCenterHighlightCarousel.kt
@@ -179,10 +179,16 @@ fun VsCenterHighlightCarousel(
                 .padding(vertical = 16.dp)
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            UiHorizontalDivider(
+                modifier = Modifier.width(344.dp),
+                color = Theme.v2.colors.border.light,
+            )
+            Spacer(modifier = Modifier.height(9.dp))
+
             Text(
                 text = stringResource(R.string.select_chain_title),
                 color = Theme.v2.colors.text.tertiary,
-                style = Theme.brockmann.body.m.medium,
+                style = Theme.brockmann.supplementary.caption,
                 modifier = Modifier.padding(bottom = 16.dp),
             )
 


### PR DESCRIPTION
## Summary
- switch the Select chain footer label to the 12sp caption style
- add the Figma divider above the label with the specified spacing

Fixes #5785

## Tests
- ./gradlew assembleDebug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a horizontal divider above the chain-selection title.
  * Updated the title typography for improved visual hierarchy and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->