### PR TITLE
fix(swap): give LI.FI Auto a real slippage tolerance

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/LiFiChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/LiFiChainApi.kt
@@ -24,7 +24,7 @@ interface LiFiChainApi {
         fromAddress: String,
         toAddress: String,
         bpsDiscount: Int,
-        slippageBps: Int? = null,
+        slippageBps: Int,
     ): LiFiSwapQuoteDeserialized
 
     companion object {
@@ -42,10 +42,12 @@ interface LiFiChainApi {
          * denomination cannot be inferred reliably for cross-chain swaps (#3300). Deriving the fee
          * from `dstAmount` sidesteps that ambiguity.
          */
-        fun integratorFeeAmount(dstAmount: BigInteger, bpsDiscount: Int = 0): BigInteger {
-            val effectiveBps = maxOf(0, INTEGRATOR_FEE_BPS - bpsDiscount)
-            return dstAmount * effectiveBps.toBigInteger() / BPS_DENOMINATOR
-        }
+        fun integratorFeeAmount(dstAmount: BigInteger, bpsDiscount: Int = 0): BigInteger =
+            dstAmount * effectiveIntegratorFeeBps(bpsDiscount).toBigInteger() / BPS_DENOMINATOR
+
+        /** The integrator fee actually charged once the caller's VULT tier discount is applied. */
+        fun effectiveIntegratorFeeBps(bpsDiscount: Int): Int =
+            maxOf(0, INTEGRATOR_FEE_BPS - bpsDiscount)
     }
 }
 
@@ -65,7 +67,7 @@ constructor(
         fromAddress: String,
         toAddress: String,
         bpsDiscount: Int,
-        slippageBps: Int?,
+        slippageBps: Int,
     ): LiFiSwapQuoteDeserialized {
         val bpsDiscountFee = round(bpsDiscount.toDouble()) / LiFiChainApi.BPS_DENOMINATOR_INT
         val updatedFeeIntegrator =
@@ -84,15 +86,15 @@ constructor(
                 parameter("fromAmount", fromAmount)
                 parameter("fromAddress", fromAddress)
                 parameter("toAddress", toAddress)
-                // LI.FI takes slippage as a fraction (0.01 = 1%); omitted = LI.FI's own default.
+                // LI.FI takes slippage as a fraction (0.01 = 1%). Always sent: omitting it
+                // leaves LI.FI's own 0.5%, too tight to survive a keysign ceremony, so the caller
+                // resolves an explicit tolerance for "Auto" too (see LiFiSlippage).
                 // Format via BigDecimal plain string: a Double would render tight tolerances (1–9
                 // bps) in scientific notation (e.g. 1.0E-4), which LI.FI rejects as non-numeric.
-                slippageBps?.let {
-                    parameter(
-                        "slippage",
-                        BigDecimal(it).movePointLeft(4).stripTrailingZeros().toPlainString(),
-                    )
-                }
+                parameter(
+                    "slippage",
+                    BigDecimal(slippageBps).movePointLeft(4).stripTrailingZeros().toPlainString(),
+                )
                 parameter("integrator", LiFiChainApi.INTEGRATOR_ACCOUNT)
                 parameter("fee", updatedFeeIntegrator)
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiQuoteSource.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.common.convertToBigIntegerOrZero
 import com.vultisig.wallet.data.common.isNotEmptyContract
 import com.vultisig.wallet.data.models.oneInchChainId
 import javax.inject.Inject
+import timber.log.Timber
 
 internal class LiFiQuoteSource @Inject constructor(private val liFiChainApi: LiFiChainApi) :
     SwapQuoteSource {
@@ -24,6 +25,9 @@ internal class LiFiQuoteSource @Inject constructor(private val liFiChainApi: LiF
         val toToken =
             if (dstToken.ticker == "CRO") ZERO_ADDRESS
             else dstToken.contractAddress.ifEmpty { dstToken.ticker }
+        val slippageBps =
+            LiFiSlippage.resolveBps(request.slippageBps, srcToken.ticker, dstToken.ticker)
+        warnOnCombinedCost(slippageBps, request.bpsDiscount)
 
         val response =
             swapApiCall("LiFi") {
@@ -36,7 +40,7 @@ internal class LiFiQuoteSource @Inject constructor(private val liFiChainApi: LiF
                     fromAddress = request.srcAddress,
                     toAddress = request.dstAddress,
                     bpsDiscount = request.bpsDiscount,
-                    slippageBps = request.slippageBps,
+                    slippageBps = slippageBps,
                 )
             }
 
@@ -45,6 +49,23 @@ internal class LiFiQuoteSource @Inject constructor(private val liFiChainApi: LiF
                 throw SwapException.handleSwapException(response.error.message)
 
             is LiFiSwapQuoteDeserialized.Result -> SwapQuoteResult.Evm(response.data.toEvmQuote())
+        }
+    }
+
+    /**
+     * The integrator fee and the slippage tolerance are two independent costs the same swap pays,
+     * so a future fee bump must not quietly compound with a wide tolerance past
+     * [LiFiSlippage.MAX_COMBINED_COST_BPS]. Reported, never enforced — a user who deliberately
+     * picks a wide tolerance still gets the quote they asked for.
+     */
+    private fun warnOnCombinedCost(slippageBps: Int, bpsDiscount: Int) {
+        val combinedBps = LiFiChainApi.effectiveIntegratorFeeBps(bpsDiscount) + slippageBps
+        if (combinedBps > LiFiSlippage.MAX_COMBINED_COST_BPS) {
+            Timber.w(
+                "LiFi affiliate + slippage combined cost is %d bps, over the %d bps ceiling",
+                combinedBps,
+                LiFiSlippage.MAX_COMBINED_COST_BPS,
+            )
         }
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiSlippage.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiSlippage.kt
@@ -60,10 +60,17 @@ internal object LiFiSlippage {
 
     /**
      * [override] is the user's own tolerance in basis points, or null for "Auto" — in which case
-     * the pair picks the tier. Never returns null, so the `slippage` param is always sent.
+     * the pair picks the tier. Never returns null or zero, so the `slippage` param is always sent
+     * and always a real tolerance.
+     *
+     * A non-positive [override] falls back to the tier rather than throwing: the swap form only
+     * ever hands over a preset or a value it already clamped to 1 bps and up, so this is an
+     * unreachable state, and failing a quote over it would be a worse outcome than quoting at the
+     * Auto tolerance.
      */
     fun resolveBps(override: Int?, srcTicker: String, dstTicker: String): Int =
-        override ?: if (isStablePair(srcTicker, dstTicker)) STABLE_PAIR_BPS else DEFAULT_BPS
+        override?.takeIf { it > 0 }
+            ?: if (isStablePair(srcTicker, dstTicker)) STABLE_PAIR_BPS else DEFAULT_BPS
 
     private fun isStable(ticker: String): Boolean = ticker.uppercase() in STABLE_TICKERS
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiSlippage.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiSlippage.kt
@@ -1,0 +1,69 @@
+package com.vultisig.wallet.data.repositories.swap
+
+/**
+ * LI.FI "Auto" slippage, ported from the SDK's `lifiSlippage.ts` (vultisig-sdk#524).
+ *
+ * The tolerance is baked into the LI.FI-prebuilt transaction's `minAmountOut` floor at quote time,
+ * so the router reverts once the simulated output drops below it. Omitting the `slippage` param
+ * leaves LI.FI's own 0.5% default, which is too tight for an MPC wallet: the keysign ceremony adds
+ * 30–90s of drift between the quote and the broadcast, and that floor is what produced the
+ * `Insufficient output` reverts in #5801.
+ *
+ * Two tiers:
+ * - stable pairs: [STABLE_PAIR_BPS], well above the typical concentrated-liquidity spread (2–5 bps)
+ *   while avoiding the 1% MEV surface on tight-peg swaps;
+ * - everything else: [DEFAULT_BPS], which covers the ceremony drift. Typical realised slippage is
+ *   under 10 bps, so this is a ceiling rather than the expected cost.
+ *
+ * Cross-chain caveat: the tolerance applies to the final destination amount only. A LI.FI
+ * bridge+swap route has a second slippage point at the bridge pool exit that the bridge protocol
+ * manages itself, so realised slippage there can exceed this floor.
+ *
+ * A user-chosen preset or custom value overrides both tiers untouched.
+ */
+internal object LiFiSlippage {
+
+    /** Auto tolerance for a volatile pair, in basis points (100 bps = 1%). */
+    const val DEFAULT_BPS = 100
+
+    /** Auto tolerance for a stable-to-stable pair, in basis points (30 bps = 0.3%). */
+    const val STABLE_PAIR_BPS = 30
+
+    /**
+     * Combined affiliate + slippage ceiling, in basis points. Logged, never enforced: the
+     * integrator fee must not silently compound with a wide tolerance into a >3% effective cost.
+     */
+    const val MAX_COMBINED_COST_BPS = 300
+
+    /**
+     * Tickers that trade within a tight peg. DAI is included because its depth against USDC is
+     * comparable to USDT's on most DEXs, so [STABLE_PAIR_BPS] is still safe headroom there.
+     */
+    val STABLE_TICKERS =
+        setOf(
+            "USDC",
+            "USDT",
+            "DAI",
+            "BUSD",
+            "TUSD",
+            "FRAX",
+            "USDP",
+            "GUSD",
+            "LUSD",
+            "USDD",
+            "FDUSD",
+            "PYUSD",
+        )
+
+    fun isStablePair(srcTicker: String, dstTicker: String): Boolean =
+        isStable(srcTicker) && isStable(dstTicker)
+
+    /**
+     * [override] is the user's own tolerance in basis points, or null for "Auto" — in which case
+     * the pair picks the tier. Never returns null, so the `slippage` param is always sent.
+     */
+    fun resolveBps(override: Int?, srcTicker: String, dstTicker: String): Int =
+        override ?: if (isStablePair(srcTicker, dstTicker)) STABLE_PAIR_BPS else DEFAULT_BPS
+
+    private fun isStable(ticker: String): Boolean = ticker.uppercase() in STABLE_TICKERS
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapQuoteSource.kt
@@ -25,10 +25,10 @@ data class SwapQuoteRequest(
     /**
      * User-chosen slippage tolerance in basis points (100 = 1%), or null for "Auto" — in which case
      * each provider keeps its own default ([DEFAULT_THORCHAIN_TOLERANCE_BPS] for THORChain/Maya,
-     * 0.5% for 1inch and Jupiter, 1% for Kyber, LI.FI's and SwapKit's own server defaults).
-     * Honoured by every provider; each converts it to its native unit (bps, percent, or fraction),
-     * and SwapKit omits it on Auto so NEAR Intents / Chainflip can negotiate their own per-route
-     * tolerance.
+     * 0.5% for 1inch and Jupiter, 1% for Kyber, [LiFiSlippage]'s stable/volatile tiers for LI.FI,
+     * and SwapKit's own server default). Honoured by every provider; each converts it to its native
+     * unit (bps, percent, or fraction), and SwapKit omits it on Auto so NEAR Intents / Chainflip
+     * can negotiate their own per-route tolerance.
      */
     val slippageBps: Int? = null,
 )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/LiFiChainApiBodyReadTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/LiFiChainApiBodyReadTest.kt
@@ -42,6 +42,7 @@ class LiFiChainApiBodyReadTest {
             fromAddress = "0xaddr",
             toAddress = "0xaddr",
             bpsDiscount = 0,
+            slippageBps = 100,
         )
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/LiFiChainApiImplRequestTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/LiFiChainApiImplRequestTest.kt
@@ -58,7 +58,7 @@ class LiFiChainApiImplRequestTest {
             fromAddress = "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
             toAddress = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM",
             bpsDiscount = bpsDiscount,
-            slippageBps = null,
+            slippageBps = 100,
         )
         return requestedUrl
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/LiFiChainApiSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/LiFiChainApiSlippageTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.api
 
+import com.vultisig.wallet.data.repositories.swap.LiFiSlippage
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -18,6 +19,10 @@ import org.junit.jupiter.api.Test
  * Pins the `slippage` query param sent to LI.FI. LI.FI takes slippage as a decimal fraction, so the
  * basis-point value must be rendered as a plain decimal — tight tolerances (1–9 bps) must not be
  * stringified in scientific notation (e.g. `1.0E-4`), which LI.FI rejects as non-numeric.
+ *
+ * The param is never omitted: LI.FI's own default is 0.5%, too tight to survive a keysign ceremony
+ * (#5801), so the caller resolves a tolerance for "Auto" too. Tier selection itself is pinned by
+ * `LiFiSlippageTest`.
  */
 class LiFiChainApiSlippageTest {
 
@@ -42,7 +47,7 @@ class LiFiChainApiSlippageTest {
             json = json,
         )
 
-    private suspend fun LiFiChainApiImpl.quoteWith(slippageBps: Int?) =
+    private suspend fun LiFiChainApiImpl.quoteWith(slippageBps: Int) =
         getSwapQuote(
             fromChain = "1",
             toChain = "1",
@@ -76,12 +81,12 @@ class LiFiChainApiSlippageTest {
     }
 
     @Test
-    fun `auto slippage omits the parameter`() = runTest {
-        var hasSlippage = true
-        val api = apiCapturing { hasSlippage = it.url.parameters.contains("slippage") }
+    fun `the stable-pair auto tier is sent as 0,003`() = runTest {
+        var slippageParam: String? = null
+        val api = apiCapturing { slippageParam = it.url.parameters["slippage"] }
 
-        runCatching { api.quoteWith(slippageBps = null) }
+        runCatching { api.quoteWith(slippageBps = LiFiSlippage.STABLE_PAIR_BPS) }
 
-        assertEquals(false, hasSlippage)
+        assertEquals("0.003", slippageParam)
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryProvidersTest.kt
@@ -43,6 +43,7 @@ import com.vultisig.wallet.data.repositories.swap.SwapQuoteResult
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.slot
 import java.math.BigInteger
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -523,14 +524,18 @@ class SwapQuoteRepositoryProvidersTest {
             message = message,
         )
 
-    private fun liFiRequest() =
+    private fun liFiRequest(
+        srcToken: Coin = coin(Chain.Ethereum, "ETH"),
+        dstToken: Coin = coin(Chain.Ethereum, "USDC", contractAddress = "0xUsdc"),
+        slippageBps: Int? = null,
+    ) =
         SwapQuoteRequest(
-            srcToken = coin(Chain.Ethereum, "ETH"),
-            dstToken = coin(Chain.Ethereum, "USDC", contractAddress = "0xUsdc"),
-            tokenValue =
-                TokenValue(value = BigInteger("1000000"), token = coin(Chain.Ethereum, "ETH")),
+            srcToken = srcToken,
+            dstToken = dstToken,
+            tokenValue = TokenValue(value = BigInteger("1000000"), token = srcToken),
             srcAddress = "0xWallet",
             dstAddress = "0xDest",
+            slippageBps = slippageBps,
         )
 
     @Test
@@ -577,6 +582,77 @@ class SwapQuoteRepositoryProvidersTest {
         assertThrows<SwapException.HighPriceImpact> {
             runBlocking { liFiSource.fetch(liFiRequest()) }
         }
+    }
+
+    @Test
+    fun `lifi resolves auto slippage to the volatile tier, never omitting the param`() = runTest {
+        val slippage = slot<Int>()
+        coEvery {
+            liFiChainApi.getSwapQuote(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                capture(slippage),
+            )
+        } returns LiFiSwapQuoteDeserialized.Result(liFiQuote())
+
+        liFiSource.fetch(liFiRequest())
+
+        assertEquals(100, slippage.captured)
+    }
+
+    @Test
+    fun `lifi resolves auto slippage to the stable tier on a stable pair`() = runTest {
+        val slippage = slot<Int>()
+        coEvery {
+            liFiChainApi.getSwapQuote(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                capture(slippage),
+            )
+        } returns LiFiSwapQuoteDeserialized.Result(liFiQuote())
+
+        liFiSource.fetch(
+            liFiRequest(
+                srcToken = coin(Chain.Ethereum, "USDC", contractAddress = "0xUsdc"),
+                dstToken = coin(Chain.Ethereum, "USDT", contractAddress = "0xUsdt"),
+            )
+        )
+
+        assertEquals(30, slippage.captured)
+    }
+
+    @Test
+    fun `lifi forwards a user slippage instead of the auto tier`() = runTest {
+        val slippage = slot<Int>()
+        coEvery {
+            liFiChainApi.getSwapQuote(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                capture(slippage),
+            )
+        } returns LiFiSwapQuoteDeserialized.Result(liFiQuote())
+
+        liFiSource.fetch(liFiRequest(slippageBps = 300))
+
+        assertEquals(300, slippage.captured)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/SwapQuoteRepositoryTest.kt
@@ -342,7 +342,7 @@ class SwapQuoteRepositoryTest {
 
     private suspend fun fetchLiFiQuote(quote: LiFiSwapQuoteJson): EVMSwapQuoteJson {
         coEvery {
-            liFiChainApi.getSwapQuote(any(), any(), any(), any(), any(), any(), any(), any())
+            liFiChainApi.getSwapQuote(any(), any(), any(), any(), any(), any(), any(), any(), any())
         } returns LiFiSwapQuoteDeserialized.Result(quote)
 
         return (liFiSource.fetch(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiSlippageTest.kt
@@ -1,0 +1,55 @@
+package com.vultisig.wallet.data.repositories.swap
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the LI.FI "Auto" tiers ported from the SDK's `lifiSlippage.ts` (vultisig-sdk#524): 0.3% for
+ * a stable-to-stable pair, 1% otherwise, and never LI.FI's own 0.5% default, which is what let
+ * the #5801 swaps revert with `Insufficient output`.
+ */
+class LiFiSlippageTest {
+
+    @Test
+    fun `auto on a stable pair resolves to the stable tier`() {
+        assertEquals(30, LiFiSlippage.resolveBps(null, "USDC", "USDT"))
+    }
+
+    @Test
+    fun `auto on a volatile pair resolves to the volatile tier`() {
+        assertEquals(100, LiFiSlippage.resolveBps(null, "ETH", "WBTC"))
+    }
+
+    @Test
+    fun `auto on a half-stable pair takes the volatile tier`() {
+        assertEquals(100, LiFiSlippage.resolveBps(null, "USDC", "ETH"))
+        assertEquals(100, LiFiSlippage.resolveBps(null, "ETH", "USDC"))
+    }
+
+    @Test
+    fun `ticker matching is case-insensitive`() {
+        assertEquals(30, LiFiSlippage.resolveBps(null, "usdc", "Dai"))
+    }
+
+    @Test
+    fun `a stable ticker only matches whole, so a wrapper like stUSDT stays volatile`() {
+        assertFalse(LiFiSlippage.isStablePair("stUSDT", "USDC"))
+        assertEquals(100, LiFiSlippage.resolveBps(null, "stUSDT", "USDC"))
+    }
+
+    @Test
+    fun `a user tolerance overrides both tiers untouched`() {
+        assertEquals(50, LiFiSlippage.resolveBps(50, "USDC", "USDT"))
+        assertEquals(300, LiFiSlippage.resolveBps(300, "ETH", "WBTC"))
+        // A deliberately tight custom value must not be widened to a tier.
+        assertEquals(1, LiFiSlippage.resolveBps(1, "ETH", "WBTC"))
+    }
+
+    @Test
+    fun `every auto tier is a real tolerance, never zero`() {
+        assertTrue(LiFiSlippage.STABLE_PAIR_BPS > 0)
+        assertTrue(LiFiSlippage.DEFAULT_BPS > LiFiSlippage.STABLE_PAIR_BPS)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/LiFiSlippageTest.kt
@@ -48,6 +48,13 @@ class LiFiSlippageTest {
     }
 
     @Test
+    fun `a non-positive override falls back to the tier instead of sending zero`() {
+        assertEquals(30, LiFiSlippage.resolveBps(0, "USDC", "USDT"))
+        assertEquals(100, LiFiSlippage.resolveBps(0, "ETH", "WBTC"))
+        assertEquals(100, LiFiSlippage.resolveBps(-25, "ETH", "WBTC"))
+    }
+
+    @Test
     fun `every auto tier is a real tolerance, never zero`() {
         assertTrue(LiFiSlippage.STABLE_PAIR_BPS > 0)
         assertTrue(LiFiSlippage.DEFAULT_BPS > LiFiSlippage.STABLE_PAIR_BPS)


### PR DESCRIPTION
Closes #5801

## Problem

LI.FI's `slippage` query param was omitted on Auto, so LI.FI applied its own **0.5%** and baked that into the prebuilt transaction's `minAmountOut`. An MPC keysign puts 30–90s between the quote and the broadcast — exactly the window that produced the `Insufficient output` reverts linked in the issue. Kyber Auto has been 1% for a while; LI.FI was the outlier.

## Change

Port the SDK's two tiers (`vultisig-sdk#524`, `lifiSlippage.ts`) into `LiFiSlippage`:

| Pair | Auto tolerance |
|---|---|
| stable → stable (USDC/USDT/DAI/…) | **0.3%** |
| everything else | **1%** |

A preset or custom value still passes straight through — Auto stays Auto, no new toggle, no UI change.

## Why the tier isn't resolved in `LiFiChainApi`

Every sibling aggregator keeps its Auto default inside the API class (`KyberApi.SLIPPAGE_TOLERANCE`, `OneInchApi.ONEINCH_DEFAULT_SLIPPAGE`, `JupiterApi.DEFAULT_SLIPPAGE_BPS`), so that looks like the matching home for this one. It isn't: `getSwapQuote` receives `fromToken`/`toToken` as **contract addresses** for ERC-20s — only natives fall back to a ticker — so it cannot tell a stable pair from a volatile one.

Resolution moves up to `LiFiQuoteSource`, which holds the `Coin`s and is the same layer the SDK's `getLifiSwapQuote.ts` resolves at. That let `LiFiChainApi.getSwapQuote(slippageBps)` become non-null, so omitting the param is no longer representable rather than merely discouraged.

Also carried over the SDK's `MAX_COMBINED_COST_BPS = 300` as a `Timber.w` — the integrator fee and the tolerance are independent costs on the same swap, and a future fee bump shouldn't quietly compound past 3%. Reported, never enforced.

## Notes

- **iOS is not the reference here.** ios#5309 is the still-open sibling — `LiFiService.lifiSlippageFraction(bps:)` returns nil on Auto and omits the param, which is the same bug. The SDK is the only platform that has shipped the tiers, and the issue names it.
- "Don't send 0" needs no extra clamp: the custom field is already bounded to `1..10_000` in `SwapFormViewModel` and `AdvancedSwapSettings`, and clearing it resets to Auto.
- No visible change. The min-payout row is deliberately blank for aggregator routes (`signedMinimumOutput` returns null for anything that isn't THOR/Maya), so the tolerance was never rendered and still isn't.

## Test plan

`./gradlew :data:testDebugUnitTest` — full suite green, 0 skipped.

- **`LiFiSlippageTest`** (new, 7): both tiers; a half-stable pair falls to volatile; case-insensitive ticker match; `stUSDT` does *not* count as stable; a deliberately tight 1 bps custom value is not widened to a tier.
- **`SwapQuoteRepositoryProvidersTest`** (3 new): the source forwards 100 on Auto, 30 on USDC→USDT, and 300 untouched when the user set it.
- **`LiFiChainApiSlippageTest`**: `auto slippage omits the parameter` is gone — that behaviour was the bug — replaced by the 30 bps → `"0.003"` formatting case, which also guards the scientific-notation trap the existing tests pin.

Manual: force the LI.FI route (Advanced → Select route), swap a volatile pair on Auto, confirm it lands; then set a 0.01% custom tolerance on the same pair and confirm it still reverts — that failure is the proof the override isn't being widened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic LI.FI slippage selection based on token-pair characteristics.
  * Added support for explicit slippage values, including zero, in swap quote requests.
  * Improved monitoring of combined integrator fees and slippage with informational warnings.
  * Standardized LI.FI slippage values sent with quote requests.

* **Documentation**
  * Clarified provider-specific slippage behavior and defaults.

* **Tests**
  * Expanded coverage for stable, volatile, mixed, wrapped-token, custom, automatic, and explicit slippage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
