### PR TITLE
refactor: drop kotlinx-datetime, consolidate on java.time

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,7 +78,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.protobuf)
-    implementation(libs.kotlinx.datetime)
 
     // androidx
     implementation(libs.androidx.core.ktx)

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -3697,7 +3697,8 @@ private fun TokenDetailSheetFullPreview(allActions: Boolean = false) {
                 canSwap = true,
                 canBuy = true,
                 canDeposit = allActions,
-                chainAddress = if (allActions) "9ceRgz57Jj1kmDBQtBWJyeSRhSpxvzWLPQb1LzGxKPWa" else "",
+                chainAddress =
+                    if (allActions) "9ceRgz57Jj1kmDBQtBWJyeSRhSpxvzWLPQb1LzGxKPWa" else "",
                 chart =
                     ChartUiModel(points = points, isPositive = true, changePercentText = "+4.21%"),
                 marketStats =

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -3697,8 +3697,7 @@ private fun TokenDetailSheetFullPreview(allActions: Boolean = false) {
                 canSwap = true,
                 canBuy = true,
                 canDeposit = allActions,
-                chainAddress =
-                    if (allActions) "9ceRgz57Jj1kmDBQtBWJyeSRhSpxvzWLPQb1LzGxKPWa" else "",
+                chainAddress = if (allActions) "9ceRgz57Jj1kmDBQtBWJyeSRhSpxvzWLPQb1LzGxKPWa" else "",
                 chart =
                     ChartUiModel(points = points, isPositive = true, changePercentText = "+4.21%"),
                 marketStats =

--- a/app/src/main/java/com/vultisig/wallet/data/mappers/MapVaultToProto.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/mappers/MapVaultToProto.kt
@@ -6,8 +6,8 @@ import com.vultisig.wallet.data.models.proto.v1.KeyShareProto
 import com.vultisig.wallet.data.models.proto.v1.VaultProto
 import com.vultisig.wallet.data.models.proto.v1.toProto
 import google.protobuf.Timestamp
+import java.time.Instant
 import javax.inject.Inject
-import kotlinx.datetime.Clock
 
 internal interface MapVaultToProto : MapperFunc<Vault, VaultProto>
 
@@ -60,7 +60,7 @@ internal class MapVaultToProtoImpl @Inject constructor() : MapVaultToProto {
             resharePrefix = from.resharePrefix,
             keyShares =
                 from.keyshares.map { KeyShareProto(publicKey = it.pubKey, keyshare = it.keyShare) },
-            createdAt = Timestamp(Clock.System.now().epochSeconds),
+            createdAt = Timestamp(Instant.now().epochSecond),
             libType = from.libType.toProto(),
             chainPublicKeys =
                 from.chainPublicKeys.map {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keygen/FastVaultVerificationViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keygen/FastVaultVerificationViewModel.kt
@@ -29,15 +29,14 @@ import com.vultisig.wallet.ui.navigation.Route.BackupVault.BackupPasswordType
 import com.vultisig.wallet.ui.navigation.Route.VaultInfo.VaultType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.LocalDate
+import java.time.ZoneId
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.todayIn
 import timber.log.Timber
 
 internal enum class VerifyPinState {
@@ -190,7 +189,7 @@ constructor(
 
                                 vaultMetadataRepo.setFastVaultPasswordReminderShownDate(
                                     vaultId = vaultId,
-                                    date = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+                                    date = LocalDate.now(ZoneId.systemDefault()),
                                 )
 
                                 if (args.tssAction == TssAction.KEYGEN) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormUiModel.kt
@@ -6,7 +6,7 @@ import com.vultisig.wallet.ui.models.send.TokenBalanceUiModel
 import com.vultisig.wallet.ui.screens.settings.TierType
 import com.vultisig.wallet.ui.screens.swap.SwapMode
 import com.vultisig.wallet.ui.utils.UiText
-import kotlinx.datetime.Instant
+import java.time.Instant
 
 /**
  * Destination-side quote display values, shown while a quote loads and after it resolves.

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.data.repositories.swap.convertToTokenValue
 import com.vultisig.wallet.data.usecases.ConvertTokenToToken
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.SearchTokenUseCase
+import com.vultisig.wallet.data.utils.plus
 import com.vultisig.wallet.data.utils.thorswapMultiplier
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
@@ -34,6 +35,7 @@ import com.vultisig.wallet.ui.utils.asUiText
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.RoundingMode
+import java.time.Instant
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
@@ -44,7 +46,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withTimeout
-import kotlinx.datetime.Clock
 import timber.log.Timber
 
 internal data class QuoteFetchResult(
@@ -1002,7 +1003,7 @@ constructor(
                     expectedDstValue = expectedDstValue,
                     fees = tokenFees,
                     data = apiQuote.copy(tx = updatedTx),
-                    expiredAt = Clock.System.now() + expiredAfter,
+                    expiredAt = Instant.now() + expiredAfter,
                     provider = provider.getSwapProviderId(),
                 )
             }
@@ -1059,7 +1060,7 @@ constructor(
                     expectedDstValue = expectedDstValue,
                     fees = tokenFees,
                     data = apiQuote,
-                    expiredAt = Clock.System.now() + expiredAfter,
+                    expiredAt = Instant.now() + expiredAfter,
                     provider = provider.getSwapProviderId(),
                 )
             }
@@ -1147,7 +1148,7 @@ constructor(
                     expectedDstValue = expectedDstValue,
                     fees = tokenFees,
                     data = apiQuote.copy(tx = updatedTx),
-                    expiredAt = Clock.System.now() + expiredAfter,
+                    expiredAt = Instant.now() + expiredAfter,
                     provider = provider.getSwapProviderId(),
                 )
             }
@@ -1287,7 +1288,7 @@ constructor(
                     expectedDstValue = expectedDstValue,
                     fees = tokenFees,
                     data = apiQuote,
-                    expiredAt = Clock.System.now() + expiredAfter,
+                    expiredAt = Instant.now() + expiredAfter,
                     // `provider` is the proto-serialized discriminator used by
                     // SwapTransactionToUiModelMapper to map back onto SwapProvider.SWAPKIT —
                     // keep it as the canonical id. The sub-provider drives the UI label below.
@@ -1623,7 +1624,7 @@ internal class QuoteCache(private val maxSize: Int = MAX_SIZE) {
                     slippageBps,
                 )
             val quote = entries[key] ?: return null
-            if (Clock.System.now() < quote.expiredAt) {
+            if (Instant.now() < quote.expiredAt) {
                 quote
             } else {
                 entries.remove(key)
@@ -1656,7 +1657,7 @@ internal class QuoteCache(private val maxSize: Int = MAX_SIZE) {
         }
 
     private fun evict() {
-        val now = Clock.System.now()
+        val now = Instant.now()
         entries.entries.removeAll { now >= it.value.expiredAt }
         val iter = entries.entries.iterator()
         while (entries.size > maxSize && iter.hasNext()) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -20,12 +20,12 @@ import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.utils.UiText
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.Instant
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
-import kotlinx.datetime.Instant
 
 /** One source-amount change that should (re)fetch a quote. */
 internal data class QuoteInput(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineController.kt
@@ -18,6 +18,7 @@ import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenAndValueToTokenValueUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.data.utils.minus
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.send.SendSrc
@@ -29,6 +30,7 @@ import dagger.assisted.AssistedInject
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
+import java.time.Instant
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -49,8 +51,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import timber.log.Timber
 
 /**
@@ -642,7 +642,7 @@ constructor(
         // A row that lapsed while the sheet was open can no longer be signed at its quoted rate:
         // don't apply it (Swap would stay enabled against an expired quote) — refresh instead, so
         // a fresh candidate set replaces the whole list.
-        if (Clock.System.now() >= candidate.result.quote.expiredAt) {
+        if (Instant.now() >= candidate.result.quote.expiredAt) {
             refreshQuoteState.value++
             return
         }
@@ -805,7 +805,7 @@ constructor(
         }
         refreshQuoteJob =
             scope.launch(ioDispatcher) {
-                delay(expiredAt - Clock.System.now())
+                delay(expiredAt - Instant.now())
                 refreshQuoteState.value++
             }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/FastVaultPasswordReminderViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/FastVaultPasswordReminderViewModel.kt
@@ -17,14 +17,13 @@ import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.back
 import com.vultisig.wallet.ui.utils.UiText
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.time.LocalDate
+import java.time.ZoneId
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.todayIn
 import timber.log.Timber
 
 internal data class FastVaultPasswordReminderUiModel(
@@ -117,7 +116,7 @@ constructor(
     private suspend fun updatePasswordNextReminderTime() {
         vaultMetadataRepo.setFastVaultPasswordReminderShownDate(
             vaultId = vaultId,
-            date = Clock.System.todayIn(TimeZone.currentSystemDefault()),
+            date = LocalDate.now(ZoneId.systemDefault()),
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/QuoteTimer.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/components/QuoteTimer.kt
@@ -20,12 +20,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.data.models.SwapQuote.Companion.expiredAfter
+import com.vultisig.wallet.data.utils.minus
 import com.vultisig.wallet.data.utils.timerFlow
 import com.vultisig.wallet.ui.theme.Theme
+import java.time.Instant
 import java.util.Locale
 import kotlin.time.Duration
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 /**
  * Countdown pill showing the remaining lifetime of the current swap quote.
@@ -39,7 +39,7 @@ internal fun QuoteTimer(expiredAt: Instant, modifier: Modifier = Modifier) {
 
     LaunchedEffect(expiredAt) {
         timerFlow().collect {
-            val now = Clock.System.now()
+            val now = Instant.now()
             val left = expiredAt - now
             timeLeft = formatDurationAsMinutesSeconds(left)
             progress = quoteTimerProgress(left, expiredAfter)

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/swap/preview/SwapPreviewData.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/swap/preview/SwapPreviewData.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.utils.plus
 import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.models.send.TokenBalanceUiModel
 import com.vultisig.wallet.ui.models.swap.DiscountInfo
@@ -23,8 +24,8 @@ import com.vultisig.wallet.ui.screens.swap.SwapScreen
 import com.vultisig.wallet.ui.utils.UiText
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.Instant
 import kotlin.time.Duration.Companion.seconds
-import kotlinx.datetime.Clock
 
 /**
  * A single preview case for [SwapScreen].
@@ -54,7 +55,7 @@ internal class SwapScreenPreviewProvider : PreviewParameterProvider<SwapScreenPr
                                     provider = UiText.DynamicString("ThorSwap"),
                                     estimatedDstTokenValue = "12.80",
                                     estimatedDstFiatValue = "5.24",
-                                    expiredAt = Clock.System.now(),
+                                    expiredAt = Instant.now(),
                                 ),
                             feeBreakdown =
                                 FeeBreakdown(
@@ -81,7 +82,7 @@ internal class SwapScreenPreviewProvider : PreviewParameterProvider<SwapScreenPr
                                     provider = UiText.DynamicString("ThorSwap"),
                                     estimatedDstTokenValue = "12.80",
                                     estimatedDstFiatValue = "5.24",
-                                    expiredAt = Clock.System.now(),
+                                    expiredAt = Instant.now(),
                                 ),
                             feeBreakdown =
                                 FeeBreakdown(
@@ -108,7 +109,7 @@ internal class SwapScreenPreviewProvider : PreviewParameterProvider<SwapScreenPr
                                     provider = UiText.DynamicString("ThorSwap"),
                                     estimatedDstTokenValue = "12.80",
                                     estimatedDstFiatValue = "5.24",
-                                    expiredAt = Clock.System.now(),
+                                    expiredAt = Instant.now(),
                                 ),
                             feeBreakdown =
                                 FeeBreakdown(
@@ -185,7 +186,7 @@ internal fun SwapFormProviderPreview() {
                         estimatedDstTokenValue = "12.80",
                         estimatedDstFiatValue = "$5.24",
                         hasQuote = true,
-                        expiredAt = Clock.System.now().plus(36.seconds),
+                        expiredAt = Instant.now().plus(36.seconds),
                     ),
                 feeBreakdown =
                     FeeBreakdown(
@@ -216,7 +217,7 @@ internal fun SwapToolbarPreview() {
                         provider = UiText.DynamicString("ThorSwap"),
                         estimatedDstTokenValue = "12.80",
                         estimatedDstFiatValue = "$5.24",
-                        expiredAt = Clock.System.now().plus(36.seconds),
+                        expiredAt = Instant.now().plus(36.seconds),
                     ),
             ),
         srcAmountTextFieldState = TextFieldState("1.5"),

--- a/app/src/main/java/com/vultisig/wallet/ui/utils/MultipleClicksDetector.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/utils/MultipleClicksDetector.kt
@@ -1,9 +1,9 @@
 package com.vultisig.wallet.ui.utils
 
+import com.vultisig.wallet.data.utils.minus
+import java.time.Instant
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 internal class MultipleClicksDetector(
     private val requiredClicks: Int = DEFAULT_REQUIRED_CLICKS,
@@ -13,7 +13,7 @@ internal class MultipleClicksDetector(
     private val clickTimestamps = mutableListOf<Instant>()
 
     fun clickAndCheckIfDetected(): Boolean {
-        val currentTime = Clock.System.now()
+        val currentTime = Instant.now()
 
         clickTimestamps.removeAll { timestamp -> currentTime - timestamp > timeout }
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelInitTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/SendFormViewModelInitTest.kt
@@ -323,12 +323,7 @@ internal class SendFormViewModelInitTest {
     private fun rippleAddress(vararg accounts: Account) =
         Address(chain = Chain.Ripple, address = RIPPLE_ADDRESS, accounts = accounts.toList())
 
-    private val jettonAccount =
-        account(
-            Coins.Ton.USDT.copy(
-                address = TON_ADDRESS,
-            )
-        )
+    private val jettonAccount = account(Coins.Ton.USDT.copy(address = TON_ADDRESS))
 
     private val rlusdAccount = account(Coins.Ripple.RLUSD.copy(address = RIPPLE_ADDRESS))
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/BuildLimitSwapTransactionUseCaseTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/BuildLimitSwapTransactionUseCaseTest.kt
@@ -20,8 +20,8 @@ import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.Instant
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -301,7 +301,7 @@ internal class BuildLimitSwapTransactionUseCaseTest {
                 expectedDstValue = TokenValue(BigInteger.ZERO, eth),
                 fees = TokenValue(BigInteger.ZERO, eth),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, eth),
-                expiredAt = Instant.DISTANT_FUTURE,
+                expiredAt = Instant.MAX,
                 data =
                     mockk<THORChainSwapQuote>(relaxed = true) {
                         every { this@mockk.router } returns router

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/QuoteCacheTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/QuoteCacheTest.kt
@@ -2,11 +2,12 @@ package com.vultisig.wallet.ui.models.swap
 
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.utils.plus
 import io.mockk.every
 import io.mockk.mockk
 import java.math.BigInteger
+import java.time.Instant
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
@@ -23,7 +24,7 @@ internal class QuoteCacheTest {
     // QuoteCache only reads `quote.expiredAt`; a relaxed mock with a future expiry avoids building
     // the full SwapQuote object graph.
     private fun freshQuote(): SwapQuote =
-        mockk<SwapQuote> { every { expiredAt } returns Clock.System.now() + 5.minutes }
+        mockk<SwapQuote> { every { expiredAt } returns Instant.now() + 5.minutes }
 
     @Test
     fun `get returns the cached quote for an identical key`() {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModelTest.kt
@@ -39,6 +39,7 @@ import com.vultisig.wallet.data.swap.limit.LimitSwapMarketPriceRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenAndValueToTokenValueUseCase
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.data.utils.plus
 import com.vultisig.wallet.ui.models.findCurrentSrc
 import com.vultisig.wallet.ui.models.firstSendSrc
 import com.vultisig.wallet.ui.models.mappers.AccountToTokenBalanceUiModelMapper
@@ -61,6 +62,7 @@ import io.mockk.unmockkStatic
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.RoundingMode
+import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
@@ -86,7 +88,6 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
-import kotlinx.datetime.Clock
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -4472,7 +4473,7 @@ internal class SwapFormViewModelTest {
         SwapQuote.ThorChain(
             expectedDstValue = expectedDstValue,
             fees = TokenValue(value = BigInteger("5000000"), token = USDC_COIN),
-            expiredAt = Clock.System.now() + 1.minutes,
+            expiredAt = Instant.now() + 1.minutes,
             recommendedMinTokenValue = TokenValue(value = BigInteger("1000"), token = ETH_COIN),
             data = mockk(relaxed = true),
         )
@@ -4483,7 +4484,7 @@ internal class SwapFormViewModelTest {
         SwapQuote.MayaChain(
             expectedDstValue = expectedDstValue,
             fees = TokenValue(value = BigInteger("5000000"), token = USDC_COIN),
-            expiredAt = Clock.System.now() + 1.minutes,
+            expiredAt = Instant.now() + 1.minutes,
             recommendedMinTokenValue = TokenValue(value = BigInteger("1000"), token = ETH_COIN),
             data = mockk(relaxed = true),
         )
@@ -4494,7 +4495,7 @@ internal class SwapFormViewModelTest {
         SwapQuote.SwapKit(
             expectedDstValue = expectedDstValue,
             fees = TokenValue(value = BigInteger("400"), token = BTC_COIN),
-            expiredAt = Clock.System.now() + 1.minutes,
+            expiredAt = Instant.now() + 1.minutes,
             data = mockk(relaxed = true),
             subProvider = "NEAR",
         )
@@ -4507,7 +4508,7 @@ internal class SwapFormViewModelTest {
         SwapQuote.OneInch(
             expectedDstValue = expectedDstValue,
             fees = fees,
-            expiredAt = Clock.System.now() + 1.minutes,
+            expiredAt = Instant.now() + 1.minutes,
             data = mockk(relaxed = true),
             provider = SwapProvider.LIFI.getSwapProviderId(),
         )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManagerTest.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.data.repositories.swap.SwapQuoteResult
 import com.vultisig.wallet.data.usecases.ConvertTokenToToken
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.SearchTokenUseCase
+import com.vultisig.wallet.data.utils.plus
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
 import com.vultisig.wallet.ui.utils.UiText
@@ -40,6 +41,7 @@ import io.mockk.slot
 import io.mockk.unmockkObject
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.Instant
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNotNull
@@ -52,7 +54,6 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -618,7 +619,7 @@ internal class SwapQuoteManagerTest {
                 SwapQuote.SwapKit(
                     expectedDstValue = TokenValue(BigInteger.ONE, eth),
                     fees = TokenValue(BigInteger.valueOf(400), btc),
-                    expiredAt = Clock.System.now().plus(5.minutes),
+                    expiredAt = Instant.now().plus(5.minutes),
                     data = mockk(relaxed = true),
                     subProvider = "NEAR",
                 )
@@ -685,7 +686,7 @@ internal class SwapQuoteManagerTest {
             SwapQuote.ThorChain(
                 expectedDstValue = thorDst,
                 fees = TokenValue(BigInteger.ZERO, eth),
-                expiredAt = Clock.System.now().plus(5.minutes),
+                expiredAt = Instant.now().plus(5.minutes),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, eth),
                 data =
                     THORChainSwapQuote(
@@ -713,7 +714,7 @@ internal class SwapQuoteManagerTest {
             SwapQuote.SwapKit(
                 expectedDstValue = swapKitDst,
                 fees = TokenValue(BigInteger.valueOf(400), btc),
-                expiredAt = Clock.System.now().plus(5.minutes),
+                expiredAt = Instant.now().plus(5.minutes),
                 data = mockk(relaxed = true),
                 subProvider = null,
             )
@@ -770,7 +771,7 @@ internal class SwapQuoteManagerTest {
             SwapQuote.SwapKit(
                 expectedDstValue = dstValue,
                 fees = TokenValue(BigInteger.ZERO, eth),
-                expiredAt = Clock.System.now().plus(5.minutes),
+                expiredAt = Instant.now().plus(5.minutes),
                 data = mockk(relaxed = true),
                 subProvider = null,
             )
@@ -825,7 +826,7 @@ internal class SwapQuoteManagerTest {
             SwapQuote.SwapKit(
                 expectedDstValue = dstValue,
                 fees = TokenValue(BigInteger.ZERO, eth),
-                expiredAt = Clock.System.now().plus(5.minutes),
+                expiredAt = Instant.now().plus(5.minutes),
                 data = mockk(relaxed = true),
                 subProvider = null,
             )
@@ -944,7 +945,7 @@ internal class SwapQuoteManagerTest {
             SwapQuote.ThorChain(
                 expectedDstValue = thorDst,
                 fees = TokenValue(BigInteger.ZERO, eth),
-                expiredAt = Clock.System.now().plus(5.minutes),
+                expiredAt = Instant.now().plus(5.minutes),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, eth),
                 data =
                     THORChainSwapQuote(
@@ -972,7 +973,7 @@ internal class SwapQuoteManagerTest {
             SwapQuote.SwapKit(
                 expectedDstValue = swapKitDst,
                 fees = TokenValue(BigInteger.valueOf(400), btc),
-                expiredAt = Clock.System.now().plus(5.minutes),
+                expiredAt = Instant.now().plus(5.minutes),
                 data = mockk(relaxed = true),
                 subProvider = null,
             )
@@ -1242,7 +1243,7 @@ internal class SwapQuoteManagerTest {
             SwapQuote.ThorChain(
                 expectedDstValue = thorDst,
                 fees = TokenValue(BigInteger.valueOf(7), eth),
-                expiredAt = Clock.System.now().plus(5.minutes),
+                expiredAt = Instant.now().plus(5.minutes),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, eth),
                 data =
                     THORChainSwapQuote(
@@ -1395,7 +1396,7 @@ internal class SwapQuoteManagerTest {
                 SwapQuote.ThorChain(
                     expectedDstValue = thorDst,
                     fees = TokenValue(BigInteger.valueOf(7), eth),
-                    expiredAt = Clock.System.now().plus(5.minutes),
+                    expiredAt = Instant.now().plus(5.minutes),
                     recommendedMinTokenValue = TokenValue(BigInteger.ZERO, eth),
                     data =
                         THORChainSwapQuote(
@@ -1649,7 +1650,7 @@ internal class SwapQuoteManagerTest {
             SwapQuote.ThorChain(
                 expectedDstValue = thorDst,
                 fees = TokenValue(BigInteger.ZERO, eth),
-                expiredAt = Clock.System.now().plus(5.minutes),
+                expiredAt = Instant.now().plus(5.minutes),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, eth),
                 data =
                     THORChainSwapQuote(

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineNetworkFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineNetworkFeeTest.kt
@@ -20,13 +20,13 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Test
 
 /**
@@ -211,7 +211,7 @@ internal class SwapQuotePipelineNetworkFeeTest {
         SwapQuote.OneInch(
             expectedDstValue = TokenValue(BigInteger.valueOf(400), srcToken),
             fees = inboundFee,
-            expiredAt = Clock.System.now(),
+            expiredAt = Instant.now(),
             data =
                 EVMSwapQuoteJson(
                     dstAmount = "400",
@@ -235,7 +235,7 @@ internal class SwapQuotePipelineNetworkFeeTest {
         SwapQuote.ThorChain(
             expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
             fees = TokenValue(BigInteger.valueOf(9), dstToken),
-            expiredAt = Clock.System.now(),
+            expiredAt = Instant.now(),
             recommendedMinTokenValue = TokenValue(BigInteger.ONE, dstToken),
             data = mockk(relaxed = true),
         )
@@ -244,7 +244,7 @@ internal class SwapQuotePipelineNetworkFeeTest {
         SwapQuote.OneInch(
             expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
             fees = TokenValue(BigInteger.valueOf(9), dstToken),
-            expiredAt = Clock.System.now(),
+            expiredAt = Instant.now(),
             data =
                 EVMSwapQuoteJson(
                     dstAmount = "400",
@@ -272,7 +272,7 @@ internal class SwapQuotePipelineNetworkFeeTest {
             providerUiText = UiText.DynamicString(""),
             estimatedDstTokenValue = "0",
             estimatedDstFiatValue = "0",
-            expiredAt = Clock.System.now(),
+            expiredAt = Instant.now(),
             feeText = "0",
             outboundFeeText = null,
             swapFeePercent = null,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineSwapKitFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipelineSwapKitFeeTest.kt
@@ -20,9 +20,9 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.Instant
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
 import org.junit.jupiter.api.Test
 
 /**
@@ -105,7 +105,7 @@ internal class SwapQuotePipelineSwapKitFeeTest {
             SwapQuote.SwapKit(
                 expectedDstValue = TokenValue(BigInteger.valueOf(400), srcToken),
                 fees = TokenValue(BigInteger.valueOf(9), srcToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 data =
                     SwapKitSwapPayloadJson(
                         fromCoin = srcToken,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilderTest.kt
@@ -23,6 +23,7 @@ import io.mockk.every
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.Instant
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -30,7 +31,6 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import kotlinx.datetime.Clock
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -77,7 +77,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.ThorChain(
                 expectedDstValue = TokenValue(BigInteger.valueOf(100), dstToken),
                 fees = TokenValue(BigInteger.valueOf(7), srcToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
                 data = data,
             )
@@ -132,7 +132,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.MayaChain(
                 expectedDstValue = TokenValue(BigInteger.valueOf(200), dstToken),
                 fees = TokenValue(BigInteger.valueOf(3), srcToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
                 data = data,
             )
@@ -182,7 +182,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.ThorChain(
                 expectedDstValue = TokenValue(BigInteger.valueOf(100), dstToken),
                 fees = TokenValue(BigInteger.valueOf(7), srcToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
                 data = data,
             )
@@ -236,7 +236,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.MayaChain(
                 expectedDstValue = TokenValue(BigInteger.valueOf(200), dstToken),
                 fees = TokenValue(BigInteger.valueOf(3), srcToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
                 data = data,
             )
@@ -294,7 +294,7 @@ internal class SwapTransactionBuilderTest {
                 SwapQuote.SwapKit(
                     expectedDstValue = TokenValue(BigInteger.valueOf(300), dstToken),
                     fees = TokenValue(BigInteger.valueOf(2), srcToken),
-                    expiredAt = Clock.System.now(),
+                    expiredAt = Instant.now(),
                     data = data,
                     subProvider = "NEAR",
                 )
@@ -331,7 +331,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.SwapKit(
                 expectedDstValue = TokenValue(BigInteger.valueOf(300), dstToken),
                 fees = TokenValue(BigInteger.valueOf(2), srcToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 data = data,
                 subProvider = null,
             )
@@ -377,7 +377,7 @@ internal class SwapTransactionBuilderTest {
                 SwapQuote.OneInch(
                     expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                     fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                    expiredAt = Clock.System.now(),
+                    expiredAt = Instant.now(),
                     data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                     provider = "1inch",
                 )
@@ -437,7 +437,7 @@ internal class SwapTransactionBuilderTest {
                 SwapQuote.OneInch(
                     expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                     fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                    expiredAt = Clock.System.now(),
+                    expiredAt = Instant.now(),
                     data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                     provider = "1inch",
                 )
@@ -492,7 +492,7 @@ internal class SwapTransactionBuilderTest {
                     // "Swap Fee" placeholder; the initiator overwrites tx.gasPrice/gas below.
                     expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                     fees = TokenValue(BigInteger.valueOf(21_000), srcToken),
-                    expiredAt = Clock.System.now(),
+                    expiredAt = Instant.now(),
                     data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                     provider = "1inch",
                 )
@@ -542,7 +542,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.OneInch(
                 expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                 fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                 provider = "1inch",
             )
@@ -589,7 +589,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.OneInch(
                 expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                 fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                 provider = "1inch",
             )
@@ -635,7 +635,7 @@ internal class SwapTransactionBuilderTest {
                 SwapQuote.OneInch(
                     expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                     fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                    expiredAt = Clock.System.now(),
+                    expiredAt = Instant.now(),
                     data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                     provider = "1inch",
                 )
@@ -686,7 +686,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.OneInch(
                 expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                 fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                 provider = "1inch",
             )
@@ -737,7 +737,7 @@ internal class SwapTransactionBuilderTest {
                 SwapQuote.OneInch(
                     expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                     fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                    expiredAt = Clock.System.now(),
+                    expiredAt = Instant.now(),
                     data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                     provider = "1inch",
                 )
@@ -790,7 +790,7 @@ internal class SwapTransactionBuilderTest {
             SwapQuote.OneInch(
                 expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                 fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                expiredAt = Clock.System.now(),
+                expiredAt = Instant.now(),
                 data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                 provider = "1inch",
             )
@@ -840,7 +840,7 @@ internal class SwapTransactionBuilderTest {
                 SwapQuote.OneInch(
                     expectedDstValue = TokenValue(BigInteger.valueOf(400), dstToken),
                     fees = TokenValue(BigInteger.valueOf(9), dstToken),
-                    expiredAt = Clock.System.now(),
+                    expiredAt = Instant.now(),
                     data = EVMSwapQuoteJson(dstAmount = "400", tx = tx0),
                     provider = "1inch",
                 )
@@ -888,7 +888,7 @@ internal class SwapTransactionBuilderTest {
                 SwapQuote.ThorChain(
                     expectedDstValue = TokenValue(BigInteger.valueOf(100), dstToken),
                     fees = TokenValue(BigInteger.valueOf(7), srcToken),
-                    expiredAt = Clock.System.now(),
+                    expiredAt = Instant.now(),
                     recommendedMinTokenValue = TokenValue(BigInteger.ZERO, srcToken),
                     data = data,
                 )

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -79,7 +79,6 @@ dependencies {
 
     // core
     implementation(libs.androidx.core.ktx)
-    implementation(libs.kotlinx.datetime)
 
     // worker
     implementation(libs.androidx.work)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/converters/LocalDateTypeConverter.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/converters/LocalDateTypeConverter.kt
@@ -1,11 +1,11 @@
 package com.vultisig.wallet.data.db.converters
 
 import androidx.room.TypeConverter
-import kotlinx.datetime.LocalDate
+import java.time.LocalDate
 
 class LocalDateTypeConverter {
 
-    @TypeConverter fun toLocalDate(value: Int): LocalDate = LocalDate.fromEpochDays(value)
+    @TypeConverter fun toLocalDate(value: Long): LocalDate = LocalDate.ofEpochDay(value)
 
-    @TypeConverter fun fromLocalDate(value: LocalDate): Int = value.toEpochDays()
+    @TypeConverter fun fromLocalDate(value: LocalDate): Long = value.toEpochDay()
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/VaultMetadataEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/VaultMetadataEntity.kt
@@ -4,7 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import com.vultisig.wallet.data.models.VaultId
-import kotlinx.datetime.LocalDate
+import java.time.LocalDate
 
 @Entity(
     tableName = "vaultMetadata",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -3,8 +3,8 @@ package com.vultisig.wallet.data.models
 import com.vultisig.wallet.data.api.models.quotes.EVMSwapQuoteJson
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
 import java.math.BigDecimal
+import java.time.Instant
 import kotlin.time.Duration.Companion.minutes
-import kotlinx.datetime.Instant
 
 sealed class SwapQuote {
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -46,7 +46,9 @@ import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.Numeric.max
 import com.vultisig.wallet.data.utils.increaseByPercent
+import com.vultisig.wallet.data.utils.plus
 import java.math.BigInteger
+import java.time.Instant
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.milliseconds
@@ -54,7 +56,6 @@ import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.datetime.Clock
 import timber.log.Timber
 import vultisig.keysign.v1.CosmosIbcDenomTrace
 import vultisig.keysign.v1.TransactionType
@@ -400,9 +401,9 @@ constructor(
                             if (token.contractAddress.startsWith("ibc/")) {
                                 val denomTrace = api.getIbcDenomTraces(token.contractAddress)
                                 val timeout =
-                                    Clock.System.now()
+                                    Instant.now()
                                         .plus(10.minutes)
-                                        .toEpochMilliseconds()
+                                        .toEpochMilli()
                                         .milliseconds
                                         .inWholeNanoseconds
 
@@ -413,9 +414,9 @@ constructor(
                                 )
                             } else {
                                 val timeout =
-                                    Clock.System.now()
+                                    Instant.now()
                                         .plus(10.minutes)
-                                        .toEpochMilliseconds()
+                                        .toEpochMilli()
                                         .milliseconds
                                         .inWholeNanoseconds
                                 CosmosIbcDenomTrace(
@@ -429,9 +430,9 @@ constructor(
                         Chain.Osmosis -> {
                             if (transactionType == TransactionType.TRANSACTION_TYPE_IBC_TRANSFER) {
                                 val timeout =
-                                    Clock.System.now()
+                                    Instant.now()
                                         .plus(10.minutes)
-                                        .toEpochMilliseconds()
+                                        .toEpochMilli()
                                         .milliseconds
                                         .inWholeNanoseconds
                                 CosmosIbcDenomTrace(
@@ -644,7 +645,7 @@ constructor(
                             BlockChainSpecific.Ton(
                                 sequenceNumber =
                                     sequenceNumberDeferred.await().toString().toULong(),
-                                expireAt = (Clock.System.now().epochSeconds + 600L).toULong(),
+                                expireAt = (Instant.now().epochSecond + 600L).toULong(),
                                 bounceable = isBounceable.await(),
                                 isDeposit = isDeposit,
                                 sendMaxAmount = isMaxAmountEnabled,
@@ -680,7 +681,7 @@ constructor(
                     } catch (_: Exception) {
                         null
                     } ?: ENERGY_TO_SUN_FACTOR.toLong()
-                val now = Clock.System.now()
+                val now = Instant.now()
                 val expiration = now + 1.hours
                 val rawData = specific.blockHeader.rawData
 
@@ -706,8 +707,8 @@ constructor(
                 BlockChainSpecificAndUtxo(
                     blockChainSpecific =
                         BlockChainSpecific.Tron(
-                            timestamp = now.toEpochMilliseconds().toULong(),
-                            expiration = expiration.toEpochMilliseconds().toULong(),
+                            timestamp = now.toEpochMilli().toULong(),
+                            expiration = expiration.toEpochMilli().toULong(),
                             blockHeaderTimestamp = rawData.timeStamp,
                             blockHeaderNumber = rawData.number,
                             blockHeaderVersion = rawData.version,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/MayaQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/MayaQuoteSource.kt
@@ -7,8 +7,9 @@ import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.SwapQuote.Companion.expiredAfter
 import com.vultisig.wallet.data.models.swapAssetComparisonName
 import com.vultisig.wallet.data.models.swapAssetName
+import com.vultisig.wallet.data.utils.plus
+import java.time.Instant
 import javax.inject.Inject
-import kotlinx.datetime.Clock
 
 internal class MayaQuoteSource @Inject constructor(private val mayaChainApi: MayaChainApi) :
     SwapQuoteSource {
@@ -47,7 +48,7 @@ internal class MayaQuoteSource @Inject constructor(private val mayaChainApi: May
                 fees = dstToken.convertToTokenValue(data.fees.total),
                 recommendedMinTokenValue = recommendedMin,
                 data = data,
-                expiredAt = Clock.System.now() + expiredAfter,
+                expiredAt = Instant.now() + expiredAfter,
             )
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -20,14 +20,15 @@ import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.SwapQuote.Companion.expiredAfter
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.utils.plus
 import java.math.BigDecimal
 import java.math.BigInteger
+import java.time.Instant
 import java.util.Base64
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.first
-import kotlinx.datetime.Clock
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -617,7 +618,7 @@ constructor(
             // Source-chain native deposit fee (BTC 8dp), same surface as the EVM/Solana inbound
             // fee.
             fees = TokenValue(inboundFeeRawUnits(srcToken, response.fees, routeFees), srcToken),
-            expiredAt = Clock.System.now() + expiredAfter,
+            expiredAt = Instant.now() + expiredAfter,
             data = payload,
             subProvider = subProvider,
             priceImpact = priceImpact,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/ThorChainQuoteSource.kt
@@ -9,10 +9,11 @@ import com.vultisig.wallet.data.models.SwapQuote
 import com.vultisig.wallet.data.models.SwapQuote.Companion.expiredAfter
 import com.vultisig.wallet.data.models.swapAssetComparisonName
 import com.vultisig.wallet.data.models.swapAssetName
+import com.vultisig.wallet.data.utils.plus
 import java.math.BigInteger
+import java.time.Instant
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.datetime.Clock
 import timber.log.Timber
 
 internal class ThorChainQuoteSource @Inject constructor(private val thorChainApi: ThorChainApi) :
@@ -49,7 +50,7 @@ internal class ThorChainQuoteSource @Inject constructor(private val thorChainApi
                 recommendedMinTokenValue =
                     srcToken.convertToTokenValue(finalData.recommendedMinAmountIn),
                 data = finalData,
-                expiredAt = Clock.System.now() + expiredAfter,
+                expiredAt = Instant.now() + expiredAfter,
             )
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/vault/VaultMetadataRepo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/vault/VaultMetadataRepo.kt
@@ -3,13 +3,11 @@ package com.vultisig.wallet.data.repositories.vault
 import com.vultisig.wallet.data.db.dao.VaultMetadataDao
 import com.vultisig.wallet.data.db.models.VaultMetadataEntity
 import com.vultisig.wallet.data.models.VaultId
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 import kotlin.math.abs
-import kotlinx.datetime.Clock
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.daysUntil
-import kotlinx.datetime.todayIn
 
 interface VaultMetadataRepo {
 
@@ -24,7 +22,7 @@ internal class VaultMetadataRepoImpl @Inject constructor(private val dao: VaultM
     override suspend fun isFastVaultPasswordReminderRequired(vaultId: VaultId): Boolean =
         getOrDefault(vaultId).fastVaultPasswordReminderShownDate.let {
             it == null ||
-                (abs(it.daysUntil(Clock.System.todayIn(TimeZone.currentSystemDefault()))) >
+                (abs(ChronoUnit.DAYS.between(it, LocalDate.now(ZoneId.systemDefault()))) >
                     FAST_VAULT_PASSWORD_REMINDER_EVERY_N_DAYS)
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/backup/CreateZipVaultBackupFileNameUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/backup/CreateZipVaultBackupFileNameUseCase.kt
@@ -1,10 +1,8 @@
 package com.vultisig.wallet.data.usecases.backup
 
 import com.vultisig.wallet.data.models.Vault
+import java.time.LocalDateTime
 import javax.inject.Inject
-import kotlinx.datetime.Clock
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
 
 fun interface CreateZipVaultBackupFileNameUseCase {
     operator fun invoke(vaults: List<Vault>): String
@@ -13,8 +11,8 @@ fun interface CreateZipVaultBackupFileNameUseCase {
 internal class CreateZipVaultBackupFileNameUseCaseImpl @Inject constructor() :
     CreateZipVaultBackupFileNameUseCase {
     override fun invoke(vaults: List<Vault>): String {
-        val now = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault())
-        return "vaults_backup_${now.date}_${
+        val now = LocalDateTime.now()
+        return "vaults_backup_${now.toLocalDate()}_${
             now.hour.toString().padStart(
                 2,
                 '0',

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/VultiDate.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/VultiDate.kt
@@ -1,15 +1,17 @@
 package com.vultisig.wallet.data.utils
 
 import java.time.Instant
+import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import kotlin.time.toJavaDuration
 import kotlin.time.toKotlinDuration
 
 object VultiDate {
     fun getEpochMonth(): Int {
-        val epochDate = Instant.ofEpochMilli(0)
-        val now = Instant.now()
-        return ChronoUnit.MONTHS.between(epochDate, now).toInt()
+        val zone = ZoneId.systemDefault()
+        val epochDate = Instant.ofEpochMilli(0).atZone(zone).toLocalDate()
+        val today = Instant.now().atZone(zone).toLocalDate()
+        return ChronoUnit.MONTHS.between(epochDate, today).toInt()
     }
 }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/VultiDate.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/VultiDate.kt
@@ -1,14 +1,20 @@
 package com.vultisig.wallet.data.utils
 
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.monthsUntil
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlin.time.toJavaDuration
+import kotlin.time.toKotlinDuration
 
 object VultiDate {
     fun getEpochMonth(): Int {
-        val epochDate = Instant.fromEpochMilliseconds(0)
-        val localDate = Clock.System.now()
-        return epochDate.monthsUntil(localDate, TimeZone.currentSystemDefault())
+        val epochDate = Instant.ofEpochMilli(0)
+        val now = Instant.now()
+        return ChronoUnit.MONTHS.between(epochDate, now).toInt()
     }
 }
+
+operator fun Instant.plus(duration: kotlin.time.Duration): Instant =
+    this.plus(duration.toJavaDuration())
+
+operator fun Instant.minus(other: Instant): kotlin.time.Duration =
+    java.time.Duration.between(other, this).toKotlinDuration()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/utils/VultiDate.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/utils/VultiDate.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.utils
 
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import kotlin.time.toJavaDuration
@@ -8,9 +9,8 @@ import kotlin.time.toKotlinDuration
 
 object VultiDate {
     fun getEpochMonth(): Int {
-        val zone = ZoneId.systemDefault()
-        val epochDate = Instant.ofEpochMilli(0).atZone(zone).toLocalDate()
-        val today = Instant.now().atZone(zone).toLocalDate()
+        val epochDate = LocalDate.ofEpochDay(0)
+        val today = LocalDate.now(ZoneId.systemDefault())
         return ChronoUnit.MONTHS.between(epochDate, today).toInt()
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/utils/VultiDateTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/utils/VultiDateTest.kt
@@ -1,0 +1,22 @@
+package com.vultisig.wallet.data.utils
+
+import java.time.YearMonth
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+internal class VultiDateTest {
+
+    // Regression test: ChronoUnit.MONTHS.between(Instant, Instant) throws
+    // UnsupportedTemporalTypeException at runtime, since Instant only supports time-based
+    // units. getEpochMonth() must diff calendar dates, not instants.
+    @Test
+    fun `getEpochMonth does not throw and returns months since the Unix epoch`() {
+        val result = assertDoesNotThrow { VultiDate.getEpochMonth() }
+
+        val now = YearMonth.now()
+        val expected = (now.year - 1970) * 12 + (now.monthValue - 1)
+
+        assertEquals(expected, result)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ core = "3.5.4"
 coreKtx = "1.17.0"
 work = "2.10.1"
 coreSplashscreen = "1.2.0"
-datetime = "0.6.1"
 espresso = "3.6.1"
 datastorePreferences = "1.1.4"
 junitJupiter = "5.11.4"
@@ -89,7 +88,6 @@ apache-compress-xz = { module = "org.tukaani:xz", version.ref = "apache-compress
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-serialization-protobuf", version.ref = "serialization" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "datetime" }
 
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }


### PR DESCRIPTION
## Description

Migrates all 27 kotlinx.datetime call sites (20 main-source, 7 test) to java.time. Since `minSdk = 26`, java.time is available natively (no desugaring needed) and was already the majority idiom in this codebase (17 files vs 20), so kotlinx-datetime was a droppable dependency rather than a required one. Pure mechanical refactor, no behavior change:

- `Clock.System.now()` → `Instant.now()`, `LocalDate`/`TimeZone`/`daysUntil`/`monthsUntil`/`toLocalDateTime`/`todayIn` → their java.time equivalents
- Added a small `Instant.plus(kotlin.time.Duration)` / `Instant.minus(Instant): kotlin.time.Duration` shim in `VultiDate.kt` for the handful of call sites mixing `Instant` arithmetic with `kotlin.time.Duration` (swap quote expiry timers, click debouncing)
- `LocalDateTypeConverter`'s Room column widened `Int` → `Long` to match `java.time.LocalDate.toEpochDay()`; both map to SQLite `INTEGER` so no migration needed (`AppDatabase` has `exportSchema = false`)
- Removed `kotlinx-datetime` from `libs.versions.toml` and both `build.gradle.kts` files

Fixes #5749

## Which feature is affected?
- [ ] Create vault ( Secure / Fast) - Please ensure you created a Secure vault & fast vault
- [ ] Sending  - Please attach a tx link here
- [ ] Swap - Please attach a tx link for the swap here
- [ ] New Chain / Chain related feature  -  Please attach tx link here

Non-functional refactor only — swap quote expiry, fast-vault password reminder cadence, and vault backup filename timestamps are computed identically, just via a different date/time API. No tx-affecting logic changed.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works

Existing swap test suite (7 files under `ui/models/swap/`) updated in place and passing unchanged.

## Additional context

## Agent Metadata (if applicable)
- **Agent**: Claude Code
- **Issue**: #5749
- **Confidence**: high
- **Needs human review for**: manual smoke check of swap quote countdown/auto-refresh, fast-vault password reminder cadence, and vault backup zip filename on a real device/emulator

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and reliability of timestamps for swap quotes, transactions, backups, and blockchain operations.
  * Updated password reminder dates to respect the device’s local time zone.
  * Preserved existing quote expiration, cache, and reminder timing behavior.
  * Added safeguards for calendar-month calculations to improve date-related reliability.

* **Refactor**
  * Standardized date and time handling across the app for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->