### PR TITLE
fix(defi): paint the last-known positions instead of cold-starting

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/DeFiPositionsSnapshotCache.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/DeFiPositionsSnapshotCache.kt
@@ -1,0 +1,39 @@
+package com.vultisig.wallet.ui.models.defi
+
+import com.vultisig.wallet.data.models.VaultId
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.reflect.KClass
+import kotlin.reflect.safeCast
+
+/**
+ * In-memory, process-lifetime cache of the last state a DeFi detail screen rendered, per vault.
+ *
+ * The detail view-models are nav-scoped, so popping back to the DeFi list destroys them and the
+ * next open would otherwise cold-start: blank cards, header on a spinner, and the enabled set back
+ * at its defaults until the store answers. Each screen hands its state over in `onCleared` and
+ * seeds from it on the next `setData`, so a re-entry paints what the user last saw while the live
+ * read refreshes underneath. This is the same trade the chains that already got it right make —
+ * [com.vultisig.wallet.data.repositories.TronDeFiSnapshotCache],
+ * [com.vultisig.wallet.data.repositories.CosmosStakingSnapshotCache] — and it deliberately stays in
+ * memory: nothing to migrate, nothing to clean up when a vault or coin is deleted, and a restart
+ * reads the chain.
+ *
+ * Entries are keyed by vault *and* snapshot type, so two screens sharing a vault cannot overwrite
+ * each other's state, and a read can only ever hand back the type it asked for.
+ */
+@Singleton
+internal class DeFiPositionsSnapshotCache @Inject constructor() {
+
+    private val snapshots = ConcurrentHashMap<String, Any>()
+
+    fun <T : Any> read(vaultId: VaultId, type: KClass<T>): T? =
+        type.safeCast(snapshots[key(vaultId, type)])
+
+    fun write(vaultId: VaultId, snapshot: Any) {
+        snapshots[key(vaultId, snapshot::class)] = snapshot
+    }
+
+    private fun key(vaultId: VaultId, type: KClass<*>): String = "$vaultId:${type.qualifiedName}"
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
@@ -108,6 +108,7 @@ internal data class LpPositionUiModel(
     val positionKey: String = "",
     val canRemove: Boolean = true,
     val chainLogo: Int? = null,
+    val isLoading: Boolean = false,
 )
 
 internal data class StakePositionUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
@@ -52,6 +52,16 @@ internal data class LpTabUiModel(
     val isLoading: Boolean = false,
     val positions: List<LpPositionUiModel> = emptyList(),
     /**
+     * Pools whose card came from a read that answered. A pool the last read could not resolve
+     * leaves a placeholder standing, and carrying that into the next reload would present a figure
+     * nothing has confirmed while skipping the shimmer that says a read is in flight.
+     *
+     * It travels with the cards rather than sitting beside them in the view-model, because the
+     * cached snapshot restores this model: a re-entry that brought the cards back without the set
+     * they were judged by would have the first reload reject every one of them.
+     */
+    val livePoolKeys: Set<String> = emptySet(),
+    /**
      * Half-finished symmetric adds, listed above the positions. They are deliberately not gated on
      * the pool being selected in the Manage-Positions dialog: a deposit the user cannot see is the
      * one that silently gets refunded.

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -740,7 +740,16 @@ constructor(
                 onError = { e ->
                     Timber.e(e, "Failed to load Maya LP positions")
                     reportLpFiat(BigDecimal.ZERO)
-                    updateModel { it.copy(lp = it.lp.copy(isLoading = false)) }
+                    updateModel {
+                        it.copy(
+                            lp =
+                                it.lp.copy(
+                                    isLoading = false,
+                                    positions =
+                                        it.lp.positions.map { p -> p.copy(isLoading = false) },
+                                )
+                        )
+                    }
                 }
             ) {
                 // The zero has to be resolved before the placeholders are built: a failed load
@@ -758,7 +767,7 @@ constructor(
                 val placeholderPositions =
                     selectedPools.map { pool ->
                         val assetTicker = pool.ticker.substringAfter("/")
-                        loaded[pool.positionKey]
+                        loaded[pool.positionKey]?.copy(isLoading = false)
                             ?: LpPositionUiModel(
                                 titleLp = "${pool.ticker} Pool",
                                 totalPriceLp = zero,
@@ -769,11 +778,11 @@ constructor(
                                 positionKey = pool.positionKey,
                                 canRemove = false,
                                 chainLogo = pool.chainLogo as? Int,
+                                isLoading = true,
                             )
                     }
-                val isCold = selectedPools.any { loaded[it.positionKey] == null }
                 updateModel {
-                    it.copy(lp = it.lp.copy(isLoading = isCold, positions = placeholderPositions))
+                    it.copy(lp = it.lp.copy(isLoading = false, positions = placeholderPositions))
                 }
 
                 val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
@@ -787,7 +796,12 @@ constructor(
                     reportLpFiat(BigDecimal.ZERO)
                     updateModel {
                         it.copy(
-                            lp = it.lp.copy(isLoading = false, positions = placeholderPositions)
+                            lp =
+                                it.lp.copy(
+                                    isLoading = false,
+                                    positions =
+                                        placeholderPositions.map { p -> p.copy(isLoading = false) },
+                                )
                         )
                     }
                     return@safeLaunch
@@ -798,7 +812,12 @@ constructor(
                     reportLpFiat(BigDecimal.ZERO)
                     updateModel {
                         it.copy(
-                            lp = it.lp.copy(isLoading = false, positions = placeholderPositions)
+                            lp =
+                                it.lp.copy(
+                                    isLoading = false,
+                                    positions =
+                                        placeholderPositions.map { p -> p.copy(isLoading = false) },
+                                )
                         )
                     }
                     return@safeLaunch

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -147,6 +147,7 @@ constructor(
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val defiPositionsRepository: DefiPositionsRepository,
     private val fiatValueCalculator: DefiFiatValueCalculator,
+    private val snapshotCache: DeFiPositionsSnapshotCache,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -175,6 +176,11 @@ constructor(
     private var loadStakingJob: Job? = null
     private var loadLpJob: Job? = null
 
+    // Pools whose card came from a read that answered. A read that could not resolve them leaves
+    // placeholders standing, and carrying those into the next reload would present a figure nothing
+    // has confirmed while skipping the shimmer that says a read is in flight.
+    private var livePoolKeys: Set<String> = emptySet()
+
     private val currentModel: MayachainDefiPositionsUiModel
         get() =
             (_state.value as? MayachainDefiUiState.Success)?.data ?: MayachainDefiPositionsUiModel()
@@ -190,7 +196,7 @@ constructor(
     fun setData(vaultId: VaultId) {
         this.vaultId = vaultId
         if (_state.value !is MayachainDefiUiState.Success) {
-            _state.value = MayachainDefiUiState.Success(MayachainDefiPositionsUiModel())
+            _state.value = MayachainDefiUiState.Success(restoredModel(vaultId))
         }
         loadBalanceVisibility()
         savedPositionsJob?.cancel()
@@ -201,6 +207,31 @@ constructor(
         observeTotalRawJob = observeTotalRaw()
         currencyJob?.cancel()
         currencyJob = observeCurrencyChanges()
+    }
+
+    /**
+     * The state this vault's screen was last showing, so a re-entry starts from the cards, totals
+     * and enabled set the user left behind rather than from an empty model whose defaults would
+     * flash the CACAO positions back on. Everything in it is refreshed by the loads [setData] kicks
+     * off straight after; only the position picker is dropped, because a sheet the user closed by
+     * leaving the screen must not reopen itself.
+     */
+    private fun restoredModel(vaultId: VaultId): MayachainDefiPositionsUiModel {
+        val cached =
+            snapshotCache.read(vaultId, MayachainDefiPositionsUiModel::class)
+                ?: return MayachainDefiPositionsUiModel()
+        return cached.copy(
+            showPositionSelectionDialog = false,
+            tempSelectedPositions = cached.selectedPositions,
+        )
+    }
+
+    override fun onCleared() {
+        val model = (_state.value as? MayachainDefiUiState.Success)?.data
+        if (::vaultId.isInitialized && model != null) {
+            snapshotCache.write(vaultId, model)
+        }
+        super.onCleared()
     }
 
     /**
@@ -229,6 +260,7 @@ constructor(
                 .drop(1)
                 .collect {
                     resetTotalsToPending()
+                    dropFiatPricedInPreviousCurrency()
 
                     bondedNodesRefreshTrigger.value++
                     loadBondedJob?.cancel()
@@ -251,6 +283,31 @@ constructor(
         _totalStakingRaw.value = null
         _totalLpFiat.value = null
         updateModel { it.copy(totalAmountPrice = null, isTotalAmountLoading = true) }
+    }
+
+    /**
+     * Drops the fiat the cards carry when the display currency changes.
+     *
+     * Every other reload now leaves settled figures in place and swaps them when the fresh ones
+     * land, which is what stops a re-entry looking like a first open. A currency switch is the one
+     * case where that would be wrong: these strings were formatted for the currency being left, so
+     * they are cleared here and the reload puts each card back on its shimmer until it can price
+     * them again.
+     */
+    private fun dropFiatPricedInPreviousCurrency() {
+        updateModel { current ->
+            current.copy(
+                bonded = current.bonded.copy(totalBondedPrice = null),
+                staking =
+                    current.staking.copy(
+                        positions =
+                            current.staking.positions.map { position ->
+                                position.copy(isLoading = true)
+                            }
+                    ),
+                lp = current.lp.copy(positions = emptyList()),
+            )
+        }
     }
 
     private fun observeTotalRaw(): Job =
@@ -352,7 +409,12 @@ constructor(
             return
         }
 
-        updateModel { it.copy(bonded = it.bonded.copy(isLoading = true)) }
+        // A total the last load already priced stays on screen while this one runs. The shimmer
+        // belongs to a cold start; re-arming it on every entry and pull is what made a re-entry
+        // look like a first open.
+        updateModel {
+            it.copy(bonded = it.bonded.copy(isLoading = it.bonded.totalBondedPrice == null))
+        }
 
         try {
             val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
@@ -459,7 +521,14 @@ constructor(
                 canStake = false,
                 canUnstake = false,
             )
-        updateModel { it.copy(staking = StakingTabUiModel(positions = listOf(loadingPosition))) }
+        // A card the last load already settled stays up while this one runs, and is replaced in
+        // place when it lands; only a position with nothing behind it yet gets the placeholder.
+        val settled = currentModel.staking.positions.filterNot { it.isLoading }
+        updateModel {
+            it.copy(
+                staking = StakingTabUiModel(positions = settled.ifEmpty { listOf(loadingPosition) })
+            )
+        }
 
         try {
             val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
@@ -657,7 +726,7 @@ constructor(
         // pools would otherwise park the LP leg here for good and strand the header on its spinner,
         // pull-to-refresh included. loadLpPositionsForDialog calls back here once it settles.
         if (!model.lpDialogLoaded) {
-            updateModel { it.copy(lp = it.lp.copy(isLoading = true)) }
+            updateModel { it.copy(lp = it.lp.copy(isLoading = it.lp.positions.isEmpty())) }
             return
         }
 
@@ -668,7 +737,7 @@ constructor(
             return
         }
 
-        updateModel { it.copy(lp = it.lp.copy(isLoading = true)) }
+        updateModel { it.copy(lp = it.lp.copy(isLoading = it.lp.positions.isEmpty())) }
 
         loadLpJob?.cancel()
         loadLpJob =
@@ -683,23 +752,32 @@ constructor(
                 // freezes these exact objects into the terminal state, so a placeholder that
                 // snapshotted an unresolved zero would strand the card on the dash for good.
                 val zero = zeroFiat()
+                // Pools the last load already priced keep their card; only a pool with nothing
+                // behind it yet falls back to the placeholder, and the shimmer is raised only for
+                // those — a refresh over cards that already carry figures leaves them readable.
+                val loaded =
+                    currentModel.lp.positions
+                        .filter { it.positionKey in livePoolKeys }
+                        .associateBy { it.positionKey }
                 val placeholderPositions =
                     selectedPools.map { pool ->
                         val assetTicker = pool.ticker.substringAfter("/")
-                        LpPositionUiModel(
-                            titleLp = "${pool.ticker} Pool",
-                            totalPriceLp = zero,
-                            icon = pool.logo,
-                            assetTicker = assetTicker,
-                            apr = null,
-                            position = "0 CACAO + 0 $assetTicker",
-                            positionKey = pool.positionKey,
-                            canRemove = false,
-                            chainLogo = pool.chainLogo as? Int,
-                        )
+                        loaded[pool.positionKey]
+                            ?: LpPositionUiModel(
+                                titleLp = "${pool.ticker} Pool",
+                                totalPriceLp = zero,
+                                icon = pool.logo,
+                                assetTicker = assetTicker,
+                                apr = null,
+                                position = "0 CACAO + 0 $assetTicker",
+                                positionKey = pool.positionKey,
+                                canRemove = false,
+                                chainLogo = pool.chainLogo as? Int,
+                            )
                     }
+                val isCold = selectedPools.any { loaded[it.positionKey] == null }
                 updateModel {
-                    it.copy(lp = LpTabUiModel(isLoading = true, positions = placeholderPositions))
+                    it.copy(lp = LpTabUiModel(isLoading = isCold, positions = placeholderPositions))
                 }
 
                 val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
@@ -898,6 +976,8 @@ constructor(
                         // header total rather than admit a value is missing.
                         LpLegTotal.Unavailable
                     }
+                livePoolKeys =
+                    if (isPriceable) selectedPools.map { it.positionKey }.toSet() else emptySet()
                 updateModel {
                     it.copy(lp = LpTabUiModel(isLoading = false, positions = lpPositions))
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -996,7 +996,7 @@ constructor(
                 updateModel {
                     it.copy(
                         lp =
-                            LpTabUiModel(
+                            it.lp.copy(
                                 isLoading = false,
                                 positions = lpPositions,
                                 livePoolKeys = livePoolKeys,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -781,8 +781,9 @@ constructor(
                                 isLoading = true,
                             )
                     }
+                val isCold = selectedPools.any { loaded[it.positionKey] == null }
                 updateModel {
-                    it.copy(lp = it.lp.copy(isLoading = false, positions = placeholderPositions))
+                    it.copy(lp = it.lp.copy(isLoading = isCold, positions = placeholderPositions))
                 }
 
                 val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModel.kt
@@ -176,11 +176,6 @@ constructor(
     private var loadStakingJob: Job? = null
     private var loadLpJob: Job? = null
 
-    // Pools whose card came from a read that answered. A read that could not resolve them leaves
-    // placeholders standing, and carrying those into the next reload would present a figure nothing
-    // has confirmed while skipping the shimmer that says a read is in flight.
-    private var livePoolKeys: Set<String> = emptySet()
-
     private val currentModel: MayachainDefiPositionsUiModel
         get() =
             (_state.value as? MayachainDefiUiState.Success)?.data ?: MayachainDefiPositionsUiModel()
@@ -302,10 +297,10 @@ constructor(
                     current.staking.copy(
                         positions =
                             current.staking.positions.map { position ->
-                                position.copy(isLoading = true)
+                                position.copy(isLoading = true, stakedFiatDisplay = null)
                             }
                     ),
-                lp = current.lp.copy(positions = emptyList()),
+                lp = current.lp.copy(positions = emptyList(), livePoolKeys = emptySet()),
             )
         }
     }
@@ -755,9 +750,10 @@ constructor(
                 // Pools the last load already priced keep their card; only a pool with nothing
                 // behind it yet falls back to the placeholder, and the shimmer is raised only for
                 // those — a refresh over cards that already carry figures leaves them readable.
+                val lpTab = currentModel.lp
                 val loaded =
-                    currentModel.lp.positions
-                        .filter { it.positionKey in livePoolKeys }
+                    lpTab.positions
+                        .filter { it.positionKey in lpTab.livePoolKeys }
                         .associateBy { it.positionKey }
                 val placeholderPositions =
                     selectedPools.map { pool ->
@@ -777,7 +773,7 @@ constructor(
                     }
                 val isCold = selectedPools.any { loaded[it.positionKey] == null }
                 updateModel {
-                    it.copy(lp = LpTabUiModel(isLoading = isCold, positions = placeholderPositions))
+                    it.copy(lp = it.lp.copy(isLoading = isCold, positions = placeholderPositions))
                 }
 
                 val vault = withContext(ioDispatcher) { vaultRepository.get(vaultId) }
@@ -791,7 +787,7 @@ constructor(
                     reportLpFiat(BigDecimal.ZERO)
                     updateModel {
                         it.copy(
-                            lp = LpTabUiModel(isLoading = false, positions = placeholderPositions)
+                            lp = it.lp.copy(isLoading = false, positions = placeholderPositions)
                         )
                     }
                     return@safeLaunch
@@ -802,7 +798,7 @@ constructor(
                     reportLpFiat(BigDecimal.ZERO)
                     updateModel {
                         it.copy(
-                            lp = LpTabUiModel(isLoading = false, positions = placeholderPositions)
+                            lp = it.lp.copy(isLoading = false, positions = placeholderPositions)
                         )
                     }
                     return@safeLaunch
@@ -976,10 +972,17 @@ constructor(
                         // header total rather than admit a value is missing.
                         LpLegTotal.Unavailable
                     }
-                livePoolKeys =
+                val livePoolKeys =
                     if (isPriceable) selectedPools.map { it.positionKey }.toSet() else emptySet()
                 updateModel {
-                    it.copy(lp = LpTabUiModel(isLoading = false, positions = lpPositions))
+                    it.copy(
+                        lp =
+                            LpTabUiModel(
+                                isLoading = false,
+                                positions = lpPositions,
+                                livePoolKeys = livePoolKeys,
+                            )
+                    )
                 }
             }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -140,6 +140,7 @@ constructor(
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val getThorChainLpPositionsUseCase: GetThorChainLpPositionsUseCase,
     private val getThorChainPendingLpDepositsUseCase: GetThorChainPendingLpDepositsUseCase,
+    private val snapshotCache: DeFiPositionsSnapshotCache,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -184,13 +185,23 @@ constructor(
     private var loadBondedNodesJob: Job? = null
     private var loadStakingPositionsJob: Job? = null
 
+    // Pools whose card came from a read that answered. A pool the last read could not resolve
+    // leaves a placeholder standing, and carrying that into the next reload would present a figure
+    // nothing has confirmed while skipping the shimmer that says a read is in flight.
+    private var livePoolKeys: Set<String> = emptySet()
+
     // A caller-supplied tab is applied once and then forgotten: the screen leaves and re-enters
     // composition every time the wallet / DeFi toggle flips, and re-seeding there would throw away
     // whichever tab the user had chosen since.
     private var hasAppliedInitialTab = false
 
+    // Guards the one-shot restore: setData also runs on every pull-to-refresh, and seeding there
+    // would drop whatever the refresh has already published back onto the snapshot.
+    private var hasRestoredSnapshot = false
+
     fun setData(vaultId: VaultId, initialTab: DeFiTab? = null) {
         this.vaultId = vaultId
+        restoreSnapshot(vaultId)
         if (initialTab != null && !hasAppliedInitialTab) {
             hasAppliedInitialTab = true
             state.update { it.copy(selectedTab = initialTab.displayNameRes) }
@@ -202,6 +213,31 @@ constructor(
         loadTotalValue()
         currencyJob?.cancel()
         currencyJob = observeCurrencyChanges()
+    }
+
+    /**
+     * Paints the state this vault's screen was last showing, so a re-entry starts from the cards,
+     * totals and enabled set the user left behind instead of from an empty model whose defaults
+     * would flash RUNE + TCY back on. Everything here is refreshed by the loads [setData] kicks off
+     * straight after; only the position picker is dropped, because a sheet the user closed by
+     * leaving the screen must not reopen itself.
+     */
+    private fun restoreSnapshot(vaultId: VaultId) {
+        if (hasRestoredSnapshot) return
+        hasRestoredSnapshot = true
+        val cached = snapshotCache.read(vaultId, ThorchainDefiPositionsUiModel::class) ?: return
+        state.value =
+            cached.copy(
+                showPositionSelectionDialog = false,
+                tempSelectedPositions = cached.selectedPositions,
+            )
+    }
+
+    override fun onCleared() {
+        if (::vaultId.isInitialized) {
+            snapshotCache.write(vaultId, state.value)
+        }
+        super.onCleared()
     }
 
     private fun loadLpPositionsForDialog(): Job =
@@ -416,6 +452,7 @@ constructor(
                 .drop(1)
                 .collect {
                     resetTotalsToPending()
+                    dropFiatPricedInPreviousCurrency()
 
                     bondedNodesRefreshTrigger.value++
                     loadBondedNodes()
@@ -438,6 +475,31 @@ constructor(
         _totalValueTCYStake.value = null
         _totalValueLpFiat.value = null
         state.update { it.copy(totalAmountPrice = null, isTotalAmountLoading = true) }
+    }
+
+    /**
+     * Drops the fiat the cards carry when the display currency changes.
+     *
+     * Every other reload now leaves settled figures in place and swaps them when the fresh ones
+     * land, which is what stops a re-entry looking like a first open. A currency switch is the one
+     * case where that would be wrong: these strings were formatted for the currency being left, so
+     * they are cleared here and the reload puts each card back on its shimmer until it can price
+     * them again.
+     */
+    private fun dropFiatPricedInPreviousCurrency() {
+        state.update { current ->
+            current.copy(
+                bonded = current.bonded.copy(totalBondedPrice = null),
+                staking =
+                    current.staking.copy(
+                        positions =
+                            current.staking.positions.map { position ->
+                                position.copy(isLoading = true)
+                            }
+                    ),
+                lp = current.lp.copy(positions = emptyList()),
+            )
+        }
     }
 
     /**
@@ -660,7 +722,12 @@ constructor(
                     return@launch
                 }
 
-                state.update { it.copy(bonded = it.bonded.copy(isLoading = true)) }
+                // A total the last load already priced stays on screen while this one runs. The
+                // shimmer belongs to a cold start; re-arming it on every entry and pull is what
+                // made a re-entry look like a first open.
+                state.update {
+                    it.copy(bonded = it.bonded.copy(isLoading = it.bonded.totalBondedPrice == null))
+                }
 
                 // Load selected positions, if disabled then show nothing
                 try {
@@ -790,11 +857,23 @@ constructor(
                     return@launch
                 }
                 val zero = zeroFiat()
+                // Cards the last load already settled stay up while this one runs, and are
+                // replaced in place when it lands; only a position with nothing behind it yet
+                // gets the placeholder. Rebuilding every card from the placeholders is what blanked
+                // the tab on re-entry.
+                // Keyed by coin rather than by selection key: RUJI and its auto-compounding
+                // sRUJI card are both toggled by the one "RUJI" tile, so keying by that would
+                // collapse the two into one and render it twice.
+                val settled =
+                    state.value.staking.positions
+                        .filterNot { it.isLoading }
+                        .associateBy { it.coin.id }
                 val defaultLoadingPositions =
                     loadDefaultStakingPositions()
                         .filter { position -> selectedPositions.contains(position.selectionKey()) }
                         .map { positionUiModel ->
-                            positionUiModel.copy(isLoading = true, stakedFiatDisplay = zero)
+                            settled[positionUiModel.coin.id]
+                                ?: positionUiModel.copy(isLoading = true, stakedFiatDisplay = zero)
                         }
                 state.update {
                     it.copy(staking = StakingTabUiModel(positions = defaultLoadingPositions))
@@ -1149,7 +1228,7 @@ constructor(
         // Dialog dataset hasn't loaded yet (or last fetch failed). Don't run with stale state —
         // loadLpPositionsForDialog calls reloadLpTab again once it succeeds.
         if (pools == null) {
-            state.update { it.copy(lp = it.lp.copy(isLoading = true)) }
+            state.update { it.copy(lp = it.lp.copy(isLoading = it.lp.positions.isEmpty())) }
             ensureAvailablePoolsLoaded()
             return
         }
@@ -1163,7 +1242,7 @@ constructor(
             return
         }
 
-        state.update { it.copy(lp = it.lp.copy(isLoading = true)) }
+        state.update { it.copy(lp = it.lp.copy(isLoading = it.lp.positions.isEmpty())) }
 
         loadLpJob?.cancel()
         loadLpJob =
@@ -1174,9 +1253,20 @@ constructor(
                 val zero = zeroFiat()
                 // Show placeholder cards for each selected pool first — even pools where the user
                 // has no liquidity yet should be visible so the Add button is reachable.
-                val placeholders = selectedPools.map { it.toPlaceholderUiModel(zero) }
+                // Pools the last load already priced keep their card; only a pool with nothing
+                // behind it yet falls back to the placeholder, and the shimmer is raised only for
+                // those — a refresh over cards that already carry figures leaves them readable.
+                val loaded =
+                    state.value.lp.positions
+                        .filter { it.positionKey in livePoolKeys }
+                        .associateBy { it.positionKey }
+                val placeholders =
+                    selectedPools.map { pool ->
+                        loaded[pool.positionKey] ?: pool.toPlaceholderUiModel(zero)
+                    }
+                val isCold = selectedPools.any { loaded[it.positionKey] == null }
                 state.update {
-                    it.copy(lp = it.lp.copy(isLoading = true, positions = placeholders))
+                    it.copy(lp = it.lp.copy(isLoading = isCold, positions = placeholders))
                 }
 
                 try {
@@ -1263,6 +1353,11 @@ constructor(
                             // understate the header total rather than admit a value is missing.
                             LpLegTotal.Unavailable
                         }
+                    livePoolKeys =
+                        selectedPools
+                            .filterNot { it in failedSelectedPools }
+                            .map { it.positionKey }
+                            .toSet()
                     state.update { it.copy(lp = it.lp.copy(isLoading = false, positions = merged)) }
                 } catch (e: Throwable) {
                     if (e is CancellationException) throw e

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -185,11 +185,6 @@ constructor(
     private var loadBondedNodesJob: Job? = null
     private var loadStakingPositionsJob: Job? = null
 
-    // Pools whose card came from a read that answered. A pool the last read could not resolve
-    // leaves a placeholder standing, and carrying that into the next reload would present a figure
-    // nothing has confirmed while skipping the shimmer that says a read is in flight.
-    private var livePoolKeys: Set<String> = emptySet()
-
     // A caller-supplied tab is applied once and then forgotten: the screen leaves and re-enters
     // composition every time the wallet / DeFi toggle flips, and re-seeding there would throw away
     // whichever tab the user had chosen since.
@@ -494,10 +489,10 @@ constructor(
                     current.staking.copy(
                         positions =
                             current.staking.positions.map { position ->
-                                position.copy(isLoading = true)
+                                position.copy(isLoading = true, stakedFiatDisplay = null)
                             }
                     ),
-                lp = current.lp.copy(positions = emptyList()),
+                lp = current.lp.copy(positions = emptyList(), livePoolKeys = emptySet()),
             )
         }
     }
@@ -1237,7 +1232,16 @@ constructor(
 
         if (selectedPools.isEmpty()) {
             loadLpJob?.cancel()
-            state.update { it.copy(lp = it.lp.copy(isLoading = false, positions = emptyList())) }
+            state.update {
+                it.copy(
+                    lp =
+                        it.lp.copy(
+                            isLoading = false,
+                            positions = emptyList(),
+                            livePoolKeys = emptySet(),
+                        )
+                )
+            }
             loadLpJob = viewModelScope.launch { reportLpFiat(BigDecimal.ZERO) }
             return
         }
@@ -1256,9 +1260,10 @@ constructor(
                 // Pools the last load already priced keep their card; only a pool with nothing
                 // behind it yet falls back to the placeholder, and the shimmer is raised only for
                 // those — a refresh over cards that already carry figures leaves them readable.
+                val lpTab = state.value.lp
                 val loaded =
-                    state.value.lp.positions
-                        .filter { it.positionKey in livePoolKeys }
+                    lpTab.positions
+                        .filter { it.positionKey in lpTab.livePoolKeys }
                         .associateBy { it.positionKey }
                 val placeholders =
                     selectedPools.map { pool ->
@@ -1353,12 +1358,21 @@ constructor(
                             // understate the header total rather than admit a value is missing.
                             LpLegTotal.Unavailable
                         }
-                    livePoolKeys =
+                    val livePoolKeys =
                         selectedPools
                             .filterNot { it in failedSelectedPools }
                             .map { it.positionKey }
                             .toSet()
-                    state.update { it.copy(lp = it.lp.copy(isLoading = false, positions = merged)) }
+                    state.update {
+                        it.copy(
+                            lp =
+                                it.lp.copy(
+                                    isLoading = false,
+                                    positions = merged,
+                                    livePoolKeys = livePoolKeys,
+                                )
+                        )
+                    }
                 } catch (e: Throwable) {
                     if (e is CancellationException) throw e
                     Timber.e(e, "Failed to load THORChain LP positions")

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -1270,8 +1270,9 @@ constructor(
                         loaded[pool.positionKey]?.copy(isLoading = false)
                             ?: pool.toPlaceholderUiModel(zero).copy(isLoading = true)
                     }
+                val isCold = selectedPools.any { loaded[it.positionKey] == null }
                 state.update {
-                    it.copy(lp = it.lp.copy(isLoading = false, positions = placeholders))
+                    it.copy(lp = it.lp.copy(isLoading = isCold, positions = placeholders))
                 }
 
                 try {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -1267,11 +1267,11 @@ constructor(
                         .associateBy { it.positionKey }
                 val placeholders =
                     selectedPools.map { pool ->
-                        loaded[pool.positionKey] ?: pool.toPlaceholderUiModel(zero)
+                        loaded[pool.positionKey]?.copy(isLoading = false)
+                            ?: pool.toPlaceholderUiModel(zero).copy(isLoading = true)
                     }
-                val isCold = selectedPools.any { loaded[it.positionKey] == null }
                 state.update {
-                    it.copy(lp = it.lp.copy(isLoading = isCold, positions = placeholders))
+                    it.copy(lp = it.lp.copy(isLoading = false, positions = placeholders))
                 }
 
                 try {
@@ -1286,7 +1286,14 @@ constructor(
                         Timber.e("Vault does not have RUNE coin for LP positions")
                         reportLpFiat(BigDecimal.ZERO)
                         state.update {
-                            it.copy(lp = it.lp.copy(isLoading = false, positions = placeholders))
+                            it.copy(
+                                lp =
+                                    it.lp.copy(
+                                        isLoading = false,
+                                        positions =
+                                            placeholders.map { p -> p.copy(isLoading = false) },
+                                    )
+                            )
                         }
                         return@launch
                     }
@@ -1378,7 +1385,13 @@ constructor(
                     Timber.e(e, "Failed to load THORChain LP positions")
                     reportLpFiat(BigDecimal.ZERO)
                     state.update {
-                        it.copy(lp = it.lp.copy(isLoading = false, positions = placeholders))
+                        it.copy(
+                            lp =
+                                it.lp.copy(
+                                    isLoading = false,
+                                    positions = placeholders.map { p -> p.copy(isLoading = false) },
+                                )
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/TonDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/TonDeFiPositionsViewModel.kt
@@ -90,6 +90,19 @@ internal sealed interface TonDeFiUiState {
 }
 
 /**
+ * Last-known TON staking state for a vault: what the screen rendered, plus the pool it was routing
+ * to. The pool address and staked amount are display/routing context the screen keeps outside its
+ * state, so they travel with it — restoring the card without them would leave Unstake dead if the
+ * refresh that follows fails.
+ */
+@Immutable
+internal data class TonStakingSnapshot(
+    val state: TonDeFiUiState.Success,
+    val poolAddress: String?,
+    val stakedDisplay: String,
+)
+
+/**
  * View-model for the native TON nominator-pool staking position on the DeFi/Earn tab.
  *
  * Reads the account's pools from tonapi, treats the largest as the primary position (mirrors
@@ -108,6 +121,7 @@ constructor(
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
     private val tokenPriceRepository: TokenPriceRepository,
     private val appCurrencyRepository: AppCurrencyRepository,
+    private val snapshotCache: DeFiPositionsSnapshotCache,
     private val navigator: Navigator<Destination>,
 ) : ViewModel() {
 
@@ -122,9 +136,48 @@ constructor(
     private var cachedStakedDisplay: String = ""
     private var loadJob: Job? = null
 
+    // Guards the one-shot restore: the screen calls setData on every resume, and seeding there
+    // would drop whatever the last load published back onto the snapshot.
+    private var hasRestoredSnapshot = false
+
     fun setData(vaultId: VaultId) {
         this.vaultId = vaultId
+        restoreSnapshot(vaultId)
         loadData(vaultId)
+    }
+
+    /**
+     * Paints the card this vault last showed instead of the first-open skeleton. The reload
+     * [setData] starts right after replaces it, and holds Stake/Unstake closed while it runs — see
+     * [isActionLocked] — so nothing is ever staged off the restored figures.
+     */
+    private fun restoreSnapshot(vaultId: VaultId) {
+        if (hasRestoredSnapshot) return
+        hasRestoredSnapshot = true
+        val cached = snapshotCache.read(vaultId, TonStakingSnapshot::class) ?: return
+        cachedPoolAddress = cached.poolAddress
+        cachedStakedDisplay = cached.stakedDisplay
+        _state.value =
+            cached.state.copy(
+                isReloading = false,
+                showPositionSelectionDialog = false,
+                tempSelectedPositions = cached.state.selectedPositions,
+            )
+    }
+
+    override fun onCleared() {
+        val success = _state.value as? TonDeFiUiState.Success
+        if (vaultId.isNotEmpty() && success != null) {
+            snapshotCache.write(
+                vaultId,
+                TonStakingSnapshot(
+                    state = success,
+                    poolAddress = cachedPoolAddress,
+                    stakedDisplay = cachedStakedDisplay,
+                ),
+            )
+        }
+        super.onCleared()
     }
 
     fun refresh() {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/LpTabComponents.kt
@@ -58,7 +58,7 @@ internal fun LpTabContent(
         state.positions.forEach { lpPosition ->
             LpWidget(
                 state = lpPosition,
-                isLoading = state.isLoading,
+                isLoading = lpPosition.isLoading,
                 onClickAdd = { onClickAdd(lpPosition.positionKey) },
                 onClickRemove = { onClickRemove(lpPosition.positionKey) },
             )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModel.kt
@@ -24,6 +24,7 @@ import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.utils.toValue
 import com.vultisig.wallet.ui.components.v2.snackbar.SnackbarType
+import com.vultisig.wallet.ui.models.defi.DeFiPositionsSnapshotCache
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -53,6 +54,13 @@ import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
+/**
+ * Last-known Circle state for a vault: what the screen rendered, plus the MSCA account it was
+ * routing withdrawals to. The address is held outside the state, so it travels with it — restoring
+ * an open account without it would leave Withdraw dead until the reload lands.
+ */
+internal data class CircleDeFiSnapshot(val model: DefiUiModel, val mscaAddress: String?)
+
 /** ViewModel for the Circle USDC DeFi positions screen. */
 @HiltViewModel
 internal class CircleDeFiPositionsViewModel
@@ -69,6 +77,7 @@ constructor(
     private val tokenPriceRepository: TokenPriceRepository,
     private val appCurrencyRepository: AppCurrencyRepository,
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
+    private val snapshotCache: DeFiPositionsSnapshotCache,
     @ApplicationContext private val context: Context,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -76,6 +85,9 @@ constructor(
     private lateinit var vaultId: String
     private var mscaAddress: String? = null
     private var loadJob: Job? = null
+
+    // Guards the one-shot restore, so a later setData cannot seed over a rendered load.
+    private var hasRestoredSnapshot = false
 
     private val _state =
         MutableStateFlow(
@@ -98,9 +110,33 @@ constructor(
     /** Initializes the ViewModel with [vaultId] and starts loading positions. */
     fun setData(vaultId: String) {
         this.vaultId = vaultId
+        restoreSnapshot(vaultId)
         loadBalanceVisibility()
         loadAccountStatus()
         loadCirclePositions()
+    }
+
+    /**
+     * Paints the deposit this vault last showed instead of the banner's loading state. The load
+     * [setData] starts right after re-reads the account and the balance, so a restored figure only
+     * stands for as long as the network takes to answer.
+     */
+    private fun restoreSnapshot(vaultId: String) {
+        if (hasRestoredSnapshot) return
+        hasRestoredSnapshot = true
+        val cached = snapshotCache.read(vaultId, CircleDeFiSnapshot::class) ?: return
+        mscaAddress = cached.mscaAddress
+        _state.value = cached.model
+    }
+
+    override fun onCleared() {
+        if (::vaultId.isInitialized) {
+            snapshotCache.write(
+                vaultId,
+                CircleDeFiSnapshot(model = _state.value, mscaAddress = mscaAddress),
+            )
+        }
+        super.onCleared()
     }
 
     /** Triggers a user-initiated pull-to-refresh; resets [isRefreshing] when complete. */
@@ -144,12 +180,17 @@ constructor(
         loadJob =
             viewModelScope.launch {
                 try {
-                    // Initial UI
+                    // Only cold-start into the loading state. A screen already showing a deposit —
+                    // restored from the snapshot, or refreshed by a pull — keeps its figures while
+                    // this read runs, rather than blanking a position the user holds for the
+                    // duration of a network call.
                     _state.update { currentState ->
-                        currentState.copy(
-                            isTotalAmountLoading = true,
-                            circleDefi = currentState.circleDefi.copy(isLoading = true),
-                        )
+                        if (currentState.totalAmountPrice != null) currentState
+                        else
+                            currentState.copy(
+                                isTotalAmountLoading = true,
+                                circleDefi = currentState.circleDefi.copy(isLoading = true),
+                            )
                     }
 
                     // Check account exists

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModel.kt
@@ -19,6 +19,7 @@ import com.vultisig.wallet.data.repositories.KaminoVaultSelectionRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.models.defi.DeFiPositionsSnapshotCache
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -46,6 +47,18 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
+ * Last-known Kamino Earn state for a vault, together with the two facts that say what its figures
+ * still answer: the enabled set the total was summed over, and the currency the cards were priced
+ * in. Restoring the model without them would have the next load drop the total on sight, which is
+ * the flash this exists to remove.
+ */
+internal data class KaminoEarnSnapshot(
+    val model: KaminoEarnUiModel,
+    val totalCoverage: Set<String>,
+    val pricedCurrency: AppCurrency?,
+)
+
+/**
  * Drives the Kamino Earn segment of the Solana DeFi tab.
  *
  * Cards are gated on the per-vault opt-in and, once enabled, always render: a vault with no deposit
@@ -65,6 +78,7 @@ constructor(
     private val tokenPriceRepository: TokenPriceRepository,
     private val appCurrencyRepository: AppCurrencyRepository,
     private val balanceVisibilityRepository: BalanceVisibilityRepository,
+    private val snapshotCache: DeFiPositionsSnapshotCache,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
@@ -89,11 +103,46 @@ constructor(
      */
     private var pricedCurrency: AppCurrency? = null
 
+    // Guards the one-shot restore: the screen calls setData on every resume, and seeding there
+    // would drop whatever the last load published back onto the snapshot.
+    private var hasRestoredSnapshot = false
+
     fun setData(vaultId: String) {
         this.vaultId = vaultId
+        restoreSnapshot(vaultId)
         forgetStoredShareTokens()
         loadBalanceVisibility()
         observeSelectionAndCurrency()
+    }
+
+    /**
+     * Paints the cards this vault last showed instead of cold-starting the tab — which, since Earn
+     * is the tab the Solana screen opens on, is the wait every re-entry pays. The reload
+     * [observeSelectionAndCurrency] starts on its first emission replaces them, and drops whatever
+     * a currency switch or a changed selection has invalidated. The picker is deliberately left
+     * closed: a sheet the user dismissed by leaving the screen must not reopen itself.
+     */
+    private fun restoreSnapshot(vaultId: String) {
+        if (hasRestoredSnapshot) return
+        hasRestoredSnapshot = true
+        val cached = snapshotCache.read(vaultId, KaminoEarnSnapshot::class) ?: return
+        totalCoverage = cached.totalCoverage
+        pricedCurrency = cached.pricedCurrency
+        _state.value = cached.model.copy(isShowingPicker = false, pendingSelection = emptySet())
+    }
+
+    override fun onCleared() {
+        if (::vaultId.isInitialized) {
+            snapshotCache.write(
+                vaultId,
+                KaminoEarnSnapshot(
+                    model = _state.value,
+                    totalCoverage = totalCoverage,
+                    pricedCurrency = pricedCurrency,
+                ),
+            )
+        }
+        super.onCleared()
     }
 
     /**

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/DeFiPositionsSnapshotCacheTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/DeFiPositionsSnapshotCacheTest.kt
@@ -1,0 +1,65 @@
+package com.vultisig.wallet.ui.models.defi
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class DeFiPositionsSnapshotCacheTest {
+
+    private data class Alpha(val value: String)
+
+    private data class Beta(val value: Int)
+
+    private val cache = DeFiPositionsSnapshotCache()
+
+    @Test
+    fun `reads back what it was handed for that vault`() {
+        cache.write(VAULT_A, Alpha("thor"))
+
+        cache.read(VAULT_A, Alpha::class) shouldBe Alpha("thor")
+    }
+
+    @Test
+    fun `a vault with no snapshot reads null`() {
+        cache.read(VAULT_A, Alpha::class) shouldBe null
+    }
+
+    @Test
+    fun `vaults do not share a snapshot`() {
+        cache.write(VAULT_A, Alpha("thor"))
+        cache.write(VAULT_B, Alpha("maya"))
+
+        cache.read(VAULT_A, Alpha::class) shouldBe Alpha("thor")
+        cache.read(VAULT_B, Alpha::class) shouldBe Alpha("maya")
+    }
+
+    @Test
+    fun `two screens on one vault keep separate snapshots`() {
+        // The Solana screen runs two view-models against the same vault; neither may overwrite the
+        // other's snapshot.
+        cache.write(VAULT_A, Alpha("staking"))
+        cache.write(VAULT_A, Beta(7))
+
+        cache.read(VAULT_A, Alpha::class) shouldBe Alpha("staking")
+        cache.read(VAULT_A, Beta::class) shouldBe Beta(7)
+    }
+
+    @Test
+    fun `a read can only hand back the type it asked for`() {
+        cache.write(VAULT_A, Alpha("thor"))
+
+        cache.read(VAULT_A, Beta::class) shouldBe null
+    }
+
+    @Test
+    fun `a later write replaces the snapshot`() {
+        cache.write(VAULT_A, Alpha("stale"))
+        cache.write(VAULT_A, Alpha("fresh"))
+
+        cache.read(VAULT_A, Alpha::class) shouldBe Alpha("fresh")
+    }
+
+    private companion object {
+        const val VAULT_A = "vault-a"
+        const val VAULT_B = "vault-b"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/DeFiSnapshotTestSupport.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/DeFiSnapshotTestSupport.kt
@@ -1,0 +1,14 @@
+package com.vultisig.wallet.ui.models.defi
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+
+/**
+ * Runs the real teardown a nav pop performs — the moment every DeFi detail view-model hands its
+ * state to [DeFiPositionsSnapshotCache] — by putting the view-model in a store and clearing it.
+ * `onCleared` is protected, so a test cannot call it directly, and stubbing the write instead would
+ * test the mock rather than the lifecycle.
+ */
+internal fun ViewModel.clearForTest() {
+    ViewModelStore().apply { put("vm", this@clearForTest) }.clear()
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
@@ -961,6 +961,26 @@ internal class MayachainDefiPositionsViewModelTest {
     }
 
     @Test
+    fun `a re-entry leaves the cached LP cards up instead of zeroing them`() = runTest {
+        // The snapshot brings the cards back, but the set naming which of them a read actually
+        // answered used to live in the view-model. A re-entry started that set empty, so the first
+        // reload swapped every restored card for a zero placeholder until the network answered.
+        selectPositions(MAYA_BOND_CACAO_KEY, MAYA_STAKE_CACAO_KEY, BTC_POOL)
+        givenLpPool(liquidityUnits = "100", units = "1000")
+        createViewModel().also { it.setData(VAULT_ID) }.clearForTest()
+
+        // The re-entry's own read never answers, so what is on screen is what the cache restored.
+        coEvery { mayachainBondRepository.getMemberDetails(CACAO_ADDRESS) } coAnswers
+            {
+                awaitCancellation()
+            }
+        val lp = successData(createViewModel().also { it.setData(VAULT_ID) }).lp
+
+        assertFalse(lp.isLoading, "a restored LP card must not go back to its shimmer")
+        assertEquals("$0.40", lp.positions.single().totalPriceLp)
+    }
+
+    @Test
     fun `a re-entry does not reopen the position picker`() = runTest {
         snapshotCache.write(VAULT_ID, LAST_RENDERED.copy(showPositionSelectionDialog = true))
         neverAnswersSelection()

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/MayachainDefiPositionsViewModelTest.kt
@@ -79,6 +79,8 @@ internal class MayachainDefiPositionsViewModelTest {
     private lateinit var appCurrencyRepository: AppCurrencyRepository
     private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
     private lateinit var defiPositionsRepository: DefiPositionsRepository
+    // The real cache, not a mock: these tests assert the round trip a nav pop and a re-entry make.
+    private lateinit var snapshotCache: DeFiPositionsSnapshotCache
 
     @BeforeEach
     fun setUp() {
@@ -93,6 +95,7 @@ internal class MayachainDefiPositionsViewModelTest {
         appCurrencyRepository = mockk(relaxed = true)
         balanceVisibilityRepository = mockk(relaxed = true)
         defiPositionsRepository = mockk(relaxed = true)
+        snapshotCache = DeFiPositionsSnapshotCache()
 
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
@@ -899,6 +902,93 @@ internal class MayachainDefiPositionsViewModelTest {
         data.totalAmountPrice shouldBe settled.totalAmountPrice
     }
 
+    @Test
+    fun `a refresh leaves the settled bonded total up instead of blanking it`() = runTest {
+        coEvery { bondUseCase.getActiveNodes(VAULT_ID, CACAO_ADDRESS) } returns
+            flowOf(listOf(bondedNode(amount = HUNDRED_CACAO)))
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        assertEquals("$200.00", successData(vm).bonded.totalBondedPrice)
+
+        // The refresh never answers, so what is on screen is what the previous load left.
+        coEvery { bondUseCase.getActiveNodes(VAULT_ID, CACAO_ADDRESS) } returns
+            flow { awaitCancellation() }
+        vm.setData(VAULT_ID)
+
+        val bonded = successData(vm).bonded
+        assertFalse(bonded.isLoading, "a priced total must not go back to its shimmer on a refresh")
+        assertEquals("100.00000000 CACAO", bonded.totalBondedAmount)
+        assertEquals("$200.00", bonded.totalBondedPrice)
+    }
+
+    @Test
+    fun `a refresh leaves the settled staking card up instead of replacing it`() = runTest {
+        coEvery { mayaCacaoStakingService.getStakingDetails(CACAO_ADDRESS) } returns
+            flowOf(
+                MayaCacaoStakingDetails(stakeAmount = FIFTY_CACAO, apr = null, canUnstake = true)
+            )
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        val settled = successData(vm).staking.positions.single()
+        assertFalse(settled.isLoading)
+
+        // The refresh never answers, so what is on screen is what the previous load left.
+        coEvery { mayaCacaoStakingService.getStakingDetails(CACAO_ADDRESS) } returns
+            flow { awaitCancellation() }
+        vm.setData(VAULT_ID)
+
+        val position = successData(vm).staking.positions.single()
+        assertFalse(position.isLoading, "a settled card must not be swapped for a placeholder")
+        assertEquals(settled.stakedAmountDisplay, position.stakedAmountDisplay)
+        assertEquals(settled.stakedFiatDisplay, position.stakedFiatDisplay)
+    }
+
+    @Test
+    fun `a re-entry paints the state the screen was last showing`() = runTest {
+        // Popping back to the DeFi list destroys this view-model, so the next open used to
+        // cold-start: zeroed cards, header on a spinner, and the enabled set flashing back to the
+        // CACAO defaults until the store answered.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        neverAnswersSelection()
+
+        val data = successData(createViewModel().also { it.setData(VAULT_ID) })
+
+        assertEquals("$12.34", data.totalAmountPrice)
+        assertFalse(data.isTotalAmountLoading)
+        assertEquals("5 CACAO", data.bonded.totalBondedAmount)
+        // An empty selection is a choice the user made, and it survives the re-entry rather than
+        // being replaced by the defaults.
+        assertEquals(emptyList(), data.selectedPositions)
+        assertEquals(data.selectedPositions, data.tempSelectedPositions)
+    }
+
+    @Test
+    fun `a re-entry does not reopen the position picker`() = runTest {
+        snapshotCache.write(VAULT_ID, LAST_RENDERED.copy(showPositionSelectionDialog = true))
+        neverAnswersSelection()
+
+        val data = successData(createViewModel().also { it.setData(VAULT_ID) })
+
+        assertFalse(data.showPositionSelectionDialog)
+    }
+
+    @Test
+    fun `hands the rendered state to the cache when the screen is popped`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        val rendered = successData(vm)
+
+        vm.clearForTest()
+
+        assertEquals(rendered, snapshotCache.read(VAULT_ID, MayachainDefiPositionsUiModel::class))
+    }
+
+    /**
+     * Leaves the saved-selection read suspended, so nothing the loads do can overwrite a restored
+     * snapshot while the assertion runs.
+     */
+    private fun neverAnswersSelection() {
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
+            flow { awaitCancellation() }
+    }
+
     private fun selectPositions(vararg keys: String) {
         coEvery { defiPositionsRepository.getSelectedPositions(Chain.MayaChain, VAULT_ID) } returns
             flowOf(keys.toSet())
@@ -982,10 +1072,22 @@ internal class MayachainDefiPositionsViewModelTest {
             // Real calculator over the mocked price repository: the fiat assertions below stay
             // end-to-end rather than asserting against a stubbed conversion.
             fiatValueCalculator = DefiFiatValueCalculator(tokenPriceRepository),
+            snapshotCache = snapshotCache,
             ioDispatcher = testDispatcher,
         )
 
     private companion object {
+        /** A settled screen, as the cache would have it after the user walked away from one. */
+        val LAST_RENDERED =
+            MayachainDefiPositionsUiModel(
+                totalAmountPrice = "$12.34",
+                isTotalAmountLoading = false,
+                bonded =
+                    BondedTabUiModel(totalBondedAmount = "5 CACAO", totalBondedPrice = "$10.00"),
+                selectedPositions = emptyList(),
+                tempSelectedPositions = emptyList(),
+            )
+
         const val VAULT_ID = "vault-1"
         const val CACAO_ADDRESS = "maya1cacaoaddress"
         const val NODE_ADDRESS = "maya1qwertyuiopasdfgh"

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -92,6 +92,8 @@ internal class ThorchainDefiPositionsViewModelTest {
     private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
     private lateinit var getThorChainLpPositionsUseCase: GetThorChainLpPositionsUseCase
     private lateinit var getThorChainPendingLpDepositsUseCase: GetThorChainPendingLpDepositsUseCase
+    // The real cache, not a mock: these tests assert the round trip a nav pop and a re-entry make.
+    private lateinit var snapshotCache: DeFiPositionsSnapshotCache
 
     @BeforeEach
     fun setUp() {
@@ -112,6 +114,7 @@ internal class ThorchainDefiPositionsViewModelTest {
         balanceVisibilityRepository = mockk(relaxed = true)
         getThorChainLpPositionsUseCase = mockk(relaxed = true)
         getThorChainPendingLpDepositsUseCase = mockk(relaxed = true)
+        snapshotCache = DeFiPositionsSnapshotCache()
 
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
@@ -1233,6 +1236,198 @@ internal class ThorchainDefiPositionsViewModelTest {
         vm.state.value.selectedPositions shouldBe defaultSelectedPositionsDialog()
     }
 
+    @Test
+    fun `a refresh leaves the settled bonded total up instead of blanking it`() = runTest {
+        selectPositions("RUNE")
+        coEvery { bondUseCase.getActiveNodes(VAULT_ID, RUNE_ADDRESS) } returns
+            flowOf(listOf(bondedNode(BigInteger("1000000000"))))
+        val viewModel = createViewModel().also { it.setData(VAULT_ID) }
+        assertEquals("$20.00", viewModel.state.value.bonded.totalBondedPrice)
+
+        // The refresh never answers, so what is on screen is what the previous load left.
+        coEvery { bondUseCase.getActiveNodes(VAULT_ID, RUNE_ADDRESS) } returns
+            flow { awaitCancellation() }
+        viewModel.setData(VAULT_ID)
+
+        val bonded = viewModel.state.value.bonded
+        assertFalse(bonded.isLoading, "a priced total must not go back to its shimmer on a refresh")
+        assertEquals("10.00000000 RUNE", bonded.totalBondedAmount)
+        assertEquals("$20.00", bonded.totalBondedPrice)
+    }
+
+    @Test
+    fun `a refresh leaves the settled staking cards up instead of replacing them`() = runTest {
+        selectPositions("TCY")
+        coEvery { tcyStakingService.getStakingDetails(any(), any()) } returns
+            flowOf(stakingDetails(Coins.ThorChain.TCY, BigInteger("500000000")))
+        val viewModel = createViewModel().also { it.setData(VAULT_ID) }
+        val settled = viewModel.state.value.staking.positions.single()
+        assertFalse(settled.isLoading)
+
+        // The refresh never answers, so what is on screen is what the previous load left.
+        coEvery { tcyStakingService.getStakingDetails(any(), any()) } returns
+            flow { awaitCancellation() }
+        viewModel.setData(VAULT_ID)
+
+        val position = viewModel.state.value.staking.positions.single()
+        assertFalse(position.isLoading, "a settled card must not be swapped for a placeholder")
+        assertEquals(settled.stakedAmountDisplay, position.stakedAmountDisplay)
+        assertEquals(settled.stakedFiatDisplay, position.stakedFiatDisplay)
+    }
+
+    @Test
+    fun `a refresh leaves the settled LP cards up instead of blanking them`() = runTest {
+        selectPositions(BTC_POOL)
+        coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } returns
+            listOf(poolStats(BTC_POOL))
+        coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } returns
+            ThorChainLpPositions(
+                listOf(lpPosition(BTC_POOL, runeRedeem = "300000000", assetRedeem = "100000000"))
+            )
+        val viewModel = createViewModel().also { it.setData(VAULT_ID) }
+        viewModel.state.value.lp.positions.single().totalPriceLp shouldBe "$8.00"
+
+        // The refresh never answers, so what is on screen is what the previous load left.
+        coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } coAnswers
+            {
+                awaitCancellation()
+            }
+        viewModel.setData(VAULT_ID)
+
+        val lp = viewModel.state.value.lp
+        assertFalse(lp.isLoading, "a priced LP card must not go back to its shimmer on a refresh")
+        lp.positions.single().totalPriceLp shouldBe "$8.00"
+    }
+
+    @Test
+    fun `a refresh keeps the two RUJI cards apart`() = runTest {
+        // RUJI and its auto-compounding sRUJI card share the one "RUJI" tile in Manage Positions,
+        // so a refresh that matched settled cards on that key would render the bonded card twice
+        // and drop the compounding one.
+        selectPositions("RUJI")
+        coEvery { rujiStakingService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flowOf(
+                listOf(
+                    stakingDetails(
+                        coin = Coins.ThorChain.RUJI,
+                        stakeAmount = BigInteger("500000000"),
+                    ),
+                    stakingDetails(
+                        coin = Coins.ThorChain.sRUJI,
+                        stakeAmount = BigInteger("300000000"),
+                    ),
+                )
+            )
+        val viewModel = createViewModel().also { it.setData(VAULT_ID) }
+        assertEquals(2, viewModel.state.value.staking.positions.size)
+
+        // The refresh never answers, so what is on screen is what the previous load left.
+        coEvery { rujiStakingService.getStakingDetails(RUNE_ADDRESS, VAULT_ID) } returns
+            flow { awaitCancellation() }
+        viewModel.setData(VAULT_ID)
+
+        val positions = viewModel.state.value.staking.positions
+        assertEquals(listOf(RUJI_ID, Coins.ThorChain.sRUJI.id), positions.map { it.coin.id })
+        assertEquals("5 RUJI", positions.first().stakedAmountDisplay)
+        assertEquals("3 RUJI", positions.last().stakedAmountDisplay)
+    }
+
+    @Test
+    fun `a reload after a failed LP read shimmers instead of standing on the placeholders`() =
+        runTest {
+            // A failed read leaves zeroed placeholder cards on screen. Carrying those into the
+            // next reload as though they were settled would present a figure nothing confirmed and
+            // hide the fact that a read is in flight.
+            selectPositions(BTC_POOL)
+            coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } returns
+                listOf(poolStats(BTC_POOL))
+            coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } throws
+                RuntimeException("midgard down")
+            val viewModel = createViewModel().also { it.setData(VAULT_ID) }
+            viewModel.state.value.lp.isLoading shouldBe false
+
+            coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } coAnswers
+                {
+                    awaitCancellation()
+                }
+            viewModel.setData(VAULT_ID)
+
+            viewModel.state.value.lp.isLoading shouldBe true
+        }
+
+    @Test
+    fun `a re-entry paints the state the screen was last showing`() = runTest {
+        // Popping back to the DeFi list destroys this view-model, so the next open used to
+        // cold-start: empty cards, header on a spinner, and the enabled set flashing back to the
+        // RUNE + TCY defaults until the store answered.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        neverAnswersSelection()
+
+        val model = createViewModel().also { it.setData(VAULT_ID) }.state.value
+
+        model.totalAmountPrice shouldBe "$12.34"
+        model.isTotalAmountLoading shouldBe false
+        model.bonded.totalBondedAmount shouldBe "5 RUNE"
+        // An empty selection is a choice the user made, and it survives the re-entry rather than
+        // being replaced by the defaults.
+        model.selectedPositions shouldBe emptyList()
+        model.selectedPositions shouldBe model.tempSelectedPositions
+    }
+
+    @Test
+    fun `a re-entry does not reopen the position picker`() = runTest {
+        snapshotCache.write(VAULT_ID, LAST_RENDERED.copy(showPositionSelectionDialog = true))
+        neverAnswersSelection()
+
+        val model = createViewModel().also { it.setData(VAULT_ID) }.state.value
+
+        model.showPositionSelectionDialog shouldBe false
+    }
+
+    @Test
+    fun `the first open with nothing cached still starts from the defaults`() = runTest {
+        neverAnswersSelection()
+
+        val model = createViewModel().also { it.setData(VAULT_ID) }.state.value
+
+        model.selectedPositions shouldBe defaultSelectedPositionsDialog()
+    }
+
+    @Test
+    fun `hands the rendered state to the cache when the screen is popped`() = runTest {
+        selectPositions("RUNE")
+        val viewModel = createViewModel().also { it.setData(VAULT_ID) }
+        val rendered = viewModel.state.value
+
+        viewModel.clearForTest()
+
+        snapshotCache.read(VAULT_ID, ThorchainDefiPositionsUiModel::class) shouldBe rendered
+    }
+
+    @Test
+    fun `a pull-to-refresh does not seed the older snapshot back over the screen`() = runTest {
+        // setData is also the refresh entry point, so the restore has to be one-shot: seeding on
+        // every call would drop what the screen has already loaded.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        selectPositions("RUNE")
+        val viewModel = createViewModel().also { it.setData(VAULT_ID) }
+        viewModel.state.value.selectedPositions shouldBe listOf("RUNE")
+
+        neverAnswersSelection()
+        viewModel.setData(VAULT_ID)
+
+        viewModel.state.value.selectedPositions shouldBe listOf("RUNE")
+    }
+
+    /**
+     * Leaves the saved-selection read suspended, so nothing the loads do can overwrite a restored
+     * snapshot while the assertion runs.
+     */
+    private fun neverAnswersSelection() {
+        coEvery { defiPositionsRepository.getSelectedPositions(Chain.ThorChain, VAULT_ID) } returns
+            flow { awaitCancellation() }
+    }
+
     private fun selectPositions(vararg keys: String) {
         coEvery { defiPositionsRepository.getSelectedPositions(Chain.ThorChain, VAULT_ID) } returns
             flowOf(keys.toSet())
@@ -1304,10 +1499,22 @@ internal class ThorchainDefiPositionsViewModelTest {
             balanceVisibilityRepository = balanceVisibilityRepository,
             getThorChainLpPositionsUseCase = getThorChainLpPositionsUseCase,
             getThorChainPendingLpDepositsUseCase = getThorChainPendingLpDepositsUseCase,
+            snapshotCache = snapshotCache,
             ioDispatcher = testDispatcher,
         )
 
     private companion object {
+        /** A settled screen, as the cache would have it after the user walked away from one. */
+        val LAST_RENDERED =
+            ThorchainDefiPositionsUiModel(
+                totalAmountPrice = "$12.34",
+                isTotalAmountLoading = false,
+                bonded =
+                    BondedTabUiModel(totalBondedAmount = "5 RUNE", totalBondedPrice = "$10.00"),
+                selectedPositions = emptyList(),
+                tempSelectedPositions = emptyList(),
+            )
+
         const val VAULT_ID = "vault-1"
         const val RUNE_ADDRESS = "thor1runeaddress"
         const val RUJI_ADDRESS = "thor1rujiaddress"

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -1356,6 +1356,32 @@ internal class ThorchainDefiPositionsViewModelTest {
         }
 
     @Test
+    fun `a re-entry leaves the cached LP cards up instead of shimmering them`() = runTest {
+        // The snapshot brings the cards back, but the set naming which of them a read actually
+        // answered used to live in the view-model. A re-entry started that set empty, so the first
+        // reload rejected every restored card and put the tab back on the shimmer the cache exists
+        // to remove.
+        selectPositions(BTC_POOL)
+        coEvery { getThorChainLpPositionsUseCase.fetchAvailablePools(any()) } returns
+            listOf(poolStats(BTC_POOL))
+        coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } returns
+            ThorChainLpPositions(
+                listOf(lpPosition(BTC_POOL, runeRedeem = "300000000", assetRedeem = "100000000"))
+            )
+        createViewModel().also { it.setData(VAULT_ID) }.clearForTest()
+
+        // The re-entry's own read never answers, so what is on screen is what the cache restored.
+        coEvery { getThorChainLpPositionsUseCase(any(), any(), any(), any()) } coAnswers
+            {
+                awaitCancellation()
+            }
+        val lp = createViewModel().also { it.setData(VAULT_ID) }.state.value.lp
+
+        assertFalse(lp.isLoading, "a restored LP card must not go back to its shimmer")
+        lp.positions.single().totalPriceLp shouldBe "$8.00"
+    }
+
+    @Test
     fun `a re-entry paints the state the screen was last showing`() = runTest {
         // Popping back to the DeFi list destroys this view-model, so the next open used to
         // cold-start: empty cards, header on a spinner, and the enabled set flashing back to the

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/TonDeFiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/TonDeFiPositionsViewModelTest.kt
@@ -23,6 +23,7 @@ import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -45,6 +46,8 @@ internal class TonDeFiPositionsViewModelTest {
     private lateinit var tokenPriceRepository: TokenPriceRepository
     private lateinit var appCurrencyRepository: AppCurrencyRepository
     private lateinit var navigator: Navigator<Destination>
+    // The real cache, not a mock: these tests assert the round trip a nav pop and a re-entry make.
+    private lateinit var snapshotCache: DeFiPositionsSnapshotCache
 
     @BeforeEach
     fun setUp() {
@@ -55,6 +58,7 @@ internal class TonDeFiPositionsViewModelTest {
         tokenPriceRepository = mockk(relaxed = true)
         appCurrencyRepository = mockk(relaxed = true)
         navigator = mockk(relaxed = true)
+        snapshotCache = DeFiPositionsSnapshotCache()
 
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
@@ -228,6 +232,60 @@ internal class TonDeFiPositionsViewModelTest {
             }
         }
 
+    @Test
+    fun `a re-entry paints the card the screen was last showing`() = runTest {
+        // Popping back to the DeFi list destroys this view-model; without a snapshot the next open
+        // sits on the first-open skeleton for as long as tonapi takes.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        // Suspend the network so the only state on screen is the restored one.
+        coEvery { tonStakingApi.getNominatorPools(TON_ADDRESS) } coAnswers
+            {
+                CompletableDeferred<List<TonAccountStakingInfoJson>>().await()
+            }
+
+        val state = createViewModel().also { it.setData(VAULT_ID) }.state.value
+
+        assertTrue(state is TonDeFiUiState.Success, "expected Success, was $state")
+        assertEquals("50 GRAM", state.tonData.stakedDisplay)
+        assertEquals("Whales", state.tonData.poolName)
+        assertTrue(state.tonData.hasPosition)
+    }
+
+    @Test
+    fun `a re-entry keeps the pool it was routing to when the refresh fails`() = runTest {
+        // The pool address lives outside the state, so it has to travel with the snapshot —
+        // otherwise a restored card offers an Unstake that silently does nothing.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        coEvery { tonStakingApi.getNominatorPools(TON_ADDRESS) } throws
+            RuntimeException("network down")
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        vm.onUnstake()
+
+        coVerify(exactly = 1) {
+            navigator.route(
+                Route.TonUnstake(vaultId = VAULT_ID, poolAddress = POOL, stakedDisplay = "50 GRAM")
+            )
+        }
+    }
+
+    @Test
+    fun `hands the rendered card to the cache when the screen is popped`() = runTest {
+        coEvery { tonStakingApi.getNominatorPools(TON_ADDRESS) } returns
+            listOf(TonAccountStakingInfoJson(pool = POOL, amount = 50_000_000_000L))
+        coEvery { tonStakingApi.getStakingPool(POOL) } returns
+            TonStakingPoolInfoJson(name = "Whales", apy = 5.0)
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        val rendered = vm.state.value as TonDeFiUiState.Success
+
+        vm.clearForTest()
+
+        assertEquals(
+            TonStakingSnapshot(state = rendered, poolAddress = POOL, stakedDisplay = "50 GRAM"),
+            snapshotCache.read(VAULT_ID, TonStakingSnapshot::class),
+        )
+    }
+
     private fun createViewModel(): TonDeFiPositionsViewModel =
         TonDeFiPositionsViewModel(
             vaultRepository = vaultRepository,
@@ -235,10 +293,30 @@ internal class TonDeFiPositionsViewModelTest {
             balanceVisibilityRepository = balanceVisibilityRepository,
             tokenPriceRepository = tokenPriceRepository,
             appCurrencyRepository = appCurrencyRepository,
+            snapshotCache = snapshotCache,
             navigator = navigator,
         )
 
     private companion object {
+        /** A settled screen, as the cache would have it after the user walked away from one. */
+        val LAST_RENDERED =
+            TonStakingSnapshot(
+                state =
+                    TonDeFiUiState.Success(
+                        tonData =
+                            TonStakingUiModel(
+                                totalAmountPrice = "$100.00",
+                                ticker = "TON",
+                                poolName = "Whales",
+                                stakedDisplay = "50 GRAM",
+                                stakedFiatDisplay = "$100.00",
+                                hasPosition = true,
+                            )
+                    ),
+                poolAddress = POOL,
+                stakedDisplay = "50 GRAM",
+            )
+
         const val VAULT_ID = "vault-1"
         const val TON_ADDRESS = "UQtonAddress"
         const val POOL = "0:a45b17f28409229b78360e3290420f13e4fe20f90d7e2bf8c4ac6703259e22fa"

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/circle/CircleDeFiPositionsViewModelTest.kt
@@ -15,8 +15,12 @@ import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.ui.components.v2.snackbar.SnackbarType
+import com.vultisig.wallet.ui.models.defi.DeFiPositionsSnapshotCache
+import com.vultisig.wallet.ui.models.defi.clearForTest
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import com.vultisig.wallet.ui.screens.v2.defi.model.DefiUiModel
 import com.vultisig.wallet.ui.utils.SnackbarFlow
 import io.mockk.Runs
 import io.mockk.clearMocks
@@ -30,6 +34,7 @@ import java.util.Locale
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -57,6 +62,8 @@ internal class CircleDeFiPositionsViewModelTest {
     private lateinit var appCurrencyRepository: AppCurrencyRepository
     private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
     private lateinit var context: Context
+    // The real cache, not a mock: these tests assert the round trip a nav pop and a re-entry make.
+    private lateinit var snapshotCache: DeFiPositionsSnapshotCache
 
     @BeforeEach
     fun setUp() {
@@ -73,6 +80,7 @@ internal class CircleDeFiPositionsViewModelTest {
         appCurrencyRepository = mockk(relaxed = true)
         balanceVisibilityRepository = mockk(relaxed = true)
         context = mockk(relaxed = true)
+        snapshotCache = DeFiPositionsSnapshotCache()
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { chainAccountAddressRepository.getAddress(Chain.Ethereum, VAULT) } returns
             (OWNER_ADDRESS to "pubKey")
@@ -186,6 +194,56 @@ internal class CircleDeFiPositionsViewModelTest {
         return captured.captured
     }
 
+    @Test
+    fun `a re-entry paints the deposit the screen was last showing`() = runTest {
+        // Popping back to the DeFi list destroys this view-model; without a snapshot the next open
+        // puts the banner back on its loading state while the account and balance are re-read.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        // Suspend the account read so the only state on screen is the restored one.
+        coEvery { scaCircleAccountRepository.getAccount(VAULT_ID) } coAnswers
+            {
+                CompletableDeferred<String?>().await()
+            }
+
+        val state = createViewModel().also { it.setData(VAULT_ID) }.state.value
+
+        assertEquals("$500.00", state.totalAmountPrice)
+        assertFalse(state.isTotalAmountLoading)
+        assertFalse(state.circleDefi.isLoading)
+        assertEquals("500 USDC", state.circleDefi.totalDeposit)
+    }
+
+    @Test
+    fun `a re-entry keeps the account withdrawals route to`() = runTest {
+        // The MSCA address lives outside the state, so it has to travel with the snapshot —
+        // otherwise a restored open account offers a Withdraw that silently does nothing.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        coEvery { scaCircleAccountRepository.getAccount(VAULT_ID) } coAnswers
+            {
+                CompletableDeferred<String?>().await()
+            }
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        vm.onWithdrawAccount()
+
+        coVerify(exactly = 1) {
+            navigator.route(match<Route.Send> { it.mscaAddress == MSCA_ADDRESS })
+        }
+    }
+
+    @Test
+    fun `hands the rendered state to the cache when the screen is popped`() = runTest {
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+        val rendered = vm.state.value
+
+        vm.clearForTest()
+
+        assertEquals(
+            CircleDeFiSnapshot(model = rendered, mscaAddress = null),
+            snapshotCache.read(VAULT_ID, CircleDeFiSnapshot::class),
+        )
+    }
+
     private fun createViewModel(): CircleDeFiPositionsViewModel =
         CircleDeFiPositionsViewModel(
             navigator = navigator,
@@ -199,11 +257,29 @@ internal class CircleDeFiPositionsViewModelTest {
             tokenPriceRepository = tokenPriceRepository,
             appCurrencyRepository = appCurrencyRepository,
             balanceVisibilityRepository = balanceVisibilityRepository,
+            snapshotCache = snapshotCache,
             context = context,
             ioDispatcher = testDispatcher,
         )
 
     private companion object {
+        /** A settled screen, as the cache would have it after the user walked away from one. */
+        val LAST_RENDERED =
+            CircleDeFiSnapshot(
+                model =
+                    DefiUiModel(
+                        totalAmountPrice = "$500.00",
+                        isTotalAmountLoading = false,
+                        circleDefi =
+                            DefiUiModel.CircleDeFi(
+                                isAccountOpen = true,
+                                totalDeposit = "500 USDC",
+                                totalDepositCurrency = "$500.00",
+                            ),
+                    ),
+                mscaAddress = MSCA_ADDRESS,
+            )
+
         const val VAULT_ID = "vault-1"
         const val OWNER_ADDRESS = "0x087077528E7028f4880e6b9DaD082910b7dfe0d2"
         const val MSCA_ADDRESS = "0xNewMscaAccount"

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -134,15 +134,20 @@ internal class KaminoEarnViewModelTest {
     @Test
     fun `a restored total survives the next load rather than being dropped on sight`() = runTest {
         // The total answers one question — this selection, in this currency — and the coverage it
-        // was summed over travels with it. Without that the load drops it immediately, which is
-        // the flash the snapshot exists to remove.
+        // was summed over travels with it. Without that the load drops it the moment it starts,
+        // which is the flash the snapshot exists to remove.
         snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        // The selection the restored total was summed over, so the load gets far enough to run its
+        // drop check for real; the fan-out behind it is held, so nothing can rebuild the figures
+        // and the total on screen is still the restored one.
         coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
-            flow { awaitCancellation() }
+            flowOf(setOf(STEAKHOUSE.address))
+        coEvery { kaminoApi.getUserPositions(WALLET_ADDRESS) } coAnswers { awaitCancellation() }
 
         val state = viewModel().also { it.setData(VAULT_ID) }.state.value
 
         state.totalValue.shouldNotBeNull().value shouldBe BigDecimal("100")
+        state.rows.single().depositedDisplay shouldBe "100 USDC"
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnViewModelTest.kt
@@ -19,8 +19,11 @@ import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.KaminoVaultSelectionRepository
 import com.vultisig.wallet.data.repositories.TokenPriceRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.ui.models.defi.DeFiPositionsSnapshotCache
+import com.vultisig.wallet.ui.models.defi.clearForTest
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.screens.v2.defi.DefiFiatTotal
 import io.kotest.assertions.withClue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -35,7 +38,9 @@ import java.text.NumberFormat
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -58,6 +63,8 @@ internal class KaminoEarnViewModelTest {
     private lateinit var tokenPriceRepository: TokenPriceRepository
     private lateinit var appCurrencyRepository: AppCurrencyRepository
     private lateinit var balanceVisibilityRepository: BalanceVisibilityRepository
+    // The real cache, not a mock: these tests assert the round trip a nav pop and a re-entry make.
+    private lateinit var snapshotCache: DeFiPositionsSnapshotCache
 
     private val defaultLocale = Locale.getDefault()
 
@@ -75,6 +82,7 @@ internal class KaminoEarnViewModelTest {
         tokenPriceRepository = mockk(relaxed = true)
         appCurrencyRepository = mockk(relaxed = true)
         balanceVisibilityRepository = mockk(relaxed = true)
+        snapshotCache = DeFiPositionsSnapshotCache()
 
         coEvery { vaultRepository.get(VAULT_ID) } returns VAULT
         coEvery { balanceVisibilityRepository.getVisibility(VAULT_ID) } returns true
@@ -102,8 +110,73 @@ internal class KaminoEarnViewModelTest {
             tokenPriceRepository = tokenPriceRepository,
             appCurrencyRepository = appCurrencyRepository,
             balanceVisibilityRepository = balanceVisibilityRepository,
+            snapshotCache = snapshotCache,
             ioDispatcher = testDispatcher,
         )
+
+    @Test
+    fun `a re-entry paints the cards the tab was last showing`() = runTest {
+        // Earn is the tab the Solana screen opens on, so this cold start is the wait every
+        // re-entry paid: no cards, no total, until the vault fan-out came back.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        // Suspend the selection read so the only state on screen is the restored one.
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flow { awaitCancellation() }
+
+        val state = viewModel().also { it.setData(VAULT_ID) }.state.value
+
+        state.rows.map { it.vaultAddress } shouldBe listOf(STEAKHOUSE.address)
+        state.rows.single().depositedDisplay shouldBe "100 USDC"
+        state.totalValue.shouldNotBeNull().value shouldBe BigDecimal("100")
+        state.hasEnabledVaults shouldBe true
+    }
+
+    @Test
+    fun `a restored total survives the next load rather than being dropped on sight`() = runTest {
+        // The total answers one question — this selection, in this currency — and the coverage it
+        // was summed over travels with it. Without that the load drops it immediately, which is
+        // the flash the snapshot exists to remove.
+        snapshotCache.write(VAULT_ID, LAST_RENDERED)
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flow { awaitCancellation() }
+
+        val state = viewModel().also { it.setData(VAULT_ID) }.state.value
+
+        state.totalValue.shouldNotBeNull().value shouldBe BigDecimal("100")
+    }
+
+    @Test
+    fun `a re-entry does not reopen the vault picker`() = runTest {
+        snapshotCache.write(
+            VAULT_ID,
+            LAST_RENDERED.copy(
+                model =
+                    LAST_RENDERED.model.copy(
+                        isShowingPicker = true,
+                        pendingSelection = setOf(STEAKHOUSE.address),
+                    )
+            ),
+        )
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns
+            flow { awaitCancellation() }
+
+        val state = viewModel().also { it.setData(VAULT_ID) }.state.value
+
+        state.isShowingPicker shouldBe false
+        state.pendingSelection shouldBe emptySet()
+    }
+
+    @Test
+    fun `hands the rendered cards to the cache when the screen is popped`() = runTest {
+        coEvery { selectionRepository.getSelectedVaults(VAULT_ID) } returns flowOf(emptySet())
+        val vm = viewModel().also { it.setData(VAULT_ID) }
+        val rendered = vm.state.value
+
+        vm.clearForTest()
+
+        snapshotCache.read(VAULT_ID, KaminoEarnSnapshot::class).shouldNotBeNull().model shouldBe
+            rendered
+    }
 
     private fun stubVault(name: String) =
         KaminoVaultStateJson(
@@ -736,6 +809,37 @@ internal class KaminoEarnViewModelTest {
 
         val STEAKHOUSE = KaminoVaultRegistry.STEAKHOUSE_USDC
         val ALLEZ = KaminoVaultRegistry.ALLEZ_SOL
+
+        /** A settled tab, as the cache would have it after the user walked away from one. */
+        val LAST_RENDERED =
+            KaminoEarnSnapshot(
+                model =
+                    KaminoEarnUiModel(
+                        hasEnabledVaults = true,
+                        rows =
+                            listOf(
+                                KaminoEarnRow(
+                                    vaultAddress = STEAKHOUSE.address,
+                                    name = "Steakhouse USDC",
+                                    curator = STEAKHOUSE.curator,
+                                    riskTier = STEAKHOUSE.riskTier,
+                                    tokenLogo = "usdc",
+                                    tokenTicker = "USDC",
+                                    depositedDisplay = "100 USDC",
+                                    depositedFiat = "$100.00",
+                                    apyDisplay = "5.00%",
+                                    pnlDisplay = null,
+                                    pnlFiat = null,
+                                    pnlDirection = KaminoEarnRow.PnlDirection.FLAT,
+                                    fiatValue = BigDecimal("100"),
+                                    hasPosition = true,
+                                )
+                            ),
+                        totalValue = DefiFiatTotal(BigDecimal("100"), AppCurrency.USD),
+                    ),
+                totalCoverage = setOf(STEAKHOUSE.address),
+                pricedCurrency = AppCurrency.USD,
+            )
 
         val VAULT =
             Vault(


### PR DESCRIPTION
## Summary

Opening a DeFi chain detail always cold-started: blank cards, header on a spinner, and the enabled set flashing back to `RUNE + TCY` until the store answered. Walk in, walk out, walk in again — same wait, same re-enable.

Two things were needed, not one. A snapshot on its own would have shown nothing, because **every reload destroys what is on screen before it fetches** — bonded re-arms `isLoading` over the total, staking replaces its positions with placeholder cards, LP replaces its cards with zeroed placeholders. Seeding from a snapshot and then letting the load blank it a frame later changes nothing the user can see.

## What changed

**`DeFiPositionsSnapshotCache`** — in memory, process-lifetime, keyed by vault **and** snapshot type so two view-models behind one screen cannot overwrite each other. Each screen hands its state over in `onCleared` and seeds from it on the first `setData`; the loads that follow refresh it underneath. Same trade `TronDeFiSnapshotCache` and `CosmosStakingSnapshotCache` already make: no second on-disk store, nothing to clean up when a vault is deleted, and a restart reads the chain.

Wired into **THORChain, MayaChain, TON, Kamino Earn and Circle**. Routing context these screens keep outside their state travels with the snapshot — TON's pool address, Circle's MSCA account, Kamino's total coverage and priced currency — because a restored card offering an action that silently does nothing is worse than no card.

**Reloads now replace figures in place** (THORChain / Maya). Bonded shimmers only while its total is unpriced, staking cards are matched and swapped one at a time, LP cards are reused per pool. Cold start is unchanged.

## Worth a look in review

- **Staking cards are keyed by coin, not by selection key.** RUJI and its auto-compounding sRUJI card are both toggled by the single `"RUJI"` tile, so keying on that collapses the two and renders the bonded card twice. Pinned by a test.
- **LP cards are only reused for pools the last read resolved** (`livePoolKeys`). A failed read leaves zeroed placeholders standing; carrying those forward would present a figure nothing confirmed while hiding that a read is in flight.
- **A currency switch still clears the cards.** Those strings were formatted for the currency being left, so `dropFiatPricedInPreviousCurrency` drops them and each card goes back to its shimmer until it can be re-priced.
- **Solana's native staking rows are deliberately untouched.** That view-model reads its stake accounts fresh because they gate Deactivate and Withdraw, and the amounts those build come from the same read. The Solana screen opens on Earn, which is cached, so the flash on entry is gone regardless.
- **The saved-selection half of the issue was already correct.** `DefiPositionsRepository` returns `null` for "never chose" and an empty set for "cleared on purpose", and both screens already apply the defaults only on `null`. What flashed was the initial UI model's own defaults, which the snapshot now replaces.

## Test plan

Unit tests — every new test verified to fail against the pre-change code:

| Suite | Before | After |
|---|---|---|
| `ThorchainDefiPositionsViewModelTest` | 50 | 60 |
| `MayachainDefiPositionsViewModelTest` | 41 | 46 |
| `KaminoEarnViewModelTest` | 29 | 33 |
| `TonDeFiPositionsViewModelTest` | 9 | 12 |
| `CircleDeFiPositionsViewModelTest` | 5 | 8 |
| `DeFiPositionsSnapshotCacheTest` | — | 6 |

`./gradlew :app:testDebugUnitTest` green in full.

Manual, per chain (THORChain, Maya, TON, Solana, Circle):

1. DeFi tab → open the chain → let it settle → back → open it again. Cards, totals and tabs paint immediately; values refresh underneath.
2. Manage Positions → clear the selection → Done → back → re-enter. The saved set stands; `RUNE + TCY` must not flash back on.
3. Force-stop the app and reopen — the first entry still shimmers.
4. Pull-to-refresh on a settled screen — figures stay readable, they do not blank.
5. Switch currency — every card *does* shimmer and re-price.
6. THORChain → Staked with both RUJI and Compounded RUJI, then pull-to-refresh — still two distinct cards.
7. Switch vaults and open the same chain — that vault's own figures, never the previous vault's.

Closes #5782


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * DeFi screens now remember and restore previously loaded positions when revisiting a vault.
  * Refreshes preserve settled staking, bonded, liquidity pool, and earning cards.
  * Currency changes and failed or unresolved pricing prevent stale values and show appropriate loading states.
  * Individual liquidity pool cards now display their own loading status.
  * Restored screens retain selections and transaction routing details without unnecessarily reopening pickers.

* **Tests**
  * Added coverage for restoration, refresh behavior, failure handling, and persistence across supported DeFi screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->