### PR TITLE
Fix sTCY DeFi portfolio balance

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainDeFiBalanceService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainDeFiBalanceService.kt
@@ -168,7 +168,8 @@ class ThorchainDeFiBalanceService(
                         balances =
                             defaultDetails
                                 .filter {
-                                    it.coin.id.equals(Coins.ThorChain.yRUNE.id, true) ||
+                                    it.coin.id.equals(Coins.ThorChain.sTCY.id, true) ||
+                                        it.coin.id.equals(Coins.ThorChain.yRUNE.id, true) ||
                                         it.coin.id.equals(Coins.ThorChain.yTCY.id, true) ||
                                         it.coin.id.equals(Coins.ThorChain.ybRUNE.id, true)
                                 }
@@ -312,7 +313,8 @@ class ThorchainDeFiBalanceService(
 
                     stakingDetails
                         .filter {
-                            it.coin.id.equals(Coins.ThorChain.yTCY.id, true) ||
+                            it.coin.id.equals(Coins.ThorChain.sTCY.id, true) ||
+                                it.coin.id.equals(Coins.ThorChain.yTCY.id, true) ||
                                 it.coin.id.equals(Coins.ThorChain.yRUNE.id, true) ||
                                 it.coin.id.equals(Coins.ThorChain.ybRUNE.id, true)
                         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/AccountsRepository.kt
@@ -98,13 +98,13 @@ constructor(
         buildCacheAddresses(vaultId).flatMapLatest { (vaultCoins, addresses) ->
             channelFlow {
                 supervisorScope {
-                    // The DeFi-only receipts ride along: no vault carries one, so this refresh —
-                    // the only ungated one — is all that keeps the row they are valued from warm.
-                    // loadDeFiAddresses refreshes them too, but only on an explicit reload, and
-                    // its cached emission reads that row, so a cold start would otherwise value a
-                    // funded position at $0.00.
+                    // Position receipts ride along: no vault necessarily carries one, so this
+                    // refresh — the only ungated one — is all that keeps the row they are valued
+                    // from warm. loadDeFiAddresses refreshes them too, but only on an explicit
+                    // reload, and its cached emission reads that row, so a cold start would
+                    // otherwise value a funded position at $0.00.
                     val loadPrices = async {
-                        tokenPriceRepository.refresh(vaultCoins + defiOnlyReceiptsFor(vaultCoins))
+                        tokenPriceRepository.refresh(vaultCoins + injectedReceiptsFor(vaultCoins))
                     }
 
                     // Always emit the last-known DB snapshot first so the UI shows cached
@@ -683,17 +683,25 @@ constructor(
      *
      * A Kamino Earn position is held in its vault's underlying token, and a wallet can hold one
      * without ever holding that token itself — it may have deposited its whole balance, or
-     * deposited from another device. Accounts here are built from `vault.coins`, so without this
-     * the position resolves to an account that is not there and is silently dropped.
+     * deposited from another device. THORChain sTCY is similar for the Portfolio DeFi tab: the
+     * receipt can exist before the user manually enables that wallet token. Accounts here are built
+     * from `vault.coins`, so without this the position resolves to an account that is not there and
+     * is silently dropped.
      *
      * Every curated vault's token is offered rather than only the enabled ones: an unfunded
      * injection is dropped once its balance resolves, so opting out removes it either way.
      */
     private fun positionOnlyTokens(chain: Chain, tokens: List<Coin>): List<Coin> {
-        if (chain != Chain.Solana) return emptyList()
         val template = tokens.firstOrNull() ?: return emptyList()
         val held = tokens.mapTo(mutableSetOf()) { it.id.lowercase() }
-        return KaminoVaultRegistry.ALLOW_LIST.mapNotNull { it.coin }
+        val injectedTokens =
+            when (chain) {
+                Chain.Solana -> KaminoVaultRegistry.ALLOW_LIST.mapNotNull { it.coin }
+                Chain.ThorChain -> listOf(Coins.ThorChain.sTCY)
+                else -> emptyList()
+            }
+
+        return injectedTokens
             .distinctBy { it.id.lowercase() }
             .filterNot { it.id.lowercase() in held }
             .map { it.copy(address = template.address, hexPublicKey = template.hexPublicKey) }
@@ -762,7 +770,7 @@ constructor(
     }
 
     /**
-     * The DeFi-only receipts worth pricing for a vault holding [vaultCoins].
+     * The injected receipts worth pricing for a vault holding [vaultCoins].
      *
      * Only the chains the vault actually holds: [defiOnlyTokens] hangs a receipt off the chain's
      * native token, so a vault without the chain can never carry the position and its row is one
@@ -772,6 +780,13 @@ constructor(
      */
     private fun defiOnlyReceiptsFor(vaultCoins: List<Coin>): List<Coin> =
         Coins.defiOnly.filter { receipt -> vaultCoins.any { it.chain == receipt.chain } }
+
+    private fun injectedReceiptsFor(vaultCoins: List<Coin>): List<Coin> =
+        defiOnlyReceiptsFor(vaultCoins) +
+            listOf(Coins.ThorChain.sTCY).filter { receipt ->
+                vaultCoins.any { it.chain == receipt.chain } &&
+                    vaultCoins.none { it.id.equals(receipt.id, ignoreCase = true) }
+            }
 
     /**
      * Drops the DeFi-only accounts that resolved to nothing.

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainDeFiBalanceServiceYbRuneTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainDeFiBalanceServiceYbRuneTest.kt
@@ -57,6 +57,26 @@ internal class ThorchainDeFiBalanceServiceYbRuneTest {
         assertEquals(BigInteger("77000000"), balances.amountFor(Coins.ThorChain.ybRUNE.id))
     }
 
+    @Test
+    fun `a fetched sTCY position reaches the DeFi balances`() = runTest {
+        coEvery { defaultStakingPositionService.getStakingDetails(ADDRESS, VAULT_ID) } returns
+            flowOf(listOf(details(Coins.ThorChain.sTCY, BigInteger("100000000000"))))
+
+        val balances = service.getRemoteDeFiBalance(ADDRESS, VAULT_ID)
+
+        assertEquals(BigInteger("100000000000"), balances.amountFor(Coins.ThorChain.sTCY.id))
+    }
+
+    @Test
+    fun `a cached sTCY position reaches the DeFi balances`() = runTest {
+        coEvery { stakingDetailsRepository.getStakingDetails(VAULT_ID) } returns
+            listOf(details(Coins.ThorChain.sTCY, BigInteger("42000000000")))
+
+        val balances = service.getCacheDeFiBalance(ADDRESS, VAULT_ID)
+
+        assertEquals(BigInteger("42000000000"), balances.amountFor(Coins.ThorChain.sTCY.id))
+    }
+
     private fun List<com.vultisig.wallet.data.blockchain.model.DeFiBalance>.amountFor(
         coinId: String
     ): BigInteger =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/AccountsRepositoryImplTest.kt
@@ -452,6 +452,83 @@ internal class AccountsRepositoryImplTest {
     }
 
     @Test
+    fun `cached DeFi addresses carry the auto-compounding TCY position without wallet sTCY`() =
+        runTest {
+            val rune = Coins.ThorChain.RUNE.copy(address = THOR_ADDRESS)
+            val tcy = Coins.ThorChain.TCY.copy(address = THOR_ADDRESS)
+            coEvery { vaultRepository.get(VAULT_ID) } returns
+                Vault(id = VAULT_ID, name = "Test Vault", coins = listOf(rune, tcy))
+
+            coEvery {
+                balanceRepository.getDeFiCachedTokeBalanceAndPrice(THOR_ADDRESS, any(), VAULT_ID)
+            } returns
+                listOf(
+                    defiBalance(Coins.ThorChain.RUNE, amount = 0L, fiat = 0L),
+                    defiBalance(Coins.ThorChain.TCY, amount = 0L, fiat = 0L),
+                    defiBalance(Coins.ThorChain.sTCY, amount = STAKED, fiat = STAKED_FIAT),
+                )
+
+            val thorchain =
+                repository.loadDeFiAddresses(VAULT_ID, isRefresh = false).toList().last().first {
+                    it.chain == Chain.ThorChain
+                }
+
+            val compounding =
+                thorchain.accounts.firstOrNull { it.token.id == Coins.ThorChain.sTCY.id }
+            assertNotNull(compounding, "the DeFi row must carry an account for the sTCY receipt")
+            assertTrue(compounding.isPositionOnly)
+            assertEquals(STAKED, compounding.tokenValue?.value?.toLong())
+            assertEquals(
+                STAKED_FIAT,
+                thorchain.accounts.sumOf { it.fiatValue?.value?.toLong() ?: 0L },
+                "the chain's DeFi total must include the auto-compounding TCY position",
+            )
+        }
+
+    @Test
+    fun `refreshed DeFi addresses fetch and price the auto-compounding TCY position without wallet sTCY`() =
+        runTest {
+            val rune = Coins.ThorChain.RUNE.copy(address = THOR_ADDRESS)
+            val tcy = Coins.ThorChain.TCY.copy(address = THOR_ADDRESS)
+            coEvery { vaultRepository.get(VAULT_ID) } returns
+                Vault(id = VAULT_ID, name = "Test Vault", coins = listOf(rune, tcy))
+            coJustRun { tokenPriceRepository.refresh(any()) }
+            coEvery {
+                balanceRepository.getDeFiCachedTokeBalanceAndPrice(any(), any(), any())
+            } returns emptyList()
+            every {
+                balanceRepository.getDefiTokenBalanceAndPrice(THOR_ADDRESS, any(), VAULT_ID)
+            } returns flowOf(defiBalance(Coins.ThorChain.RUNE, amount = 0L, fiat = 0L))
+            every {
+                balanceRepository.getDefiTokenBalanceAndPrice(
+                    THOR_ADDRESS,
+                    match { it.id == Coins.ThorChain.sTCY.id },
+                    VAULT_ID,
+                )
+            } returns flowOf(defiBalance(Coins.ThorChain.sTCY, amount = STAKED, fiat = STAKED_FIAT))
+
+            val thorchain =
+                repository.loadDeFiAddresses(VAULT_ID, isRefresh = true).toList().last().first {
+                    it.chain == Chain.ThorChain
+                }
+
+            val compounding =
+                thorchain.accounts.firstOrNull { it.token.id == Coins.ThorChain.sTCY.id }
+            assertNotNull(compounding, "the refreshed DeFi row must carry the sTCY receipt")
+            assertTrue(compounding.isPositionOnly)
+            assertEquals(
+                STAKED_FIAT,
+                thorchain.accounts.sumOf { it.fiatValue?.value?.toLong() ?: 0L },
+                "the refreshed total must include the auto-compounding TCY position",
+            )
+            coVerify {
+                tokenPriceRepository.refresh(
+                    match { it.any { coin -> coin.id == Coins.ThorChain.sTCY.id } }
+                )
+            }
+        }
+
+    @Test
     fun `a vault holding no DeFi-only position carries no account for it`() = runTest {
         val rune = Coins.ThorChain.RUNE.copy(address = THOR_ADDRESS)
         coEvery { vaultRepository.get(VAULT_ID) } returns
@@ -593,6 +670,11 @@ internal class AccountsRepositoryImplTest {
         coVerify {
             tokenPriceRepository.refresh(
                 match { it.any { coin -> coin.id == Coins.ThorChain.sRUJI.id } }
+            )
+        }
+        coVerify {
+            tokenPriceRepository.refresh(
+                match { it.any { coin -> coin.id == Coins.ThorChain.sTCY.id } }
             )
         }
         job.cancel()


### PR DESCRIPTION
## Summary
- Include sTCY in THORChain default staking DeFi balances for cached reads
- Include sTCY in the matching remote balance path
- Add regression coverage for fetched and cached sTCY positions

Closes #5764

## Test plan
- ./gradlew :data:testDebugUnitTest --tests com.vultisig.wallet.data.blockchain.thorchain.ThorchainDeFiBalanceServiceYbRuneTest
- ./gradlew :data:testDebugUnitTest
- ./gradlew assembleDebug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * sTCY staking balances are now included in DeFi balance displays for both newly fetched and cached data.
  * DeFi-only sTCY positions are now included in account balances and price refreshes, even when the receipt is not held in the wallet.

* **Bug Fixes**
  * Corrected staking balance retrieval so eligible sTCY positions are reflected consistently.
  * Preserved fiat pricing for accounts containing sTCY DeFi positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->