### PR TITLE
feat(swap): add a custom token from the asset search empty state

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -2572,6 +2572,7 @@ private fun SelectAssetSecuredPreview(showSecured: Boolean) {
         searchFieldState = TextFieldState(),
         onAssetClick = {},
         onSelectChain = {},
+        onAddCustomTokenClick = {},
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/NoFoundContent.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/tokenitem/NoFoundContent.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.components.v2.tokenitem
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -20,7 +21,10 @@ import com.vultisig.wallet.ui.theme.Theme
 
 @Preview
 @Composable
-internal fun NoFoundContent(message: String = "No chains found") {
+internal fun NoFoundContent(
+    message: String = "No chains found",
+    @DrawableRes icon: Int = R.drawable.iconcrypto,
+) {
     TopShineContainer {
         Column(
             horizontalAlignment = Alignment.Companion.CenterHorizontally,
@@ -28,7 +32,7 @@ internal fun NoFoundContent(message: String = "No chains found") {
             modifier = Modifier.Companion.fillMaxWidth().padding(vertical = 24.dp),
         ) {
             Image(
-                painter = painterResource(R.drawable.iconcrypto),
+                painter = painterResource(icon),
                 contentDescription = null,
                 modifier = Modifier.Companion.size(20.dp),
             )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetScreen.kt
@@ -53,6 +53,7 @@ internal fun SelectAssetScreen(model: SelectAssetViewModel = hiltViewModel()) {
                 searchFieldState = model.searchFieldState,
                 onAssetClick = model::selectAsset,
                 onSelectChain = model::selectChain,
+                onAddCustomTokenClick = model::addCustomToken,
             )
         },
     )
@@ -64,6 +65,7 @@ internal fun SelectAssetScreen(
     searchFieldState: TextFieldState,
     onAssetClick: (AssetUiModel) -> Unit,
     onSelectChain: (Chain) -> Unit,
+    onAddCustomTokenClick: () -> Unit,
 ) {
 
     V2Scaffold(
@@ -85,8 +87,29 @@ internal fun SelectAssetScreen(
         content = {
             val assets = state.assets
             if (assets.isEmpty()) {
-                Column(modifier = Modifier.padding(all = 16.dp)) {
-                    NoFoundContent(message = stringResource(R.string.select_asset_no_result))
+                // 4.dp here plus the CTA's own 12.dp keeps Figma's 16.dp gap while giving the
+                // 12.sp label a tappable height.
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                    modifier = Modifier.padding(all = 16.dp),
+                ) {
+                    NoFoundContent(
+                        message = stringResource(R.string.select_asset_no_token_found),
+                        icon = R.drawable.circle_dashed,
+                    )
+
+                    if (state.canAddCustomToken) {
+                        Text(
+                            text = stringResource(R.string.select_asset_add_custom_token),
+                            style = Theme.brockmann.supplementary.caption,
+                            color = Theme.v2.colors.alerts.info,
+                            textAlign = TextAlign.Center,
+                            modifier =
+                                Modifier.fillMaxWidth()
+                                    .clickable(onClick = onAddCustomTokenClick)
+                                    .padding(vertical = 12.dp),
+                        )
+                    }
                 }
             } else {
                 LazyColumn(contentPadding = PaddingValues(all = 16.dp)) {
@@ -254,5 +277,6 @@ private fun SelectAssetScreenPreview() {
         searchFieldState = TextFieldState(),
         onAssetClick = {},
         onSelectChain = {},
+        onAddCustomTokenClick = {},
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
@@ -3,6 +3,7 @@
 package com.vultisig.wallet.ui.screens.select
 
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,6 +13,7 @@ import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.ImageModel
+import com.vultisig.wallet.data.models.canSelectTokens
 import com.vultisig.wallet.data.models.getCoinLogo
 import com.vultisig.wallet.data.models.isLpToken
 import com.vultisig.wallet.data.models.isRippleIssuedToken
@@ -24,6 +26,7 @@ import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
 import com.vultisig.wallet.data.usecases.chaintokens.GetChainTokensUseCase
 import com.vultisig.wallet.ui.models.NetworkUiModel
+import com.vultisig.wallet.ui.models.TokenSelectionViewModel.Companion.REQUEST_SEARCHED_TOKEN_ID
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
 import com.vultisig.wallet.ui.navigation.Destination
@@ -34,6 +37,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.uuid.ExperimentalUuidApi
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
@@ -51,6 +55,7 @@ internal data class SelectAssetUiModel(
     val selectedChain: Chain = Chain.ThorChain,
     val chains: List<NetworkUiModel> = emptyList(),
     val assets: List<AssetUiModel> = emptyList(),
+    val canAddCustomToken: Boolean = false,
 )
 
 internal data class AssetUiModel(
@@ -87,8 +92,14 @@ constructor(
 
     val state =
         MutableStateFlow(
-            SelectAssetUiModel(selectedChain = Chain.fromRaw(args.preselectedNetworkId))
+            Chain.fromRaw(args.preselectedNetworkId).let { chain ->
+                SelectAssetUiModel(selectedChain = chain, canAddCustomToken = chain.canSelectTokens)
+            }
         )
+
+    // A custom token is written straight to the vault, and loadAddress reads the vault once per
+    // subscription, so the picker only picks the new token up when this restarts the chain flow.
+    private val assetsRefreshTrigger = MutableStateFlow(0)
 
     init {
         collectAssets()
@@ -100,8 +111,9 @@ constructor(
             val vault = vaultRepository.get(vaultId) ?: return@launch
             state
                 .map { it.selectedChain }
+                .combine(assetsRefreshTrigger) { chain, refresh -> chain to refresh }
                 .distinctUntilChanged()
-                .flatMapLatest { chain ->
+                .flatMapLatest { (chain, _) ->
                     combine(
                         accountRepository.loadAddress(vaultId, chain).catch {
                             Timber.e(it)
@@ -177,6 +189,7 @@ constructor(
     }
 
     private var isSelecting = false
+    private var addCustomTokenJob: Job? = null
 
     fun selectAsset(asset: AssetUiModel) {
         // Guards against a double-tap on two rows (realistically possible now that same-ticker
@@ -196,7 +209,26 @@ constructor(
     }
 
     fun selectChain(chain: Chain) {
-        state.update { it.copy(selectedChain = chain) }
+        state.update { it.copy(selectedChain = chain, canAddCustomToken = chain.canSelectTokens) }
+    }
+
+    fun addCustomToken() {
+        val chain = state.value.selectedChain
+        // One waiter at a time: dismissing the custom-token sheet leaves the previous request
+        // suspended, and a second tap would otherwise enable the next token twice.
+        addCustomTokenJob?.cancel()
+        addCustomTokenJob =
+            viewModelScope.launch {
+                navigator.route(Route.CustomToken(chain.raw))
+                val addedToken =
+                    requestResultRepository.request<Coin>(REQUEST_SEARCHED_TOKEN_ID)
+                        ?: return@launch
+                enableTokenUseCase(vaultId, addedToken)
+                assetsRefreshTrigger.update { it + 1 }
+                // The query that found nothing still filters the list, so point it at what was
+                // just added instead of leaving the user on the same empty state.
+                searchFieldState.setTextAndPlaceCursorAtEnd(addedToken.ticker)
+            }
     }
 
     fun back() {

--- a/app/src/main/res/drawable/circle_dashed.xml
+++ b/app/src/main/res/drawable/circle_dashed.xml
@@ -1,0 +1,62 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M10.8008,3.6848C11.1932,3.6284 11.594,3.5996 12.0008,3.5996C12.4076,3.5996 12.8084,3.6284 13.2008,3.6848"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#4879FD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M17.0312,5.2715C17.3481,5.5091 17.6516,5.7719 17.9396,6.0599C18.2277,6.3479 18.4904,6.6515 18.728,6.9683"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#4879FD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M20.3145,10.7998C20.3709,11.1922 20.3997,11.593 20.3997,11.9998C20.3997,12.4066 20.3709,12.8074 20.3145,13.1998"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#4879FD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M18.7281,17.0303C18.4905,17.3471 18.2276,17.6507 17.9396,17.9387C17.6516,18.2267 17.348,18.4895 17.0312,18.7271"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#4879FD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M13.2008,20.3145C12.8084,20.3709 12.4076,20.3997 12.0008,20.3997C11.594,20.3997 11.1932,20.3709 10.8008,20.3145"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#4879FD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M6.9702,18.7281C6.6534,18.4905 6.3498,18.2276 6.0618,17.9396C5.7738,17.6516 5.511,17.348 5.2734,17.0312"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#4879FD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M3.6848,13.1998C3.6284,12.8074 3.5996,12.4066 3.5996,11.9998C3.5996,11.593 3.6284,11.1922 3.6848,10.7998"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#4879FD"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5.2715,6.9693C5.5091,6.6525 5.7719,6.3489 6.0599,6.0609C6.3479,5.7729 6.6515,5.5101 6.9683,5.2725"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#4879FD"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -13,6 +13,8 @@
     <string name="vault_settings_delete_title">Löschen</string>
     <string name="select_asset_title">Asset auswählen</string>
     <string name="select_asset_no_result">Kein Ergebnis gefunden.</string>
+    <string name="select_asset_no_token_found">Kein Token gefunden</string>
+    <string name="select_asset_add_custom_token">+ Benutzerdefinierten Token hinzufügen</string>
     <string name="select_asset_secured_badge">Gesichert</string>
     <string name="select_chain_chain_title">Blockchain</string>
     <string name="select_chain_balance_title">Guthaben</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -15,6 +15,8 @@
     <string name="swap_form_on_chain">en</string>
     <string name="select_asset_title">Seleccionar activo</string>
     <string name="select_asset_no_result">No se encontraron resultados.</string>
+    <string name="select_asset_no_token_found">No se encontró ningún token</string>
+    <string name="select_asset_add_custom_token">+ Agregar token personalizado</string>
     <string name="select_asset_secured_badge">Garantizado</string>
     <string name="select_chain_chain_title">Cadena</string>
     <string name="select_chain_balance_title">Saldo</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -71,6 +71,8 @@
     <string name="vault_settings_security_screen_content_bottomsheet">Onemogućavanje sigurnosti na lancu znači da Blockaid ne može provjeriti transakcije. Bit ćete manje zaštićeni.</string>
     <string name="select_asset_title">Odaberi imovinu</string>
     <string name="select_asset_no_result">Nema rezultata.</string>
+    <string name="select_asset_no_token_found">Token nije pronađen</string>
+    <string name="select_asset_add_custom_token">+ Dodaj prilagođeni token</string>
     <string name="select_asset_secured_badge">Osigurano</string>
     <string name="select_chain_chain_title">Lanac</string>
     <string name="select_chain_balance_title">Stanje</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -71,6 +71,8 @@
     <string name="vault_settings_security_screen_content_bottomsheet">La disabilitazione della sicurezza on-chain significa che Blockaid non può verificare le transazioni. Sarai meno protetto.</string>
     <string name="select_asset_title">Seleziona asset</string>
     <string name="select_asset_no_result">Nessun risultato trovato.</string>
+    <string name="select_asset_no_token_found">Nessun token trovato</string>
+    <string name="select_asset_add_custom_token">+ Aggiungi token personalizzato</string>
     <string name="select_asset_secured_badge">Garantito</string>
     <string name="select_chain_chain_title">Catena</string>
     <string name="select_chain_balance_title">Saldo</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -826,6 +826,8 @@
     <string name="verify_swap_recipient">수신자</string>
     <string name="select_asset_title">자산 선택</string>
     <string name="select_asset_no_result">결과를 찾을 수 없습니다.</string>
+    <string name="select_asset_no_token_found">토큰을 찾을 수 없습니다</string>
+    <string name="select_asset_add_custom_token">+ 사용자 정의 토큰 추가</string>
     <string name="select_asset_secured_badge">보안</string>
     <string name="select_chain_chain_title">체인</string>
     <string name="select_chain_balance_title">잔액</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -13,6 +13,8 @@
     <string name="swap_form_on_chain">op</string>
     <string name="select_asset_title">Asset selecteren</string>
     <string name="select_asset_no_result">Geen resultaat gevonden.</string>
+    <string name="select_asset_no_token_found">Geen token gevonden</string>
+    <string name="select_asset_add_custom_token">+ Aangepaste token toevoegen</string>
     <string name="select_asset_secured_badge">Gedekt</string>
     <string name="select_chain_chain_title">Keten</string>
     <string name="select_chain_balance_title">Saldo</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -90,6 +90,8 @@
     <string name="dialog_default_error_title">Erro</string>
     <string name="select_asset_title">Selecionar ativo</string>
     <string name="select_asset_no_result">Nenhum resultado encontrado.</string>
+    <string name="select_asset_no_token_found">Nenhum token encontrado</string>
+    <string name="select_asset_add_custom_token">+ Adicionar token personalizado</string>
     <string name="select_asset_secured_badge">Garantido</string>
     <string name="select_chain_chain_title">Cadeia</string>
     <string name="select_chain_balance_title">Saldo</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -15,6 +15,8 @@
     <string name="swap_form_on_chain">на</string>
     <string name="select_asset_title">Выбрать актив</string>
     <string name="select_asset_no_result">Результат не найден.</string>
+    <string name="select_asset_no_token_found">Токен не найден</string>
+    <string name="select_asset_add_custom_token">+ Добавить пользовательский токен</string>
     <string name="select_asset_secured_badge">Залоговый</string>
     <string name="select_chain_chain_title">Сеть</string>
     <string name="select_chain_balance_title">Баланс</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -785,6 +785,8 @@
     <!-- Select Asset/Chain -->
     <string name="select_asset_title">选择资产</string>
     <string name="select_asset_no_result">未找到结果。</string>
+    <string name="select_asset_no_token_found">未找到代币</string>
+    <string name="select_asset_add_custom_token">+ 添加自定义代币</string>
     <string name="select_asset_secured_badge">担保</string>
     <string name="select_chain_chain_title">链</string>
     <string name="select_chain_balance_title">余额</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -837,6 +837,8 @@
     <string name="verify_swap_recipient">Recipient</string>
     <string name="select_asset_title">Select asset</string>
     <string name="select_asset_no_result">No result found.</string>
+    <string name="select_asset_no_token_found">No token found</string>
+    <string name="select_asset_add_custom_token">+ Add custom token</string>
     <string name="select_asset_secured_badge">Secured</string>
     <string name="select_chain_chain_title">Chain</string>
     <string name="select_chain_balance_title">Balance</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModelTest.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
 import com.vultisig.wallet.data.usecases.chaintokens.GetChainTokensUseCase
+import com.vultisig.wallet.ui.models.TokenSelectionViewModel.Companion.REQUEST_SEARCHED_TOKEN_ID
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -20,6 +21,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -117,6 +122,57 @@ internal class SelectAssetViewModelTest {
 
             coVerify(exactly = 0) { enableTokenUseCase.invoke(any(), any()) }
             coVerify(exactly = 1) { requestResultRepository.respond(REQUEST_ID, any()) }
+        }
+
+    @Test
+    fun `canAddCustomToken follows the chain selected in the carousel`() =
+        runTest(testDispatcher) {
+            val vm = createViewModel()
+
+            // ThorChain is the preselected chain and supports custom tokens.
+            assertTrue(vm.state.value.canAddCustomToken)
+
+            vm.selectChain(Chain.ZkSync)
+            assertFalse(vm.state.value.canAddCustomToken)
+
+            vm.selectChain(Chain.Ethereum)
+            assertTrue(vm.state.value.canAddCustomToken)
+        }
+
+    @Test
+    fun `addCustomToken opens the custom token flow for the selected chain and enables the result`() =
+        runTest(testDispatcher) {
+            val vm = createViewModel()
+            val customToken = usdcCoin()
+            coEvery { requestResultRepository.request<Coin>(REQUEST_SEARCHED_TOKEN_ID) } returns
+                customToken
+
+            vm.selectChain(Chain.Ethereum)
+            vm.addCustomToken()
+
+            coVerify(exactly = 1) { navigator.route(Route.CustomToken(Chain.Ethereum.raw)) }
+            coVerify(exactly = 1) { enableTokenUseCase.invoke(VAULT_ID, customToken) }
+            // The query that found nothing would keep hiding the token that was just added.
+            assertEquals(customToken.ticker, vm.searchFieldState.text.toString())
+        }
+
+    @Test
+    fun `a dismissed custom token sheet leaves no waiter that double-enables the next token`() =
+        runTest(testDispatcher) {
+            val vm = createViewModel()
+            val customToken = usdcCoin()
+            val pendingResult = CompletableDeferred<Coin?>()
+            coEvery { requestResultRepository.request<Coin>(REQUEST_SEARCHED_TOKEN_ID) } coAnswers
+                {
+                    pendingResult.await()
+                }
+
+            // First tap is dismissed without adding anything, so its request never resolves.
+            vm.addCustomToken()
+            vm.addCustomToken()
+            pendingResult.complete(customToken)
+
+            coVerify(exactly = 1) { enableTokenUseCase.invoke(VAULT_ID, customToken) }
         }
 
     private fun createViewModel() =


### PR DESCRIPTION
Closes #5786

Figma: [Swap Screen - add custom token](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=81853-75673)

<img src="https://i.imgur.com/kRx33yi.png" width="320" alt="Select asset — no token found, with + Add custom token" />

## What

Searching the asset picker for a token the catalog doesn't carry ended at "No result found." — a dead end, even on chains where the app can resolve any contract address. Adding it meant leaving the swap, walking to the chain's manage-tokens list, adding it there, and starting the swap over.

The empty state now shows the Figma card (`No token found`, dashed-circle icon) with **+ Add custom token** under it, routing to the same `Route.CustomToken` sheet manage-tokens uses. No second adder: `CustomTokenViewModel` already responds with the resolved coin and leaves persistence to the caller, so the picker enables it exactly the way `TokenSelectionViewModel` does.

The CTA is gated on `Chain.canSelectTokens` — the same predicate manage-tokens uses — so it stays hidden on zkSync and Cronos.

## Two things the picker had to learn

**`loadAddress` is a one-shot flow.** It reads the vault once per subscription and completes, so a coin written to the vault after collection started never reaches the list — enabling the token alone would have left the empty state exactly as it was. The chain key upstream of `flatMapLatest` now carries a refresh counter that the enable bumps, restarting the read. Anything else that mutates this picker's vault coins will need the same bump.

**The query that found nothing keeps filtering.** After the token is added the search field is set to its ticker, so the user lands on the row they just created instead of the same empty card.

Dismissing the custom-token sheet leaves its `request` suspended for good, so a second tap would have parked two waiters on one rendezvous and enabled the next token twice. One cancellable job at a time; there's a test for it.

## Notes

`NoFoundContent` is shared by nine screens, so the dashed-circle icon arrives as an optional parameter rather than a global swap. Its 15sp message style is left alone even though this frame's card is Title3 — moving it would move the other eight empty states. Happy to change that globally if you'd rather.

iOS has nothing to match here: [ios#5303](https://github.com/vultisig/vultisig-ios/issues/5303) is still open and its custom-token flow lives only under `Features/Wallet/TokenSelection`, never in a swap picker. Figma is the reference.

Two new string keys in all 10 locales, reusing each locale's existing token / custom-token terminology.

## Test plan

- `:app:assembleDebug`, `:app:lintDebug` clean; ktfmt applied.
- `SelectAssetViewModelTest` — 5 tests, 0 skipped, 3 new: the CTA gate follows the carousel chain, `addCustomToken` routes to the selected chain and enables + surfaces the result, and a dismissed sheet leaves no waiter that double-enables the next token.
- Manual, on device: vault with Ethereum enabled → Swap → tap the From token pill → search `jkd` → the card and CTA appear → **+ Add custom token** → paste an uncurated ERC-20 (e.g. `0x95ad61b0a150d79219dcf64e1e6cc01f0b64c4ce`) → Search → Add → back in the picker with the ticker in the search field and the token listed. Swiping the carousel to zkSync hides the CTA.

Verified on device — the screenshot above is a real Android render on the Ethereum chain with a query that matches nothing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for adding custom tokens directly from the asset-selection screen when available.
  - Custom tokens are enabled, refreshed, and shown in search results after being added.
  - Improved empty search results with clearer messaging and an add-token action.
  - Added localized text for the new asset-selection states across supported languages.

- **Bug Fixes**
  - Prevented duplicate custom-token requests and preserved the search query after adding a token.

- **Style**
  - Added a dashed circular visual for the empty-state interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
