### PR TITLE
fix(ci): run :data instrumented tests, not just :app's

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -157,4 +157,4 @@ jobs:
           disable-spellchecker: true
           script: |
             # Run debug instrumented tests (connectedDebugAndroidTest)
-            ./gradlew app:connectedDebugAndroidTest --stacktrace
+            ./gradlew app:connectedDebugAndroidTest data:connectedDebugAndroidTest --stacktrace


### PR DESCRIPTION
## Summary
- `.github/workflows/android.yml:160` ran `app:connectedDebugAndroidTest`, a qualified task path AGP scopes to `:app` only — `:data`'s 50 instrumented tests (Sui/Kamino cross-device signing parity checks) have never been compiled or executed by CI, while the `instrumented-tests` check reported green.
- Added `data:connectedDebugAndroidTest` alongside the existing `:app` invocation so both modules run.

## Verification
- Ran `./gradlew :data:connectedDebugAndroidTest` locally against a real emulator: all 50 tests pass as-is (no bit-rot to fix).
- Deliberately broke an assertion in `SuiHelperInputDataTest` and re-ran — the task correctly `BUILD FAILED`, confirming the job will go red on a real failure. Reverted the deliberate break before committing.

## Test plan
- [x] `./gradlew assembleDebug` succeeds
- [x] `./gradlew :data:connectedDebugAndroidTest` runs all 5 classes / 50 tests and passes
- [x] A deliberately broken `:data` instrumented test turns the check red (verified locally, reverted)
- [x] CI log will show a `:data:connectedDebugAndroidTest` task once this runs

Fixes #5714

https://claude.ai/code/session_014Xg4CV66Vt8V2qejqxZkAi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Android instrumented test runs to cover both the app and data modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->