### PR TITLE
fix(home): float the bottom navigator over the content

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensListHeightTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensListHeightTest.kt
@@ -1,0 +1,84 @@
+package com.vultisig.wallet.ui.screens.v2.chaintokens
+
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.data.models.CryptoConnectionType
+import com.vultisig.wallet.ui.models.ChainTokenUiModel
+import com.vultisig.wallet.ui.models.ChainTokensUiModel
+import com.vultisig.wallet.ui.screens.v2.home.components.BottomNavigatorOverlay
+import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class ChainTokensListHeightTest {
+
+    @get:Rule val compose = createComposeRule()
+
+    /**
+     * The token list wraps its content, so the room reserved for the floating navigator has to be
+     * taken on the column hosting the card and never as padding inside the list — inside, a chain
+     * holding one token renders a card with a tall band of dead space under its only row.
+     */
+    @Test
+    fun aSingleTokenCardHugsItsRow() {
+        compose.setContent {
+            OnBoardingComposeTheme {
+                BottomNavigatorOverlay(
+                    isNavigatorVisible = true,
+                    activeType = CryptoConnectionType.Wallet,
+                    onTypeClick = {},
+                    onCameraClick = {},
+                ) {
+                    ChainTokensScreen(
+                        uiModel =
+                            ChainTokensUiModel(
+                                chainName = "Bitcoin",
+                                chainAddress = "bc1ql2v0000000000000000000000000j4g60yc",
+                                totalBalance = "$15.16",
+                                tokens =
+                                    listOf(
+                                        ChainTokenUiModel(
+                                            id = "BTC-Bitcoin",
+                                            name = "BTC",
+                                            balance = "0.00019793 BTC",
+                                            fiatBalance = "$15.16",
+                                        )
+                                    ),
+                            ),
+                        onBackClick = {},
+                        onRefresh = {},
+                        onShowSearchBar = {},
+                        onHideSearchBar = {},
+                        onSend = {},
+                        onSwap = {},
+                        onBuy = {},
+                        onDeposit = {},
+                        onReceive = {},
+                        onHistory = {},
+                        onSelectTokens = {},
+                        onTokenClick = {},
+                    )
+                }
+            }
+        }
+        compose.waitForIdle()
+
+        val card = compose.onNodeWithTag(TokenListTestTag).fetchSemanticsNode().boundsInRoot
+        val row = compose.onNodeWithText("BTC").fetchSemanticsNode().boundsInRoot
+        val deadSpaceBelowTheRow = card.bottom - row.bottom
+        val allowance = with(compose.density) { CardPaddingAllowance.toPx() }
+
+        assertTrue(
+            "the card runs ${deadSpaceBelowTheRow}px past its only row",
+            deadSpaceBelowTheRow <= allowance,
+        )
+    }
+
+    private companion object {
+        /** The row's own vertical padding plus the card's inset — anything beyond this is slack. */
+        val CardPaddingAllowance = 48.dp
+    }
+}

--- a/app/src/androidTest/java/com/vultisig/wallet/ui/screens/v2/home/components/BottomNavigatorOverlayTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/ui/screens/v2/home/components/BottomNavigatorOverlayTest.kt
@@ -1,0 +1,97 @@
+package com.vultisig.wallet.ui.screens.v2.home.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.data.models.CryptoConnectionType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+private const val ContentTag = "content"
+
+class BottomNavigatorOverlayTest {
+
+    @get:Rule val compose = createComposeRule()
+
+    /**
+     * The navigator used to live in a `Scaffold` bottom-bar slot, which pushed content up above it
+     * and left an opaque band of the screen background where the last card should have been
+     * (#5784). It floats over the content now, so the content still owns the full height.
+     */
+    @Test
+    fun contentKeepsTheFullHeightUnderneathTheNavigator() {
+        compose.setContent { Overlay(isNavigatorVisible = true) }
+        compose.waitForIdle()
+
+        val rootBottom = compose.onRoot().fetchSemanticsNode().boundsInRoot.bottom
+        val contentBottom =
+            compose.onNodeWithTag(ContentTag).fetchSemanticsNode().boundsInRoot.bottom
+
+        assertEquals(rootBottom, contentBottom, 1f)
+    }
+
+    /**
+     * Content drawing behind the navigator is only right as long as it can also be scrolled clear
+     * of it, which is what the published padding buys — so it has to cover the navigator's own
+     * height, not merely be non-zero.
+     */
+    @Test
+    fun thePublishedPaddingCoversTheNavigator() {
+        var reserved: Dp = 0.dp
+        compose.setContent { Overlay(isNavigatorVisible = true) { reserved = it } }
+        compose.waitForIdle()
+
+        val navigatorHeight =
+            compose.onNodeWithTag(BottomNavigatorTestTag).fetchSemanticsNode().size.height
+        val reservedPx = with(compose.density) { reserved.roundToPx() }
+
+        assertTrue(
+            "reserved ${reservedPx}px does not clear the ${navigatorHeight}px navigator",
+            reservedPx >= navigatorHeight,
+        )
+    }
+
+    /**
+     * The navigator is hidden while the search bar is open. Dropping the reservation with it would
+     * reflow the whole list on every search, so the space stays booked either way.
+     */
+    @Test
+    fun hidingTheNavigatorLeavesTheReservationInPlace() {
+        var isNavigatorVisible by mutableStateOf(true)
+        var reserved: Dp = 0.dp
+        compose.setContent { Overlay(isNavigatorVisible = isNavigatorVisible) { reserved = it } }
+        compose.waitForIdle()
+        val whileVisible = reserved
+
+        isNavigatorVisible = false
+        compose.waitForIdle()
+
+        compose.onNodeWithTag(BottomNavigatorTestTag).assertDoesNotExist()
+        assertEquals(whileVisible, reserved)
+    }
+
+    @Composable
+    private fun Overlay(isNavigatorVisible: Boolean, onReserved: (Dp) -> Unit = {}) {
+        BottomNavigatorOverlay(
+            isNavigatorVisible = isNavigatorVisible,
+            activeType = CryptoConnectionType.Wallet,
+            onTypeClick = {},
+            onCameraClick = {},
+        ) {
+            onReserved(LocalBottomNavigatorPadding.current)
+            Box(modifier = Modifier.fillMaxSize().testTag(ContentTag))
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ScaffoldWithExpandableTopBar.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/scaffold/ScaffoldWithExpandableTopBar.kt
@@ -31,7 +31,6 @@ internal fun ScaffoldWithExpandableTopBar(
     topBarExpandedContent: @Composable BoxScope.() -> Unit,
     topBarCollapsedContent: (@Composable BoxScope.() -> Unit)? = null,
     scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(),
-    bottomBarContent: @Composable () -> Unit = {},
     content: @Composable (PaddingValues) -> Unit,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
@@ -55,7 +54,6 @@ internal fun ScaffoldWithExpandableTopBar(
                     backgroundColor = backgroundColor,
                 )
             },
-            bottomBar = bottomBarContent,
         ) { paddingValues ->
             // A downward drag that starts on a non-scrollable region of the content (the empty area
             // below a short list, headers, banners) would otherwise never reach PullToRefreshBox,

--- a/app/src/main/java/com/vultisig/wallet/ui/components/v2/visuals/BottomFadeEffect.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/v2/visuals/BottomFadeEffect.kt
@@ -8,16 +8,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.ui.theme.Theme
 
 @Composable
-internal fun BottomFadeEffect(modifier: Modifier = Modifier) {
+internal fun BottomFadeEffect(modifier: Modifier = Modifier, height: Dp = 60.dp) {
     Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .height(60.dp)
+                .height(height)
                 .background(
                     brush =
                         Brush.verticalGradient(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/ChainDashboardScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/ChainDashboardScreen.kt
@@ -1,19 +1,13 @@
 package com.vultisig.wallet.ui.screens
 
-import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.vultisig.wallet.data.models.CryptoConnectionType
 import com.vultisig.wallet.ui.components.v2.topbar.V2Topbar
@@ -34,8 +28,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.maya.MayachainDefiPositionsScreen
 import com.vultisig.wallet.ui.screens.v2.defi.thorchain.ThorchainDefiPositionsScreen
 import com.vultisig.wallet.ui.screens.v2.defi.ton.TonDeFiPositionsScreen
 import com.vultisig.wallet.ui.screens.v2.defi.tron.TronDeFiPositionsScreen
-import com.vultisig.wallet.ui.screens.v2.home.components.CameraButton
-import com.vultisig.wallet.ui.screens.v2.home.components.CryptoConnectionSelect
+import com.vultisig.wallet.ui.screens.v2.home.components.BottomNavigatorOverlay
 
 @Composable
 internal fun ChainDashboardScreen(viewModel: ChainDashboardViewModel = hiltViewModel()) {
@@ -84,41 +77,23 @@ private fun ChainDashboardScreen(
     onBackClick: () -> Unit,
     content: @Composable () -> Unit = {},
 ) {
-    Scaffold(
-        topBar = {
-            if (uiModel.route !is Wallet) {
-                V2Topbar(title = null, onBackClick = onBackClick)
-            }
-        },
-        bottomBar = {
-            Box(modifier = Modifier.fillMaxWidth().animateContentSize()) {
-                if (uiModel.isBottomBarVisible) {
-                    Row(
-                        modifier =
-                            Modifier.fillMaxWidth()
-                                .padding(horizontal = 16.dp)
-                                .align(Alignment.BottomCenter),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        CryptoConnectionSelect(
-                            activeType = uiModel.cryptoConnectionType,
-                            availableCryptoTypes = uiModel.availableCryptoTypes,
-                            onTypeClick = onTypeClick,
-                        )
-                        CameraButton(onClick = onCameraClick)
-                    }
+    BottomNavigatorOverlay(
+        isNavigatorVisible = uiModel.isBottomBarVisible,
+        activeType = uiModel.cryptoConnectionType,
+        availableCryptoTypes = uiModel.availableCryptoTypes,
+        onTypeClick = onTypeClick,
+        onCameraClick = onCameraClick,
+    ) {
+        Scaffold(
+            topBar = {
+                if (uiModel.route !is Wallet) {
+                    V2Topbar(title = null, onBackClick = onBackClick)
                 }
             }
-        },
-    ) { paddingValues ->
-        Box(
-            modifier =
-                Modifier.padding(
-                    top = paddingValues.calculateTopPadding(),
-                    bottom = paddingValues.calculateBottomPadding(),
-                )
-        ) {
-            content()
+        ) { paddingValues ->
+            Box(modifier = Modifier.padding(top = paddingValues.calculateTopPadding())) {
+                content()
+            }
         }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingPositionsScreen.kt
@@ -64,6 +64,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.DeFiTab
 import com.vultisig.wallet.ui.screens.v2.defi.ManagePositionsButton
 import com.vultisig.wallet.ui.screens.v2.defi.NoPositionsContainer
 import com.vultisig.wallet.ui.screens.v2.defi.PositionsSelectionDialog
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 import com.vultisig.wallet.ui.utils.formatPercent
@@ -196,7 +197,13 @@ internal fun CosmosStakingPositionsContent(
             ) {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+                    contentPadding =
+                        PaddingValues(
+                            start = 16.dp,
+                            end = 16.dp,
+                            top = 16.dp,
+                            bottom = 16.dp + LocalBottomNavigatorPadding.current,
+                        ),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     // Banner + tab row scroll with the list as part of the whole screen (mirrors

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/home/VaultAccountsScreen.kt
@@ -50,7 +50,6 @@ import com.vultisig.wallet.ui.components.v2.containers.TopShineContainer
 import com.vultisig.wallet.ui.components.v2.scaffold.ScaffoldWithExpandableTopBar
 import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.components.v2.texts.LoadableValue
-import com.vultisig.wallet.ui.components.v2.visuals.BottomFadeEffect
 import com.vultisig.wallet.ui.models.AccountUiModel
 import com.vultisig.wallet.ui.models.VaultAccountsUiModel
 import com.vultisig.wallet.ui.models.VaultAccountsViewModel
@@ -59,11 +58,11 @@ import com.vultisig.wallet.ui.screens.settings.bottomsheets.notifications.Notifi
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.notifications.VaultNotificationOptInBottomSheet
 import com.vultisig.wallet.ui.screens.v2.home.components.AccountList
 import com.vultisig.wallet.ui.screens.v2.home.components.Banners
-import com.vultisig.wallet.ui.screens.v2.home.components.CameraButton
+import com.vultisig.wallet.ui.screens.v2.home.components.BottomNavigatorOverlay
 import com.vultisig.wallet.ui.screens.v2.home.components.ChooseVaultButton
-import com.vultisig.wallet.ui.screens.v2.home.components.CryptoConnectionSelect
 import com.vultisig.wallet.ui.screens.v2.home.components.DefiExpandedTopbarContent
 import com.vultisig.wallet.ui.screens.v2.home.components.HomePageTabMenuAndSearchBar
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.screens.v2.home.components.NoChainFound
 import com.vultisig.wallet.ui.screens.v2.home.components.NotEnabledContainer
 import com.vultisig.wallet.ui.screens.v2.home.components.TopRow
@@ -182,188 +181,177 @@ internal fun VaultAccountsScreen(
 
     val context = LocalContext.current
 
-    ScaffoldWithExpandableTopBar(
-        snackbarState = snackbarState,
-        isRefreshing = state.isRefreshing,
-        onRefresh = onRefresh,
-        topBarCollapsedContent = {
-            Column(modifier = Modifier.padding(top = 16.dp)) {
-                Row(
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .background(Theme.v2.colors.backgrounds.primary)
-                            .padding(horizontal = 16.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    ChooseVaultButton(
+    BottomNavigatorOverlay(
+        isNavigatorVisible = isBottomBarVisible.value,
+        activeType = state.cryptoConnectionType,
+        onTypeClick = onCryptoConnectionTypeClick,
+        onCameraClick = openCamera,
+    ) {
+        ScaffoldWithExpandableTopBar(
+            snackbarState = snackbarState,
+            isRefreshing = state.isRefreshing,
+            onRefresh = onRefresh,
+            topBarCollapsedContent = {
+                Column(modifier = Modifier.padding(top = 16.dp)) {
+                    Row(
+                        modifier =
+                            Modifier.fillMaxWidth()
+                                .background(Theme.v2.colors.backgrounds.primary)
+                                .padding(horizontal = 16.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        ChooseVaultButton(
+                            vaultName = state.vaultName,
+                            isFastVault = state.isFastVault,
+                            onClick = onToggleVaultListClick,
+                        )
+
+                        Column(horizontalAlignment = Alignment.End) {
+                            Text(
+                                text = stringResource(R.string.home_portfolio_balance),
+                                color = Theme.v2.colors.text.tertiary,
+                                style = Theme.brockmann.body.s.medium,
+                            )
+                            UiSpacer(size = 2.dp)
+
+                            LoadableValue(
+                                value = state.totalFiatValue,
+                                isVisible = state.isBalanceValueVisible,
+                                style = Theme.satoshi.price.bodyS,
+                                color = Theme.v2.colors.text.primary,
+                            )
+                        }
+                    }
+
+                    UiSpacer(size = 16.dp)
+
+                    UiHorizontalDivider(color = Theme.v2.colors.border.light)
+
+                    UiSpacer(size = 16.dp)
+                }
+            },
+            topBarExpandedContent = {
+                ExpandedTopbarContainer {
+                    TopRow(
+                        onOpenHistoryClick = onOpenHistoryClick,
+                        onOpenSettingsClick = onOpenSettingsClick,
+                        onToggleVaultListClick = onToggleVaultListClick,
                         vaultName = state.vaultName,
                         isFastVault = state.isFastVault,
-                        onClick = onToggleVaultListClick,
                     )
-
-                    Column(horizontalAlignment = Alignment.End) {
-                        Text(
-                            text = stringResource(R.string.home_portfolio_balance),
-                            color = Theme.v2.colors.text.tertiary,
-                            style = Theme.brockmann.body.s.medium,
-                        )
-                        UiSpacer(size = 2.dp)
-
-                        LoadableValue(
-                            value = state.totalFiatValue,
-                            isVisible = state.isBalanceValueVisible,
-                            style = Theme.satoshi.price.bodyS,
-                            color = Theme.v2.colors.text.primary,
-                        )
-                    }
-                }
-
-                UiSpacer(size = 16.dp)
-
-                UiHorizontalDivider(color = Theme.v2.colors.border.light)
-
-                UiSpacer(size = 16.dp)
-            }
-        },
-        topBarExpandedContent = {
-            ExpandedTopbarContainer {
-                TopRow(
-                    onOpenHistoryClick = onOpenHistoryClick,
-                    onOpenSettingsClick = onOpenSettingsClick,
-                    onToggleVaultListClick = onToggleVaultListClick,
-                    vaultName = state.vaultName,
-                    isFastVault = state.isFastVault,
-                )
-                AnimatedContent(targetState = isWallet, transitionSpec = slideAndFadeSpec()) {
-                    isWalletTabSelected ->
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                    ) {
-                        UiSpacer(size = 24.dp)
-                        if (isWalletTabSelected) {
-                            WalletExpandedTopbarContent(
-                                state = state,
-                                onToggleBalanceVisibility = onToggleBalanceVisibility,
-                                onSend = onSend,
-                                onSwap = onSwap,
-                                onBuy = onBuy,
-                                onReceive = onReceive,
-                            )
-                        } else {
-                            DefiExpandedTopbarContent(
-                                state = state,
-                                onToggleBalanceVisibility = onToggleBalanceVisibility,
-                            )
-                        }
-                    }
-                }
-            }
-        },
-        bottomBarContent =
-            if (isBottomBarVisible.value) {
-                {
-                    Box(modifier = Modifier.fillMaxWidth()) {
-                        Row(
-                            modifier =
-                                Modifier.fillMaxWidth()
-                                    .padding(horizontal = 16.dp)
-                                    .align(Alignment.BottomCenter),
-                            horizontalArrangement = Arrangement.SpaceBetween,
+                    AnimatedContent(targetState = isWallet, transitionSpec = slideAndFadeSpec()) {
+                        isWalletTabSelected ->
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
                         ) {
-                            CryptoConnectionSelect(
-                                onTypeClick = onCryptoConnectionTypeClick,
-                                activeType = state.cryptoConnectionType,
-                            )
-                            CameraButton(onClick = openCamera)
-                        }
-                    }
-                }
-            } else {
-                {}
-            },
-        content = { innerPadding ->
-            Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
-                LazyColumn(
-                    modifier =
-                        Modifier.background(Theme.v2.colors.backgrounds.primary).fillMaxSize(),
-                    contentPadding = PaddingValues(bottom = 30.dp),
-                ) {
-                    item {
-                        AnimatedVisibility(
-                            visible =
-                                state.banners.isNotEmpty() &&
-                                    state.cryptoConnectionType == CryptoConnectionType.Wallet,
-                            enter = fadeIn() + expandVertically(),
-                            exit = fadeOut() + shrinkVertically(),
-                        ) {
-                            Banners(
-                                modifier =
-                                    Modifier.padding(horizontal = 16.dp).padding(bottom = 16.dp),
-                                banners = state.banners,
-                                onBannerClick = onBannerClick,
-                                onBannerDismiss = onBannerDismiss,
-                                context = context,
-                            )
-                        }
-                    }
-
-                    item {
-                        HomePageTabMenuAndSearchBar(
-                            modifier =
-                                Modifier.animateItem()
-                                    .padding(horizontal = 16.dp)
-                                    .padding(bottom = 16.dp),
-                            onEditClick = onChooseChains,
-                            isTabMenu = isTabMenu,
-                            onSearchClick = { isTabMenu = false },
-                            onCancelSearchClick = { isTabMenu = true },
-                            searchTextFieldState = state.searchTextFieldState,
-                        )
-                    }
-
-                    item {
-                        TopShineContainer(modifier = Modifier.padding(horizontal = 16.dp)) {
-                            when {
-                                isShowingSearchResult.value && state.noChainFound ->
-                                    NoChainFound(onChooseChains = onChooseChains)
-
-                                // Only once the accounts flow has emitted does an empty list mean
-                                // the user disabled every chain; before that it just means the
-                                // addresses are still being derived, which on a cold start with
-                                // many chains takes seconds.
-                                state.areAccountsLoaded && state.getAccounts.isEmpty() ->
-                                    NotEnabledContainer(
-                                        title =
-                                            stringResource(R.string.home_page_no_chains_enabled),
-                                        content =
-                                            stringResource(
-                                                R.string.home_page_no_chain_enabled_desc
-                                            ),
-                                        // Rendered inside the chain-list container above, so it
-                                        // steps down rather than matching it.
-                                        radius = Theme.v2.radius.md,
-                                    )
-
-                                else ->
-                                    AccountList(
-                                        onAccountClick = onAccountClick,
-                                        snackbarState = snackbarState,
-                                        isBalanceVisible = state.isBalanceValueVisible,
-                                        accounts = state.getAccounts,
-                                        showAddress = isWallet,
-                                    )
+                            UiSpacer(size = 24.dp)
+                            if (isWalletTabSelected) {
+                                WalletExpandedTopbarContent(
+                                    state = state,
+                                    onToggleBalanceVisibility = onToggleBalanceVisibility,
+                                    onSend = onSend,
+                                    onSwap = onSwap,
+                                    onBuy = onBuy,
+                                    onReceive = onReceive,
+                                )
+                            } else {
+                                DefiExpandedTopbarContent(
+                                    state = state,
+                                    onToggleBalanceVisibility = onToggleBalanceVisibility,
+                                )
                             }
                         }
                     }
                 }
-                if (isTabMenu) {
-                    BottomFadeEffect(modifier = Modifier.align(Alignment.BottomCenter))
+            },
+            content = { innerPadding ->
+                Box(
+                    modifier =
+                        Modifier.fillMaxSize().padding(top = innerPadding.calculateTopPadding())
+                ) {
+                    LazyColumn(
+                        modifier =
+                            Modifier.background(Theme.v2.colors.backgrounds.primary).fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = LocalBottomNavigatorPadding.current),
+                    ) {
+                        item {
+                            AnimatedVisibility(
+                                visible =
+                                    state.banners.isNotEmpty() &&
+                                        state.cryptoConnectionType == CryptoConnectionType.Wallet,
+                                enter = fadeIn() + expandVertically(),
+                                exit = fadeOut() + shrinkVertically(),
+                            ) {
+                                Banners(
+                                    modifier =
+                                        Modifier.padding(horizontal = 16.dp)
+                                            .padding(bottom = 16.dp),
+                                    banners = state.banners,
+                                    onBannerClick = onBannerClick,
+                                    onBannerDismiss = onBannerDismiss,
+                                    context = context,
+                                )
+                            }
+                        }
+
+                        item {
+                            HomePageTabMenuAndSearchBar(
+                                modifier =
+                                    Modifier.animateItem()
+                                        .padding(horizontal = 16.dp)
+                                        .padding(bottom = 16.dp),
+                                onEditClick = onChooseChains,
+                                isTabMenu = isTabMenu,
+                                onSearchClick = { isTabMenu = false },
+                                onCancelSearchClick = { isTabMenu = true },
+                                searchTextFieldState = state.searchTextFieldState,
+                            )
+                        }
+
+                        item {
+                            TopShineContainer(modifier = Modifier.padding(horizontal = 16.dp)) {
+                                when {
+                                    isShowingSearchResult.value && state.noChainFound ->
+                                        NoChainFound(onChooseChains = onChooseChains)
+
+                                    // Only once the accounts flow has emitted does an
+                                    // empty list mean the user disabled every chain;
+                                    // before that it just means the addresses are still
+                                    // being derived, which on a cold start with many
+                                    // chains takes seconds.
+                                    state.areAccountsLoaded && state.getAccounts.isEmpty() ->
+                                        NotEnabledContainer(
+                                            title =
+                                                stringResource(
+                                                    R.string.home_page_no_chains_enabled
+                                                ),
+                                            content =
+                                                stringResource(
+                                                    R.string.home_page_no_chain_enabled_desc
+                                                ),
+                                            // Rendered inside the chain-list container above, so it
+                                            // steps down rather than matching it.
+                                            radius = Theme.v2.radius.md,
+                                        )
+
+                                    else ->
+                                        AccountList(
+                                            onAccountClick = onAccountClick,
+                                            snackbarState = snackbarState,
+                                            isBalanceVisible = state.isBalanceValueVisible,
+                                            accounts = state.getAccounts,
+                                            showAddress = isWallet,
+                                        )
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        },
-    )
+            },
+        )
+    }
 }
 
 @Preview

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/chaintokens/ChainTokensScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -44,7 +45,6 @@ import com.vultisig.wallet.ui.components.v2.containers.TopShineContainer
 import com.vultisig.wallet.ui.components.v2.scaffold.ScaffoldWithExpandableTopBar
 import com.vultisig.wallet.ui.components.v2.snackbar.rememberVsSnackbarState
 import com.vultisig.wallet.ui.components.v2.texts.LoadableValue
-import com.vultisig.wallet.ui.components.v2.visuals.BottomFadeEffect
 import com.vultisig.wallet.ui.models.ChainTokenUiModel
 import com.vultisig.wallet.ui.models.ChainTokensUiModel
 import com.vultisig.wallet.ui.models.ChainTokensViewModel
@@ -58,6 +58,7 @@ import com.vultisig.wallet.ui.screens.v2.home.components.AssetAction
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionItem
 import com.vultisig.wallet.ui.screens.v2.home.components.AssetActionRow
 import com.vultisig.wallet.ui.screens.v2.home.components.CopiableAddress
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.KeyboardAware
 import com.vultisig.wallet.ui.utils.VsUriHandler
@@ -94,6 +95,8 @@ internal fun ChainTokensScreen(
         onDismissQbtcBanner = viewModel::dismissQbtcClaimBanner,
     )
 }
+
+internal const val TokenListTestTag = "chain_token_list"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -254,9 +257,14 @@ internal fun ChainTokensScreen(
         },
         content = { paddingValues ->
             Box(modifier = Modifier.fillMaxSize().padding(paddingValues)) {
+                // Reserved on the column, not inside the card: the token list wraps its
+                // content, so bottom padding there would inflate the card with dead space when
+                // it holds a single token.
                 Column(
                     modifier =
-                        Modifier.background(Theme.v2.colors.backgrounds.primary).fillMaxSize()
+                        Modifier.background(Theme.v2.colors.backgrounds.primary)
+                            .fillMaxSize()
+                            .padding(bottom = LocalBottomNavigatorPadding.current)
                 ) {
                     ChainTokensTabMenuAndSearchBar(
                         modifier = Modifier.padding(horizontal = 16.dp),
@@ -269,7 +277,9 @@ internal fun ChainTokensScreen(
                         canSelectTokens = uiModel.canSelectTokens,
                     )
 
-                    TopShineContainer(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                    TopShineContainer(
+                        modifier = Modifier.fillMaxWidth().padding(16.dp).testTag(TokenListTestTag)
+                    ) {
                         LazyColumn {
                             itemsIndexed(items = uiModel.tokens, key = { _, token -> token.id }) {
                                 index,
@@ -314,13 +324,15 @@ internal fun ChainTokensScreen(
                     }
                 }
 
+                // The floating navigator already fades the foot of the screen, so the CTA only
+                // has to clear it.
                 if (uiModel.showClaimQbtcButton) {
                     ClaimQbtcBottomCta(
                         onClaim = onClaimQbtc,
-                        modifier = Modifier.align(Alignment.BottomCenter),
+                        modifier =
+                            Modifier.align(Alignment.BottomCenter)
+                                .padding(bottom = LocalBottomNavigatorPadding.current),
                     )
-                } else {
-                    BottomFadeEffect(modifier = Modifier.align(Alignment.BottomCenter))
                 }
             }
         },

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/BaseDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/BaseDeFiPositionsScreen.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.tab.VsTab
 import com.vultisig.wallet.ui.components.v2.tab.VsTabGroup
 import com.vultisig.wallet.ui.screens.v2.defi.model.DefiUiModel
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.theme.Theme
 import kotlinx.serialization.Serializable
 
@@ -50,7 +51,8 @@ fun BaseDeFiPositionsScreenContent(
                 Modifier.fillMaxSize()
                     .background(Theme.v2.colors.backgrounds.primary)
                     .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 12.dp, bottom = 12.dp + LocalBottomNavigatorPadding.current),
             horizontalAlignment = CenterHorizontally,
         ) {
             BalanceBanner(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/MayachainDefiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/maya/MayachainDefiPositionsScreen.kt
@@ -50,6 +50,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.hasMayaStakingPositions
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions.ADD_LP
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions.REMOVE_LP
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.theme.Theme
 
 /**
@@ -144,7 +145,8 @@ internal fun MayachainDefiPositionsScreenContent(
                 Modifier.fillMaxSize()
                     .background(Theme.v2.colors.backgrounds.primary)
                     .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 12.dp, bottom = 12.dp + LocalBottomNavigatorPadding.current),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             BalanceBanner(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/solana/SolanaStakingPositionsScreen.kt
@@ -60,6 +60,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.HeaderDeFiWidget
 import com.vultisig.wallet.ui.screens.v2.defi.InfoItem
 import com.vultisig.wallet.ui.screens.v2.defi.ManagePositionsButton
 import com.vultisig.wallet.ui.screens.v2.defi.PositionsSelectionDialog
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -153,7 +154,8 @@ internal fun SolanaStakingPositionsContent(
                 Modifier.fillMaxSize()
                     .background(Theme.v2.colors.backgrounds.primary)
                     .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 12.dp, bottom = 12.dp + LocalBottomNavigatorPadding.current),
             horizontalAlignment = CenterHorizontally,
         ) {
             SolanaHeaderBanner(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/thorchain/ThorchainDefiPositionsScreen.kt
@@ -52,6 +52,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.hasLpPositions
 import com.vultisig.wallet.ui.screens.v2.defi.hasStakingPositions
 import com.vultisig.wallet.ui.screens.v2.defi.model.BondNodeState
 import com.vultisig.wallet.ui.screens.v2.defi.model.DeFiNavActions
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.theme.Theme
 
 /**
@@ -139,7 +140,8 @@ internal fun ThorchainDefiPositionScreenContent(
                 Modifier.fillMaxSize()
                     .background(Theme.v2.colors.backgrounds.primary)
                     .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
+                    .padding(horizontal = 16.dp)
+                    .padding(top = 12.dp, bottom = 12.dp + LocalBottomNavigatorPadding.current),
             horizontalAlignment = CenterHorizontally,
         ) {
             BalanceBanner(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/ton/TonDeFiPositionsScreen.kt
@@ -54,6 +54,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.DeFiTab
 import com.vultisig.wallet.ui.screens.v2.defi.ManagePositionsButton
 import com.vultisig.wallet.ui.screens.v2.defi.NoPositionsContainer
 import com.vultisig.wallet.ui.screens.v2.defi.PositionsSelectionDialog
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 import kotlinx.coroutines.delay
@@ -137,7 +138,13 @@ private fun TonDeFiPositionsScreenContent(
             // instead of pinning the header above the list, mirroring iOS (#4761).
             LazyColumn(
                 modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+                contentPadding =
+                    PaddingValues(
+                        start = 16.dp,
+                        end = 16.dp,
+                        top = 16.dp,
+                        bottom = 16.dp + LocalBottomNavigatorPadding.current,
+                    ),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 item {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/tron/TronDeFiPositionsScreen.kt
@@ -43,6 +43,7 @@ import com.vultisig.wallet.ui.screens.v2.defi.DeFiTab
 import com.vultisig.wallet.ui.screens.v2.defi.ManagePositionsButton
 import com.vultisig.wallet.ui.screens.v2.defi.NoPositionsContainer
 import com.vultisig.wallet.ui.screens.v2.defi.PositionsSelectionDialog
+import com.vultisig.wallet.ui.screens.v2.home.components.LocalBottomNavigatorPadding
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
 
@@ -111,7 +112,13 @@ private fun TronDeFiPositionsScreenContent(
             // instead of pinning the header above the list, mirroring iOS (#4761).
             LazyColumn(
                 modifier = Modifier.fillMaxSize().background(Theme.v2.colors.backgrounds.primary),
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
+                contentPadding =
+                    PaddingValues(
+                        start = 16.dp,
+                        end = 16.dp,
+                        top = 16.dp,
+                        bottom = 16.dp + LocalBottomNavigatorPadding.current,
+                    ),
                 verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 item {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/BottomNavigator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/home/components/BottomNavigator.kt
@@ -1,0 +1,85 @@
+package com.vultisig.wallet.ui.screens.v2.home.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.vultisig.wallet.data.models.CryptoConnectionType
+import com.vultisig.wallet.ui.components.v2.visuals.BottomFadeEffect
+
+/**
+ * Height of the floating navigator: the 64dp Wallet/DeFi pill plus the 1dp gradient ring drawn
+ * around it. The camera button is shorter (62dp), so the pill sets the height.
+ */
+private val NavigatorHeight = 66.dp
+
+/** Breathing room between the last row of content and the pill, mirroring iOS `VultiTabBar`. */
+private val NavigatorContentSpacing = 16.dp
+
+/**
+ * Bottom space the floating navigator covers on the screen hosting it.
+ *
+ * The navigator is drawn as an overlay rather than in a `Scaffold` bottom-bar slot, so content runs
+ * behind it instead of stopping short above an opaque block. Scrollable content anywhere inside a
+ * host reads this and adds it as bottom padding, so its last row can still be scrolled clear of the
+ * pill.
+ */
+internal val LocalBottomNavigatorPadding = staticCompositionLocalOf { 0.dp }
+
+internal const val BottomNavigatorTestTag = "bottom_navigator"
+
+/**
+ * Draws [content] full-bleed with the Wallet/DeFi pill and the camera button floating over its
+ * bottom edge, above a fade into the background so content passing underneath stays legible.
+ */
+@Composable
+internal fun BottomNavigatorOverlay(
+    isNavigatorVisible: Boolean,
+    activeType: CryptoConnectionType,
+    onTypeClick: (CryptoConnectionType) -> Unit,
+    onCameraClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    availableCryptoTypes: List<CryptoConnectionType> = BOTH_CRYPTO_CONNECTION_TYPES,
+    content: @Composable () -> Unit,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        // Reserved whether or not the navigator is currently shown, so content does not reflow when
+        // it is hidden for the search bar.
+        CompositionLocalProvider(
+            LocalBottomNavigatorPadding provides NavigatorHeight + NavigatorContentSpacing
+        ) {
+            content()
+        }
+
+        if (isNavigatorVisible) {
+            BottomFadeEffect(
+                height = NavigatorHeight + NavigatorContentSpacing,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
+            Row(
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .align(Alignment.BottomCenter)
+                        .padding(horizontal = 16.dp)
+                        .testTag(BottomNavigatorTestTag),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                CryptoConnectionSelect(
+                    activeType = activeType,
+                    availableCryptoTypes = availableCryptoTypes,
+                    onTypeClick = onTypeClick,
+                )
+                CameraButton(onClick = onCameraClick)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #5784

The bottom navigator sat on an opaque full-width block that clipped the content above it. It floats over the content now, with the pill and camera as the only painted things.

| Before (from the issue) | After (Solana DeFi, on device) |
|---|---|
| <img src="https://github.com/user-attachments/assets/df89ffde-c082-49b1-9f1f-156a497f4b69" width="320" /> | <img src="https://i.imgur.com/N5B0a2k.png" width="320" /> |

The after shot is the Solana DeFi detail scrolled to the end: the RWA USDC card runs behind the pill and fades out, and both cards can be scrolled fully clear of it.

## What was actually wrong

Material3's `bottomBar` slot paints nothing — the block was the Scaffold container colour showing through. Both hosts padded their content out of the bar's region (`ChainDashboardScreen`'s `calculateBottomPadding()`, `VaultAccountsScreen`'s `padding(innerPadding)`), so nothing drew there and the card met a hard edge against the bare background.

## The change

A single overlay, `BottomNavigatorOverlay`, now hosts both screens:

- The pill and camera are drawn over the content (`Box` + `align(BottomCenter)`); the `bottomBar` slot is gone from `ChainDashboardScreen`, and `ScaffoldWithExpandableTopBar` loses its `bottomBarContent` parameter with it.
- `LocalBottomNavigatorPadding` publishes the 82dp the navigator covers (66dp pill + 16dp breathing room, matching iOS's 64 + 16) down the tree, so lists take it as **`contentPadding`** rather than layout padding — content draws behind, and the last row still scrolls clear. A CompositionLocal because `ChainDashboardScreen` hosts eight different screens; threading a parameter through all of them would have been pure signature churn.
- The reservation holds whether or not the navigator is showing, so opening the search bar no longer reflows the list.

Applied across all nine hosted screens: home, chain tokens, THORChain/MayaChain/Solana/Circle (scrolling `Column`s) and Tron/TON/Cosmos (`LazyColumn` `contentPadding`).

**One thing worth a look:** the existing `BottomFadeEffect` moved out of home and the token list into the overlay. At the true foot of the screen it now covers every hosted screen instead of two, which is what iOS does (`VultiTabBar.bottomGradient`, an 80pt fade in the same background colour) and what keeps content legible as it passes under an opaque pill. It is not a bar background, but it is more than "only the pill and camera" — easy to drop if you read the ask more strictly.

Out of scope: Android's pill is opaque `#0d2446` where Figma has a translucent, blurred `rgba(19,46,86,0.6)`. Left alone.

## Note on a list that wraps its content

The token list lives inside the `TopShineContainer` card and sizes itself to its content, so `contentPadding` there is measured as part of the card — a chain holding one token rendered a card with a tall band of dead space under its only row. The reservation is taken on the hosting column instead. `ChainTokensListHeightTest` pins it: on the bad version it fails with `the card runs 188.0px past its only row`.

## Test plan

- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugAndroidTestKotlin`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :app:lintDebug`
- [x] `./gradlew :app:ktfmtCheck`
- [x] `./gradlew :app:connectedDebugAndroidTest` — 4 new instrumented tests, `failures="0"`:
  - `BottomNavigatorOverlayTest` — content keeps the full height under the navigator, the published padding covers the navigator, hiding it leaves the reservation in place
  - `ChainTokensListHeightTest` — a single-token card hugs its row
- [x] On device: Solana DeFi detail (above), Bitcoin token list (single token, card hugs its row)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared bottom navigation overlay with wallet/DeFi selection and camera controls.
  * Added configurable bottom fade sizing and consistent navigation-aware spacing across dashboard, account, staking, DeFi, and token screens.
  * Added improved token-list and bottom-navigation layout handling to keep content visible above the navigator.

* **Tests**
  * Added UI coverage for navigator spacing, visibility behavior, full-height content, and single-token card layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->