### PR TITLE
CI: align setup-gradle to v6

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,7 +31,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## Summary
- Bump the build-and-test job from gradle/actions/setup-gradle@v5 to @v6
- Keep all android.yml jobs on the same setup-gradle major version

Closes #5797

## Test plan
- Not run locally; workflow-only dependency alignment
- CI should confirm build-and-test, lint, and instrumented-tests still pass