### PR TITLE
fix(defi): count positions on the DeFi home chain rows

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -143,6 +143,11 @@ internal data class AccountUiModel(
     val assetsSize: Int = 0,
     val nativeTokenTicker: String = "",
     val isDeFiProvider: Boolean = false,
+    /**
+     * Active DeFi positions on the chain, or null while none of them has resolved yet. Only ever
+     * set on a DeFi row; a wallet row keeps reporting its token count instead.
+     */
+    val defiPositionsCount: Int? = null,
 )
 
 @HiltViewModel

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/AddressToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/AddressToUiModelMapper.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.models.mappers
 import com.vultisig.wallet.data.mappers.SuspendMapperFunc
 import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.calculateAccountsPartialFiatValue
+import com.vultisig.wallet.data.models.calculateActiveDefiPositionsCount
 import com.vultisig.wallet.data.models.logo
 import com.vultisig.wallet.ui.models.AccountUiModel
 import javax.inject.Inject
@@ -36,6 +37,12 @@ constructor(
                 },
             assetsSize = from.accounts.size,
             nativeTokenTicker = nativeAccount.token.ticker,
+            isDeFiProvider = isDefiProvider,
+            // A DeFi row reports how many positions the vault holds on the chain, not how many
+            // tokens it tracks there. Counted only for DeFi rows, so a wallet row still reports
+            // its asset count.
+            defiPositionsCount =
+                if (isDefiProvider) from.accounts.calculateActiveDefiPositionsCount() else null,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AccountItem.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/AccountItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -89,34 +90,58 @@ internal fun AccountItem(
                 isVisible = isBalanceVisible,
             )
 
-            if (account.assetsSize > 1) {
-                ToggleVisibilityText(
-                    isVisible = isBalanceVisible,
-                    text =
-                        stringResource(R.string.vault_accounts_account_assets, account.assetsSize),
-                    style = Theme.brockmann.supplementary.caption,
-                    color = Theme.v2.colors.text.tertiary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            } else {
-                AnimatedContent(
-                    targetState = account.nativeTokenAmount,
-                    label = "ChainAccount NativeTokenAmount",
-                ) { nativeTokenAmount ->
-                    if (nativeTokenAmount != null) {
-                        ToggleVisibilityText(
-                            isVisible = isBalanceVisible,
-                            text = nativeTokenAmount,
-                            style = Theme.brockmann.supplementary.caption,
-                            color = Theme.v2.colors.text.tertiary,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    } else {
-                        UiPlaceholderLoader(modifier = Modifier.width(48.dp))
+            when {
+                account.isDeFiProvider ->
+                    AnimatedContent(
+                        targetState = account.defiPositionsCount,
+                        label = "ChainAccount DefiPositionsCount",
+                    ) { positionsCount ->
+                        if (positionsCount != null) {
+                            ToggleVisibilityText(
+                                isVisible = isBalanceVisible,
+                                text = defiPositionsSubtitle(positionsCount),
+                                style = Theme.brockmann.supplementary.caption,
+                                color = Theme.v2.colors.text.tertiary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        } else {
+                            UiPlaceholderLoader(modifier = Modifier.width(48.dp))
+                        }
                     }
-                }
+
+                account.assetsSize > 1 ->
+                    ToggleVisibilityText(
+                        isVisible = isBalanceVisible,
+                        text =
+                            stringResource(
+                                R.string.vault_accounts_account_assets,
+                                account.assetsSize,
+                            ),
+                        style = Theme.brockmann.supplementary.caption,
+                        color = Theme.v2.colors.text.tertiary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+
+                else ->
+                    AnimatedContent(
+                        targetState = account.nativeTokenAmount,
+                        label = "ChainAccount NativeTokenAmount",
+                    ) { nativeTokenAmount ->
+                        if (nativeTokenAmount != null) {
+                            ToggleVisibilityText(
+                                isVisible = isBalanceVisible,
+                                text = nativeTokenAmount,
+                                style = Theme.brockmann.supplementary.caption,
+                                color = Theme.v2.colors.text.tertiary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        } else {
+                            UiPlaceholderLoader(modifier = Modifier.width(48.dp))
+                        }
+                    }
             }
         }
 
@@ -129,6 +154,14 @@ internal fun AccountItem(
         )
     }
 }
+
+@Composable
+private fun defiPositionsSubtitle(count: Int): String =
+    if (count > 0) {
+        pluralStringResource(R.plurals.defi_chain_positions_count, count, count)
+    } else {
+        stringResource(R.string.no_positions_found)
+    }
 
 @Preview
 @Composable

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1258,6 +1258,10 @@
     <string name="add">Hinzufügen</string>
     <string name="remove">Entfernen</string>
     <string name="no_positions_found">Keine Positionen gefunden</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="one">%1$d Position</item>
+        <item quantity="other">%1$d Positionen</item>
+    </plurals>
     <string name="select_positions">Positionen auswählen</string>
     <string name="enable_at_least_one_position">Aktivieren Sie mindestens eine Position, um Salden anzuzeigen und Positionen zu verwalten.</string>
     <string name="bandwidth">Bandbreite</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1256,6 +1256,11 @@
     <string name="add">Añadir</string>
     <string name="remove">Eliminar</string>
     <string name="no_positions_found">No se encontraron posiciones</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="one">%1$d posición</item>
+        <item quantity="many">%1$d de posiciones</item>
+        <item quantity="other">%1$d posiciones</item>
+    </plurals>
     <string name="select_positions">Seleccionar posiciones</string>
     <string name="enable_at_least_one_position">Habilite al menos una posición para ver saldos y gestionar posiciones.</string>
     <string name="bandwidth">Ancho de banda</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1261,6 +1261,11 @@
     <string name="add">Dodaj</string>
     <string name="remove">Ukloni</string>
     <string name="no_positions_found">Nema pronađenih pozicija</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="one">%1$d pozicija</item>
+        <item quantity="few">%1$d pozicije</item>
+        <item quantity="other">%1$d pozicija</item>
+    </plurals>
     <string name="select_positions">Odaberite pozicije</string>
     <string name="enable_at_least_one_position">Omogućite barem jednu poziciju za pregled stanja i upravljanje pozicijama.</string>
     <string name="bandwidth">Propusnost</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1256,6 +1256,11 @@
     <string name="add">Aggiungi</string>
     <string name="remove">Rimuovi</string>
     <string name="no_positions_found">Nessuna posizione trovata</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="one">%1$d posizione</item>
+        <item quantity="many">%1$d di posizioni</item>
+        <item quantity="other">%1$d posizioni</item>
+    </plurals>
     <string name="select_positions">Seleziona posizioni</string>
     <string name="enable_at_least_one_position">Abilita almeno una posizione per visualizzare i saldi e gestire le posizioni.</string>
     <string name="bandwidth">Larghezza di banda</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1288,6 +1288,9 @@
     <string name="add">추가</string>
     <string name="remove">제거</string>
     <string name="no_positions_found">포지션을 찾을 수 없습니다</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="other">포지션 %1$d개</item>
+    </plurals>
     <string name="select_positions">포지션 선택</string>
     <string name="enable_at_least_one_position">잔액을 확인하고 포지션을 관리하려면 최소 하나의 포지션을 활성화하세요.</string>
     <string name="bandwidth">대역폭</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1253,6 +1253,10 @@
     <string name="add">Toevoegen</string>
     <string name="remove">Verwijderen</string>
     <string name="no_positions_found">Geen posities gevonden</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="one">%1$d positie</item>
+        <item quantity="other">%1$d posities</item>
+    </plurals>
     <string name="select_positions">Selecteer posities</string>
     <string name="enable_at_least_one_position">Schakel ten minste één positie in om saldi te bekijken en posities te beheren.</string>
     <string name="bandwidth">Bandbreedte</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1255,6 +1255,11 @@
     <string name="add">Adicionar</string>
     <string name="remove">Remover</string>
     <string name="no_positions_found">Nenhuma posição encontrada</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="one">%1$d posição</item>
+        <item quantity="many">%1$d de posições</item>
+        <item quantity="other">%1$d posições</item>
+    </plurals>
     <string name="select_positions">Selecionar posições</string>
     <string name="enable_at_least_one_position">Ative pelo menos uma posição para visualizar saldos e gerenciar posições.</string>
     <string name="bandwidth">Largura de banda</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1261,6 +1261,12 @@
     <string name="add">Добавить</string>
     <string name="remove">Удалить</string>
     <string name="no_positions_found">Позиции не найдены</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="one">%1$d позиция</item>
+        <item quantity="few">%1$d позиции</item>
+        <item quantity="many">%1$d позиций</item>
+        <item quantity="other">%1$d позиции</item>
+    </plurals>
     <string name="select_positions">Выбрать позиции</string>
     <string name="enable_at_least_one_position">Включите хотя бы одну позицию для просмотра балансов и управления позициями.</string>
     <string name="bandwidth">пропускная способность</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1587,6 +1587,9 @@
     <string name="add">添加</string>
     <string name="remove">移除</string>
     <string name="no_positions_found">未找到仓位</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="other">%1$d 个仓位</item>
+    </plurals>
     <string name="select_positions">选择仓位</string>
     <string name="enable_at_least_one_position">请至少启用一个仓位以查看余额和管理仓位。</string>
     <string name="bandwidth">带宽</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1318,6 +1318,10 @@
     <string name="add">Add</string>
     <string name="remove">Remove</string>
     <string name="no_positions_found">No positions found</string>
+    <plurals name="defi_chain_positions_count">
+        <item quantity="one">%1$d position</item>
+        <item quantity="other">%1$d positions</item>
+    </plurals>
     <string name="select_positions">Select positions</string>
     <string name="enable_at_least_one_position">Enable at least one position to view balances and manage positions.</string>
     <string name="bandwidth">Bandwidth</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/AddressToUiModelMapperDefiPositionsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/AddressToUiModelMapperDefiPositionsTest.kt
@@ -64,12 +64,18 @@ internal class AddressToUiModelMapperDefiPositionsTest {
             isNativeToken = isNativeToken,
         )
 
-    private fun account(ticker: String, amount: BigInteger?, isNativeToken: Boolean = false) =
+    private fun account(
+        ticker: String,
+        amount: BigInteger?,
+        isNativeToken: Boolean = false,
+        defiPositionsCount: Int? = null,
+    ) =
         Account(
             token = coin(ticker, isNativeToken),
             tokenValue = amount?.let { TokenValue(it, ticker, 8) },
             fiatValue = amount?.let { FiatValue(BigDecimal.ONE, "USD") },
             price = null,
+            defiPositionsCount = defiPositionsCount,
         )
 
     private fun address(isDefiProvider: Boolean, vararg accounts: Account) =
@@ -110,6 +116,21 @@ internal class AddressToUiModelMapperDefiPositionsTest {
             )
 
         model.defiPositionsCount shouldBe 0
+    }
+
+    @Test
+    fun `a defi row reports multiple positions behind one token balance`() = runTest {
+        val model =
+            mapper(
+                address(
+                    isDefiProvider = true,
+                    account("RUNE", BigInteger.ZERO, isNativeToken = true),
+                    account("USDC", BigInteger("150"), defiPositionsCount = 2),
+                )
+            )
+
+        model.defiPositionsCount shouldBe 2
+        model.assetsSize shouldBe 2
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/mappers/AddressToUiModelMapperDefiPositionsTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/mappers/AddressToUiModelMapperDefiPositionsTest.kt
@@ -1,0 +1,144 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.mappers
+
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.DefiChainUiModel
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.TokenValue
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * The DeFi home row counts the vault's active positions on the chain; the wallet row keeps counting
+ * the tokens it tracks there.
+ */
+internal class AddressToUiModelMapperDefiPositionsTest {
+
+    private val fiatValueToStringMapper =
+        mockk<FiatValueToStringMapper>().also {
+            coEvery { it.invoke(any(), any(), any()) } returns "$1.00"
+        }
+
+    private val tokenValueToStringWithUnitMapper =
+        mockk<TokenValueToStringWithUnitMapper>().also {
+            every { it.invoke(any()) } returns "1 RUNE"
+        }
+
+    private val chainToDefiChainUiMapper =
+        mockk<ChainToDefiChainUiMapper>().also {
+            every { it.invoke(any()) } answers
+                {
+                    val chain = firstArg<Chain>()
+                    DefiChainUiModel(logo = 0, raw = chain.raw, chain = chain)
+                }
+        }
+
+    private val mapper =
+        AddressToUiModelMapperImpl(
+            fiatValueToStringMapper = fiatValueToStringMapper,
+            mapTokenValueToStringWithUnitMapper = tokenValueToStringWithUnitMapper,
+            chainToDefiChainUiMapper = chainToDefiChainUiMapper,
+        )
+
+    private fun coin(ticker: String, isNativeToken: Boolean = false) =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = ticker,
+            logo = "",
+            address = "thor1abc",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = isNativeToken,
+        )
+
+    private fun account(ticker: String, amount: BigInteger?, isNativeToken: Boolean = false) =
+        Account(
+            token = coin(ticker, isNativeToken),
+            tokenValue = amount?.let { TokenValue(it, ticker, 8) },
+            fiatValue = amount?.let { FiatValue(BigDecimal.ONE, "USD") },
+            price = null,
+        )
+
+    private fun address(isDefiProvider: Boolean, vararg accounts: Account) =
+        Address(
+            chain = Chain.ThorChain,
+            address = "thor1abc",
+            accounts = accounts.toList(),
+            isDefiProvider = isDefiProvider,
+        )
+
+    @Test
+    fun `a defi row reports its funded positions, not its token count`() = runTest {
+        val model =
+            mapper(
+                address(
+                    isDefiProvider = true,
+                    account("RUNE", BigInteger("100"), isNativeToken = true),
+                    account("TCY", BigInteger("50")),
+                    account("RUJI", BigInteger.ZERO),
+                    account("USDC", BigInteger.ZERO),
+                )
+            )
+
+        model.defiPositionsCount shouldBe 2
+        model.assetsSize shouldBe 4
+        model.isDeFiProvider shouldBe true
+    }
+
+    @Test
+    fun `a defi row with nothing staked reports no positions`() = runTest {
+        val model =
+            mapper(
+                address(
+                    isDefiProvider = true,
+                    account("RUNE", BigInteger.ZERO, isNativeToken = true),
+                    account("TCY", BigInteger.ZERO),
+                )
+            )
+
+        model.defiPositionsCount shouldBe 0
+    }
+
+    @Test
+    fun `a defi row still resolving reports an unknown count`() = runTest {
+        val model =
+            mapper(
+                address(
+                    isDefiProvider = true,
+                    account("RUNE", null, isNativeToken = true),
+                    account("TCY", null),
+                )
+            )
+
+        model.defiPositionsCount shouldBe null
+    }
+
+    @Test
+    fun `a wallet row carries no position count`() = runTest {
+        val model =
+            mapper(
+                address(
+                    isDefiProvider = false,
+                    account("RUNE", BigInteger("100"), isNativeToken = true),
+                    account("TCY", BigInteger("50")),
+                )
+            )
+
+        model.defiPositionsCount shouldBe null
+        model.assetsSize shouldBe 2
+        model.isDeFiProvider shouldBe false
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/model/DeFiBalance.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/model/DeFiBalance.kt
@@ -10,5 +10,6 @@ data class DeFiBalance(val chain: Chain, val balances: List<Balance>) {
         val amount: BigInteger,
         val coinRewards: Coin? = null,
         val rewardsAmount: BigInteger = BigInteger.ZERO,
+        val positionCount: Int? = null,
     )
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaDeFiBalanceService.kt
@@ -50,9 +50,17 @@ class SolanaDeFiBalanceService(
                 .flatMap { it.balances }
                 .groupBy { it.coin.id.lowercase() }
                 .map { (_, group) ->
-                    group.reduce { running, balance ->
-                        running.copy(amount = running.amount + balance.amount)
-                    }
+                    val amount =
+                        group.fold(BigInteger.ZERO) { running, balance -> running + balance.amount }
+                    val positionCount =
+                        group.sumOf { balance ->
+                            if (balance.amount > BigInteger.ZERO) {
+                                balance.positionCount ?: 1
+                            } else {
+                                0
+                            }
+                        }
+                    group.first().copy(amount = amount, positionCount = positionCount)
                 }
                 .filter { it.amount > BigInteger.ZERO }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceService.kt
@@ -181,6 +181,7 @@ class KaminoDeFiBalanceService(
                             entries.fold(BigInteger.ZERO) { running, (_, amount) ->
                                 running + amount
                             },
+                        positionCount = entries.size,
                     )
                 }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
@@ -22,6 +22,7 @@ data class Account(
      * form may spend.
      */
     val isPositionOnly: Boolean = false,
+    val defiPositionsCount: Int? = null,
 ) {
     companion object {
         val EMPTY = Account(token = Coin.EMPTY, tokenValue = null, fiatValue = null, price = null)
@@ -94,5 +95,8 @@ fun List<Account>.calculateAccountsPartialFiatValue(): FiatValue? {
 fun List<Account>.calculateActiveDefiPositionsCount(): Int? {
     if (isEmpty()) return 0
     if (none { it.tokenValue != null }) return null
-    return count { (it.tokenValue?.value?.signum() ?: 0) > 0 }
+    return sumOf { account ->
+        val tokenValue = account.tokenValue ?: return@sumOf 0
+        if (tokenValue.value.signum() > 0) account.defiPositionsCount ?: 1 else 0
+    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Account.kt
@@ -79,3 +79,20 @@ fun List<Account>.calculateAccountsPartialFiatValue(): FiatValue? {
         FiatValue(acc.value + fiatValue.value, fiatValue.currency)
     }
 }
+
+/**
+ * How many of the chain's DeFi positions currently hold something.
+ *
+ * A DeFi address carries one account per token the chain can hold a position in — the vault's own
+ * coins plus the injected receipts — and each one's token value *is* the position it backs, so an
+ * account above zero is an active position and a zero is a position the vault has not opened. That
+ * makes this the count behind the very figure the row already paints, which sums the same accounts.
+ *
+ * Null while nothing has resolved yet: a cold start would otherwise report a funded chain as having
+ * no positions for as long as its balances take to arrive.
+ */
+fun List<Account>.calculateActiveDefiPositionsCount(): Int? {
+    if (isEmpty()) return 0
+    if (none { it.tokenValue != null }) return null
+    return count { (it.tokenValue?.value?.signum() ?: 0) > 0 }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/CoinValues.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/CoinValues.kt
@@ -3,7 +3,11 @@ package com.vultisig.wallet.data.models
 import java.math.BigDecimal
 import java.math.BigInteger
 
-data class TokenBalance(val tokenValue: TokenValue?, val fiatValue: FiatValue?)
+data class TokenBalance(
+    val tokenValue: TokenValue?,
+    val fiatValue: FiatValue?,
+    val defiPositionsCount: Int? = null,
+)
 
 data class TokenBalanceAndPrice(val tokenBalance: TokenBalance, val price: FiatValue?)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -664,10 +664,19 @@ constructor(
     }
 
     private fun Account.applyBalance(balance: TokenBalance): Account =
-        copy(tokenValue = balance.tokenValue, fiatValue = balance.fiatValue)
+        copy(
+            tokenValue = balance.tokenValue,
+            fiatValue = balance.fiatValue,
+            defiPositionsCount = balance.defiPositionsCount,
+        )
 
     private fun Account.applyBalance(balance: TokenBalance, price: FiatValue?): Account =
-        copy(tokenValue = balance.tokenValue, fiatValue = balance.fiatValue, price = price)
+        copy(
+            tokenValue = balance.tokenValue,
+            fiatValue = balance.fiatValue,
+            price = price,
+            defiPositionsCount = balance.defiPositionsCount,
+        )
 
     private fun Address.distinctByChainAndContractAddress() =
         copy(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -297,7 +297,12 @@ constructor(
                 }
 
             TokenBalanceAndPrice(
-                tokenBalance = TokenBalance(tokenValue = tokenValue, fiatValue = fiatValue),
+                tokenBalance =
+                    TokenBalance(
+                        tokenValue = tokenValue,
+                        fiatValue = fiatValue,
+                        defiPositionsCount = balance.positionCount,
+                    ),
                 price =
                     if (price != null) {
                         FiatValue(price, currency.ticker)
@@ -398,7 +403,12 @@ constructor(
 
         emit(
             TokenBalanceAndPrice(
-                tokenBalance = TokenBalance(tokenValue = tokenValue, fiatValue = fiatValue),
+                tokenBalance =
+                    TokenBalance(
+                        tokenValue = tokenValue,
+                        fiatValue = fiatValue,
+                        defiPositionsCount = defiBalance?.positionCount,
+                    ),
                 price = FiatValue(value = price, currency = currency.ticker),
             )
         )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/SolanaDeFiBalanceServiceTest.kt
@@ -43,6 +43,18 @@ internal class SolanaDeFiBalanceServiceTest {
         // The pipeline resolves one balance per coin, so leaving these as two entries would report
         // whichever it matched first as the whole position.
         assertEquals(BigInteger("1500000000"), balance.amount)
+        assertEquals(2, balance.positionCount)
+    }
+
+    @Test
+    fun `a grouped Kamino token keeps its original number of positions`() = runTest {
+        coEvery { kamino.getRemoteDeFiBalance(ADDRESS, VAULT_ID) } returns
+            balances(Coins.Solana.USDC to BigInteger("250000000")).withPositionCount(2)
+
+        val balance = service().getRemoteDeFiBalance(ADDRESS, VAULT_ID).single().balances.single()
+
+        assertEquals(BigInteger("250000000"), balance.amount)
+        assertEquals(2, balance.positionCount)
     }
 
     @Test
@@ -103,6 +115,13 @@ internal class SolanaDeFiBalanceServiceTest {
                 balances = entries.map { (coin, amount) -> DeFiBalance.Balance(coin, amount) },
             )
         )
+
+    private fun List<DeFiBalance>.withPositionCount(positionCount: Int) = map { defiBalance ->
+        defiBalance.copy(
+            balances =
+                defiBalance.balances.map { balance -> balance.copy(positionCount = positionCount) }
+        )
+    }
 
     private companion object {
         const val VAULT_ID = "vault-id"

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/solana/kamino/KaminoDeFiBalanceServiceTest.kt
@@ -76,6 +76,7 @@ internal class KaminoDeFiBalanceServiceTest {
 
         assertEquals(1, balances.size)
         assertEquals(BigInteger("150000000"), balances.single().amount)
+        assertEquals(2, balances.single().positionCount)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CalculateActiveDefiPositionsCountTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CalculateActiveDefiPositionsCountTest.kt
@@ -25,12 +25,13 @@ class CalculateActiveDefiPositionsCountTest {
             isNativeToken = ticker == "RUNE",
         )
 
-    private fun account(ticker: String, amount: BigInteger?) =
+    private fun account(ticker: String, amount: BigInteger?, defiPositionsCount: Int? = null) =
         Account(
             token = coin(ticker),
             tokenValue = amount?.let { TokenValue(it, ticker, 8) },
             fiatValue = amount?.let { FiatValue(BigDecimal.ONE, "USD") },
             price = null,
+            defiPositionsCount = defiPositionsCount,
         )
 
     @Test
@@ -65,6 +66,17 @@ class CalculateActiveDefiPositionsCountTest {
         val accounts = listOf(account("RUNE", null), account("TCY", BigInteger("50")))
 
         assertEquals(1, accounts.calculateActiveDefiPositionsCount())
+    }
+
+    @Test
+    fun `an aggregated token balance can count multiple active positions`() {
+        val accounts =
+            listOf(
+                account("SOL", BigInteger("100"), defiPositionsCount = 1),
+                account("USDC", BigInteger("50"), defiPositionsCount = 2),
+            )
+
+        assertEquals(3, accounts.calculateActiveDefiPositionsCount())
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CalculateActiveDefiPositionsCountTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CalculateActiveDefiPositionsCountTest.kt
@@ -1,0 +1,74 @@
+package com.vultisig.wallet.data.models
+
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [calculateActiveDefiPositionsCount], the count the DeFi home row reports in place of
+ * the wallet's token inventory.
+ */
+class CalculateActiveDefiPositionsCountTest {
+
+    private fun coin(ticker: String) =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = ticker,
+            logo = "",
+            address = "addr",
+            decimal = 8,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = ticker == "RUNE",
+        )
+
+    private fun account(ticker: String, amount: BigInteger?) =
+        Account(
+            token = coin(ticker),
+            tokenValue = amount?.let { TokenValue(it, ticker, 8) },
+            fiatValue = amount?.let { FiatValue(BigDecimal.ONE, "USD") },
+            price = null,
+        )
+
+    @Test
+    fun `counts only the accounts holding something`() {
+        val accounts =
+            listOf(
+                account("RUNE", BigInteger("100")),
+                account("TCY", BigInteger("50")),
+                account("RUJI", BigInteger.ZERO),
+                account("yRUNE", BigInteger.ZERO),
+            )
+
+        assertEquals(2, accounts.calculateActiveDefiPositionsCount())
+    }
+
+    @Test
+    fun `a chain whose positions are all empty has none`() {
+        val accounts = listOf(account("RUNE", BigInteger.ZERO), account("TCY", BigInteger.ZERO))
+
+        assertEquals(0, accounts.calculateActiveDefiPositionsCount())
+    }
+
+    @Test
+    fun `nothing resolved yet is unknown rather than none`() {
+        val accounts = listOf(account("RUNE", null), account("TCY", null))
+
+        assertNull(accounts.calculateActiveDefiPositionsCount())
+    }
+
+    @Test
+    fun `a single resolved position counts while its neighbours are still pending`() {
+        val accounts = listOf(account("RUNE", null), account("TCY", BigInteger("50")))
+
+        assertEquals(1, accounts.calculateActiveDefiPositionsCount())
+    }
+
+    @Test
+    fun `an address carrying no accounts has none rather than being unknown`() {
+        assertEquals(0, emptyList<Account>().calculateActiveDefiPositionsCount())
+    }
+}


### PR DESCRIPTION
Closes #5780

## Problem

Every DeFi chain row was painting the Wallet subtitle: the vault's token count on that chain (`"12 Assets"`), or the native amount when the chain held a single coin (`3.831213 TRX`). Neither reports the positions the row exists for — a vault tracking twelve THORChain tokens while staking two of them read "12 Assets".

`assetsSize` is `from.accounts.size` (`AddressToUiModelMapper.kt:37`), and `AccountItem` chose between it and the native amount with no notion of a DeFi row at all.

## Fix

The count comes off the row's own accounts. A DeFi address carries one account per token the chain can hold a position in — the vault's coins plus the injected `defiOnly` / position-only receipts — and each account's token value *is* the position it backs, so the accounts above zero are the active positions. That makes the subtitle the count behind the very figure printed above it, which sums the same list, rather than a second reading that could disagree with it.

- `calculateActiveDefiPositionsCount()` on `List<Account>`, next to the existing portfolio folds.
- `AddressToUiModelMapper` sets it for DeFi rows only, and finally populates the previously-dead `isDeFiProvider` flag on `AccountUiModel`.
- `AccountItem` renders `"N positions"` / `"No positions found"` for a DeFi row. Wallet rows are untouched: still `"N Assets"`, still the native amount for single-token chains.

**Unresolved is not zero.** The fold answers `null` until something has resolved, so a cold start holds the same placeholder the native amount already used instead of claiming a funded chain has no positions and then correcting itself.

**Pluralised**, unlike iOS and Windows, which both format a flat `"%d positions"`. Tron, TON and the Cosmos staking chains are 0-or-1 by construction, so the flat form would ship "1 positions" as the common case rather than the edge one — visible as `Circle · 1 position` below.

## Strings

`no_positions_found` already existed in all ten locales and already matched iOS, so it is reused. `defi_chain_positions_count` is new in all ten, using each locale's established term for "position" — including `仓位` for zh-rCN, which is what the rest of this app's Chinese uses (iOS says `持仓`), and the full `one/few/many` sets for ru and hr.

## Two divergences from iOS, deliberate

- **The opt-in.** `DefiBalanceService.defiPositionCount` gates on the Manage Positions selection. Nothing in the Android home balance path reads that selection, and the row's fiat total does not either — gating the count alone would have made the subtitle disagree with the figure above it. Solana is the exception and already behaves: `KaminoDeFiBalanceService` gates on its own vault selection, so toggling a Kamino vault off does drop the count.
- **Bond granularity.** A vault bonded to several nodes counts as **1** here, because `ThorchainDeFiBalanceService` sums bonds into a single RUNE figure (and `MayaDeFiBalanceService` merges bond + stake into one CACAO figure) long before the row sees them. iOS counts each node. Matching it would need a parallel per-position counter reading six-plus repositories on the home screen, which would then disagree with the row's own total.

## Test plan

- `calculateActiveDefiPositionsCount`: funded-only counting, all-empty, nothing-resolved, one resolved among pending, empty address. (5 new)
- `AddressToUiModelMapper`: a DeFi row reports positions rather than its token count, reports zero, reports unknown while resolving; a wallet row carries no count. (4 new)
- Full suites green: `:data` + `:app` — 5798 tests, 0 failures.
- `:app:lintDebug` passes with no warning on the new resource (`many` included for es/it/pt, which lint asks for).
- ktfmt applied.

## Result

DeFi tab, real device — Solana and THORChain plural, Circle singular:

![DeFi home rows counting positions](https://i.imgur.com/8Sq3Jsp.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeFi provider rows now display the number of active positions.
  * Counts support loading, zero-position, singular, and plural states.
  * Position counts are localized across supported languages.
  * Counts now reflect positions aggregated across supported DeFi balances.

* **Bug Fixes**
  * Wallet rows continue showing existing token and asset counts without DeFi position labels.

* **Tests**
  * Added coverage for active, empty, unresolved, and partially resolved DeFi positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->