### PR TITLE
feat(done): drive the transaction hero from the decoder

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -380,6 +380,8 @@ class PreviewActivity : ComponentActivity() {
                     "send_tx_done" -> SendTxDonePreview()
                     "send_tx_done_decoded" -> SendTxDoneDecodedPreview()
                     "send_tx_done_projected" -> SendTxDoneProjectedPreview()
+                    "send_tx_done_unresolved" -> SendTxDoneUnresolvedPreview()
+                    "send_tx_done_title" -> SendTxDoneTitleOnlyPreview()
                     "deposit_mint_done" -> DepositMintDonePreview()
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "limit_orders_tab" -> LimitOrdersTabPreview()
@@ -1612,6 +1614,30 @@ private fun SendTxDoneProjectedPreview() {
                 ),
             scope = stringResource(R.string.withdrawing_share_of_staked_position, "50%"),
         )
+    )
+}
+
+/**
+ * The guard that matters: a position read that failed or timed out. The verb and the asset are
+ * still true, so both are shown — the amount and the fiat line are omitted rather than filled with
+ * the payload's carrier value, which for a fractional unstake is dust.
+ */
+@Composable
+private fun SendTxDoneUnresolvedPreview() {
+    SendTxDoneWithOperationHero(
+        HeroContent.Projected(
+            title = stringResource(R.string.done_verb_unstaked),
+            estimate = null,
+            scope = stringResource(R.string.withdrawing_share_of_staked_position, "50%"),
+        )
+    )
+}
+
+/** A reading that names the operation but states no quantity at all. */
+@Composable
+private fun SendTxDoneTitleOnlyPreview() {
+    SendTxDoneWithOperationHero(
+        HeroContent.Title(stringResource(R.string.done_verb_claimed_rewards))
     )
 }
 

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -1592,7 +1592,7 @@ private fun SendTxDoneDecodedPreview() {
                 HeroCoinAmount(
                     amount = "1,250.5",
                     ticker = "TCY",
-                    logo = Coins.ThorChain.RUNE.logo,
+                    logo = Coins.ThorChain.TCY.logo,
                     fiatValue = "$412.66",
                 ),
         )
@@ -1609,7 +1609,7 @@ private fun SendTxDoneProjectedPreview() {
                 HeroCoinAmount(
                     amount = "625.25",
                     ticker = "TCY",
-                    logo = Coins.ThorChain.RUNE.logo,
+                    logo = Coins.ThorChain.TCY.logo,
                     fiatValue = "$206.33",
                 ),
             scope = stringResource(R.string.withdrawing_share_of_staked_position, "50%"),

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -378,6 +378,8 @@ class PreviewActivity : ComponentActivity() {
                     "camera_button" -> CameraButton(onClick = {})
                     "banner" -> BannerPreview()
                     "send_tx_done" -> SendTxDonePreview()
+                    "send_tx_done_decoded" -> SendTxDoneDecodedPreview()
+                    "send_tx_done_projected" -> SendTxDoneProjectedPreview()
                     "deposit_mint_done" -> DepositMintDonePreview()
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "limit_orders_tab" -> LimitOrdersTabPreview()
@@ -1569,6 +1571,76 @@ private fun tonJettonSendState(decoded: Boolean): VerifyTransactionUiModel {
         consentAddress = false,
         consentAmount = false,
         hasFastSign = false,
+    )
+}
+
+/**
+ * The done card as the decoder drives it: the past-tense verb, and the asset and amount read from
+ * the signed content rather than from the payload's carrier coin.
+ *
+ * Stands in for a registered chain decoder, which the app does not have yet — every real payload
+ * currently decodes to `Unknown` and takes the [SendTxDonePreview] fallback instead.
+ */
+@Composable
+private fun SendTxDoneDecodedPreview() {
+    SendTxDoneWithOperationHero(
+        HeroContent.Send(
+            title = stringResource(R.string.done_verb_staked),
+            coin =
+                HeroCoinAmount(
+                    amount = "1,250.5",
+                    ticker = "TCY",
+                    logo = Coins.ThorChain.RUNE.logo,
+                    fiatValue = "$412.66",
+                ),
+        )
+    )
+}
+
+/** The same card for an execution-set amount, where the projected quantity stays approximate. */
+@Composable
+private fun SendTxDoneProjectedPreview() {
+    SendTxDoneWithOperationHero(
+        HeroContent.Projected(
+            title = stringResource(R.string.done_verb_unstaked),
+            estimate =
+                HeroCoinAmount(
+                    amount = "625.25",
+                    ticker = "TCY",
+                    logo = Coins.ThorChain.RUNE.logo,
+                    fiatValue = "$206.33",
+                ),
+            scope = stringResource(R.string.withdrawing_share_of_staked_position, "50%"),
+        )
+    )
+}
+
+@Composable
+private fun SendTxDoneWithOperationHero(operationHero: HeroContent) {
+    val runeCoin = Coins.ThorChain.RUNE
+
+    SendTxOverviewScreen(
+        showToolbar = true,
+        showSaveToAddressBook = false,
+        transactionHash = "9F2C1B...7A4E",
+        transactionLink = "https://runescan.io/tx/9F2C1B",
+        transactionStatus = TransactionStatus.Confirmed,
+        onComplete = {},
+        onBack = {},
+        onAddToAddressBook = {},
+        tx =
+            UiTransactionInfo(
+                type = UiTransactionInfoType.Deposit,
+                token = ValuedToken(token = runeCoin, value = "0.00000001", fiatValue = "$0.00"),
+                from = "thor1abcdefghijklmnopqrstuvwxyz0123456789ab",
+                to = "",
+                memo = "tcy-:5000",
+                networkFeeTokenValue = "0.02 RUNE",
+                networkFeeFiatValue = "$0.03",
+                operationHero = operationHero,
+            ),
+        isTransactionDetailVisible = false,
+        onTransactionDetailVisibleChange = {},
     )
 }
 
@@ -3697,7 +3769,8 @@ private fun TokenDetailSheetFullPreview(allActions: Boolean = false) {
                 canSwap = true,
                 canBuy = true,
                 canDeposit = allActions,
-                chainAddress = if (allActions) "9ceRgz57Jj1kmDBQtBWJyeSRhSpxvzWLPQb1LzGxKPWa" else "",
+                chainAddress =
+                    if (allActions) "9ceRgz57Jj1kmDBQtBWJyeSRhSpxvzWLPQb1LzGxKPWa" else "",
                 chart =
                     ChartUiModel(points = points, isPositive = true, changePercentText = "+4.21%"),
                 marketStats =

--- a/app/src/main/java/com/vultisig/wallet/ui/components/VsOverviewToken.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VsOverviewToken.kt
@@ -46,9 +46,43 @@ internal fun VsOverviewToken(
     withContainer: Boolean = true,
 ) {
     val token: Coin = valuedToken.token
-    val chainLogo = token.chain.monoToneLogo
-    val value: String = valuedToken.value
 
+    VsOverviewToken(
+        header = header,
+        tokenLogo = getCoinLogo(token.logo),
+        ticker = token.ticker,
+        chainLogo =
+            token.chain.monoToneLogo.takeIf { !token.isNativeToken || token.chain.isLayer2 },
+        value = valuedToken.value,
+        fiatValue = valuedToken.fiatValue,
+        shape = shape,
+        modifier = modifier,
+        withContainer = withContainer,
+    )
+}
+
+/**
+ * The same card addressed by its display parts rather than by a [ValuedToken].
+ *
+ * Used where the asset shown is not the transaction's own coin — the done screen's decoder-driven
+ * hero resolves its asset from the signed units, which may be a chain-native denom the payload
+ * never named. [chainLogo] is null there because the resolved asset carries no payload chain badge.
+ *
+ * An empty [value] renders the ticker alone, for a reading that identifies the asset but states no
+ * truthful quantity.
+ */
+@Composable
+internal fun VsOverviewToken(
+    header: String,
+    tokenLogo: ImageModel,
+    ticker: String,
+    chainLogo: Int?,
+    value: String,
+    fiatValue: String?,
+    shape: Shape,
+    modifier: Modifier = Modifier,
+    withContainer: Boolean = true,
+) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier =
@@ -71,18 +105,16 @@ internal fun VsOverviewToken(
 
         UiSpacer(12.dp)
 
-        TokenAndChainLogo(
-            tokenLogo = getCoinLogo(token.logo),
-            tokenTicker = token.ticker,
-            chainLogo = chainLogo.takeIf { !token.isNativeToken || token.chain.isLayer2 },
-        )
+        TokenAndChainLogo(tokenLogo = tokenLogo, tokenTicker = ticker, chainLogo = chainLogo)
 
         UiSpacer(12.dp)
 
         val text = buildAnnotatedString {
-            append(value)
-            append(" ")
-            withStyle(SpanStyle(color = Theme.v2.colors.text.tertiary)) { append(token.ticker) }
+            if (value.isNotEmpty()) {
+                append(value)
+                append(" ")
+            }
+            withStyle(SpanStyle(color = Theme.v2.colors.text.tertiary)) { append(ticker) }
         }
 
         Text(
@@ -93,11 +125,13 @@ internal fun VsOverviewToken(
             maxLines = 1,
         )
 
-        Text(
-            text = valuedToken.fiatValue,
-            style = Theme.brockmann.supplementary.captionSmall,
-            color = Theme.v2.colors.text.tertiary,
-        )
+        if (fiatValue != null) {
+            Text(
+                text = fiatValue,
+                style = Theme.brockmann.supplementary.captionSmall,
+                color = Theme.v2.colors.text.tertiary,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/components/VsOverviewToken.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VsOverviewToken.kt
@@ -69,9 +69,10 @@ internal fun VsOverviewToken(
  * never named. [chainLogo] is null there because the resolved asset carries no payload chain badge.
  *
  * An empty [value] renders the ticker alone, for a reading that identifies the asset but states no
- * truthful quantity. [scope] is what the transaction committed to in words — "50% of your staked
- * position" — which stays exact even when the settled amount is only an estimate, so it is the last
- * thing to be dropped rather than the first.
+ * truthful quantity; an empty [ticker] drops the asset row entirely, for one that could not
+ * identify the asset either. [scope] is what the transaction committed to in words — "50% of your
+ * staked position" — which stays exact even when the settled amount is only an estimate, so it is
+ * the last thing to be dropped rather than the first.
  */
 @Composable
 internal fun VsOverviewToken(
@@ -106,27 +107,31 @@ internal fun VsOverviewToken(
             maxLines = 1,
         )
 
-        UiSpacer(12.dp)
+        // Naming an asset the reading could not establish would be a claim of its own, so the logo
+        // and the amount row are dropped together rather than falling back to the payload's coin.
+        if (ticker.isNotEmpty()) {
+            UiSpacer(12.dp)
 
-        TokenAndChainLogo(tokenLogo = tokenLogo, tokenTicker = ticker, chainLogo = chainLogo)
+            TokenAndChainLogo(tokenLogo = tokenLogo, tokenTicker = ticker, chainLogo = chainLogo)
 
-        UiSpacer(12.dp)
+            UiSpacer(12.dp)
 
-        val text = buildAnnotatedString {
-            if (value.isNotEmpty()) {
-                append(value)
-                append(" ")
+            val text = buildAnnotatedString {
+                if (value.isNotEmpty()) {
+                    append(value)
+                    append(" ")
+                }
+                withStyle(SpanStyle(color = Theme.v2.colors.text.tertiary)) { append(ticker) }
             }
-            withStyle(SpanStyle(color = Theme.v2.colors.text.tertiary)) { append(ticker) }
-        }
 
-        Text(
-            text = text,
-            style = Theme.brockmann.body.s.medium,
-            color = Theme.v2.colors.text.primary,
-            textAlign = TextAlign.Center,
-            maxLines = 1,
-        )
+            Text(
+                text = text,
+                style = Theme.brockmann.body.s.medium,
+                color = Theme.v2.colors.text.primary,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+            )
+        }
 
         if (fiatValue != null) {
             Text(
@@ -137,7 +142,7 @@ internal fun VsOverviewToken(
         }
 
         if (scope != null) {
-            UiSpacer(4.dp)
+            UiSpacer(if (ticker.isEmpty()) 12.dp else 4.dp)
 
             Text(
                 text = scope,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/VsOverviewToken.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/VsOverviewToken.kt
@@ -69,7 +69,9 @@ internal fun VsOverviewToken(
  * never named. [chainLogo] is null there because the resolved asset carries no payload chain badge.
  *
  * An empty [value] renders the ticker alone, for a reading that identifies the asset but states no
- * truthful quantity.
+ * truthful quantity. [scope] is what the transaction committed to in words — "50% of your staked
+ * position" — which stays exact even when the settled amount is only an estimate, so it is the last
+ * thing to be dropped rather than the first.
  */
 @Composable
 internal fun VsOverviewToken(
@@ -82,6 +84,7 @@ internal fun VsOverviewToken(
     shape: Shape,
     modifier: Modifier = Modifier,
     withContainer: Boolean = true,
+    scope: String? = null,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -130,6 +133,17 @@ internal fun VsOverviewToken(
                 text = fiatValue,
                 style = Theme.brockmann.supplementary.captionSmall,
                 color = Theme.v2.colors.text.tertiary,
+            )
+        }
+
+        if (scope != null) {
+            UiSpacer(4.dp)
+
+            Text(
+                text = scope,
+                style = Theme.brockmann.supplementary.captionSmall,
+                color = Theme.v2.colors.text.tertiary,
+                textAlign = TextAlign.Center,
             )
         }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/components/hero/HeroContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/hero/HeroContent.kt
@@ -6,16 +6,19 @@ import androidx.compose.runtime.Immutable
  * Content for the dApp signing "hero" region.
  *
  * Drives the large, centered display above the transaction summary across the verify → sign → done
- * screens. The four shapes correspond to how much resolved information is available about the
- * action being signed:
+ * screens. The shapes correspond to how much resolved information is available about the action
+ * being signed:
  * - [Title] — bare function name fallback. Used by the done screens before the simulation has
  *   propagated. Carries no warning copy because at that point the signature is already on chain.
  * - [Unverified] — explicit "Unverified function" hero (warning glyph + localized title +
  *   review-details subtitle). Emitted by the use case when Blockaid simulation has loaded but
  *   returned no balance change. The localized strings are resolved at the composable boundary so
  *   the data type stays Android-resource-free.
- * - [Send] — resolved single-sided balance change, sourced from a Blockaid transfer simulation.
+ * - [Send] — resolved single-sided balance change, sourced from a Blockaid transfer simulation or
+ *   from a signed amount the transaction decoder read.
  * - [Swap] — resolved from-to balance change, sourced from a Blockaid swap simulation.
+ * - [Projected] — a settlement estimate paired with the scope the transaction commits to. Distinct
+ *   from [Send] so an estimate can never look committed.
  *
  * Mirrors the iOS `HeroContent` enum and the vultisig-windows extension's `BlockaidTransferDisplay`
  * / `BlockaidSwapDisplay` / `EvmCalldataFallback` primitives so the three platforms render the same
@@ -24,21 +27,60 @@ import androidx.compose.runtime.Immutable
 @Immutable
 sealed interface HeroContent {
 
-    @Immutable data class Title(val title: String) : HeroContent
+    /** The verb, when this shape carries one. */
+    val title: String?
 
-    @Immutable data object Unverified : HeroContent
-
-    @Immutable data class Send(val title: String?, val coin: HeroCoinAmount) : HeroContent
+    @Immutable data class Title(override val title: String) : HeroContent
 
     @Immutable
-    data class Swap(val title: String?, val from: HeroCoinAmount, val to: HeroCoinAmount) :
+    data object Unverified : HeroContent {
+        override val title: String? = null
+    }
+
+    @Immutable data class Send(override val title: String?, val coin: HeroCoinAmount) : HeroContent
+
+    @Immutable
+    data class Swap(override val title: String?, val from: HeroCoinAmount, val to: HeroCoinAmount) :
         HeroContent
+
+    /**
+     * A settlement estimate paired with the scope the transaction commits to. Callers must
+     * separately disclose any signed carrier amount this hero replaces.
+     */
+    @Immutable
+    data class Projected(
+        override val title: String?,
+        val estimate: HeroCoinAmount?,
+        val scope: String,
+    ) : HeroContent
 }
+
+/** Replaces only the verb, preserving richer figures. A null [title] is inert. */
+internal fun HeroContent.retitled(title: String?): HeroContent =
+    if (title == null) this
+    else
+        when (this) {
+            is HeroContent.Title -> HeroContent.Title(title)
+            HeroContent.Unverified -> this
+            is HeroContent.Send -> copy(title = title)
+            is HeroContent.Swap -> copy(title = title)
+            is HeroContent.Projected -> copy(title = title)
+        }
 
 /**
  * Display-ready coin amount for the hero.
  *
  * `logo` carries the asset's image URL; an empty string signals "use the chain's native fallback" —
  * used for native SOL/ETH where Blockaid's per-request CDN URL would be unreliable.
+ *
+ * `fiatValue` is the pre-formatted fiat worth of `amount` (e.g. `$12.34`), rendered as a sub-line
+ * under the amount. Null when no price was resolvable, or for callers that intentionally omit fiat
+ * — a Blockaid simulation prices nothing, so only decoder-built amounts populate it.
  */
-@Immutable data class HeroCoinAmount(val amount: String, val ticker: String, val logo: String)
+@Immutable
+data class HeroCoinAmount(
+    val amount: String,
+    val ticker: String,
+    val logo: String,
+    val fiatValue: String? = null,
+)

--- a/app/src/main/java/com/vultisig/wallet/ui/components/hero/HeroContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/hero/HeroContent.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.components.hero
 
+import androidx.annotation.DrawableRes
 import androidx.compose.runtime.Immutable
 
 /**
@@ -76,6 +77,10 @@ internal fun HeroContent.retitled(title: String?): HeroContent =
  * `fiatValue` is the pre-formatted fiat worth of `amount` (e.g. `$12.34`), rendered as a sub-line
  * under the amount. Null when no price was resolvable, or for callers that intentionally omit fiat
  * — a Blockaid simulation prices nothing, so only decoder-built amounts populate it.
+ *
+ * `chainLogo` is the badge drawable for the asset's own chain, so a decoder-resolved token keeps
+ * the chain context the card gives every other token. Null when the amount came from a source that
+ * resolved no chain — a Blockaid simulation — or for a native asset that needs no badge.
  */
 @Immutable
 data class HeroCoinAmount(
@@ -83,4 +88,5 @@ data class HeroCoinAmount(
     val ticker: String,
     val logo: String,
     val fiatValue: String? = null,
+    @DrawableRes val chainLogo: Int? = null,
 )

--- a/app/src/main/java/com/vultisig/wallet/ui/components/hero/HeroContentView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/hero/HeroContentView.kt
@@ -54,6 +54,7 @@ internal fun HeroContentView(content: HeroContent, modifier: Modifier = Modifier
                 )
             is HeroContent.Send -> SendHero(content)
             is HeroContent.Swap -> SwapHero(content)
+            is HeroContent.Projected -> ProjectedHero(content)
         }
     }
 }
@@ -134,6 +135,24 @@ private fun SendHero(content: HeroContent.Send) {
     HeroCoinRow(coin = content.coin, iconSize = 36.dp)
 }
 
+/**
+ * An execution-set quantity: the scope the transaction commits to is always shown, and an estimate
+ * is rendered above it only when a position read resolved one. The estimate is prefixed so it can
+ * never be mistaken for a committed amount.
+ */
+@Composable
+private fun ProjectedHero(content: HeroContent.Projected) {
+    content.title?.let { TitleAbove(it) }
+    content.estimate?.let { HeroCoinRow(coin = it, iconSize = 36.dp, approximate = true) }
+    Text(
+        text = content.scope,
+        style = Theme.brockmann.body.s.medium,
+        color = Theme.v2.colors.text.tertiary,
+        textAlign = TextAlign.Center,
+        modifier = Modifier.fillMaxWidth(),
+    )
+}
+
 @Composable
 private fun SwapHero(content: HeroContent.Swap) {
     content.title?.let { TitleAbove(it) }
@@ -160,7 +179,7 @@ private fun TitleAbove(title: String) {
 }
 
 @Composable
-private fun HeroCoinRow(coin: HeroCoinAmount, iconSize: Dp) {
+private fun HeroCoinRow(coin: HeroCoinAmount, iconSize: Dp, approximate: Boolean = false) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -209,8 +228,9 @@ private fun HeroCoinRow(coin: HeroCoinAmount, iconSize: Dp) {
         }
         val tertiaryColor = Theme.v2.colors.text.tertiary
         val text =
-            remember(coin.amount, coin.ticker, tertiaryColor) {
+            remember(coin.amount, coin.ticker, tertiaryColor, approximate) {
                 buildAnnotatedString {
+                    if (approximate) append("≈ ")
                     append(coin.amount)
                     withStyle(SpanStyle(color = tertiaryColor)) { append(" ${coin.ticker}") }
                 }
@@ -226,6 +246,17 @@ private fun HeroCoinRow(coin: HeroCoinAmount, iconSize: Dp) {
             // ellipsis the user has no cue that the displayed value is truncated.
             overflow = TextOverflow.Ellipsis,
         )
+        // Only decoder-built amounts carry a price; a Blockaid simulation resolves none, so the
+        // sub-line is absent rather than showing a zero worth.
+        coin.fiatValue?.let { fiat ->
+            Text(
+                text = fiat,
+                style = Theme.brockmann.supplementary.captionSmall,
+                color = tertiaryColor,
+                textAlign = TextAlign.Center,
+                maxLines = 1,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -64,10 +64,12 @@ import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import com.vultisig.wallet.data.usecases.txstatus.TxStatusConfigurationProvider
 import com.vultisig.wallet.data.utils.compatibleDerivationPath
 import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
 import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
+import com.vultisig.wallet.ui.models.transactiondecoding.DoneTransactionPresentation
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -284,6 +286,11 @@ internal data class KeysignUiState(
     val approveTxLink: String = "",
     val swapProgressLink: String? = null,
     val showSaveToAddressBook: Boolean = false,
+    /**
+     * The done screen's decoder-driven hero, resolved from the final signed payload. Null until it
+     * resolves, and null for every reading the normal-send card already describes better.
+     */
+    val operationHero: HeroContent? = null,
 )
 
 /**
@@ -333,6 +340,7 @@ constructor(
     private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
     private val inAppReviewRepository: InAppReviewRepository,
     private val pendingLimitOrderRepository: PendingLimitOrderRepository,
+    private val doneTransactionPresentation: DoneTransactionPresentation,
 ) : ViewModel() {
 
     /** Creates [KeysignViewModel] with runtime-provided assisted parameters. */
@@ -435,6 +443,51 @@ constructor(
         }
 
         observeInAppReviewEligibility()
+        loadDoneOperationHero()
+    }
+
+    /**
+     * Reads the final signed payload so the done screen describes what was actually signed rather
+     * than defaulting to "Sent".
+     *
+     * Both devices run this: the initiator and the co-signer construct this view model from the
+     * same payload, so they produce the same reading. It is deliberately best-effort — a failed or
+     * slow position read leaves the existing card exactly as it is, and never blocks the screen.
+     */
+    private fun loadDoneOperationHero() {
+        val payload = keysignPayload ?: return
+        // A swap done screen is owned by its own two-sided layout, which reads both legs from the
+        // swap payload. The decoder must not intercept it.
+        if (payload.swapPayload != null) return
+
+        viewModelScope.safeLaunch(
+            onError = { Timber.w(it, "Failed to resolve the done operation hero") }
+        ) {
+            val hero =
+                withContext(Dispatchers.IO) {
+                    doneTransactionPresentation.resolve(payload, vault.coins)
+                }
+
+            _state.update { current ->
+                current.copy(
+                    operationHero = hero,
+                    // A Blockaid simulation owns figures the decoder cannot improve on, so only
+                    // its verb is replaced. Nothing happens when the reading is one the normal-send
+                    // card already describes.
+                    transactionUiModel = current.transactionUiModel?.retitledForDone(payload),
+                )
+            }
+        }
+    }
+
+    /** Applies the done verb to an already-resolved simulated hero, preserving its figures. */
+    private fun TransactionTypeUiModel.retitledForDone(
+        payload: KeysignPayload
+    ): TransactionTypeUiModel {
+        val send = this as? TransactionTypeUiModel.Send ?: return this
+        val simulated = send.tx.heroContent ?: return this
+        val retitled = doneTransactionPresentation.retitleResolvedHero(simulated, payload)
+        return TransactionTypeUiModel.Send(send.tx.copy(heroContent = retitled))
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -429,15 +429,20 @@ constructor(
         if (target != null) {
             viewModelScope.safeLaunch {
                 val labels = resolveDestinationLabels(target.chain, target.dstAddress)
-                _state.update {
-                    it.copy(
+                _state.update { current ->
+                    current.copy(
                         showSaveToAddressBook = labels.showSaveToAddressBook,
+                        // Layer the labels onto whatever is in state, not onto the model captured
+                        // at construction. [loadDoneOperationHero] writes to the same field, and
+                        // rebuilding from the constructor's copy would drop its decoded verb
+                        // whenever this job happened to land second.
                         transactionUiModel =
-                            transactionTypeUiModel.withResolvedLabels(
-                                srcVaultName = vault.name,
-                                dstVaultName = labels.dstVaultName,
-                                dstAddressBookTitle = labels.dstAddressBookTitle,
-                            ),
+                            (current.transactionUiModel ?: transactionTypeUiModel)
+                                .withResolvedLabels(
+                                    srcVaultName = vault.name,
+                                    dstVaultName = labels.dstVaultName,
+                                    dstAddressBookTitle = labels.dstAddressBookTitle,
+                                ),
                     )
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -65,6 +65,7 @@ import com.vultisig.wallet.data.usecases.txstatus.TxStatusConfigurationProvider
 import com.vultisig.wallet.data.utils.compatibleDerivationPath
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.components.hero.HeroContent
+import com.vultisig.wallet.ui.components.hero.retitled
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
 import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
@@ -463,9 +464,13 @@ constructor(
         viewModelScope.safeLaunch(
             onError = { Timber.w(it, "Failed to resolve the done operation hero") }
         ) {
-            val hero =
+            // Both readings are decoded here, off the main thread. The state update below must
+            // stay cheap: `update` runs its lambda on the calling dispatcher and re-runs it on CAS
+            // contention, so decoding inside it would put repeated chain parsing on the UI thread.
+            val (hero, doneVerb) =
                 withContext(Dispatchers.IO) {
-                    doneTransactionPresentation.resolve(payload, vault.coins)
+                    doneTransactionPresentation.resolve(payload, vault.coins) to
+                        doneTransactionPresentation.specificTitle(payload)
                 }
 
             _state.update { current ->
@@ -474,20 +479,17 @@ constructor(
                     // A Blockaid simulation owns figures the decoder cannot improve on, so only
                     // its verb is replaced. Nothing happens when the reading is one the normal-send
                     // card already describes.
-                    transactionUiModel = current.transactionUiModel?.retitledForDone(payload),
+                    transactionUiModel = current.transactionUiModel?.retitledForDone(doneVerb),
                 )
             }
         }
     }
 
     /** Applies the done verb to an already-resolved simulated hero, preserving its figures. */
-    private fun TransactionTypeUiModel.retitledForDone(
-        payload: KeysignPayload
-    ): TransactionTypeUiModel {
+    private fun TransactionTypeUiModel.retitledForDone(verb: String?): TransactionTypeUiModel {
         val send = this as? TransactionTypeUiModel.Send ?: return this
         val simulated = send.tx.heroContent ?: return this
-        val retitled = doneTransactionPresentation.retitleResolvedHero(simulated, payload)
-        return TransactionTypeUiModel.Send(send.tx.copy(heroContent = retitled))
+        return TransactionTypeUiModel.Send(send.tx.copy(heroContent = simulated.retitled(verb)))
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
@@ -1,0 +1,214 @@
+package com.vultisig.wallet.ui.models.transactiondecoding
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.data.repositories.AppCurrencyRepository
+import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
+import com.vultisig.wallet.ui.components.hero.HeroContent
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+import java.text.NumberFormat
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.flow.first
+
+/**
+ * Converts provenance-aware readings into display content. This is the single boundary where
+ * unsigned ticker, logo, and decimal metadata may enter.
+ *
+ * Mirrors the iOS `DecodedTransactionPresentation`. Amount scaling and asset resolution are shared
+ * between Verify and Done; only the surface-owned title differs, which is why [hero] takes the
+ * title rather than deriving it.
+ */
+@Singleton
+internal class DecodedTransactionPresentation
+@Inject
+constructor(
+    private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase,
+    private val fiatValueToString: FiatValueToStringMapper,
+    private val appCurrencyRepository: AppCurrencyRepository,
+    private val projectionCoordinator: ProjectionCoordinator,
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper,
+) {
+
+    /**
+     * Builds a hero, using [coin] only for presentation metadata. Every readable amount either
+     * renders as a figure or degrades to the bare verb, so this always produces content.
+     */
+    suspend fun hero(decoded: DecodedTransaction, coin: Coin, title: String): HeroContent {
+        // Execution-set quantities state their signed scope immediately. A later chain read may
+        // add an estimate, but never owns the verb/scope.
+        projectionCoordinator.hero(decoded, title)?.let {
+            return it
+        }
+
+        val amount = decoded.amount
+        val titleOnly = HeroContent.Title(title)
+
+        return when (amount) {
+            is DecodedAmount.Units ->
+                when (val asset = amount.asset) {
+                    DecodedAsset.TransactionCoin -> sendHero(title, coin, amount.value) ?: titleOnly
+
+                    // The chain-native unit is committed by the operation, so resolve its display
+                    // metadata from the chain rather than from payload sidecars.
+                    DecodedAsset.ChainNative ->
+                        nativeAsset(coin)?.let { sendHero(title, it, amount.value) } ?: titleOnly
+
+                    is DecodedAsset.Denom ->
+                        denomAsset(coin, asset.value)?.let { sendHero(title, it, amount.value) }
+                            ?: titleOnly
+                }
+
+            // Projection and localized scope arrive with fractional readers.
+            is DecodedAmount.Fraction -> titleOnly
+            DecodedAmount.Unstated -> titleOnly
+        }
+    }
+
+    /**
+     * A verb over a zero is the bug in better clothes: an unrepresentable, non-positive, or
+     * rounds-to-nothing quantity degrades to the bare verb rather than presenting a carrier amount
+     * as the operation amount.
+     */
+    private suspend fun sendHero(title: String, coin: Coin, raw: BigInteger): HeroContent? {
+        // Values wider than the precision the display formatter carries are refused rather than
+        // rounded: an amount that cannot be represented exactly is not shown at all.
+        if (raw.abs().toString().length > MAX_SIGNIFICANT_DIGITS) return null
+
+        val tokenValue = TokenValue(value = raw, unit = coin.ticker, decimals = coin.decimal)
+        if (tokenValue.decimal <= BigDecimal.ZERO) return null
+
+        // The app's own amount formatter, so a decoder-driven card reads exactly like the one it
+        // replaces — same grouping, same precision, same large-value suffixes.
+        val amount = mapTokenValueToDecimalUiString(tokenValue)
+        // A dust quantity that rounds away at display precision states nothing truthful either.
+        // Only a bare "0" parses; a grouped or suffixed amount throws and is kept.
+        if (runCatching { BigDecimal(amount) }.getOrNull()?.signum() == 0) return null
+
+        return HeroContent.Send(title = title, coin = heroAmount(coin, tokenValue, amount))
+    }
+
+    /**
+     * Prices the amount off the trusted local rate for [coin]; an unpriceable amount shows none.
+     */
+    private suspend fun heroAmount(
+        coin: Coin,
+        tokenValue: TokenValue,
+        amount: String,
+    ): HeroCoinAmount {
+        val fiat =
+            runCatching {
+                    val currency = appCurrencyRepository.currency.first()
+                    val value = convertTokenValueToFiat(coin, tokenValue, currency)
+                    if (value.value > BigDecimal.ZERO) fiatValueToString(value) else null
+                }
+                .getOrNull()
+
+        return HeroCoinAmount(
+            amount = amount,
+            ticker = coin.ticker,
+            logo = coin.logo,
+            fiatValue = fiat,
+        )
+    }
+
+    /**
+     * The chain's own native asset, resolved from the curated catalogue rather than from the
+     * payload's coin — the signed unit is committed by the operation, not by peer-supplied
+     * metadata.
+     */
+    private fun nativeAsset(coin: Coin): Coin? =
+        Coins.coins[coin.chain]?.firstOrNull { it.isNativeToken }
+
+    /**
+     * ⚠️ **The chain's own denom, resolved from the chain rather than from the payload.** A Cosmos
+     * SignDoc names `uatom`, and the curated table keys ATOM at an empty contract address — so a
+     * contract lookup finds nothing and a delegate that states its amount perfectly well would
+     * render as a bare verb. Matching the chain's fee unit is what closes that, and it is exact:
+     * denoms are case-sensitive.
+     *
+     * Every other denom is matched case-sensitively for the same reason, which is why
+     * [Coins.findCuratedByContract] — deliberately case-insensitive for pool strings — is not used
+     * here.
+     */
+    private fun denomAsset(coin: Coin, denom: String): Coin? {
+        if (denom == coin.chain.feeUnit) return nativeAsset(coin)
+        return Coins.coins[coin.chain]?.firstOrNull { it.contractAddress == denom }
+    }
+
+    companion object {
+        /**
+         * Matches the precision iOS refuses beyond — `Decimal` carries 38 significant digits, and
+         * an amount wider than that is a wire artefact rather than a quantity anyone holds.
+         */
+        private const val MAX_SIGNIFICANT_DIGITS = 38
+
+        /**
+         * Done uses completed-action copy while Verify keeps the present-progressive wording. Every
+         * operation has an explicit decision; swaps remain owned by their dedicated two-sided Done
+         * screen and return null so the caller keeps that layout.
+         */
+        fun doneTitleRes(operation: DecodedOperation): Int? =
+            when (operation) {
+                DecodedOperation.Transfer,
+                DecodedOperation.ContractCall,
+                DecodedOperation.Unknown -> R.string.done_verb_sent
+                DecodedOperation.Swap -> null
+                DecodedOperation.Approve -> R.string.done_verb_approved
+                DecodedOperation.Stake -> R.string.done_verb_staked
+                DecodedOperation.Unstake -> R.string.done_verb_unstaked
+                DecodedOperation.Bond -> R.string.done_verb_bonded
+                DecodedOperation.Unbond -> R.string.done_verb_unbonded
+                DecodedOperation.Rebond -> R.string.done_verb_rebonded
+                DecodedOperation.Leave -> R.string.done_verb_left
+                DecodedOperation.Delegate -> R.string.done_verb_delegated
+                DecodedOperation.Undelegate -> R.string.done_verb_undelegated
+                DecodedOperation.Redelegate -> R.string.done_verb_redelegated
+                DecodedOperation.ClaimRewards -> R.string.done_verb_claimed_rewards
+                DecodedOperation.Mint -> R.string.done_verb_minted
+                DecodedOperation.Redeem -> R.string.done_verb_redeemed
+                DecodedOperation.SecuredAssetWithdraw -> R.string.done_verb_withdrew
+                DecodedOperation.AddLiquidity -> R.string.done_verb_added_liquidity
+                DecodedOperation.RemoveLiquidity -> R.string.done_verb_removed_liquidity
+                DecodedOperation.Merge -> R.string.done_verb_merged
+                DecodedOperation.Unmerge -> R.string.done_verb_unmerged
+                DecodedOperation.IbcTransfer -> R.string.done_verb_bridged
+                DecodedOperation.Vote -> R.string.done_verb_voted
+                DecodedOperation.SecuredAssetDeposit -> R.string.done_verb_deposited
+                DecodedOperation.SwitchChain -> R.string.done_verb_switched
+                DecodedOperation.LimitOrderPlacement -> R.string.done_verb_placed_limit_order
+                DecodedOperation.LimitOrderCancel -> R.string.limit_swap_cancel_done_sent
+            }
+
+        /**
+         * Basis points as a percentage, without trailing noise: 10000 reads "100%", 5006 reads
+         * "50.06%".
+         *
+         * ⚠️ Formatted through [NumberFormat.getPercentInstance] rather than by appending an ASCII
+         * `%`. Where the symbol sits, whether a space precedes it, and which symbol is used at all
+         * are locale rules.
+         */
+        fun percentage(basisPoints: Int): String {
+            val fraction =
+                BigDecimal(basisPoints).divide(BigDecimal(10_000)).setScale(4, RoundingMode.DOWN)
+            return NumberFormat.getPercentInstance(Locale.getDefault())
+                .apply {
+                    minimumFractionDigits = 0
+                    maximumFractionDigits = 2
+                }
+                .format(fraction)
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
@@ -4,6 +4,8 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.isLayer2
+import com.vultisig.wallet.data.models.monoToneLogo
 import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
 import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
 import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
@@ -121,6 +123,11 @@ constructor(
             ticker = coin.ticker,
             logo = coin.logo,
             fiatValue = fiat,
+            // The badge follows the resolved asset, under the same rule the card applies to every
+            // other token: a USDC amount keeps its Base or Arbitrum context, a native asset needs
+            // no badge, and an L2 native keeps one because its ticker alone is ambiguous.
+            chainLogo =
+                coin.chain.monoToneLogo.takeIf { !coin.isNativeToken || coin.chain.isLayer2 },
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DoneTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DoneTransactionPresentation.kt
@@ -7,7 +7,6 @@ import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
 import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionDecoder
 import com.vultisig.wallet.data.models.transaction_decoding.asSignedTransactionContent
 import com.vultisig.wallet.ui.components.hero.HeroContent
-import com.vultisig.wallet.ui.components.hero.retitled
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -67,13 +66,6 @@ constructor(
 
         return presentation.hero(decoded, trustedCoin(payload, trustedCoins), title)
     }
-
-    /**
-     * Supplies the done verb to a richer presentation — a Blockaid simulation, for instance —
-     * without replacing its figures.
-     */
-    fun retitleResolvedHero(hero: HeroContent?, payload: KeysignPayload): HeroContent? =
-        hero?.retitled(specificTitle(payload))
 
     /**
      * The vault's own coin for the payload's asset, which carries the trusted decimals and logo.

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DoneTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DoneTransactionPresentation.kt
@@ -1,0 +1,103 @@
+package com.vultisig.wallet.ui.models.transactiondecoding
+
+import android.content.Context
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionDecoder
+import com.vultisig.wallet.data.models.transaction_decoding.asSignedTransactionContent
+import com.vultisig.wallet.ui.components.hero.HeroContent
+import com.vultisig.wallet.ui.components.hero.retitled
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Adapts the shared signed-transaction reading to Done's completed-action vocabulary. It owns no
+ * chain parsing and no amount formatting.
+ *
+ * Mirrors the iOS `DoneTransactionPresentation`.
+ */
+@Singleton
+internal class DoneTransactionPresentation
+@Inject
+constructor(
+    @ApplicationContext private val context: Context,
+    private val decoder: SignedTransactionDecoder,
+    private val presentation: DecodedTransactionPresentation,
+    private val resolvedTransactionHero: ResolvedTransactionHero,
+) {
+
+    /**
+     * The past-tense verb for a specifically-read operation, or null to keep the normal-send card's
+     * existing presentation.
+     */
+    fun specificTitle(payload: KeysignPayload): String? {
+        val operation = decoder.decode(payload.asSignedTransactionContent()).operation
+        if (operation in FALLBACK_OPERATIONS) return null
+        return DecodedTransactionPresentation.doneTitleRes(operation)?.let(context::getString)
+    }
+
+    /** The synchronous hero, built from the signed amount alone. */
+    suspend fun hero(payload: KeysignPayload, trustedCoins: List<Coin>): HeroContent? {
+        val decoded = decoder.decode(payload.asSignedTransactionContent())
+        if (decoded.operation in FALLBACK_OPERATIONS) return null
+        val title =
+            DecodedTransactionPresentation.doneTitleRes(decoded.operation)?.let(context::getString)
+                ?: return null
+
+        return presentation.hero(decoded, trustedCoin(payload, trustedCoins), title)
+    }
+
+    /**
+     * The hero including any optional chain-state projection. A projection that fails or times out
+     * degrades to [hero]; it never blocks the done screen and never fabricates a number.
+     */
+    suspend fun resolve(payload: KeysignPayload, trustedCoins: List<Coin>): HeroContent? {
+        val content = payload.asSignedTransactionContent()
+        val decoded = decoder.decode(content)
+        if (decoded.operation in FALLBACK_OPERATIONS) return null
+        val title =
+            DecodedTransactionPresentation.doneTitleRes(decoded.operation)?.let(context::getString)
+                ?: return null
+
+        resolvedTransactionHero.resolve(content, trustedCoins, title)?.let {
+            return it
+        }
+
+        return presentation.hero(decoded, trustedCoin(payload, trustedCoins), title)
+    }
+
+    /**
+     * Supplies the done verb to a richer presentation — a Blockaid simulation, for instance —
+     * without replacing its figures.
+     */
+    fun retitleResolvedHero(hero: HeroContent?, payload: KeysignPayload): HeroContent? =
+        hero?.retitled(specificTitle(payload))
+
+    /**
+     * The vault's own coin for the payload's asset, which carries the trusted decimals and logo.
+     * Falls back to the payload's coin when the vault holds no match — the payload is peer-supplied
+     * on a co-signer, so a local match is preferred wherever one exists.
+     */
+    private fun trustedCoin(payload: KeysignPayload, coins: List<Coin>): Coin =
+        coins.firstOrNull {
+            it.chain == payload.coin.chain &&
+                it.ticker.equals(payload.coin.ticker, ignoreCase = true) &&
+                it.contractAddress.equals(payload.coin.contractAddress, ignoreCase = true)
+        } ?: payload.coin
+
+    companion object {
+        /**
+         * These readings intentionally retain the normal-send card's `Sent` fallback and its
+         * already-computed amount. A generic contract call or an unreadable transaction does not
+         * justify replacing that richer fallback.
+         */
+        private val FALLBACK_OPERATIONS =
+            setOf(
+                DecodedOperation.Transfer,
+                DecodedOperation.ContractCall,
+                DecodedOperation.Unknown,
+            )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ProjectionCoordinator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ProjectionCoordinator.kt
@@ -1,0 +1,72 @@
+package com.vultisig.wallet.ui.models.transactiondecoding
+
+import android.content.Context
+import com.vultisig.wallet.R
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
+import com.vultisig.wallet.ui.components.hero.HeroContent
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Turns a decoded reading into a hero that says what is certain immediately, and what is estimated
+ * when it arrives.
+ *
+ * Mirrors the iOS `ProjectionCoordinator`. Only quantities settled at execution get a committed
+ * scope; an absolute signed amount has nothing to project and is rendered by
+ * [DecodedTransactionPresentation] instead.
+ */
+@Singleton
+internal class ProjectionCoordinator
+@Inject
+constructor(@ApplicationContext private val context: Context) {
+
+    /** Returns a committed scope only for quantities settled at execution. */
+    fun scope(decoded: DecodedTransaction): String? =
+        when (val amount = decoded.amount) {
+            is DecodedAmount.Fraction ->
+                // The signed share remains exact even when the projected amount is not.
+                context.getString(
+                    R.string.withdrawing_share_of_staked_position,
+                    DecodedTransactionPresentation.percentage(amount.basisPoints),
+                )
+
+            DecodedAmount.Unstated ->
+                when (decoded.operation) {
+                    DecodedOperation.Unstake -> context.getString(R.string.scope_your_whole_stake)
+                    DecodedOperation.ClaimRewards ->
+                        context.getString(R.string.scope_rewards_accrued_so_far)
+                    else -> null
+                }
+
+            is DecodedAmount.Units -> null
+        }
+
+    /** Builds the immediate verb-and-scope hero; an estimate is optional. */
+    fun hero(
+        decoded: DecodedTransaction,
+        title: String,
+        estimate: HeroCoinAmount? = null,
+    ): HeroContent? {
+        val scope = scope(decoded) ?: return null
+        return HeroContent.Projected(title = title, estimate = estimate, scope = scope)
+    }
+
+    companion object {
+        /** Short enough that optional chain state cannot stall the done screen. */
+        val TIMEOUT = 5.seconds
+
+        /**
+         * Applies the same deadline to every optional position read. Every failure — a timeout, a
+         * network error, an empty answer — degrades to the existing scope rather than fabricating a
+         * number.
+         */
+        suspend fun estimate(read: suspend () -> HeroCoinAmount?): HeroCoinAmount? =
+            withTimeoutOrNull(TIMEOUT) { runCatching { read() }.getOrNull() }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ProjectionCoordinator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ProjectionCoordinator.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withTimeoutOrNull
 
 /**
@@ -62,11 +63,23 @@ constructor(@ApplicationContext private val context: Context) {
         val TIMEOUT = 5.seconds
 
         /**
-         * Applies the same deadline to every optional position read. Every failure — a timeout, a
-         * network error, an empty answer — degrades to the existing scope rather than fabricating a
-         * number.
+         * Applies the same deadline to every optional position read. An ordinary reader failure — a
+         * network error, a malformed response, an empty answer — degrades to the existing scope
+         * rather than fabricating a number.
+         *
+         * Cancellation is rethrown rather than swallowed. The deadline itself cancels through
+         * [withTimeoutOrNull], and a caller going away (the view model being cleared) must not be
+         * turned into a silent null that leaves the rest of the coroutine running.
          */
         suspend fun estimate(read: suspend () -> HeroCoinAmount?): HeroCoinAmount? =
-            withTimeoutOrNull(TIMEOUT) { runCatching { read() }.getOrNull() }
+            withTimeoutOrNull(TIMEOUT) {
+                try {
+                    read()
+                } catch (cancellation: CancellationException) {
+                    throw cancellation
+                } catch (_: Exception) {
+                    null
+                }
+            }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ResolvedTransactionHero.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ResolvedTransactionHero.kt
@@ -1,0 +1,57 @@
+package com.vultisig.wallet.ui.models.transactiondecoding
+
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionDecoder
+import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
+import com.vultisig.wallet.ui.components.hero.HeroContent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Resolves an execution-set amount from chain state. */
+internal interface PositionReading {
+
+    /** Whether this reader answers for the decoded transaction on this coin. */
+    fun handles(decoded: DecodedTransaction, coin: Coin): Boolean
+
+    /** The resolved amount, or null when the read failed or returned nothing. */
+    suspend fun amount(decoded: DecodedTransaction, coin: Coin): HeroCoinAmount?
+}
+
+/**
+ * Resolves optional chain-state amounts behind decoder-layer readers, keeping chain knowledge out
+ * of the keysign view models.
+ *
+ * Mirrors the iOS `ResolvedTransactionHero`. The registry is empty until the per-chain signed
+ * decoders land; with no reader matching, callers fall back to the signed amount the decoder
+ * already read.
+ */
+@Singleton
+internal class ResolvedTransactionHero
+@Inject
+constructor(
+    private val decoder: SignedTransactionDecoder,
+    private val projectionCoordinator: ProjectionCoordinator,
+) {
+
+    /** Chain readers are registered here as their signed decoders become available. */
+    private val readers: List<PositionReading> = emptyList()
+
+    /** Resolves through the first reader matching a trusted local coin. */
+    suspend fun resolve(
+        content: SignedTransactionContent,
+        trustedCoins: List<Coin>,
+        title: String,
+        readers: List<PositionReading> = this.readers,
+    ): HeroContent? {
+        val decoded = decoder.decode(content)
+
+        for (reader in readers) {
+            val coin = trustedCoins.firstOrNull { reader.handles(decoded, it) } ?: continue
+            val amount = ProjectionCoordinator.estimate { reader.amount(decoded, coin) }
+            return projectionCoordinator.hero(decoded, title, amount)
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/JoinKeysignView.kt
@@ -223,6 +223,7 @@ internal fun JoinKeysignView() {
                     hasBackClick = false,
                     dappMetadata = dappMetadata,
                     coinLogoRes = keysignViewModel.coinLogoRes,
+                    operationHero = keysignUiState.operationHero,
                 )
             }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/Keysign.kt
@@ -38,6 +38,7 @@ import app.rive.rememberViewModelInstance
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.KeepScreenOn
+import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.components.loader.VsSigningProgressIndicator
 import com.vultisig.wallet.ui.components.rive.RiveAnimation
 import com.vultisig.wallet.ui.components.rive.rememberRiveResourceFile
@@ -92,6 +93,7 @@ internal fun KeysignView(
     showSaveToAddressBook: Boolean,
     dappMetadata: DAppMetadata? = null,
     @DrawableRes coinLogoRes: Int? = null,
+    operationHero: HeroContent? = null,
 ) {
     // Block system back while signing/broadcasting is in progress. Popping the nav entry here
     // cancels the ViewModel's coroutine scope mid-broadcast, before a terminal state lands, and a
@@ -172,7 +174,10 @@ internal fun KeysignView(
                                     onComplete = onComplete,
                                     onBack = onBack,
                                     transactionStatus = targetState.transactionStatus,
-                                    tx = transactionTypeUiModel.toUiTransactionInfo(),
+                                    tx =
+                                        transactionTypeUiModel
+                                            .toUiTransactionInfo()
+                                            .copy(operationHero = operationHero),
                                     showToolbar = showToolbar,
                                     onAddToAddressBook = onAddToAddressBook,
                                     showSaveToAddressBook = showSaveToAddressBook,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/keysign/KeysignScreen.kt
@@ -101,5 +101,6 @@ private fun Keysign(
         hasBackClick = true,
         dappMetadata = keysignViewModel.dappMetadata,
         coinLogoRes = keysignViewModel.coinLogoRes,
+        operationHero = uiState.operationHero,
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -462,7 +462,17 @@ private fun doneHeroDisplay(tx: UiTransactionInfo): DoneHeroDisplay {
             }
         }
 
-        is HeroContent.Title -> fallback.copy(verb = verb, value = "", fiatValue = null)
+        // A title-only reading names an operation and nothing else. Keeping the payload token
+        // would pair "Claimed rewards" with branding for an asset the reading never identified.
+        is HeroContent.Title ->
+            DoneHeroDisplay(
+                verb = verb,
+                tokenLogo = fallbackLogo,
+                ticker = "",
+                chainLogo = null,
+                value = "",
+                fiatValue = null,
+            )
 
         // A swap done screen is owned by its own two-sided layout, and an Unverified hero is never
         // produced by the decoder; both keep the transaction's existing figures.

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -446,10 +446,19 @@ private fun doneHeroDisplay(tx: UiTransactionInfo): DoneHeroDisplay {
                     scope = hero.scope,
                 )
             } else {
-                // The position read resolved nothing, so the scope is the only quantity the
-                // decoder proved. Dropping it here would leave a verb over a blank amount and
-                // discard the one figure that is certain.
-                fallback.copy(verb = verb, value = "", fiatValue = null, scope = hero.scope)
+                // The position read resolved nothing, so the scope is the only thing the decoder
+                // proved — and it is shown alone. The payload's coin is the carrier here, not
+                // necessarily the asset the operation acted on: a TCY unstake is signed against a
+                // dust RUNE amount, and naming RUNE would be a claim the reading never made.
+                DoneHeroDisplay(
+                    verb = verb,
+                    tokenLogo = fallbackLogo,
+                    ticker = "",
+                    chainLogo = null,
+                    value = "",
+                    fiatValue = null,
+                    scope = hero.scope,
+                )
             }
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -77,6 +77,12 @@ internal fun SendTxOverviewScreen(
     // and surface the caution as the Figma caution box (amber banner) pinned at the bottom.
     val isUnverifiedFunction = tx.heroContent == HeroContent.Unverified
 
+    // A Blockaid verdict of "could not verify this function" is a claim about this exact
+    // transaction, and the caution banner below still makes it. Letting a decoder reading restate
+    // the same transaction as a confident "Approved 500 USDC" above that banner would put the two
+    // in direct contradiction, so the simulation's verdict wins and the reading stands down.
+    val operationHero = tx.operationHero.takeUnless { isUnverifiedFunction }
+
     TxDoneScaffold(
         transactionHash = transactionHash,
         transactionLink = transactionLink,
@@ -113,7 +119,7 @@ internal fun SendTxOverviewScreen(
                 // the asset it was read from, says more than the selector it was decoded out of.
                 // A Blockaid simulation above still wins, since it carries figures the decoder has
                 // no way to improve on.
-                functionName = tx.functionName.takeIf { tx.operationHero == null },
+                functionName = tx.functionName.takeIf { operationHero == null },
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 val trustSet = tx.rippleTrustSet
@@ -172,7 +178,7 @@ internal fun SendTxOverviewScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier.fillMaxWidth(),
                     ) {
-                        val display = doneHeroDisplay(tx)
+                        val display = doneHeroDisplay(tx, operationHero)
 
                         VsOverviewToken(
                             header = display.verb,
@@ -395,9 +401,12 @@ internal data class DoneHeroDisplay(
  * replaces the verb and, where the signed content states a truthful quantity, the asset and amount
  * with it. It never substitutes a zero or a carrier amount: a reading that resolved no amount shows
  * the asset alone.
+ *
+ * [operationHero] is passed in rather than read off [tx] because the caller gates it: a reading is
+ * stood down when a Blockaid simulation has already declared the same transaction unverifiable.
  */
 @Composable
-private fun doneHeroDisplay(tx: UiTransactionInfo): DoneHeroDisplay {
+private fun doneHeroDisplay(tx: UiTransactionInfo, operationHero: HeroContent?): DoneHeroDisplay {
     val token = tx.token.token
     val fallbackLogo = getCoinLogo(token.logo)
     val fallbackChainLogo =
@@ -419,7 +428,7 @@ private fun doneHeroDisplay(tx: UiTransactionInfo): DoneHeroDisplay {
             fiatValue = tx.token.fiatValue,
         )
 
-    val hero = tx.operationHero ?: return fallback
+    val hero = operationHero ?: return fallback
     val verb = hero.title ?: fallbackVerb
 
     return when (hero) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -109,7 +109,11 @@ internal fun SendTxOverviewScreen(
         tokenContent = {
             TransactionHero(
                 heroContent = tx.heroContent.takeUnless { it == HeroContent.Unverified },
-                functionName = tx.functionName,
+                // A decoder reading outranks the raw function name: "Approved", with the amount and
+                // the asset it was read from, says more than the selector it was decoded out of.
+                // A Blockaid simulation above still wins, since it carries figures the decoder has
+                // no way to improve on.
+                functionName = tx.functionName.takeIf { tx.operationHero == null },
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 val trustSet = tx.rippleTrustSet
@@ -424,9 +428,9 @@ private fun doneHeroDisplay(tx: UiTransactionInfo): DoneHeroDisplay {
                 verb = verb,
                 tokenLogo = getCoinLogo(hero.coin.logo),
                 ticker = hero.coin.ticker,
-                // The decoder resolves its asset from the signed units, which may not be the
-                // payload's coin, so the payload's chain badge would mislabel it.
-                chainLogo = null,
+                // The badge travels with the resolved asset rather than the payload's coin, so a
+                // decoded USDC amount keeps its Base or Arbitrum context.
+                chainLogo = hero.coin.chainLogo,
                 value = hero.coin.amount,
                 fiatValue = hero.coin.fiatValue,
             )
@@ -438,7 +442,7 @@ private fun doneHeroDisplay(tx: UiTransactionInfo): DoneHeroDisplay {
                     verb = verb,
                     tokenLogo = getCoinLogo(estimate.logo),
                     ticker = estimate.ticker,
-                    chainLogo = null,
+                    chainLogo = estimate.chainLogo,
                     // A projection settles at execution, so it stays visibly approximate — and the
                     // scope below it is the part that stays exact.
                     value = "≈ ${estimate.amount}",

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -177,6 +177,7 @@ internal fun SendTxOverviewScreen(
                             chainLogo = display.chainLogo,
                             value = display.value,
                             fiatValue = display.fiatValue,
+                            scope = display.scope,
                             shape = Theme.v2.radius.xl,
                             modifier = Modifier.fillMaxWidth(),
                         )
@@ -375,6 +376,11 @@ internal data class DoneHeroDisplay(
     val chainLogo: Int?,
     val value: String,
     val fiatValue: String?,
+    /**
+     * What the transaction committed to in words, for an amount that only settles at execution.
+     * Null for every reading whose quantity is stated outright by the signed content.
+     */
+    val scope: String? = null,
 )
 
 /**
@@ -433,14 +439,17 @@ private fun doneHeroDisplay(tx: UiTransactionInfo): DoneHeroDisplay {
                     tokenLogo = getCoinLogo(estimate.logo),
                     ticker = estimate.ticker,
                     chainLogo = null,
-                    // A projection settles at execution, so it stays visibly approximate.
+                    // A projection settles at execution, so it stays visibly approximate — and the
+                    // scope below it is the part that stays exact.
                     value = "≈ ${estimate.amount}",
                     fiatValue = estimate.fiatValue,
+                    scope = hero.scope,
                 )
             } else {
-                // The position read resolved nothing. Name the asset and the operation; inventing
-                // an amount here is what the scope line exists to avoid.
-                fallback.copy(verb = verb, value = "", fiatValue = null)
+                // The position read resolved nothing, so the scope is the only quantity the
+                // decoder proved. Dropping it here would leave a verb over a blank amount and
+                // discard the one figure that is certain.
+                fallback.copy(verb = verb, value = "", fiatValue = null, scope = hero.scope)
             }
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SendTxOverviewScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -24,9 +25,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.chains.helpers.RippleDappTx
+import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.data.models.OPERATION_MINT
 import com.vultisig.wallet.data.models.RippleTrustSetDisplay
+import com.vultisig.wallet.data.models.getCoinLogo
+import com.vultisig.wallet.data.models.isLayer2
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.monoToneLogo
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.ui.components.CopyIcon
 import com.vultisig.wallet.ui.components.SignRippleDisplayView
@@ -163,14 +168,15 @@ internal fun SendTxOverviewScreen(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier.fillMaxWidth(),
                     ) {
+                        val display = doneHeroDisplay(tx)
+
                         VsOverviewToken(
-                            header =
-                                if (tx.type == UiTransactionInfoType.Send) {
-                                    stringResource(R.string.tx_overview_screen_tx_send)
-                                } else {
-                                    stringResource(R.string.tx_overview_screen_tx_deposit)
-                                },
-                            valuedToken = tx.token,
+                            header = display.verb,
+                            tokenLogo = display.tokenLogo,
+                            ticker = display.ticker,
+                            chainLogo = display.chainLogo,
+                            value = display.value,
+                            fiatValue = display.fiatValue,
                             shape = Theme.v2.radius.xl,
                             modifier = Modifier.fillMaxWidth(),
                         )
@@ -354,6 +360,99 @@ internal fun SendTxOverviewScreen(
     )
 }
 
+/**
+ * The verb, asset, amount, and fiat the done card renders.
+ *
+ * Mirrors the iOS `DoneHeroDisplay`. It selects between the decoder-driven reading and the existing
+ * normal-send presentation; the card itself is unchanged either way, and every field falls back to
+ * what the transaction already computed rather than to a fabricated figure.
+ */
+@Immutable
+internal data class DoneHeroDisplay(
+    val verb: String,
+    val tokenLogo: ImageModel,
+    val ticker: String,
+    val chainLogo: Int?,
+    val value: String,
+    val fiatValue: String?,
+)
+
+/**
+ * Builds the done card's display.
+ *
+ * With no decoder reading — a plain transfer, an unreadable transaction — this is exactly the
+ * existing card: the send/deposit header and the transaction's own token and figures. A reading
+ * replaces the verb and, where the signed content states a truthful quantity, the asset and amount
+ * with it. It never substitutes a zero or a carrier amount: a reading that resolved no amount shows
+ * the asset alone.
+ */
+@Composable
+private fun doneHeroDisplay(tx: UiTransactionInfo): DoneHeroDisplay {
+    val token = tx.token.token
+    val fallbackLogo = getCoinLogo(token.logo)
+    val fallbackChainLogo =
+        token.chain.monoToneLogo.takeIf { !token.isNativeToken || token.chain.isLayer2 }
+    val fallbackVerb =
+        if (tx.type == UiTransactionInfoType.Send) {
+            stringResource(R.string.tx_overview_screen_tx_send)
+        } else {
+            stringResource(R.string.tx_overview_screen_tx_deposit)
+        }
+
+    val fallback =
+        DoneHeroDisplay(
+            verb = fallbackVerb,
+            tokenLogo = fallbackLogo,
+            ticker = token.ticker,
+            chainLogo = fallbackChainLogo,
+            value = tx.token.value,
+            fiatValue = tx.token.fiatValue,
+        )
+
+    val hero = tx.operationHero ?: return fallback
+    val verb = hero.title ?: fallbackVerb
+
+    return when (hero) {
+        is HeroContent.Send ->
+            DoneHeroDisplay(
+                verb = verb,
+                tokenLogo = getCoinLogo(hero.coin.logo),
+                ticker = hero.coin.ticker,
+                // The decoder resolves its asset from the signed units, which may not be the
+                // payload's coin, so the payload's chain badge would mislabel it.
+                chainLogo = null,
+                value = hero.coin.amount,
+                fiatValue = hero.coin.fiatValue,
+            )
+
+        is HeroContent.Projected -> {
+            val estimate = hero.estimate
+            if (estimate != null) {
+                DoneHeroDisplay(
+                    verb = verb,
+                    tokenLogo = getCoinLogo(estimate.logo),
+                    ticker = estimate.ticker,
+                    chainLogo = null,
+                    // A projection settles at execution, so it stays visibly approximate.
+                    value = "≈ ${estimate.amount}",
+                    fiatValue = estimate.fiatValue,
+                )
+            } else {
+                // The position read resolved nothing. Name the asset and the operation; inventing
+                // an amount here is what the scope line exists to avoid.
+                fallback.copy(verb = verb, value = "", fiatValue = null)
+            }
+        }
+
+        is HeroContent.Title -> fallback.copy(verb = verb, value = "", fiatValue = null)
+
+        // A swap done screen is owned by its own two-sided layout, and an Unverified hero is never
+        // produced by the decoder; both keep the transaction's existing figures.
+        is HeroContent.Swap,
+        HeroContent.Unverified -> fallback
+    }
+}
+
 @Composable
 private fun AddToAddressBookButton(modifier: Modifier = Modifier, onClick: () -> Unit = {}) {
     Row(
@@ -497,6 +596,12 @@ internal data class UiTransactionInfo(
      * Carried through from [com.vultisig.wallet.ui.models.TransactionDetailsUiModel.heroContent].
      */
     val heroContent: HeroContent? = null,
+    /**
+     * Decoder-selected operation data for the existing normal-send done hero. Kept separate from
+     * [heroContent], whose Blockaid-simulated figures own a richer layout, so a decoder reading can
+     * relabel the card without discarding trusted amounts.
+     */
+    val operationHero: HeroContent? = null,
     /**
      * Decoded terms of a dApp-supplied XRPL transaction (SignRipple). When present the done screen
      * shows the decoded summary (Type / Selling / Buying / Issuer) instead of a "0 XRP" hero — the

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1714,4 +1714,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">Quell-Validator befindet sich in einer Redelegations-Abkühlphase</string>
     <string name="cosmos_staking_insufficient_fee_balance">Nicht genügend liquides %1$s zur Deckung der Netzwerkgebühr. Fordern Sie zuerst Belohnungen an oder laden Sie auf.</string>
     <string name="cosmos_staking_max_entries_reached">Du hast die maximale Anzahl von %1$d ausstehenden Anfragen für diesen Validator erreicht. Warte, bis eine abgeschlossen ist, bevor du fortfährst.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">Gesendet</string>
+    <string name="done_verb_approved">Genehmigt</string>
+    <string name="done_verb_staked">Gestakt</string>
+    <string name="done_verb_unstaked">Entstakt</string>
+    <string name="done_verb_bonded">Gebondet</string>
+    <string name="done_verb_unbonded">Bonding gelöst</string>
+    <string name="done_verb_rebonded">Neu gebondet</string>
+    <string name="done_verb_left">Verlassen</string>
+    <string name="done_verb_delegated">Delegiert</string>
+    <string name="done_verb_undelegated">Delegation beendet</string>
+    <string name="done_verb_redelegated">Neu delegiert</string>
+    <string name="done_verb_claimed_rewards">Belohnungen beansprucht</string>
+    <string name="done_verb_minted">Geprägt</string>
+    <string name="done_verb_redeemed">Eingelöst</string>
+    <string name="done_verb_withdrew">Ausgezahlt</string>
+    <string name="done_verb_added_liquidity">Liquidität hinzugefügt</string>
+    <string name="done_verb_removed_liquidity">Liquidität entfernt</string>
+    <string name="done_verb_merged">Zusammengeführt</string>
+    <string name="done_verb_unmerged">Getrennt</string>
+    <string name="done_verb_bridged">Kettenübergreifend übertragen</string>
+    <string name="done_verb_voted">Abgestimmt</string>
+    <string name="done_verb_deposited">Eingezahlt</string>
+    <string name="done_verb_switched">Gewechselt</string>
+    <string name="done_verb_placed_limit_order">Limit-Order platziert</string>
+    <string name="limit_swap_cancel_done_sent">Stornierung gesendet</string>
+    <string name="scope_your_whole_stake">dein gesamter Stake</string>
+    <string name="scope_rewards_accrued_so_far">bisher angefallene Belohnungen</string>
+    <string name="withdrawing_share_of_staked_position">%1$s deiner Stake-Position</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1712,4 +1712,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">El validador de origen está en un período de espera de redelegación</string>
     <string name="cosmos_staking_insufficient_fee_balance">No hay suficiente %1$s líquido para cubrir la comisión de red. Reclama las recompensas primero o recarga.</string>
     <string name="cosmos_staking_max_entries_reached">Has alcanzado el máximo de %1$d solicitudes pendientes para este validador. Espera a que se complete una antes de continuar.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">Enviado</string>
+    <string name="done_verb_approved">Aprobado</string>
+    <string name="done_verb_staked">Stake realizado</string>
+    <string name="done_verb_unstaked">Stake retirado</string>
+    <string name="done_verb_bonded">Vinculado</string>
+    <string name="done_verb_unbonded">Desvinculado</string>
+    <string name="done_verb_rebonded">Revinculado</string>
+    <string name="done_verb_left">Salida completada</string>
+    <string name="done_verb_delegated">Delegado</string>
+    <string name="done_verb_undelegated">Delegación cancelada</string>
+    <string name="done_verb_redelegated">Redelegado</string>
+    <string name="done_verb_claimed_rewards">Recompensas reclamadas</string>
+    <string name="done_verb_minted">Acuñado</string>
+    <string name="done_verb_redeemed">Canjeado</string>
+    <string name="done_verb_withdrew">Retirado</string>
+    <string name="done_verb_added_liquidity">Liquidez añadida</string>
+    <string name="done_verb_removed_liquidity">Liquidez retirada</string>
+    <string name="done_verb_merged">Fusionado</string>
+    <string name="done_verb_unmerged">Separado</string>
+    <string name="done_verb_bridged">Transferido entre cadenas</string>
+    <string name="done_verb_voted">Voto emitido</string>
+    <string name="done_verb_deposited">Depositado</string>
+    <string name="done_verb_switched">Cambiado</string>
+    <string name="done_verb_placed_limit_order">Orden límite creada</string>
+    <string name="limit_swap_cancel_done_sent">Cancelación enviada</string>
+    <string name="scope_your_whole_stake">todo tu stake</string>
+    <string name="scope_rewards_accrued_so_far">recompensas acumuladas hasta ahora</string>
+    <string name="withdrawing_share_of_staked_position">%1$s de tu posición en staking</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1722,4 +1722,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">Izvorni validator je u razdoblju mirovanja redelegacije</string>
     <string name="cosmos_staking_insufficient_fee_balance">Nema dovoljno likvidnog %1$s za pokrivanje mrežne naknade. Najprije zatražite nagrade ili nadoplatite.</string>
     <string name="cosmos_staking_max_entries_reached">Dosegnuli ste najveći broj od %1$d zahtjeva na čekanju za ovaj validator. Pričekajte da se jedan dovrši prije nastavka.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">Poslano</string>
+    <string name="done_verb_approved">Odobreno</string>
+    <string name="done_verb_staked">Stakano</string>
+    <string name="done_verb_unstaked">Ulog povučen</string>
+    <string name="done_verb_bonded">Vezano</string>
+    <string name="done_verb_unbonded">Odvezano</string>
+    <string name="done_verb_rebonded">Ponovno vezano</string>
+    <string name="done_verb_left">Napušteno</string>
+    <string name="done_verb_delegated">Delegirano</string>
+    <string name="done_verb_undelegated">Delegacija poništena</string>
+    <string name="done_verb_redelegated">Ponovno delegirano</string>
+    <string name="done_verb_claimed_rewards">Nagrade preuzete</string>
+    <string name="done_verb_minted">Iskovano</string>
+    <string name="done_verb_redeemed">Otkupljeno</string>
+    <string name="done_verb_withdrew">Podignuto</string>
+    <string name="done_verb_added_liquidity">Dodana likvidnost</string>
+    <string name="done_verb_removed_liquidity">Uklonjena likvidnost</string>
+    <string name="done_verb_merged">Spojeno</string>
+    <string name="done_verb_unmerged">Razdvojeno</string>
+    <string name="done_verb_bridged">Premošteno</string>
+    <string name="done_verb_voted">Glasano</string>
+    <string name="done_verb_deposited">Položeno</string>
+    <string name="done_verb_switched">Prebačeno</string>
+    <string name="done_verb_placed_limit_order">Postavljen limit nalog</string>
+    <string name="limit_swap_cancel_done_sent">Otkazivanje poslano</string>
+    <string name="scope_your_whole_stake">cijeli vaš ulog</string>
+    <string name="scope_rewards_accrued_so_far">do sada stečene nagrade</string>
+    <string name="withdrawing_share_of_staked_position">%1$s vaše uložene pozicije</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1715,4 +1715,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">Il validatore di origine è in un periodo di attesa di ridelegazione</string>
     <string name="cosmos_staking_insufficient_fee_balance">%1$s liquido insufficiente per coprire la commissione di rete. Riscuoti prima le ricompense o ricarica.</string>
     <string name="cosmos_staking_max_entries_reached">Hai raggiunto il numero massimo di %1$d richieste in sospeso per questo validatore. Attendi che una si completi prima di continuare.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">Inviato</string>
+    <string name="done_verb_approved">Approvato</string>
+    <string name="done_verb_staked">Messo in stake</string>
+    <string name="done_verb_unstaked">Stake annullato</string>
+    <string name="done_verb_bonded">Vincolato</string>
+    <string name="done_verb_unbonded">Svincolato</string>
+    <string name="done_verb_rebonded">Rivincolato</string>
+    <string name="done_verb_left">Uscito</string>
+    <string name="done_verb_delegated">Delegato</string>
+    <string name="done_verb_undelegated">Delega annullata</string>
+    <string name="done_verb_redelegated">Ridelegato</string>
+    <string name="done_verb_claimed_rewards">Ricompense reclamate</string>
+    <string name="done_verb_minted">Coniato</string>
+    <string name="done_verb_redeemed">Riscattato</string>
+    <string name="done_verb_withdrew">Prelevato</string>
+    <string name="done_verb_added_liquidity">Liquidità aggiunta</string>
+    <string name="done_verb_removed_liquidity">Liquidità rimossa</string>
+    <string name="done_verb_merged">Unito</string>
+    <string name="done_verb_unmerged">Separato</string>
+    <string name="done_verb_bridged">Trasferito tra catene</string>
+    <string name="done_verb_voted">Voto espresso</string>
+    <string name="done_verb_deposited">Depositato</string>
+    <string name="done_verb_switched">Spostato</string>
+    <string name="done_verb_placed_limit_order">Ordine limite piazzato</string>
+    <string name="limit_swap_cancel_done_sent">Annullamento inviato</string>
+    <string name="scope_your_whole_stake">tutto il tuo stake</string>
+    <string name="scope_rewards_accrued_so_far">ricompense maturate finora</string>
+    <string name="withdrawing_share_of_staked_position">%1$s della tua posizione in stake</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1730,4 +1730,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">원 검증인이 재위임 쿨다운 중입니다</string>
     <string name="cosmos_staking_insufficient_fee_balance">네트워크 수수료를 충당할 유동 %1$s이(가) 부족합니다. 먼저 보상을 청구하거나 충전하세요.</string>
     <string name="cosmos_staking_max_entries_reached">이 검증인에 대한 대기 중인 요청이 최대 %1$d개에 도달했습니다. 계속하기 전에 하나가 완료될 때까지 기다리세요.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">전송됨</string>
+    <string name="done_verb_approved">승인됨</string>
+    <string name="done_verb_staked">스테이킹됨</string>
+    <string name="done_verb_unstaked">언스테이킹됨</string>
+    <string name="done_verb_bonded">본딩됨</string>
+    <string name="done_verb_unbonded">언본딩됨</string>
+    <string name="done_verb_rebonded">재본딩됨</string>
+    <string name="done_verb_left">탈퇴함</string>
+    <string name="done_verb_delegated">위임됨</string>
+    <string name="done_verb_undelegated">위임 해제됨</string>
+    <string name="done_verb_redelegated">재위임됨</string>
+    <string name="done_verb_claimed_rewards">보상 수령됨</string>
+    <string name="done_verb_minted">발행됨</string>
+    <string name="done_verb_redeemed">상환됨</string>
+    <string name="done_verb_withdrew">출금됨</string>
+    <string name="done_verb_added_liquidity">유동성 추가됨</string>
+    <string name="done_verb_removed_liquidity">유동성 제거됨</string>
+    <string name="done_verb_merged">병합됨</string>
+    <string name="done_verb_unmerged">병합 해제됨</string>
+    <string name="done_verb_bridged">브리지 완료</string>
+    <string name="done_verb_voted">투표함</string>
+    <string name="done_verb_deposited">입금됨</string>
+    <string name="done_verb_switched">전환됨</string>
+    <string name="done_verb_placed_limit_order">지정가 주문 생성됨</string>
+    <string name="limit_swap_cancel_done_sent">취소 전송됨</string>
+    <string name="scope_your_whole_stake">스테이킹 전액</string>
+    <string name="scope_rewards_accrued_so_far">현재까지 누적된 보상</string>
+    <string name="withdrawing_share_of_staked_position">스테이킹 포지션의 %1$s</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1706,4 +1706,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">Bronvalidator heeft een herdelegatie-afkoelperiode</string>
     <string name="cosmos_staking_insufficient_fee_balance">Niet genoeg liquide %1$s om de netwerkkosten te dekken. Claim eerst beloningen of vul aan.</string>
     <string name="cosmos_staking_max_entries_reached">Je hebt het maximum van %1$d openstaande verzoeken voor deze validator bereikt. Wacht tot er één is voltooid voordat je doorgaat.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">Verzonden</string>
+    <string name="done_verb_approved">Goedgekeurd</string>
+    <string name="done_verb_staked">Gestaked</string>
+    <string name="done_verb_unstaked">Ontstaked</string>
+    <string name="done_verb_bonded">Gebonden</string>
+    <string name="done_verb_unbonded">Ontbonden</string>
+    <string name="done_verb_rebonded">Opnieuw gebonden</string>
+    <string name="done_verb_left">Verlaten</string>
+    <string name="done_verb_delegated">Gedelegeerd</string>
+    <string name="done_verb_undelegated">Delegatie ingetrokken</string>
+    <string name="done_verb_redelegated">Opnieuw gedelegeerd</string>
+    <string name="done_verb_claimed_rewards">Beloningen geclaimd</string>
+    <string name="done_verb_minted">Gemunt</string>
+    <string name="done_verb_redeemed">Ingewisseld</string>
+    <string name="done_verb_withdrew">Opgenomen</string>
+    <string name="done_verb_added_liquidity">Liquiditeit toegevoegd</string>
+    <string name="done_verb_removed_liquidity">Liquiditeit verwijderd</string>
+    <string name="done_verb_merged">Samengevoegd</string>
+    <string name="done_verb_unmerged">Gesplitst</string>
+    <string name="done_verb_bridged">Gebridged</string>
+    <string name="done_verb_voted">Gestemd</string>
+    <string name="done_verb_deposited">Gestort</string>
+    <string name="done_verb_switched">Gewisseld</string>
+    <string name="done_verb_placed_limit_order">Limietorder geplaatst</string>
+    <string name="limit_swap_cancel_done_sent">Annulering verzonden</string>
+    <string name="scope_your_whole_stake">je volledige stake</string>
+    <string name="scope_rewards_accrued_so_far">tot nu toe opgebouwde beloningen</string>
+    <string name="withdrawing_share_of_staked_position">%1$s van je gestakete positie</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1710,4 +1710,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">O validador de origem está num período de espera de redelegação</string>
     <string name="cosmos_staking_insufficient_fee_balance">Não há %1$s líquido suficiente para cobrir a taxa de rede. Reivindique as recompensas primeiro ou recarregue.</string>
     <string name="cosmos_staking_max_entries_reached">Você atingiu o máximo de %1$d solicitações pendentes para este validador. Aguarde a conclusão de uma antes de continuar.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">Enviado</string>
+    <string name="done_verb_approved">Aprovado</string>
+    <string name="done_verb_staked">Stake realizado</string>
+    <string name="done_verb_unstaked">Stake cancelado</string>
+    <string name="done_verb_bonded">Vinculado</string>
+    <string name="done_verb_unbonded">Desvinculado</string>
+    <string name="done_verb_rebonded">Revinculado</string>
+    <string name="done_verb_left">Saída concluída</string>
+    <string name="done_verb_delegated">Delegado</string>
+    <string name="done_verb_undelegated">Delegação cancelada</string>
+    <string name="done_verb_redelegated">Redelegado</string>
+    <string name="done_verb_claimed_rewards">Recompensas reivindicadas</string>
+    <string name="done_verb_minted">Cunhado</string>
+    <string name="done_verb_redeemed">Resgatado</string>
+    <string name="done_verb_withdrew">Sacado</string>
+    <string name="done_verb_added_liquidity">Liquidez adicionada</string>
+    <string name="done_verb_removed_liquidity">Liquidez removida</string>
+    <string name="done_verb_merged">Mesclado</string>
+    <string name="done_verb_unmerged">Separado</string>
+    <string name="done_verb_bridged">Transferido entre redes</string>
+    <string name="done_verb_voted">Voto registrado</string>
+    <string name="done_verb_deposited">Depositado</string>
+    <string name="done_verb_switched">Trocado</string>
+    <string name="done_verb_placed_limit_order">Ordem limite criada</string>
+    <string name="limit_swap_cancel_done_sent">Cancelamento enviado</string>
+    <string name="scope_your_whole_stake">todo o seu stake</string>
+    <string name="scope_rewards_accrued_so_far">recompensas acumuladas até agora</string>
+    <string name="withdrawing_share_of_staked_position">%1$s da sua posição em stake</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1724,4 +1724,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">Исходный валидатор находится в периоде ожидания переделегирования</string>
     <string name="cosmos_staking_insufficient_fee_balance">Недостаточно ликвидных %1$s для оплаты комиссии сети. Сначала получите награды или пополните баланс.</string>
     <string name="cosmos_staking_max_entries_reached">Достигнуто максимальное число ожидающих запросов (%1$d) для этого валидатора. Дождитесь завершения одного из них, прежде чем продолжить.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">Отправлено</string>
+    <string name="done_verb_approved">Одобрено</string>
+    <string name="done_verb_staked">Застейкано</string>
+    <string name="done_verb_unstaked">Стейкинг отменён</string>
+    <string name="done_verb_bonded">Привязано</string>
+    <string name="done_verb_unbonded">Отвязано</string>
+    <string name="done_verb_rebonded">Перепривязано</string>
+    <string name="done_verb_left">Выход выполнен</string>
+    <string name="done_verb_delegated">Делегировано</string>
+    <string name="done_verb_undelegated">Делегирование отменено</string>
+    <string name="done_verb_redelegated">Переделегировано</string>
+    <string name="done_verb_claimed_rewards">Награды получены</string>
+    <string name="done_verb_minted">Отчеканено</string>
+    <string name="done_verb_redeemed">Выкуплено</string>
+    <string name="done_verb_withdrew">Выведено</string>
+    <string name="done_verb_added_liquidity">Ликвидность добавлена</string>
+    <string name="done_verb_removed_liquidity">Ликвидность удалена</string>
+    <string name="done_verb_merged">Объединено</string>
+    <string name="done_verb_unmerged">Объединение отменено</string>
+    <string name="done_verb_bridged">Переведено между сетями</string>
+    <string name="done_verb_voted">Голос отдан</string>
+    <string name="done_verb_deposited">Внесено</string>
+    <string name="done_verb_switched">Переключено</string>
+    <string name="done_verb_placed_limit_order">Лимитный ордер размещён</string>
+    <string name="limit_swap_cancel_done_sent">Отмена отправлена</string>
+    <string name="scope_your_whole_stake">весь ваш стейк</string>
+    <string name="scope_rewards_accrued_so_far">накопленные на данный момент награды</string>
+    <string name="withdrawing_share_of_staked_position">%1$s вашей стейкинг-позиции</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2037,4 +2037,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">源验证人处于重新委托冷却期</string>
     <string name="cosmos_staking_insufficient_fee_balance">可用 %1$s 不足以支付网络费用。请先领取奖励或充值。</string>
     <string name="cosmos_staking_max_entries_reached">您对该验证人的待处理请求已达到上限 %1$d 个。请等待其中一个完成后再继续。</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">已发送</string>
+    <string name="done_verb_approved">已批准</string>
+    <string name="done_verb_staked">已质押</string>
+    <string name="done_verb_unstaked">已解除质押</string>
+    <string name="done_verb_bonded">已绑定</string>
+    <string name="done_verb_unbonded">已解绑</string>
+    <string name="done_verb_rebonded">已重新绑定</string>
+    <string name="done_verb_left">已退出</string>
+    <string name="done_verb_delegated">已委托</string>
+    <string name="done_verb_undelegated">已解除委托</string>
+    <string name="done_verb_redelegated">已重新委托</string>
+    <string name="done_verb_claimed_rewards">已领取奖励</string>
+    <string name="done_verb_minted">已铸造</string>
+    <string name="done_verb_redeemed">已赎回</string>
+    <string name="done_verb_withdrew">已提取</string>
+    <string name="done_verb_added_liquidity">已添加流动性</string>
+    <string name="done_verb_removed_liquidity">已移除流动性</string>
+    <string name="done_verb_merged">已合并</string>
+    <string name="done_verb_unmerged">已取消合并</string>
+    <string name="done_verb_bridged">已完成跨链转账</string>
+    <string name="done_verb_voted">已投票</string>
+    <string name="done_verb_deposited">已存入</string>
+    <string name="done_verb_switched">已切换</string>
+    <string name="done_verb_placed_limit_order">已下限价单</string>
+    <string name="limit_swap_cancel_done_sent">取消已发送</string>
+    <string name="scope_your_whole_stake">您的全部质押</string>
+    <string name="scope_rewards_accrued_so_far">至今累积的奖励</string>
+    <string name="withdrawing_share_of_staked_position">您质押仓位的 %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1771,4 +1771,33 @@
     <string name="cosmos_staking_redelegate_cooldown_fallback">Source validator is under a redelegation cooldown</string>
     <string name="cosmos_staking_insufficient_fee_balance">Not enough liquid %1$s to cover the network fee. Claim rewards first or top up.</string>
     <string name="cosmos_staking_max_entries_reached">You\'ve reached the maximum of %1$d pending requests for this validator. Wait for one to complete before continuing.</string>
+    <!-- Transaction done screen: past-tense operation vocabulary read from the signed transaction -->
+    <string name="done_verb_sent">Sent</string>
+    <string name="done_verb_approved">Approved</string>
+    <string name="done_verb_staked">Staked</string>
+    <string name="done_verb_unstaked">Unstaked</string>
+    <string name="done_verb_bonded">Bonded</string>
+    <string name="done_verb_unbonded">Unbonded</string>
+    <string name="done_verb_rebonded">Rebonded</string>
+    <string name="done_verb_left">Left</string>
+    <string name="done_verb_delegated">Delegated</string>
+    <string name="done_verb_undelegated">Undelegated</string>
+    <string name="done_verb_redelegated">Redelegated</string>
+    <string name="done_verb_claimed_rewards">Claimed rewards</string>
+    <string name="done_verb_minted">Minted</string>
+    <string name="done_verb_redeemed">Redeemed</string>
+    <string name="done_verb_withdrew">Withdrew</string>
+    <string name="done_verb_added_liquidity">Added liquidity</string>
+    <string name="done_verb_removed_liquidity">Removed liquidity</string>
+    <string name="done_verb_merged">Merged</string>
+    <string name="done_verb_unmerged">Unmerged</string>
+    <string name="done_verb_bridged">Bridged</string>
+    <string name="done_verb_voted">Voted</string>
+    <string name="done_verb_deposited">Deposited</string>
+    <string name="done_verb_switched">Switched</string>
+    <string name="done_verb_placed_limit_order">Placed limit order</string>
+    <string name="limit_swap_cancel_done_sent">Cancellation sent</string>
+    <string name="scope_your_whole_stake">your whole stake</string>
+    <string name="scope_rewards_accrued_so_far">rewards accrued so far</string>
+    <string name="withdrawing_share_of_staked_position">%1$s of your staked position</string>
 </resources>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -273,6 +273,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             inAppReviewRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
+            doneTransactionPresentation = mockk(relaxed = true),
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelInAppReviewTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelInAppReviewTest.kt
@@ -164,6 +164,7 @@ internal class KeysignViewModelInAppReviewTest {
             inAppReviewRepository = inAppReviewRepository,
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
+            doneTransactionPresentation = mockk(relaxed = true),
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
@@ -105,6 +105,7 @@ internal class KeysignViewModelSaveTransactionHistoryTest {
             inAppReviewRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
+            doneTransactionPresentation = mockk(relaxed = true),
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateEvmActualFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateEvmActualFeeTest.kt
@@ -147,6 +147,7 @@ internal class KeysignViewModelTryUpdateEvmActualFeeTest {
             inAppReviewRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = gasFeeToEstimatedFee,
             pendingLimitOrderRepository = mockk(relaxed = true),
+            doneTransactionPresentation = mockk(relaxed = true),
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 


### PR DESCRIPTION
Mirrors [vultisig-ios#5229](https://github.com/vultisig/vultisig-ios/pull/5229). Follows on from #5706 (the decoder foundation, iOS [#5217](https://github.com/vultisig/vultisig-ios/pull/5217)) under the parent ticket #5657.

## Summary

The normal-send Done card already matched the design; what was missing was the data behind it. It now reads the final `KeysignPayload` on both the initiating and the co-signing device, so both describe the same signed transaction instead of always defaulting to **Sent**.

- Past-tense Done vocabulary for all 28 `DecodedOperation` cases, localized across every shipping locale. Plain transfers, generic contract calls, and unreadable transactions keep the existing **Sent** default.
- Amounts, assets, and fiat come from the signed content and the vault's own trusted coins. A zero, a carrier amount, or a quantity that rounds away at display precision degrades to the bare verb rather than being presented as the operation amount.
- Projections resolve behind a 5s deadline. A failed or slow position read never blocks the screen and never fabricates a number.
- Richer providers keep precedence: an XRPL TrustSet, a limit-order cancellation, and a Blockaid simulation keep their layouts and figures, and only borrow the Done verb.
- Both swap Done paths and the existing card's layout are unchanged.

## Please read before reviewing: this is wiring, not yet visible behaviour

`SignedTransactionDecoder`'s registry is still empty on Android — the per-chain decoders (iOS #5219–#5224) and the Verify integration (iOS #5218) are not mirrored yet. Until a chain decoder registers, every transaction decodes to `Unknown`, lands in the fallback set, and the Done card renders exactly as it does today.

So this PR is intentionally a visual no-op. It is the layer the chain decoders plug into, and the acceptance criteria about verbs replacing **Sent** can only be demonstrated once those land.

## Three deliberate divergences from the iOS diff

Android's architecture differs, so a literal port would have been worse:

1. **No `TransactionHeroResolver` surface/provider machinery.** Android already encodes that precedence as branch order in `SendTxOverviewScreen`'s `tokenContent` (trustSet → signRipple → default). `operationHero` reaches only the default branch, so the stronger providers keep precedence without a new indirection layer.
2. **Resolution lives in `KeysignViewModel`, not the composable.** Both devices construct that ViewModel from the same payload, which is what gives initiator/co-signer parity. iOS uses a per-screen `.task(id:)`.
3. **No `refreshedFiat` / rate-change re-render path.** Fiat is priced once in the resolving coroutine through `ConvertTokenValueToFiatUseCase`, which already refreshes on a zero price. Amounts are formatted with `TokenValueToDecimalUiStringMapper` so a decoder-driven card reads identically to the one it replaces — same grouping, precision, and large-value suffixes.

Also skipped on purpose: `HeroContent.Receive` (belongs to iOS #5218 and is unreachable here) and `scopeDelegatedAmountAfterRent` (`DecodedAmount.AccountFunding` has no Android equivalent).

## Localization

28 keys across all 10 locale files. German, Spanish, Croatian, Italian, Korean, Portuguese, and Chinese come from the iOS strings.

**Dutch and Russian have no iOS source** — those two were written against the terminology already established in each locale file (`Gestaked` / `Gebonden` / `Limietorder`, `Застейкано` / `Привязано` / `Лимитный ордер`). A native-speaker glance at `values-nl` and `values-ru` would be welcome.

## Test plan

- [x] `:app:compileDebugKotlin`, `:app:lintDebug` — clean
- [x] `:app:testDebugUnitTest` + `:data:testDebugUnitTest` — pass
- [x] Existing `KeysignViewModel` tests updated for the new constructor dependency
- [x] Done screen verified unchanged for send, deposit, XRPL TrustSet, dApp XRPL, and limit-order-cancel paths — with an empty decoder registry every one of them takes the existing fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SErms3rPgwTB5VNa6f1U2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved completed transaction summaries with operation-specific labels, assets, amounts, fiat values, and chain details.
  - Added projected estimates and execution scopes for staking, unstaking, rewards, and supported operations.
  - Added graceful handling for unavailable, unsupported, empty, or approximate transaction amounts.
  - Enhanced token displays with optional chain logos, fiat values, scope text, and flexible formatting.

- **Localization**
  - Added translated completion labels, limit-order cancellation statuses, and staking-related messages across multiple languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->