### PR TITLE
fix(defi): make the Kamino vault picker the shared selection sheet

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -50,6 +50,7 @@ import com.vultisig.wallet.data.blockchain.cosmos.qbtc.claim.QbtcClaimError
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakePositionRow
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoCurator
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakeState
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Address
@@ -226,8 +227,10 @@ import com.vultisig.wallet.ui.screens.transaction.toUiTransactionInfo
 import com.vultisig.wallet.ui.screens.v2.chaintokens.ChainTokensScreen
 import com.vultisig.wallet.ui.screens.v2.defi.DeFiTab
 import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
+import com.vultisig.wallet.ui.screens.v2.defi.PositionsSelectionDialog
 import com.vultisig.wallet.ui.screens.v2.defi.maya.RemoveLpScreenContent
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.screens.v2.defi.solana.KAMINO_EARN_PICKER_POSITIONS
 import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoAmountContent
 import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnRow
 import com.vultisig.wallet.ui.screens.v2.defi.solana.KaminoEarnUiModel
@@ -362,6 +365,7 @@ class PreviewActivity : ComponentActivity() {
                     "solana_defi_earn_empty" ->
                         SolanaDeFiPreview(tab = DeFiTab.EARN, hasEnabledVaults = false)
                     "solana_defi_staked" -> SolanaDeFiPreview(tab = DeFiTab.STAKED)
+                    "solana_defi_picker" -> SolanaDeFiPickerPreview()
                     "kamino_deposit_form" -> KaminoAmountPreview(isWithdraw = false)
                     "kamino_withdraw_form" -> KaminoAmountPreview(isWithdraw = true)
                     "swap_confirm" -> SwapConfirmPreview()
@@ -4137,6 +4141,21 @@ private fun SolanaDeFiPreview(tab: DeFiTab, hasEnabledVaults: Boolean = true) {
                 isBalanceVisible = true,
             ),
         selectedTab = tab,
+    )
+}
+
+/**
+ * The Earn tab with the shared "Select positions" sheet open over it, as Manage positions opens it.
+ */
+@Composable
+private fun SolanaDeFiPickerPreview() {
+    SolanaDeFiPreview(tab = DeFiTab.EARN)
+
+    PositionsSelectionDialog(
+        earnPositions = KAMINO_EARN_PICKER_POSITIONS,
+        selectedPositions = listOf(KaminoVaultRegistry.STEAKHOUSE_USDC.address),
+        searchTextFieldState = rememberTextFieldState(),
+        onPositionSelectionChange = { _, _ -> },
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiComponents.kt
@@ -68,6 +68,7 @@ import com.vultisig.wallet.ui.components.v2.utils.roundToPx
 import com.vultisig.wallet.ui.screens.referral.SetBackgroundBanner
 import com.vultisig.wallet.ui.screens.swap.components.HintBox
 import com.vultisig.wallet.ui.screens.v2.defi.model.PositionUiModelDialog
+import com.vultisig.wallet.ui.screens.v2.defi.model.matching
 import com.vultisig.wallet.ui.screens.v2.home.components.NotEnabledContainer
 import com.vultisig.wallet.ui.theme.Theme
 
@@ -337,6 +338,7 @@ fun ApyInfoItem(apy: String, modifier: Modifier = Modifier) {
 @Composable
 internal fun PositionsSelectionDialog(
     selectedPositions: List<String>,
+    earnPositions: List<PositionUiModelDialog> = emptyList(),
     bondPositions: List<PositionUiModelDialog> = emptyList(),
     stakePositions: List<PositionUiModelDialog> = emptyList(),
     lpPositions: List<PositionUiModelDialog> = emptyList(),
@@ -345,42 +347,18 @@ internal fun PositionsSelectionDialog(
     onDoneClick: () -> Unit = {},
     onCancelClick: () -> Unit = {},
 ) {
-    val searchQuery = searchTextFieldState.text.toString().lowercase()
+    val searchQuery = searchTextFieldState.text.toString()
 
-    val updateBondPositions =
-        remember(bondPositions, selectedPositions) {
-            bondPositions.map { it.copy(isSelected = selectedPositions.contains(it.positionKey)) }
-        }
-
-    val updateStakePositions =
-        remember(stakePositions, selectedPositions) {
-            stakePositions.map { it.copy(isSelected = selectedPositions.contains(it.positionKey)) }
-        }
-
-    val updateLpPositions =
-        remember(lpPositions, selectedPositions) {
-            lpPositions.map { it.copy(isSelected = selectedPositions.contains(it.positionKey)) }
-        }
+    val filteredEarnPositions =
+        rememberFilteredPositions(earnPositions, selectedPositions, searchQuery)
 
     val filteredBondPositions =
-        remember(searchQuery, updateBondPositions) {
-            if (searchQuery.isEmpty()) updateBondPositions
-            else updateBondPositions.filter { it.ticker.lowercase().contains(searchQuery) }
-        }
+        rememberFilteredPositions(bondPositions, selectedPositions, searchQuery)
 
     val filteredStakePositions =
-        remember(searchQuery, updateStakePositions) {
-            if (searchQuery.isEmpty()) updateStakePositions
-            else updateStakePositions.filter { it.ticker.lowercase().contains(searchQuery) }
-        }
+        rememberFilteredPositions(stakePositions, selectedPositions, searchQuery)
 
-    val filteredLpPositions =
-        remember(searchQuery, updateLpPositions) {
-            if (searchQuery.isEmpty()) updateLpPositions
-            else updateLpPositions.filter { it.ticker.lowercase().contains(searchQuery) }
-        }
-
-    val groups = mutableListOf<TokenSelectionGroupUiModel<PositionUiModelDialog>>()
+    val filteredLpPositions = rememberFilteredPositions(lpPositions, selectedPositions, searchQuery)
 
     fun buildItems(positions: List<PositionUiModelDialog>) =
         positions.map { GridTokenUiModel.SingleToken(data = it) }
@@ -403,38 +381,28 @@ internal fun PositionsSelectionDialog(
         )
     }
 
-    if (filteredBondPositions.isNotEmpty()) {
-        groups.add(
-            TokenSelectionGroupUiModel(
-                title = stringResource(R.string.defi_bond),
-                items = buildItems(filteredBondPositions),
-                mapper = ::buildMapper,
-                plusUiModel = null,
-            )
+    // Earn leads, the same order the chain screen's tab row uses and the one iOS's picker builds:
+    // the two lists describe the same positions, and disagreeing on which comes first is how a
+    // user hunts for the section they were just looking at.
+    val sections =
+        listOf(
+            stringResource(R.string.defi_tab_earn) to filteredEarnPositions,
+            stringResource(R.string.defi_bond) to filteredBondPositions,
+            stringResource(R.string.defi_stake) to filteredStakePositions,
+            stringResource(R.string.liquidity_pool) to filteredLpPositions,
         )
-    }
 
-    if (filteredStakePositions.isNotEmpty()) {
-        groups.add(
-            TokenSelectionGroupUiModel(
-                title = stringResource(R.string.defi_stake),
-                items = buildItems(filteredStakePositions),
-                mapper = ::buildMapper,
-                plusUiModel = null,
-            )
-        )
-    }
-
-    if (filteredLpPositions.isNotEmpty()) {
-        groups.add(
-            TokenSelectionGroupUiModel(
-                title = stringResource(R.string.liquidity_pool),
-                items = buildItems(filteredLpPositions),
-                mapper = ::buildMapper,
-                plusUiModel = null,
-            )
-        )
-    }
+    val groups =
+        sections
+            .filter { (_, positions) -> positions.isNotEmpty() }
+            .map { (title, positions) ->
+                TokenSelectionGroupUiModel(
+                    title = title,
+                    items = buildItems(positions),
+                    mapper = ::buildMapper,
+                    plusUiModel = null,
+                )
+            }
 
     TokenSelectionList(
         groups = groups,
@@ -471,6 +439,27 @@ internal fun PositionsSelectionDialog(
         onCancelClick = onCancelClick,
         onPasteClick = searchTextFieldState::setTextAndPlaceCursorAtEnd,
     )
+}
+
+/**
+ * One section of the picker: its positions stamped with the live selection, then narrowed to
+ * [searchQuery].
+ *
+ * Selection is applied here rather than by the caller because the picker owns the pending edit — a
+ * section is handed the catalogue of what exists, and which of it is on is answered in one place
+ * for every section.
+ */
+@Composable
+private fun rememberFilteredPositions(
+    positions: List<PositionUiModelDialog>,
+    selectedPositions: List<String>,
+    searchQuery: String,
+): List<PositionUiModelDialog> {
+    val selected =
+        remember(positions, selectedPositions) {
+            positions.map { it.copy(isSelected = selectedPositions.contains(it.positionKey)) }
+        }
+    return remember(searchQuery, selected) { selected.matching(searchQuery) }
 }
 
 /**

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/model/PositionUiModelDialog.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/model/PositionUiModelDialog.kt
@@ -8,4 +8,20 @@ internal data class PositionUiModelDialog(
     val isSelected: Boolean = true,
     val positionKey: String = ticker,
     val chainLogo: ImageModel? = null,
+    /**
+     * Free text the picker's search matches against. A coin position has only its ticker, which is
+     * why that is the default; a curated vault adds its curator, so "rockawayx" finds RWA USDC the
+     * way it does on iOS (`DefiSelectableAsset.searchTerms`).
+     */
+    val searchTerms: List<String> = listOf(ticker),
 )
+
+/**
+ * The positions [query] matches, or all of them when nothing is being searched for.
+ *
+ * A free function rather than a step inside the picker so the matching rule can be tested without a
+ * composition, and so every section of the picker searches the same way.
+ */
+internal fun List<PositionUiModelDialog>.matching(query: String): List<PositionUiModelDialog> =
+    if (query.isEmpty()) this
+    else filter { position -> position.searchTerms.any { it.contains(query, ignoreCase = true) } }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnComponents.kt
@@ -11,19 +11,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.selection.toggleable
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,15 +26,16 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoCurator
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoRiskTier
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.blockchain.solana.kamino.coin
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.ui.components.TokenLogo
 import com.vultisig.wallet.ui.components.UiHorizontalDivider
 import com.vultisig.wallet.ui.components.UiSpacer
-import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.screens.v2.defi.ActionButton
 import com.vultisig.wallet.ui.screens.v2.defi.FIAT_VALUE_UNAVAILABLE
 import com.vultisig.wallet.ui.screens.v2.defi.InfoItem
+import com.vultisig.wallet.ui.screens.v2.defi.model.PositionUiModelDialog
 import com.vultisig.wallet.ui.theme.Theme
 import java.math.BigDecimal
 
@@ -51,85 +46,23 @@ private val LOGO_SIZE = 36.dp
 private val LOGO_PAIR_WIDTH = 60.dp
 
 /**
- * Picker for which curated vaults the Earn tab shows.
+ * The curated vaults offered in the shared "Select positions" picker.
  *
- * Without this the tab has no way to be populated at all — the opt-in gates every card, so the
- * feature is unreachable until the user can turn a vault on.
+ * The pinned name rather than the live one: this is a catalogue of what the app offers, and the
+ * catalogue is the allow-list — the same descriptors iOS builds its Earn cells from. The cell shows
+ * the underlying token's mark, because the vault is what is picked but the token is what the user
+ * recognises, and the curator joins the name as a search term so "rockawayx" finds RWA USDC.
  */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-internal fun KaminoVaultPickerSheet(
-    selected: Set<String>,
-    onToggle: (String, Boolean) -> Unit,
-    onDone: () -> Unit,
-    onDismiss: () -> Unit,
-) {
-    ModalBottomSheet(
-        onDismissRequest = onDismiss,
-        sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
-        containerColor = Theme.v2.colors.backgrounds.primary,
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth().padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
-        ) {
-            Text(
-                text = stringResource(R.string.kamino_earn_title),
-                style = Theme.brockmann.headings.title3,
-                color = Theme.v2.colors.text.primary,
-            )
-
-            KaminoVaultRegistry.ALLOW_LIST.forEach { vault ->
-                val isSelected = vault.address in selected
-                Row(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .kaminoCard()
-                            .toggleable(
-                                value = isSelected,
-                                role = Role.Checkbox,
-                                onValueChange = { onToggle(vault.address, it) },
-                            )
-                            .padding(16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = vault.fallbackName,
-                            style = Theme.brockmann.body.m.medium,
-                            color = Theme.v2.colors.text.primary,
-                        )
-                        Text(
-                            text =
-                                stringResource(
-                                    R.string.kamino_earn_curated_by,
-                                    vault.curator.displayName,
-                                ),
-                            style = Theme.brockmann.body.s.medium,
-                            color = Theme.v2.colors.text.tertiary,
-                        )
-                    }
-
-                    Text(
-                        text = stringResource(vault.riskTier.labelRes),
-                        style = Theme.brockmann.supplementary.caption,
-                        color = vault.riskTier.labelColor(),
-                    )
-
-                    UiSpacer(12.dp)
-
-                    Checkbox(checked = isSelected, onCheckedChange = null)
-                }
-            }
-
-            VsButton(
-                label = stringResource(R.string.save_changes),
-                onClick = onDone,
-                modifier = Modifier.fillMaxWidth(),
+internal val KAMINO_EARN_PICKER_POSITIONS: List<PositionUiModelDialog>
+    get() =
+        KaminoVaultRegistry.ALLOW_LIST.map { vault ->
+            PositionUiModelDialog(
+                logo = vault.coin?.let { getCoinLogo(it.logo) } ?: R.drawable.kamino,
+                ticker = vault.fallbackName,
+                positionKey = vault.address,
+                searchTerms = listOf(vault.fallbackName, vault.curator.displayName),
             )
         }
-    }
-}
 
 /**
  * The Kamino Earn segment: one card per enabled vault.

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -24,6 +25,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -57,6 +59,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.FIAT_VALUE_UNAVAILABLE
 import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
 import com.vultisig.wallet.ui.screens.v2.defi.InfoItem
 import com.vultisig.wallet.ui.screens.v2.defi.ManagePositionsButton
+import com.vultisig.wallet.ui.screens.v2.defi.PositionsSelectionDialog
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -75,6 +78,7 @@ internal fun SolanaStakingPositionsScreen(
     val state by viewModel.state.collectAsState()
     val kaminoState by kaminoViewModel.state.collectAsState()
     var selectedTab by rememberSaveable { mutableStateOf(DeFiTab.EARN) }
+    val pickerSearchTextFieldState = remember { TextFieldState() }
 
     LifecycleResumeEffect(vaultId) {
         viewModel.setData(vaultId)
@@ -110,11 +114,15 @@ internal fun SolanaStakingPositionsScreen(
     )
 
     if (kaminoState.isShowingPicker) {
-        KaminoVaultPickerSheet(
-            selected = kaminoState.pendingSelection,
-            onToggle = kaminoViewModel::onVaultToggled,
-            onDone = kaminoViewModel::savePicker,
-            onDismiss = kaminoViewModel::closePicker,
+        // The same sheet every other picker in the app opens — Kamino vaults are just its Earn
+        // section, so there is nothing here that is Solana's own chrome.
+        PositionsSelectionDialog(
+            earnPositions = KAMINO_EARN_PICKER_POSITIONS,
+            selectedPositions = kaminoState.pendingSelection.toList(),
+            searchTextFieldState = pickerSearchTextFieldState,
+            onPositionSelectionChange = kaminoViewModel::onVaultToggled,
+            onDoneClick = kaminoViewModel::savePicker,
+            onCancelClick = kaminoViewModel::closePicker,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -78,7 +78,7 @@ internal fun SolanaStakingPositionsScreen(
     val state by viewModel.state.collectAsState()
     val kaminoState by kaminoViewModel.state.collectAsState()
     var selectedTab by rememberSaveable { mutableStateOf(DeFiTab.EARN) }
-    val pickerSearchTextFieldState = remember { TextFieldState() }
+    val pickerSearchTextFieldState = remember(kaminoState.isShowingPicker) { TextFieldState() }
 
     LifecycleResumeEffect(vaultId) {
         viewModel.setData(vaultId)

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -525,8 +525,6 @@
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Liquiditätspool</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">Kuratiert von %1$s</string>
     <string name="kamino_earn_deposited">Eingezahlt: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">Verdient: %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -525,8 +525,6 @@
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Pool de liquidez</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">Curado por %1$s</string>
     <string name="kamino_earn_deposited">Depositado: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">Ganado: %1$s</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -526,8 +526,6 @@
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Pool likvidnosti</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">Kurirao %1$s</string>
     <string name="kamino_earn_deposited">Deponirano: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">Zarađeno: %1$s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -525,8 +525,6 @@
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Pool di liquidità</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">Curato da %1$s</string>
     <string name="kamino_earn_deposited">Depositato: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">Guadagnato: %1$s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -63,8 +63,6 @@
     <string name="defi_stake">스테이킹</string>
     <string name="liquidity_pool">유동성 풀</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">%1$s 큐레이션</string>
     <string name="kamino_earn_deposited">예치됨: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">수익: %1$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -522,8 +522,6 @@
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Liquiditeitspool</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">Samengesteld door %1$s</string>
     <string name="kamino_earn_deposited">Gestort: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">Verdiend: %1$s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -523,8 +523,6 @@
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Pool de liquidez</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">Curado por %1$s</string>
     <string name="kamino_earn_deposited">Depositado: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">Ganho: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -524,8 +524,6 @@
     <string name="defi_stake">Стейк</string>
     <string name="liquidity_pool">Пул ликвидности</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">Куратор: %1$s</string>
     <string name="kamino_earn_deposited">Депонировано: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">Заработано: %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -59,8 +59,6 @@
     <string name="defi_stake">质押</string>
     <string name="liquidity_pool">流动性池</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">由 %1$s 策划</string>
     <string name="kamino_earn_deposited">已存入：%1$s</string>
     <string name="kamino_earn_apy">年化收益率</string>
     <string name="kamino_earn_earned">已赚取：%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -66,8 +66,6 @@
     <string name="defi_stake">Stake</string>
     <string name="liquidity_pool">Liquidity Pool</string>
     <!-- Kamino Earn -->
-    <string name="kamino_earn_title">Kamino Earn</string>
-    <string name="kamino_earn_curated_by">Curated by %1$s</string>
     <string name="kamino_earn_deposited">Deposited: %1$s</string>
     <string name="kamino_earn_apy">APY</string>
     <string name="kamino_earn_earned">Earned: %1$s</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/model/PositionUiModelDialogTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/model/PositionUiModelDialogTest.kt
@@ -1,0 +1,48 @@
+package com.vultisig.wallet.ui.screens.v2.defi.model
+
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class PositionUiModelDialogTest {
+
+    private val rune = PositionUiModelDialog(logo = 0, ticker = "RUNE")
+    private val tcy = PositionUiModelDialog(logo = 0, ticker = "TCY")
+    private val lp = PositionUiModelDialog(logo = 0, ticker = "RUNE/BTC")
+
+    private val coinPositions = listOf(rune, tcy, lp)
+
+    @Test
+    fun `a coin position searches by its ticker alone`() {
+        rune.searchTerms shouldContainExactly listOf("RUNE")
+    }
+
+    @Test
+    fun `matching a ticker keeps only the positions carrying it`() {
+        coinPositions.matching("rune") shouldContainExactly listOf(rune, lp)
+    }
+
+    @Test
+    fun `an empty query is not a filter`() {
+        coinPositions.matching("") shouldContainExactly coinPositions
+    }
+
+    @Test
+    fun `extra search terms widen the match without replacing the ticker`() {
+        val vault =
+            PositionUiModelDialog(
+                logo = 0,
+                ticker = "RWA USDC",
+                positionKey = "DWSXb18xZApz29vnQpgR2m6MynCT7PznaXt7Ut7M7KaP",
+                searchTerms = listOf("RWA USDC", "RockawayX"),
+            )
+
+        listOf(vault).matching("rockawayx") shouldContainExactly listOf(vault)
+        listOf(vault).matching("rwa") shouldContainExactly listOf(vault)
+    }
+
+    @Test
+    fun `the key defaults to the ticker so existing coin sections are unchanged`() {
+        rune.positionKey shouldBe "RUNE"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnPickerPositionsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnPickerPositionsTest.kt
@@ -1,0 +1,71 @@
+package com.vultisig.wallet.ui.screens.v2.defi.solana
+
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
+import com.vultisig.wallet.data.blockchain.solana.kamino.coin
+import com.vultisig.wallet.data.models.getCoinLogo
+import com.vultisig.wallet.ui.screens.v2.defi.model.matching
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+internal class KaminoEarnPickerPositionsTest {
+
+    @Test
+    fun `every curated vault is offered, in the registry's order`() {
+        KAMINO_EARN_PICKER_POSITIONS.map { it.positionKey } shouldContainExactly
+            KaminoVaultRegistry.ALLOW_LIST.map { it.address }
+    }
+
+    @Test
+    fun `a cell is keyed by vault address and labelled with the vault's own name`() {
+        for (vault in KaminoVaultRegistry.ALLOW_LIST) {
+            val position = KAMINO_EARN_PICKER_POSITIONS.single { it.positionKey == vault.address }
+
+            withClue(vault.fallbackName) {
+                // The key is what reaches KaminoVaultSelectionRepository, so a ticker here would
+                // alias both USDC vaults onto one selection.
+                position.ticker shouldBe vault.fallbackName
+                position.logo shouldBe getCoinLogo(vault.coin!!.logo)
+            }
+        }
+    }
+
+    @Test
+    fun `the two USDC vaults are told apart by their addresses, not their token`() {
+        val usdcVaults = KaminoVaultRegistry.ALLOW_LIST.filter { it.coin?.ticker == "USDC" }
+
+        withClue("the fixture needs two vaults sharing a token to be worth asserting") {
+            (usdcVaults.size >= 2) shouldBe true
+        }
+
+        val cells = KAMINO_EARN_PICKER_POSITIONS.filter { it.logo == getCoinLogo("usdc") }
+
+        cells.map { it.positionKey }.distinct().size shouldBe cells.size
+    }
+
+    @Test
+    fun `searching a curator finds the vault it runs`() {
+        // "RWA USDC" carries nothing of RockawayX in its name, so this only passes because the
+        // curator is a search term of its own — the behaviour iOS has.
+        val matches = KAMINO_EARN_PICKER_POSITIONS.matching("rockaway")
+
+        matches.map { it.ticker } shouldContainExactly listOf("RWA USDC")
+    }
+
+    @Test
+    fun `search is case-insensitive and matches part of a name`() {
+        KAMINO_EARN_PICKER_POSITIONS.matching("STEAK").map { it.ticker } shouldContainExactly
+            listOf("Steakhouse USDC")
+    }
+
+    @Test
+    fun `an empty query leaves every vault on offer`() {
+        KAMINO_EARN_PICKER_POSITIONS.matching("") shouldBe KAMINO_EARN_PICKER_POSITIONS
+    }
+
+    @Test
+    fun `a query nothing answers empties the section rather than falling back to everything`() {
+        KAMINO_EARN_PICKER_POSITIONS.matching("thorchain").isEmpty() shouldBe true
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnPickerPositionsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/v2/defi/solana/KaminoEarnPickerPositionsTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.screens.v2.defi.solana
 
+import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoVaultRegistry
 import com.vultisig.wallet.data.blockchain.solana.kamino.coin
 import com.vultisig.wallet.data.models.getCoinLogo
@@ -26,7 +27,8 @@ internal class KaminoEarnPickerPositionsTest {
                 // The key is what reaches KaminoVaultSelectionRepository, so a ticker here would
                 // alias both USDC vaults onto one selection.
                 position.ticker shouldBe vault.fallbackName
-                position.logo shouldBe getCoinLogo(vault.coin!!.logo)
+                val expectedLogo = vault.coin?.let { getCoinLogo(it.logo) } ?: R.drawable.kamino
+                position.logo shouldBe expectedLogo
             }
         }
     }


### PR DESCRIPTION
Closes #5781

## Summary

Manage positions on **Solana → Earn** opened a picker of its own: a Material `ModalBottomSheet` with card rows carrying the curator and risk tier, a Material `Checkbox`, no search, and a "Save Changes" button. Every other picker in the app — token select, chain select, THOR/Maya positions — is `TokenSelectionList`: title, subtitle, search, 74dp grid cells with the shared check, Done / Cancel.

iOS has no Kamino picker either. `DefiChainSelectPositionsScreen` puts the vaults in the same `AssetSelectionContainerSheet` the coin positions use, as an `.earn` `AssetSection` **inserted at index 0** so the sheet's order matches the chain screen's tab row. So the fix is a new `earnPositions` parameter on `PositionsSelectionDialog`, rendered as the first group — not a second composable. `KaminoVaultPickerSheet` is gone.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/DINXEOS.png) | ![after](https://i.imgur.com/r1VI5I0.png) |

## Details

**The cell is the vault's pinned name over its underlying token's mark**, mirroring iOS `KaminoVaultSelectionGridCell` — the vault is what is picked, the token is what the user recognises. The pinned `fallbackName` rather than the live name the Earn card shows: the picker is a catalogue of what the app offers, and the catalogue is `KaminoVaultRegistry.ALLOW_LIST`. `positionKey` is the vault address, because a ticker would alias both USDC vaults onto one selection.

**Search had to widen.** iOS's `DefiSelectableAsset.searchTerms` is `[fallbackName, curator]`, while the dialog filtered on `ticker` alone — so "rockawayx" would have found nothing, since "RWA USDC" carries no trace of RockawayX in its name. `PositionUiModelDialog` gains `searchTerms`, defaulting to `listOf(ticker)`, which leaves every existing coin section matching exactly as before. The rule moves into a free `matching(query)` so it can be tested without a composition.

**The curator subtitle and risk chip deliberately do not come across.** The shared 74dp cell has no room for them and iOS's cell shows neither. They stay on the Earn card, which is untouched. That orphans `kamino_earn_title` and `kamino_earn_curated_by`, removed from all ten locale files.

**Persistence is unchanged** — the same pending set, saved by the same `KaminoVaultSelectionRepository` on Done, dismissed without saving on Cancel.

The dialog's four near-identical `remember` pairs collapse into one `rememberFilteredPositions`, so adding a fourth section shortened the function rather than growing it.

## Test plan

- [x] `./gradlew :app:testDebugUnitTest` — 2309 tests, 0 failures. 12 new across `KaminoEarnPickerPositionsTest` and `PositionUiModelDialogTest`: every allow-listed vault is offered in registry order, cells are keyed by address (not ticker, which would alias the two USDC vaults), searching a curator finds the vault it runs, and the default `searchTerms` leaves coin sections matching by ticker exactly as before.
- [x] `./gradlew :app:lintDebug`
- [x] `./gradlew :app:compileDebugAndroidTestKotlin`
- [x] `./gradlew :app:ktfmtFormat`
- [x] Rendered on device via `PreviewActivity` (`-e screen solana_defi_picker`, added in this PR) for the screenshots above.

**In-app path:** Home → Solana → DeFi → Earn tab → the pencil (Manage positions). The sheet should be the same one Bond/Stake/LP open on THORChain, with an "Earn" section. Toggle a vault, press the tick, and the Earn tab reloads with that vault's card; press the cross instead and the enabled set is untouched. Typing `rockaway` in the search should leave only RWA USDC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared position-selection dialog across Earn, Bond, Stake, and Liquidity Pool views.
  - Added case-insensitive search for position tickers, names, and curator details.
  - Improved Solana Earn vault selection with curated labels, logos, ordering, and support for duplicate tokens.

- **Tests**
  - Added coverage for position searching, filtering, selection behavior, and vault display details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->