### PR TITLE
feat(keysign): integrate decoded heroes into Verify

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -153,6 +153,9 @@ import com.vultisig.wallet.ui.models.send.GasSettingsUiModel
 import com.vultisig.wallet.ui.models.send.SendFormUiModel
 import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.models.send.TokenBalanceUiModel
+import com.vultisig.wallet.ui.models.sign.DecodedCustomMessage
+import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
+import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
 import com.vultisig.wallet.ui.models.solanastaking.KaminoAmountUiState
 import com.vultisig.wallet.ui.models.solanastaking.SolanaStakePositionRow
 import com.vultisig.wallet.ui.models.solanastaking.SolanaStakingPositionsUiState
@@ -204,6 +207,7 @@ import com.vultisig.wallet.ui.screens.settings.DiscountTiersScreenPreview
 import com.vultisig.wallet.ui.screens.settings.TierType
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.FeatureGateBottomSheet
 import com.vultisig.wallet.ui.screens.settings.bottomsheets.sharelink.TierDiscountBottomSheetContent
+import com.vultisig.wallet.ui.screens.sign.VerifySignMessageScreen
 import com.vultisig.wallet.ui.screens.swap.SwapScreen
 import com.vultisig.wallet.ui.screens.swap.VerifySwapScreen
 import com.vultisig.wallet.ui.screens.swap.components.LimitSwapForm
@@ -410,6 +414,24 @@ class PreviewActivity : ComponentActivity() {
                     "verify_decoded_send_before" -> VerifyDecodedSendHeroPreview(hero = null)
                     "verify_decoded_send_after" ->
                         VerifyDecodedSendHeroPreview(hero = decodedBondHero())
+                    "sign_message_hash_before" -> SignMessageDecodedPreview(decoded = null)
+                    "sign_message_hash_after" ->
+                        SignMessageDecodedPreview(decoded = DecodedCustomMessage.Hash)
+                    "sign_message_text" ->
+                        SignMessageDecodedPreview(
+                            decoded = DecodedCustomMessage.Text("Sign in to Uniswap")
+                        )
+                    "sign_message_call" ->
+                        SignMessageDecodedPreview(
+                            message = SIGN_MESSAGE_CALLDATA,
+                            decoded =
+                                DecodedCustomMessage.ContractCall(
+                                    function = "transfer(address,uint256)",
+                                    arguments =
+                                        "[{\"name\":\"to\",\"value\":\"0x9876…5432\"}," +
+                                            "{\"name\":\"amount\",\"value\":\"125000000\"}]",
+                                ),
+                        )
                     "deposit_mint_done" -> DepositMintDonePreview()
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "limit_orders_tab" -> LimitOrdersTabPreview()
@@ -1825,6 +1847,48 @@ private fun VerifyDecodedSendHeroPreview(hero: HeroContent?) {
         onConsentAddress = {},
         onConsentAmount = {},
         onBackClick = {},
+    )
+}
+
+/** The 32-byte digest from the reported case: opaque, and not calldata. */
+private const val SIGN_MESSAGE_DIGEST =
+    "0xfc2e852f3d6effd607b325d140a32237c00ef518b06e0b02c420ba62f9964bd8"
+
+/** Real `transfer(address,uint256)` calldata: a 4-byte selector plus two 32-byte words. */
+private const val SIGN_MESSAGE_CALLDATA =
+    "0xa9059cbb0000000000000000000000009876543210fedcba9876543210fedcba98765432" +
+        "0000000000000000000000000000000000000000000000000000000007735940"
+
+/**
+ * The sign_message Verify screen, which renders a reading of the payload above the payload itself.
+ *
+ * [decoded] `null` is the state before a reading lands — and the state this screen was always in: a
+ * bare 32-byte digest with nothing saying that is what it is. [DecodedCustomMessage.Hash] names it.
+ * The other two are the cases that carry real content.
+ *
+ * The digest is the one from issue reproduction: iOS labels it "Contract Function Call (fc2e852f)"
+ * by reading its first four bytes as a selector, which is not what those bytes are.
+ */
+@Composable
+private fun SignMessageDecodedPreview(
+    decoded: DecodedCustomMessage?,
+    message: String = SIGN_MESSAGE_DIGEST,
+) {
+    VerifySignMessageScreen(
+        state =
+            VerifySignMessageUiModel(
+                model =
+                    SignMessageTransactionUiModel(
+                        method = "sign_message",
+                        message = message,
+                        decoded = decoded,
+                    )
+            ),
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        onBackClick = {},
+        onFastSignClick = {},
+        onConfirm = {},
     )
 }
 

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -396,6 +396,20 @@ class PreviewActivity : ComponentActivity() {
                     "send_tx_done_projected" -> SendTxDoneProjectedPreview()
                     "send_tx_done_unresolved" -> SendTxDoneUnresolvedPreview()
                     "send_tx_done_title" -> SendTxDoneTitleOnlyPreview()
+                    "verify_decoded_deposit_before" -> VerifyDecodedDepositPreview(hero = null)
+                    "verify_decoded_deposit_after" ->
+                        VerifyDecodedDepositPreview(hero = decodedStakeHero(), memo = "tcy+")
+                    "verify_decoded_deposit_projected" ->
+                        VerifyDecodedDepositPreview(
+                            hero = decodedUnstakeProjection(resolved = true)
+                        )
+                    "verify_decoded_deposit_unresolved" ->
+                        VerifyDecodedDepositPreview(
+                            hero = decodedUnstakeProjection(resolved = false)
+                        )
+                    "verify_decoded_send_before" -> VerifyDecodedSendHeroPreview(hero = null)
+                    "verify_decoded_send_after" ->
+                        VerifyDecodedSendHeroPreview(hero = decodedBondHero())
                     "deposit_mint_done" -> DepositMintDonePreview()
                     "transaction_history_empty" -> TransactionHistoryEmptyState()
                     "limit_orders_tab" -> LimitOrdersTabPreview()
@@ -1681,6 +1695,136 @@ private fun SendTxDoneWithOperationHero(operationHero: HeroContent) {
             ),
         isTransactionDetailVisible = false,
         onTransactionDetailVisibleChange = {},
+    )
+}
+
+/**
+ * The three heroes a decoded reading can produce on Verify, against the surfaces that render them.
+ *
+ * They exist because the reading itself is not reachable yet: `SignedTransactionDecoder` registers
+ * no chain readers, so every transaction decodes to `Unknown` and each screen keeps its own
+ * presentation. These feed the resolved hero straight into the UI model, which is exactly what the
+ * view models do once a chain decoder lands, so the rendering, the vocabulary, and the left-aligned
+ * verb are all verifiable now.
+ *
+ * The data is the TCY position the done-screen previews use, so a Verify and a Done capture read as
+ * the same transaction at two points in time.
+ */
+@Composable
+private fun decodedStakeHero(): HeroContent =
+    HeroContent.Send(
+        title = stringResource(R.string.cosmos_staking_youre_staking),
+        coin =
+            HeroCoinAmount(
+                amount = "1,250.5",
+                ticker = "TCY",
+                logo = Coins.ThorChain.TCY.logo,
+                fiatValue = "$412.66",
+            ),
+    )
+
+/**
+ * An execution-set quantity. [resolved] = true is a position read that answered; false is the guard
+ * that matters — a read that failed or timed out. The verb and the signed scope are true either
+ * way, so both are shown; only the estimate is dropped, rather than being backfilled with the
+ * payload's carrier amount, which for a fractional unstake is dust.
+ */
+@Composable
+private fun decodedUnstakeProjection(resolved: Boolean): HeroContent =
+    HeroContent.Projected(
+        title = stringResource(R.string.cosmos_staking_youre_unstaking),
+        estimate =
+            if (resolved) {
+                HeroCoinAmount(
+                    amount = "625.25",
+                    ticker = "TCY",
+                    logo = Coins.ThorChain.TCY.logo,
+                    fiatValue = "$206.33",
+                )
+            } else {
+                null
+            },
+        scope = stringResource(R.string.withdrawing_share_of_staked_position, "50%"),
+    )
+
+@Composable
+private fun decodedBondHero(): HeroContent =
+    HeroContent.Send(
+        title = stringResource(R.string.verify_verb_bonding),
+        coin =
+            HeroCoinAmount(
+                amount = "75",
+                ticker = "RUNE",
+                logo = Coins.ThorChain.RUNE.logo,
+                fiatValue = "$337.50",
+            ),
+    )
+
+/**
+ * The function-call Verify surface. A null [hero] is the state before a chain decoder lands: the
+ * generic "You’re sending" header over the carrier amount, which for a `tcy-` unstake is one
+ * satoshi-scale dust figure that says nothing about the position being closed.
+ */
+@Composable
+private fun VerifyDecodedDepositPreview(hero: HeroContent?, memo: String = "tcy-:5000") {
+    val rune = Coins.ThorChain.RUNE
+    VerifyDepositScreen(
+        state =
+            VerifyDepositUiModel(
+                depositTransactionUiModel =
+                    DepositTransactionUiModel(
+                        token =
+                            ValuedToken(token = rune, value = "0.00000001", fiatValue = "$0.00"),
+                        srcAddress = "thor1abcdefghijklmnopqrstuvwxyz0123456789ab",
+                        srcVaultName = "Main Vault",
+                        dstAddress = "thor1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz9k8lqe",
+                        memo = memo,
+                        networkFeeTokenValue = "0.02 RUNE",
+                        networkFeeFiatValue = "$0.03",
+                        titleRes = R.string.verify_deposit_sending,
+                        heroContent = hero,
+                    ),
+                isLoading = false,
+            ),
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.verify_swap_sign_button),
+        onFastSignClick = {},
+        onConfirm = {},
+        onBackClick = {},
+    )
+}
+
+/**
+ * The Send Verify surface, which both the initiator and a joining co-signer render. A null [hero]
+ * is the current state: the native-amount card with no verb over it.
+ */
+@Composable
+private fun VerifyDecodedSendHeroPreview(hero: HeroContent?) {
+    val rune = Coins.ThorChain.RUNE
+    VerifySendScreen(
+        state =
+            VerifyTransactionUiModel(
+                transaction =
+                    TransactionDetailsUiModel(
+                        token = ValuedToken(token = rune, value = "75", fiatValue = "$337.50"),
+                        srcAddress = "thor1abcdefghijklmnopqrstuvwxyz0123456789ab",
+                        srcVaultName = "Main Vault",
+                        dstAddress = "thor1zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz9k8lqe",
+                        memo = "BOND:thor1node0000000000000000000000000000000000",
+                        networkFeeTokenValue = "0.02 RUNE",
+                        networkFeeFiatValue = "$0.03",
+                        heroContent = hero,
+                    ),
+                hasFastSign = true,
+            ),
+        isConsentsEnabled = true,
+        hasToolbar = true,
+        confirmTitle = stringResource(R.string.keysign_sign_transaction),
+        onFastSignClick = {},
+        onConfirm = {},
+        onConsentAddress = {},
+        onConsentAmount = {},
+        onBackClick = {},
     )
 }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/components/hero/HeroContentView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/hero/HeroContentView.kt
@@ -37,24 +37,37 @@ import java.util.Locale
  * The composable owns no padding or background — the parent card provides those — so it can be
  * dropped into the existing `tokenContent` slot of `TxDoneScaffold` and the inner column of
  * `VerifySendScreen` without altering surrounding layout.
+ *
+ * [verbAlignment] places the verb and the copy that qualifies it. Verify leads with the verb, so it
+ * passes [Alignment.Start]; the done screens keep the centred default. Figures are unaffected: a
+ * coin row and a swap's two legs are centred on every surface.
  */
 @Composable
-internal fun HeroContentView(content: HeroContent, modifier: Modifier = Modifier) {
+internal fun HeroContentView(
+    content: HeroContent,
+    modifier: Modifier = Modifier,
+    verbAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
+) {
+    val verbTextAlign = if (verbAlignment == Alignment.Start) TextAlign.Start else TextAlign.Center
     Column(
         modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         when (content) {
-            is HeroContent.Title -> TitleOnlyHero(text = content.title, caption = null)
+            is HeroContent.Title ->
+                TitleOnlyHero(text = content.title, caption = null, textAlign = verbTextAlign)
             HeroContent.Unverified ->
                 TitleOnlyHero(
                     text = stringResource(R.string.dapp_hero_unverified_function_title),
                     caption = stringResource(R.string.dapp_hero_unverified_function_subtitle),
+                    textAlign = verbTextAlign,
                 )
-            is HeroContent.Send -> SendHero(content)
+            is HeroContent.Send -> SendHero(content, verbTextAlign)
+            // A swap states both legs, so its verb sits over a two-row figure and stays centred
+            // on every surface — the same exception iOS makes.
             is HeroContent.Swap -> SwapHero(content)
-            is HeroContent.Projected -> ProjectedHero(content)
+            is HeroContent.Projected -> ProjectedHero(content, verbTextAlign)
         }
     }
 }
@@ -72,12 +85,22 @@ internal fun TransactionHero(
     heroContent: HeroContent?,
     functionName: String?,
     modifier: Modifier = Modifier,
+    verbAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     content: @Composable () -> Unit,
 ) {
     when {
-        heroContent != null -> HeroContentView(content = heroContent, modifier = modifier)
+        heroContent != null ->
+            HeroContentView(
+                content = heroContent,
+                modifier = modifier,
+                verbAlignment = verbAlignment,
+            )
         functionName != null ->
-            HeroContentView(content = HeroContent.Title(functionName), modifier = modifier)
+            HeroContentView(
+                content = HeroContent.Title(functionName),
+                modifier = modifier,
+                verbAlignment = verbAlignment,
+            )
         else -> content()
     }
 }
@@ -96,7 +119,7 @@ internal fun TransactionHero(
  * Unverified state passes a non-null caption.
  */
 @Composable
-private fun TitleOnlyHero(text: String, caption: String?) {
+private fun TitleOnlyHero(text: String, caption: String?, textAlign: TextAlign) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -114,7 +137,7 @@ private fun TitleOnlyHero(text: String, caption: String?) {
             text = text,
             style = Theme.brockmann.headings.title2,
             color = Theme.v2.colors.text.primary,
-            textAlign = TextAlign.Center,
+            textAlign = textAlign,
             modifier = Modifier.fillMaxWidth(),
         )
         if (caption != null) {
@@ -122,7 +145,7 @@ private fun TitleOnlyHero(text: String, caption: String?) {
                 text = caption,
                 style = Theme.brockmann.body.s.medium,
                 color = Theme.v2.colors.text.tertiary,
-                textAlign = TextAlign.Center,
+                textAlign = textAlign,
                 modifier = Modifier.fillMaxWidth(),
             )
         }
@@ -130,8 +153,8 @@ private fun TitleOnlyHero(text: String, caption: String?) {
 }
 
 @Composable
-private fun SendHero(content: HeroContent.Send) {
-    content.title?.let { TitleAbove(it) }
+private fun SendHero(content: HeroContent.Send, verbTextAlign: TextAlign) {
+    content.title?.let { TitleAbove(it, verbTextAlign) }
     HeroCoinRow(coin = content.coin, iconSize = 36.dp)
 }
 
@@ -141,21 +164,22 @@ private fun SendHero(content: HeroContent.Send) {
  * never be mistaken for a committed amount.
  */
 @Composable
-private fun ProjectedHero(content: HeroContent.Projected) {
-    content.title?.let { TitleAbove(it) }
+private fun ProjectedHero(content: HeroContent.Projected, verbTextAlign: TextAlign) {
+    content.title?.let { TitleAbove(it, verbTextAlign) }
     content.estimate?.let { HeroCoinRow(coin = it, iconSize = 36.dp, approximate = true) }
+    // The scope qualifies the verb rather than the figure, so it follows the verb's alignment.
     Text(
         text = content.scope,
         style = Theme.brockmann.body.s.medium,
         color = Theme.v2.colors.text.tertiary,
-        textAlign = TextAlign.Center,
+        textAlign = verbTextAlign,
         modifier = Modifier.fillMaxWidth(),
     )
 }
 
 @Composable
 private fun SwapHero(content: HeroContent.Swap) {
-    content.title?.let { TitleAbove(it) }
+    content.title?.let { TitleAbove(it, TextAlign.Center) }
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -168,12 +192,12 @@ private fun SwapHero(content: HeroContent.Swap) {
 }
 
 @Composable
-private fun TitleAbove(title: String) {
+private fun TitleAbove(title: String, textAlign: TextAlign) {
     Text(
         text = title,
         style = Theme.brockmann.body.s.medium,
         color = Theme.v2.colors.text.secondary,
-        textAlign = TextAlign.Center,
+        textAlign = textAlign,
         modifier = Modifier.fillMaxWidth(),
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VerifyTransactionViewModel.kt
@@ -9,10 +9,12 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.chains.helpers.RippleDappTx
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.RippleTrustSetDisplay
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.Transaction
 import com.vultisig.wallet.data.models.TransactionId
+import com.vultisig.wallet.data.models.transaction_decoding.asSignedTransactionContent
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.repositories.ContractAbiRepository
@@ -40,6 +42,7 @@ import com.vultisig.wallet.ui.models.keysign.isUnlimitedApproval
 import com.vultisig.wallet.ui.models.keysign.prettifyEvmFunctionName
 import com.vultisig.wallet.ui.models.mappers.TransactionToUiModelMapper
 import com.vultisig.wallet.ui.models.swap.ValuedToken
+import com.vultisig.wallet.ui.models.transactiondecoding.VerifyTransactionPresentation
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -227,6 +230,7 @@ constructor(
     private val tokenRepository: TokenRepository,
     @param:PrettyJson private val json: Json,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
+    private val verifyTransactionPresentation: VerifyTransactionPresentation,
 ) : ViewModel() {
 
     private val args = savedStateHandle.toRoute<Route.VerifySend>()
@@ -382,7 +386,8 @@ constructor(
 
             val allVaults = withContext(ioDispatcher) { vaultRepository.getAll() }
             val chain = tx.token.chain
-            val srcVaultName = allVaults.find { it.id == vaultId }?.name
+            val signingVault = allVaults.find { it.id == vaultId }
+            val srcVaultName = signingVault?.name
             val dstVaultName =
                 resolveDstVaultName(
                     allVaults = allVaults,
@@ -462,7 +467,38 @@ constructor(
 
             _uiState.update { it.copy(transaction = namedUiModel) }
 
+            loadDecodedHero(tx, signingVault?.coins.orEmpty())
             scanTransaction()
+        }
+    }
+
+    /**
+     * Reads what this transaction actually does, so a send-routed DeFi operation names itself
+     * rather than reading as a plain transfer. A transfer — which is what nearly everything on this
+     * screen is — is a reading the decoder is deliberately silent on, so the screen keeps its own
+     * presentation.
+     *
+     * Best-effort and never a signing dependency: a failed read leaves the screen exactly as it is.
+     */
+    private fun loadDecodedHero(tx: Transaction, trustedCoins: List<Coin>) {
+        viewModelScope.safeLaunch(
+            onError = { Timber.w(it, "Failed to resolve the decoded verify hero") }
+        ) {
+            val hero =
+                withContext(ioDispatcher) {
+                    verifyTransactionPresentation.resolve(
+                        content = tx.asSignedTransactionContent(),
+                        coin = tx.token,
+                        trustedCoins = trustedCoins,
+                    )
+                } ?: return@safeLaunch
+
+            _uiState.update {
+                it.copy(
+                    transaction =
+                        it.transaction.copy(heroContent = hero.applyTo(it.transaction.heroContent))
+                )
+            }
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModel.kt
@@ -11,6 +11,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.DepositTransaction
 import com.vultisig.wallet.data.models.nativeToken
+import com.vultisig.wallet.data.models.transaction_decoding.asSignedTransactionContent
 import com.vultisig.wallet.data.repositories.AddressBookRepository
 import com.vultisig.wallet.data.repositories.BalanceRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
@@ -18,11 +19,15 @@ import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
+import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
 import com.vultisig.wallet.ui.models.limitorder.LimitOrderCancelPresentation
 import com.vultisig.wallet.ui.models.mappers.DepositTransactionToUiModelMapper
+import com.vultisig.wallet.ui.models.mappers.depositVerifyAcceptsDecodedHero
 import com.vultisig.wallet.ui.models.mappers.depositVerifyTitleRes
 import com.vultisig.wallet.ui.models.swap.ValuedToken
+import com.vultisig.wallet.ui.models.transactiondecoding.VerifyTransactionPresentation
 import com.vultisig.wallet.ui.navigation.Route
 import com.vultisig.wallet.ui.navigation.SendDst
 import com.vultisig.wallet.ui.navigation.util.LaunchKeysignUseCase
@@ -90,6 +95,13 @@ internal data class DepositTransactionUiModel(
      * (issue #5644). iOS surfaces the same case as `.amountUnverifiable`.
      */
     val unverifiedWithdrawShares: String? = null,
+    /**
+     * The decoded reading of the transaction about to be signed, when the screen has nothing more
+     * specific of its own to say. Replaces the header verb and the amount below it; null everywhere
+     * the screen already names the operation — a limit-order cancel, a Kamino deposit or withdraw,
+     * an unbond — and for every reading the decoder is deliberately silent on.
+     */
+    val heroContent: HeroContent? = null,
 )
 
 internal data class VerifyDepositUiModel(
@@ -121,6 +133,7 @@ constructor(
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
     private val launchKeysign: LaunchKeysignUseCase,
     private val isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase,
+    private val verifyTransactionPresentation: VerifyTransactionPresentation,
 ) : ViewModel() {
 
     val state = MutableStateFlow(VerifyDepositUiModel())
@@ -176,6 +189,8 @@ constructor(
                         )
                 state.update { it.copy(depositTransactionUiModel = depositTransactionUiModel) }
 
+                loadDecodedHero(transaction)
+
                 // Keep isLoading true (Sign button disabled) until the balance lookup resolves, so
                 // a zero-balance voter cannot tap Sign mid round-trip while hasEnoughBalance is
                 // still at its default true and start the doomed ceremony this targets (#5044).
@@ -196,6 +211,47 @@ constructor(
 
         loadFastSign()
         loadPassword()
+    }
+
+    /**
+     * Reads what this deposit actually does from the transaction the signer builds from, so the
+     * header names the operation rather than calling every DeFi transaction a send.
+     *
+     * Best-effort and never a signing dependency: an unreadable transaction, a failed position
+     * read, or a reading the decoder is silent on all leave the screen exactly as it is. A screen
+     * that already names the operation keeps its own presentation — see
+     * [depositVerifyAcceptsDecodedHero].
+     */
+    private fun loadDecodedHero(transaction: DepositTransaction) {
+        if (
+            !depositVerifyAcceptsDecodedHero(
+                depositVerifyTitleRes(transaction.operation, transaction.memo)
+            )
+        ) {
+            return
+        }
+
+        viewModelScope.safeLaunch(
+            onError = { Timber.w(it, "Failed to resolve the decoded deposit verify hero") }
+        ) {
+            val hero =
+                withContext(ioDispatcher) {
+                    verifyTransactionPresentation.resolve(
+                        content = transaction.asSignedTransactionContent(),
+                        coin = transaction.srcToken,
+                        trustedCoins = vaultRepository.get(transaction.vaultId)?.coins.orEmpty(),
+                    )
+                } ?: return@safeLaunch
+
+            state.update {
+                it.copy(
+                    depositTransactionUiModel =
+                        it.depositTransactionUiModel.copy(
+                            heroContent = hero.applyTo(it.depositTransactionUiModel.heroContent)
+                        )
+                )
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -838,6 +838,12 @@ constructor(
      */
     private fun loadDecodedVerifyHero(payload: KeysignPayload, vaultCoins: List<Coin>) {
         decodedVerifyHeroJob?.cancel()
+        // A reading belongs to exactly one payload. Cleared before the read rather than only
+        // written after it, so a payload whose reading is silent, unreadable, or fails leaves
+        // nothing behind: NSD can re-surface a mediator service and drive this a second time, and
+        // a retained verb would let the simulation paths below retitle the new transaction with
+        // the previous one's operation.
+        decodedVerifyHero = null
         decodedVerifyHeroJob =
             viewModelScope.safeLaunch(
                 onError = { Timber.w(it, "Failed to resolve the decoded verify hero") }
@@ -849,9 +855,11 @@ constructor(
                             coin = payload.coin,
                             trustedCoins = vaultCoins,
                         )
-                    } ?: return@safeLaunch
+                    }
 
                 decodedVerifyHero = resolved
+                if (resolved == null) return@safeLaunch
+
                 verifyUiModel.update { it.withDecodedHero(resolved) }
             }
     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -18,7 +18,6 @@ import com.vultisig.wallet.data.blockchain.solana.kamino.ResolveKaminoRelayedInt
 import com.vultisig.wallet.data.chains.helpers.SigningHelper
 import com.vultisig.wallet.data.common.DeepLinkHelper
 import com.vultisig.wallet.data.common.Endpoints
-import com.vultisig.wallet.data.common.normalizeMessageFormat
 import com.vultisig.wallet.data.mappers.KeysignMessageFromProtoMapper
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
@@ -52,6 +51,7 @@ import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
 import com.vultisig.wallet.ui.models.keygen.MediatorServiceDiscoveryListener
 import com.vultisig.wallet.ui.models.limitorder.LimitOrderCancelPresentation
 import com.vultisig.wallet.ui.models.mappers.depositVerifyAcceptsDecodedHero
+import com.vultisig.wallet.ui.models.sign.CustomMessageDecoder
 import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
 import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
@@ -280,6 +280,7 @@ constructor(
     private val blockaidSimulationService: BlockaidSimulationService,
     private val buildHeroContent: BuildHeroContentUseCase,
     private val verifyTransactionPresentation: VerifyTransactionPresentation,
+    private val customMessageDecoder: CustomMessageDecoder,
     private val qbtcClaimCosign: QbtcClaimCosignUseCase,
     private val tonDappHeroResolver: TonDappHeroResolver,
     private val resolveQbtcClaimCoins: ResolveQbtcClaimCoinsUseCase,
@@ -292,8 +293,6 @@ constructor(
 ) : ViewModel() {
     companion object {
         private const val VAULT_PARAMETER = "vault"
-
-        private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
     }
 
     private val args = savedStateHandle.toRoute<Route.Keysign.Join>()
@@ -329,6 +328,7 @@ constructor(
     private var blockaidSimulationJob: Job? = null
     private var tonJettonHeroJob: Job? = null
     private var decodedVerifyHeroJob: Job? = null
+    private var decodedCustomMessageJob: Job? = null
 
     /**
      * The decoded reading of the payload on the verify screen, kept so a simulation hero landing
@@ -557,10 +557,12 @@ constructor(
 
         customMessagePayload = customMessage
 
+        // The payload exactly as it will be signed. A reading of it arrives separately and is
+        // shown alongside, so the bytes are on screen from the first frame either way.
         val model =
             SignMessageTransactionUiModel(
                 method = customMessage.method,
-                message = getNormalizedCustomMessage(customMessage),
+                message = customMessage.message,
             )
 
         transactionTypeUiModel = TransactionTypeUiModel.SignMessage(model)
@@ -568,23 +570,40 @@ constructor(
         verifyUiModel.value =
             VerifyUiModel.SignMessage(model = VerifySignMessageUiModel(model = model))
 
+        loadDecodedCustomMessage(customMessage)
+
         return true
     }
 
-    private fun getNormalizedCustomMessage(customMessage: CustomMessagePayload) =
-        // For "eth_signTypedData_v4", the extension sends both the message and the domain
-        // as pre-hashed values. Because these fields are already hashed, the original data
-        // cannot be decoded from the resulting hex string.
-        // Therefore, we display the raw hex instead.
-        //
-        // Reference:
-        // https://github.com/ethers-io/ethers.js/blob/98c49d091eb84a9146dfba8476f18e4c3e3d1d31/src.ts/hash/typed-data.ts#L520
-        // https://github.com/vultisig/vultisig-windows/blob/e7e5b388ca022c9e3f02a85346336b837857a856/core/inpage-provider/popup/view/resolvers/signMessage/overview/index.tsx#L36
-        if (customMessage.method.equals(other = ETH_SIGN_TYPED_DATA_V4, ignoreCase = true)) {
-            customMessage.message
-        } else {
-            customMessage.message.normalizeMessageFormat()
-        }
+    /**
+     * Reads the custom message so a joining device says what it is signing rather than showing a
+     * bare hex string. Resolved off the join path because it can reach the network: the verify
+     * screen is already rendered by the time this lands, and a failed read simply adds nothing.
+     *
+     * The initiator resolves the same reading through the same decoder, so both devices agree.
+     */
+    private fun loadDecodedCustomMessage(customMessage: CustomMessagePayload) {
+        decodedCustomMessageJob?.cancel()
+        decodedCustomMessageJob =
+            viewModelScope.safeLaunch(
+                onError = { Timber.w(it, "Failed to decode the custom message") }
+            ) {
+                val decoded =
+                    customMessageDecoder.decode(
+                        method = customMessage.method,
+                        message = customMessage.message,
+                        chain = customMessage.chain,
+                    ) ?: return@safeLaunch
+
+                verifyUiModel.update { current ->
+                    if (current !is VerifyUiModel.SignMessage) current
+                    else
+                        VerifyUiModel.SignMessage(
+                            current.model.copy(model = current.model.model.copy(decoded = decoded))
+                        )
+                }
+            }
+    }
 
     private suspend fun handleKeysignMessage(proto: KeysignMessageProto): Boolean {
         val message = mapKeysignMessageFromProto(proto)
@@ -1173,6 +1192,7 @@ constructor(
         blockaidSimulationJob?.cancel()
         tonJettonHeroJob?.cancel()
         decodedVerifyHeroJob?.cancel()
+        decodedCustomMessageJob?.cancel()
     }
 
     private fun waitForKeysignToStart() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -34,6 +34,7 @@ import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.proto.v1.KeysignMessageProto
 import com.vultisig.wallet.data.models.proto.v1.KeysignPayloadProto
+import com.vultisig.wallet.data.models.transaction_decoding.asSignedTransactionContent
 import com.vultisig.wallet.data.repositories.AppCurrencyRepository
 import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -50,9 +51,12 @@ import com.vultisig.wallet.ui.models.VerifyTransactionUiModel
 import com.vultisig.wallet.ui.models.deposit.VerifyDepositUiModel
 import com.vultisig.wallet.ui.models.keygen.MediatorServiceDiscoveryListener
 import com.vultisig.wallet.ui.models.limitorder.LimitOrderCancelPresentation
+import com.vultisig.wallet.ui.models.mappers.depositVerifyAcceptsDecodedHero
 import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
 import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
+import com.vultisig.wallet.ui.models.transactiondecoding.VerifyHero
+import com.vultisig.wallet.ui.models.transactiondecoding.VerifyTransactionPresentation
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.NavigationOptions
 import com.vultisig.wallet.ui.navigation.Navigator
@@ -275,6 +279,7 @@ constructor(
     private val keysignViewModelFactory: KeysignViewModel.Factory,
     private val blockaidSimulationService: BlockaidSimulationService,
     private val buildHeroContent: BuildHeroContentUseCase,
+    private val verifyTransactionPresentation: VerifyTransactionPresentation,
     private val qbtcClaimCosign: QbtcClaimCosignUseCase,
     private val tonDappHeroResolver: TonDappHeroResolver,
     private val resolveQbtcClaimCoins: ResolveQbtcClaimCoinsUseCase,
@@ -323,6 +328,14 @@ constructor(
     private var _jobWaitingForKeysignStart: Job? = null
     private var blockaidSimulationJob: Job? = null
     private var tonJettonHeroJob: Job? = null
+    private var decodedVerifyHeroJob: Job? = null
+
+    /**
+     * The decoded reading of the payload on the verify screen, kept so a simulation hero landing
+     * after it can still borrow the decoded verb. Volatile because the simulation jobs read it from
+     * their own coroutines.
+     */
+    @Volatile private var decodedVerifyHero: VerifyHero? = null
     private val isJoiningKeysign = AtomicBoolean(false)
     private var isNavigateToHome: Boolean = false
 
@@ -630,15 +643,19 @@ constructor(
 
             // A Kamino payload states none of what it is in a field — no memo, no deposit flag —
             // so it reaches the deposit screen on the strength of its own bytes or not at all.
-            kamino != null ->
+            kamino != null -> {
                 applyVerifyResult(
                     joinDepositUiModelBuilder.build(payload, _currentVault.id, kamino)
                 )
+                loadDecodedVerifyHero(payload, _currentVault.coins)
+            }
 
-            isDepositPayload(payload) ->
+            isDepositPayload(payload) -> {
                 // Resolve against _currentVault (post auto-switch), matching the swap/send builders
                 // and the done-screen, so a vault-switched ceremony shows one From name everywhere.
                 applyVerifyResult(joinDepositUiModelBuilder.build(payload, _currentVault.id))
+                loadDecodedVerifyHero(payload, _currentVault.coins)
+            }
 
             else -> {
                 val sendResult =
@@ -660,6 +677,7 @@ constructor(
                 } else {
                     loadBlockaidSimulation(payload, sendResult.functionName)
                 }
+                loadDecodedVerifyHero(payload, sendResult.vaultCoins)
                 scanTransaction(sendResult.transaction)
             }
         }
@@ -765,7 +783,14 @@ constructor(
                         isRawDappTransaction = payload.signSolana != null,
                     )
                 updateSendUiModel(verifyUiModel) { current ->
-                    current.copy(transaction = current.transaction.copy(heroContent = hero))
+                    // The decoded reading, when there is one, keeps the simulation's figures and
+                    // contributes only its verb — see [loadDecodedVerifyHero] for the ordering.
+                    current.copy(
+                        transaction =
+                            current.transaction.copy(
+                                heroContent = decodedVerifyHero?.applyTo(hero) ?: hero
+                            )
+                    )
                 }
                 // Mirror the resolved hero into [transactionTypeUiModel] so the
                 // done screen's `KeysignViewModel` carries the same content forward
@@ -777,6 +802,73 @@ constructor(
                 }
             }
     }
+
+    /**
+     * Reads what the payload actually signs so a joining device names the operation rather than
+     * defaulting to the send wording. Best-effort and never a signing dependency: an unreadable
+     * transaction, a failed position read, or a silent reading all leave the screen as it is.
+     *
+     * The result is held in [decodedVerifyHero] as well as applied, because the simulation jobs
+     * above resolve concurrently and may land in either order — whichever writes second reapplies
+     * the reading, so the verb survives the race.
+     *
+     * Deliberately confined to [verifyUiModel]. The done screen resolves its own past-tense
+     * vocabulary from the same payload, so mirroring a present-progressive verb into
+     * [transactionTypeUiModel] the way the simulation heroes do would show "You’re staking" on a
+     * transaction that has already been signed.
+     */
+    private fun loadDecodedVerifyHero(payload: KeysignPayload, vaultCoins: List<Coin>) {
+        decodedVerifyHeroJob?.cancel()
+        decodedVerifyHeroJob =
+            viewModelScope.safeLaunch(
+                onError = { Timber.w(it, "Failed to resolve the decoded verify hero") }
+            ) {
+                val resolved =
+                    withContext(Dispatchers.IO) {
+                        verifyTransactionPresentation.resolve(
+                            content = payload.asSignedTransactionContent(),
+                            coin = payload.coin,
+                            trustedCoins = vaultCoins,
+                        )
+                    } ?: return@safeLaunch
+
+                decodedVerifyHero = resolved
+                verifyUiModel.update { it.withDecodedHero(resolved) }
+            }
+    }
+
+    /**
+     * Places a decoded reading on whichever verify surface this ceremony is showing. A swap or a
+     * message signature is never displaced: both render their own two-sided or raw presentation,
+     * which a verb cannot improve on.
+     */
+    private fun VerifyUiModel.withDecodedHero(hero: VerifyHero): VerifyUiModel =
+        when (this) {
+            is VerifyUiModel.Send ->
+                VerifyUiModel.Send(
+                    model.copy(
+                        transaction =
+                            model.transaction.copy(
+                                heroContent = hero.applyTo(model.transaction.heroContent)
+                            )
+                    )
+                )
+
+            is VerifyUiModel.Deposit -> {
+                val deposit = model.depositTransactionUiModel
+                if (!depositVerifyAcceptsDecodedHero(deposit.titleRes)) this
+                else
+                    VerifyUiModel.Deposit(
+                        model.copy(
+                            depositTransactionUiModel =
+                                deposit.copy(heroContent = hero.applyTo(deposit.heroContent))
+                        )
+                    )
+            }
+
+            is VerifyUiModel.Swap,
+            is VerifyUiModel.SignMessage -> this
+        }
 
     /**
      * Resolve the jetton hero for a TonConnect request from the decoded message bodies. Surfaces
@@ -808,7 +900,10 @@ constructor(
      */
     private fun pushTonHero(hero: HeroContent) {
         updateSendUiModel(verifyUiModel) { current ->
-            current.copy(transaction = current.transaction.copy(heroContent = hero))
+            current.copy(
+                transaction =
+                    current.transaction.copy(heroContent = decodedVerifyHero?.applyTo(hero) ?: hero)
+            )
         }
         (transactionTypeUiModel as? TransactionTypeUiModel.Send)?.let { send ->
             transactionTypeUiModel = TransactionTypeUiModel.Send(send.tx.copy(heroContent = hero))
@@ -1076,6 +1171,8 @@ constructor(
     private fun cleanUp() {
         _jobWaitingForKeysignStart?.cancel()
         blockaidSimulationJob?.cancel()
+        tonJettonHeroJob?.cancel()
+        decodedVerifyHeroJob?.cancel()
     }
 
     private fun waitForKeysignToStart() {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vultisig.wallet.R
+import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.api.FeatureFlagApi
 import com.vultisig.wallet.data.api.KeysignVerify
@@ -85,6 +86,7 @@ import dagger.assisted.AssistedInject
 import java.util.*
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -342,6 +344,13 @@ constructor(
     private val inAppReviewRepository: InAppReviewRepository,
     private val pendingLimitOrderRepository: PendingLimitOrderRepository,
     private val doneTransactionPresentation: DoneTransactionPresentation,
+    /**
+     * Injected so the two reads this view model starts at construction stay on the caller's
+     * scheduler. With a hardcoded [Dispatchers.IO] they hop to a real pool thread and resume back
+     * onto `Dispatchers.Main`, which under test can land after `resetMain()` — an uncaught
+     * `IllegalStateException` that surfaces on whichever test runs next in the same JVM.
+     */
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
     /** Creates [KeysignViewModel] with runtime-provided assisted parameters. */
@@ -473,7 +482,7 @@ constructor(
             // stay cheap: `update` runs its lambda on the calling dispatcher and re-runs it on CAS
             // contention, so decoding inside it would put repeated chain parsing on the UI thread.
             val (hero, doneVerb) =
-                withContext(Dispatchers.IO) {
+                withContext(ioDispatcher) {
                     doneTransactionPresentation.resolve(payload, vault.coins) to
                         doneTransactionPresentation.specificTitle(payload)
                 }
@@ -544,7 +553,7 @@ constructor(
         chain: Chain,
         dstAddress: String,
     ): DestinationLabels {
-        val allVaults = withContext(Dispatchers.IO) { vaultRepository.getAll() }
+        val allVaults = withContext(ioDispatcher) { vaultRepository.getAll() }
         val dstVaultName =
             resolveDstVaultName(
                 allVaults = allVaults,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/mappers/DepositTransactionToUiModelMapper.kt
@@ -43,6 +43,19 @@ internal fun depositVerifyTitleRes(operation: String, memo: String = ""): Int =
         else -> R.string.verify_deposit_sending
     }
 
+/**
+ * Whether a decoded reading may replace this screen's header.
+ *
+ * Only the generic "You're sending" is displaceable. Every other title is a specific presentation
+ * the screen resolved from its own structured knowledge — a limit-order cancel identified by its
+ * memo, a Kamino deposit or withdraw, an unbond — and those describe the transaction at least as
+ * well as a decoded verb would, while carrying rows (the order pair, the donated-dust warning) that
+ * belong with them. This is the ordering the iOS `TransactionHeroResolver` encodes by registering
+ * its specific providers ahead of the decoder.
+ */
+internal fun depositVerifyAcceptsDecodedHero(@StringRes titleRes: Int): Boolean =
+    titleRes == R.string.verify_deposit_sending
+
 internal class DepositTransactionUiModelMapperImpl
 @Inject
 constructor(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/sign/CustomMessageDecoder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/sign/CustomMessageDecoder.kt
@@ -1,0 +1,146 @@
+package com.vultisig.wallet.ui.models.sign
+
+import com.vultisig.wallet.data.common.normalizeMessageFormat
+import com.vultisig.wallet.data.common.remove0x
+import com.vultisig.wallet.data.repositories.FourByteRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** What a custom sign-message payload turned out to be, once read. */
+internal sealed interface DecodedCustomMessage {
+
+    /** Text the payload actually carries, after hex and any chain-specific framing. */
+    data class Text(val value: String) : DecodedCustomMessage
+
+    /** Well-formed calldata: the resolved function, and its arguments when those decode too. */
+    data class ContractCall(val function: String, val arguments: String?) : DecodedCustomMessage
+
+    /**
+     * A bare digest. Nothing was decoded and the bytes are all there is, which is worth saying
+     * rather than leaving an unexplained hex string on a signing screen.
+     */
+    data object Hash : DecodedCustomMessage
+}
+
+/**
+ * Reads a custom sign-message payload so the verify screen can say what is being signed.
+ *
+ * Mirrors the iOS `CustomMessageDecoder` with two deliberate departures, both because the payload
+ * this app actually receives is usually a digest rather than content:
+ * - `eth_signTypedData_v4` is not JSON-decoded. The extension sends the message and domain
+ *   pre-hashed, so the original data cannot be recovered from the hex — the same reason
+ *   `JoinKeysignViewModel.getNormalizedCustomMessage` already refuses it.
+ * - A payload is only read as a contract call when it is shaped like one. iOS treats the first four
+ *   bytes of any hex payload as a selector, which turns a 32-byte digest into a confident "Contract
+ *   Function Call (…)" for a function nobody is calling. See [contractCall].
+ */
+@Singleton
+internal class CustomMessageDecoder
+@Inject
+constructor(private val fourByteRepository: FourByteRepository) {
+
+    /**
+     * Returns what [message] is, or null when it is already plain text and the screen's own
+     * rendering of it is the whole truth.
+     */
+    suspend fun decode(method: String, message: String, chain: String?): DecodedCustomMessage? {
+        // Only a 0x payload hides anything. Anything else is already the message.
+        if (!message.startsWith(HEX_PREFIX)) return null
+
+        // Pre-hashed by the extension: there is no typed data left in these bytes to show.
+        if (method.equals(ETH_SIGN_TYPED_DATA_V4, ignoreCase = true)) return digest(message)
+
+        if (
+            method.equals(SIGN_MESSAGE, ignoreCase = true) &&
+                chain.equals(TRON_CHAIN, ignoreCase = true)
+        ) {
+            tronSignedMessage(message)?.let {
+                return DecodedCustomMessage.Text(it)
+            }
+        }
+
+        readableText(message)?.let {
+            return DecodedCustomMessage.Text(it)
+        }
+
+        contractCall(message)?.let {
+            return it
+        }
+
+        return digest(message)
+    }
+
+    /**
+     * The payload as text, or null when it does not strictly decode as UTF-8.
+     *
+     * [normalizeMessageFormat] returns its input unchanged on anything it cannot decode — malformed
+     * hex, or bytes that are not valid UTF-8 — so a changed value is exactly the signal that a real
+     * string came out. It is reused rather than reimplemented so this screen cannot disagree with
+     * what the co-signer already shows.
+     */
+    private fun readableText(message: String): String? =
+        message.normalizeMessageFormat().takeIf { it != message && it.isNotBlank() }
+
+    /**
+     * TRON TIP-191: the signed bytes are `\x19TRON Signed Message:\n<length><body>`. The framing is
+     * the wallet's, not the user's, so only the body is shown.
+     *
+     * The leading `\x19` may already be gone: [normalizeMessageFormat] trims control characters off
+     * both ends, so the prefix is matched from `TRON` onward.
+     */
+    private fun tronSignedMessage(message: String): String? {
+        val decoded = readableText(message) ?: return null
+        val unframed = decoded.trimStart(TRON_MESSAGE_FRAMING)
+        if (!unframed.startsWith(TRON_MESSAGE_PREFIX)) return decoded
+
+        val afterPrefix = unframed.removePrefix(TRON_MESSAGE_PREFIX)
+        val digits = afterPrefix.takeWhile { it.isDigit() }
+        val length = digits.toIntOrNull() ?: return decoded
+
+        // The length counts bytes, not characters, so it is applied to the encoded body.
+        val body = afterPrefix.removePrefix(digits).toByteArray(Charsets.UTF_8)
+        if (body.size < length) return decoded
+        return String(body, 0, length, Charsets.UTF_8)
+    }
+
+    /**
+     * The payload read as an EVM call, or null when it is not shaped like one.
+     *
+     * ABI calldata is a 4-byte selector followed by whole 32-byte words, so a well-formed call is
+     * 4, 36, 68, … bytes. The shape check is what keeps a digest from being announced as a
+     * function: a 32-byte hash leaves 28 bytes after the selector, which is not a word boundary, so
+     * it is refused here rather than named after its first four bytes.
+     */
+    private suspend fun contractCall(message: String): DecodedCustomMessage.ContractCall? {
+        val hex = message.remove0x()
+        if (hex.length % 2 != 0) return null
+
+        val bytes = hex.length / 2
+        if (bytes < SELECTOR_BYTES || (bytes - SELECTOR_BYTES) % ABI_WORD_BYTES != 0) return null
+
+        val signature = fourByteRepository.decodeFunction(message) ?: return null
+        return DecodedCustomMessage.ContractCall(
+            function = signature,
+            arguments = fourByteRepository.decodeFunctionArgs(signature, message),
+        )
+    }
+
+    /** Names a payload that is exactly one digest, so its opacity is stated rather than implied. */
+    private fun digest(message: String): DecodedCustomMessage? =
+        DecodedCustomMessage.Hash.takeIf { message.remove0x().length == DIGEST_BYTES * 2 }
+
+    private companion object {
+        private const val HEX_PREFIX = "0x"
+        private const val ETH_SIGN_TYPED_DATA_V4 = "eth_signTypedData_v4"
+        private const val SIGN_MESSAGE = "sign_message"
+        private const val TRON_CHAIN = "tron"
+        private const val TRON_MESSAGE_PREFIX = "TRON Signed Message:\n"
+
+        /** TIP-191's leading byte, which [normalizeMessageFormat] may already have trimmed. */
+        private const val TRON_MESSAGE_FRAMING = '\u0019'
+
+        private const val SELECTOR_BYTES = 4
+        private const val ABI_WORD_BYTES = 32
+        private const val DIGEST_BYTES = 32
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModel.kt
@@ -24,7 +24,13 @@ import timber.log.Timber
 
 internal data class SignMessageTransactionUiModel(
     val method: String = "",
+    /**
+     * The payload exactly as it will be signed. Always rendered: a reading is shown alongside it,
+     * never instead of it.
+     */
     val message: String = "",
+    /** What [message] turned out to be, or null when it is already plain text. */
+    val decoded: DecodedCustomMessage? = null,
 )
 
 internal data class VerifySignMessageUiModel(
@@ -39,6 +45,7 @@ internal class VerifySignMessageViewModel
 constructor(
     savedStateHandle: SavedStateHandle,
     private val customMessagePayloadRepo: CustomMessagePayloadRepo,
+    private val customMessageDecoder: CustomMessageDecoder,
     private val vaultPasswordRepository: VaultPasswordRepository,
     private val launchKeysignUseCase: LaunchKeysignUseCase,
     private val isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase,
@@ -71,6 +78,16 @@ constructor(
                         )
                 )
             }
+
+            // Best-effort and never a signing dependency: the payload above is already on screen,
+            // and a reading that fails or is refused simply adds nothing to it.
+            val decoded =
+                customMessageDecoder.decode(
+                    method = payload.method,
+                    message = payload.message,
+                    chain = payload.chain,
+                )
+            state.update { it.copy(model = it.model.copy(decoded = decoded)) }
         }
 
         loadFastSign()

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
@@ -26,6 +26,18 @@ import javax.inject.Singleton
 import kotlinx.coroutines.flow.first
 
 /**
+ * The vault's own coin for [coin], which carries the trusted decimals and logo. Falls back to
+ * [coin] itself when the vault holds no match — on a joining co-signer that coin is peer-supplied,
+ * so a local match is preferred wherever one exists.
+ */
+internal fun List<Coin>.trustedMatchFor(coin: Coin): Coin =
+    firstOrNull {
+        it.chain == coin.chain &&
+            it.ticker.equals(coin.ticker, ignoreCase = true) &&
+            it.contractAddress.equals(coin.contractAddress, ignoreCase = true)
+    } ?: coin
+
+/**
  * Converts provenance-aware readings into display content. This is the single boundary where
  * unsigned ticker, logo, and decimal metadata may enter.
  *
@@ -197,6 +209,57 @@ constructor(
                 DecodedOperation.SwitchChain -> R.string.done_verb_switched
                 DecodedOperation.LimitOrderPlacement -> R.string.done_verb_placed_limit_order
                 DecodedOperation.LimitOrderCancel -> R.string.limit_swap_cancel_done_sent
+            }
+
+        /**
+         * Verify uses present-progressive copy: the transaction has not been signed yet, so the
+         * verb names what the user is about to do. Every operation carries an explicit decision,
+         * and the null branch is the deliberately-silent set — readings whose surface already
+         * describes the transaction better than a verb could.
+         *
+         * A transfer is what the send screens are; a swap is rendered two-sided by its own verify
+         * screen; an approval names its spender and allowance; a vote moves nothing, so the verb
+         * would be the whole hero; a contract call of unknown shape and an unreadable transaction
+         * have nothing to add. `RemoveLiquidity` is silent for a different reason: naming it would
+         * displace the carrier amount the transaction actually charges.
+         */
+        fun verifyTitleRes(operation: DecodedOperation): Int? =
+            when (operation) {
+                DecodedOperation.Transfer,
+                DecodedOperation.Swap,
+                DecodedOperation.Approve,
+                DecodedOperation.Vote,
+                DecodedOperation.ContractCall,
+                DecodedOperation.RemoveLiquidity,
+                DecodedOperation.Unknown -> null
+
+                // The Cosmos staking verify screen already ships this exact wording in all ten
+                // locales; reusing it keeps a decoded delegate reading identical to the screen a
+                // user reaches the same operation through.
+                DecodedOperation.Stake -> R.string.cosmos_staking_youre_staking
+                DecodedOperation.Unstake -> R.string.cosmos_staking_youre_unstaking
+                DecodedOperation.ClaimRewards -> R.string.cosmos_staking_youre_claiming
+
+                DecodedOperation.Bond -> R.string.verify_verb_bonding
+                DecodedOperation.Unbond -> R.string.verify_verb_unbonding
+                DecodedOperation.Rebond -> R.string.verify_verb_rebonding
+                DecodedOperation.Leave -> R.string.verify_verb_leaving
+                DecodedOperation.SecuredAssetDeposit -> R.string.verify_verb_depositing
+                DecodedOperation.SecuredAssetWithdraw -> R.string.verify_verb_withdrawing
+                DecodedOperation.SwitchChain -> R.string.verify_verb_switching
+                DecodedOperation.Delegate -> R.string.verify_verb_delegating
+                DecodedOperation.Undelegate -> R.string.verify_verb_undelegating
+                DecodedOperation.Redelegate -> R.string.verify_verb_redelegating
+                DecodedOperation.AddLiquidity -> R.string.verify_verb_adding_liquidity
+                DecodedOperation.Redeem -> R.string.verify_verb_redeeming
+                DecodedOperation.Mint -> R.string.verify_verb_minting
+                DecodedOperation.Merge -> R.string.verify_verb_merging
+                DecodedOperation.Unmerge -> R.string.verify_verb_unmerging
+                DecodedOperation.IbcTransfer -> R.string.verify_verb_bridging
+
+                // The limit-order screens own this wording already, on both routes.
+                DecodedOperation.LimitOrderPlacement -> R.string.verify_limit_order_title
+                DecodedOperation.LimitOrderCancel -> R.string.verify_limit_order_cancel_title
             }
 
         /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DoneTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DoneTransactionPresentation.kt
@@ -45,7 +45,7 @@ constructor(
             DecodedTransactionPresentation.doneTitleRes(decoded.operation)?.let(context::getString)
                 ?: return null
 
-        return presentation.hero(decoded, trustedCoin(payload, trustedCoins), title)
+        return presentation.hero(decoded, trustedCoins.trustedMatchFor(payload.coin), title)
     }
 
     /**
@@ -64,20 +64,8 @@ constructor(
             return it
         }
 
-        return presentation.hero(decoded, trustedCoin(payload, trustedCoins), title)
+        return presentation.hero(decoded, trustedCoins.trustedMatchFor(payload.coin), title)
     }
-
-    /**
-     * The vault's own coin for the payload's asset, which carries the trusted decimals and logo.
-     * Falls back to the payload's coin when the vault holds no match — the payload is peer-supplied
-     * on a co-signer, so a local match is preferred wherever one exists.
-     */
-    private fun trustedCoin(payload: KeysignPayload, coins: List<Coin>): Coin =
-        coins.firstOrNull {
-            it.chain == payload.coin.chain &&
-                it.ticker.equals(payload.coin.ticker, ignoreCase = true) &&
-                it.contractAddress.equals(payload.coin.contractAddress, ignoreCase = true)
-        } ?: payload.coin
 
     companion object {
         /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/VerifyTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/VerifyTransactionPresentation.kt
@@ -1,0 +1,83 @@
+package com.vultisig.wallet.ui.models.transactiondecoding
+
+import android.content.Context
+import androidx.compose.runtime.Immutable
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionDecoder
+import com.vultisig.wallet.ui.components.hero.HeroContent
+import com.vultisig.wallet.ui.components.hero.retitled
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * One verify-surface reading of a transaction, carrying the pieces the surface needs to place it
+ * against whatever hero it already resolved.
+ *
+ * Mirrors the ordering the iOS `TransactionHeroResolver` registers: a chain-state projection
+ * outranks a simulation because it states a scope no figure can ("your whole stake"); a simulation
+ * outranks the plain decoder because it prices a balance change the signed bytes never state, and
+ * only borrows the decoded verb; the signed-amount reading is the last claimant.
+ */
+@Immutable
+internal data class VerifyHero(
+    /** The verb alone, for a surface that already holds richer figures. */
+    val verb: String,
+    /** A chain-state projection, when a reader resolved one. Null until chain readers land. */
+    val projected: HeroContent?,
+    /** The hero built from the signed amount alone. */
+    val decoded: HeroContent,
+) {
+    /** Places this reading over the hero [existing] the surface resolved on its own. */
+    fun applyTo(existing: HeroContent?): HeroContent =
+        projected ?: existing?.retitled(verb) ?: decoded
+}
+
+/**
+ * Adapts the shared signed-transaction reading to Verify's present-progressive vocabulary. It owns
+ * no chain parsing and no amount formatting.
+ *
+ * Mirrors the iOS `DecodedTransactionPresentation` verify path. The iOS surface/provider registry
+ * is not ported: Android already expresses hero precedence as branch order on each verify surface —
+ * a Blockaid or TON simulation, a limit-order title, an XRPL trust line — so [VerifyHero.applyTo]
+ * carries the one ordering decision the registry existed to encode.
+ *
+ * The initiator and a joining co-signer both read through [SignedTransactionContent], so the two
+ * devices show the same verb for the same transaction.
+ */
+@Singleton
+internal class VerifyTransactionPresentation
+@Inject
+constructor(
+    @ApplicationContext private val context: Context,
+    private val decoder: SignedTransactionDecoder,
+    private val presentation: DecodedTransactionPresentation,
+    private val resolvedTransactionHero: ResolvedTransactionHero,
+) {
+
+    /**
+     * Reads [content], or returns null for a deliberately silent operation — a plain transfer, a
+     * swap, an approval, a vote, an unknown call — which leaves the surface's own presentation
+     * exactly as it is.
+     *
+     * A projection that fails or times out degrades to the signed amount; it never blocks the
+     * verify screen and never fabricates a number.
+     */
+    suspend fun resolve(
+        content: SignedTransactionContent,
+        coin: Coin,
+        trustedCoins: List<Coin>,
+    ): VerifyHero? {
+        val decoded = decoder.decode(content)
+        val title =
+            DecodedTransactionPresentation.verifyTitleRes(decoded.operation)
+                ?.let(context::getString) ?: return null
+
+        return VerifyHero(
+            verb = title,
+            projected = resolvedTransactionHero.resolve(content, trustedCoins, title),
+            decoded = presentation.hero(decoded, trustedCoins.trustedMatchFor(coin), title),
+        )
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/VerifyDepositScreen.kt
@@ -44,6 +44,7 @@ import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.dapp.DappRequestBanner
+import com.vultisig.wallet.ui.components.hero.HeroContentView
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.library.UiPlaceholderLoader
 import com.vultisig.wallet.ui.components.topbar.VsTopAppBar
@@ -142,28 +143,37 @@ internal fun VerifyDepositScreen(
                             )
                             .padding(all = 24.dp)
                 ) {
-                    Text(
-                        text = stringResource(tx.titleRes),
-                        style = Theme.brockmann.headings.subtitle,
-                        color = Theme.v2.colors.text.secondary,
-                    )
-
-                    // Which order is being closed, in THORChain's own asset spelling. A cancel
-                    // moves
-                    // no funds by design, so the amount below it is either zero or the dust Bifrost
-                    // needs to observe — the pair is the only thing that identifies the order.
-                    tx.limitCancelPair?.let { pair ->
-                        UiSpacer(4.dp)
+                    val hero = tx.heroContent
+                    if (hero != null) {
+                        // What the transaction actually does, read from what will be signed. It
+                        // replaces the header and the amount together, because a projected reading
+                        // states its scope ("your whole stake") in place of a figure.
+                        HeroContentView(content = hero, verbAlignment = Alignment.Start)
+                    } else {
                         Text(
-                            text = pair,
-                            style = Theme.brockmann.supplementary.footnote,
-                            color = Theme.v2.colors.text.tertiary,
+                            text = stringResource(tx.titleRes),
+                            style = Theme.brockmann.headings.subtitle,
+                            color = Theme.v2.colors.text.secondary,
                         )
+
+                        // Which order is being closed, in THORChain's own asset spelling. A cancel
+                        // moves
+                        // no funds by design, so the amount below it is either zero or the dust
+                        // Bifrost needs to observe — the pair is the only thing that identifies the
+                        // order.
+                        tx.limitCancelPair?.let { pair ->
+                            UiSpacer(4.dp)
+                            Text(
+                                text = pair,
+                                style = Theme.brockmann.supplementary.footnote,
+                                color = Theme.v2.colors.text.tertiary,
+                            )
+                        }
+
+                        UiSpacer(24.dp)
+
+                        SwapToken(valuedToken = tx.token, isLoading = state.isLoading)
                     }
-
-                    UiSpacer(24.dp)
-
-                    SwapToken(valuedToken = tx.token, isLoading = state.isLoading)
 
                     // A joining co-signer's Kamino withdraw: the amount above is a token
                     // projection of a share figure, at a rate that never crossed the wire. Naming

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/send/VerifySendScreen.kt
@@ -242,6 +242,9 @@ internal fun VerifySendScreen(
                         heroContent = tx.heroContent,
                         functionName = heroTitle,
                         modifier = Modifier.fillMaxWidth(),
+                        // Verify leads with the verb, so it sits against the card's left edge with
+                        // the rows below it. Done keeps the centred default.
+                        verbAlignment = Alignment.Start,
                     ) {
                         val rippleDapp = tx.signRipple
                         if (rippleDapp != null) {

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/sign/VerifySignMessageScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/sign/VerifySignMessageScreen.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.topbar.VsTopAppBar
+import com.vultisig.wallet.ui.models.sign.DecodedCustomMessage
 import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
 import com.vultisig.wallet.ui.models.sign.VerifySignMessageUiModel
 import com.vultisig.wallet.ui.models.sign.VerifySignMessageViewModel
@@ -82,6 +83,7 @@ internal fun VerifySignMessageScreen(
     VerifySignMessageScreen(
         method = transactionUiModel.method,
         message = transactionUiModel.message,
+        decoded = transactionUiModel.decoded,
         confirmTitle = confirmTitle,
         hasFastSign = state.hasFastSign,
         onFastSignClick = onFastSignClick,
@@ -95,6 +97,7 @@ internal fun VerifySignMessageScreen(
 private fun VerifySignMessageScreen(
     method: String,
     message: String,
+    decoded: DecodedCustomMessage?,
     hasFastSign: Boolean,
     hasToolbar: Boolean,
     confirmTitle: String,
@@ -141,8 +144,45 @@ private fun VerifySignMessageScreen(
                 value = method,
             )
 
+            // What the payload turned out to be, when it could be read. Shown above the payload
+            // rather than in place of it, so nothing that gets signed is ever hidden behind a
+            // friendlier rendering of it.
+            when (decoded) {
+                is DecodedCustomMessage.Text ->
+                    SignMessageCard(
+                        title = stringResource(R.string.verify_sign_message_decoded_message),
+                        value = decoded.value,
+                    )
+
+                is DecodedCustomMessage.ContractCall -> {
+                    SignMessageCard(
+                        title =
+                            stringResource(R.string.verify_transaction_function_signature_title),
+                        value = decoded.function,
+                    )
+                    decoded.arguments?.let { arguments ->
+                        SignMessageCard(
+                            title =
+                                stringResource(R.string.verify_transaction_function_inputs_title),
+                            value = arguments,
+                        )
+                    }
+                }
+
+                // A digest is named by the card below rather than described by one of its own.
+                DecodedCustomMessage.Hash,
+                null -> Unit
+            }
+
             SignMessageCard(
-                title = stringResource(R.string.verify_sign_message_message_sign),
+                title =
+                    stringResource(
+                        if (decoded is DecodedCustomMessage.Hash) {
+                            R.string.verify_sign_message_message_hash
+                        } else {
+                            R.string.verify_sign_message_message_sign
+                        }
+                    ),
                 value = message,
             )
         }
@@ -155,6 +195,7 @@ private fun VerifySignMessageScreenPreview() {
     VerifySignMessageScreen(
         method = "method",
         message = "message",
+        decoded = null,
         confirmTitle = "Sign",
         hasFastSign = false,
         hasToolbar = false,

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1756,6 +1756,23 @@
     <string name="done_verb_switched">Gewechselt</string>
     <string name="done_verb_placed_limit_order">Limit-Order platziert</string>
     <string name="limit_swap_cancel_done_sent">Stornierung gesendet</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">Du bondest</string>
+    <string name="verify_verb_unbonding">Du löst das Bonding</string>
+    <string name="verify_verb_rebonding">Du bondest neu</string>
+    <string name="verify_verb_leaving">Du verlässt</string>
+    <string name="verify_verb_depositing">Du zahlst ein</string>
+    <string name="verify_verb_withdrawing">Du zahlst aus</string>
+    <string name="verify_verb_switching">Du wechselst</string>
+    <string name="verify_verb_delegating">Du delegierst</string>
+    <string name="verify_verb_undelegating">Du beendest die Delegation</string>
+    <string name="verify_verb_redelegating">Du delegierst neu</string>
+    <string name="verify_verb_adding_liquidity">Du fügst Liquidität hinzu</string>
+    <string name="verify_verb_redeeming">Du löst ein</string>
+    <string name="verify_verb_minting">Du prägst</string>
+    <string name="verify_verb_merging">Du führst zusammen</string>
+    <string name="verify_verb_unmerging">Du trennst</string>
+    <string name="verify_verb_bridging">Du überträgst kettenübergreifend</string>
     <string name="scope_your_whole_stake">dein gesamter Stake</string>
     <string name="scope_rewards_accrued_so_far">bisher angefallene Belohnungen</string>
     <string name="withdrawing_share_of_staked_position">%1$s deiner Stake-Position</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -733,6 +733,9 @@
     <string name="signing_error_transaction_timeout">Die Transaktion ist aufgrund langsamer Signierung fehlgeschlagen. Bitte versuchen Sie es erneut.</string>
     <string name="hint_message_to_sign">Zu unterschreibende Nachricht</string>
     <string name="verify_sign_message_message_sign">Zu unterschreibende Nachricht</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">Dekodierte Nachricht</string>
+    <string name="verify_sign_message_message_hash">Nachrichten-Hash</string>
     <string name="address_book_empty_description">Bewahren Sie alle wichtigen Adressen an einem Ort auf.</string>
     <string name="address_book_empty_title">Ihr Adressbuch ist leer</string>
     <string name="check_updates_settings_title">Aktualisierungen prüfen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1755,6 +1755,23 @@
     <string name="done_verb_switched">Cambiado</string>
     <string name="done_verb_placed_limit_order">Orden límite creada</string>
     <string name="limit_swap_cancel_done_sent">Cancelación enviada</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">Estás vinculando</string>
+    <string name="verify_verb_unbonding">Estás desvinculando</string>
+    <string name="verify_verb_rebonding">Estás revinculando</string>
+    <string name="verify_verb_leaving">Estás saliendo</string>
+    <string name="verify_verb_depositing">Estás depositando</string>
+    <string name="verify_verb_withdrawing">Estás retirando</string>
+    <string name="verify_verb_switching">Estás cambiando</string>
+    <string name="verify_verb_delegating">Estás delegando</string>
+    <string name="verify_verb_undelegating">Estás cancelando la delegación</string>
+    <string name="verify_verb_redelegating">Estás redelegando</string>
+    <string name="verify_verb_adding_liquidity">Estás añadiendo liquidez</string>
+    <string name="verify_verb_redeeming">Estás canjeando</string>
+    <string name="verify_verb_minting">Estás acuñando</string>
+    <string name="verify_verb_merging">Estás fusionando</string>
+    <string name="verify_verb_unmerging">Estás separando</string>
+    <string name="verify_verb_bridging">Estás transfiriendo entre cadenas</string>
     <string name="scope_your_whole_stake">todo tu stake</string>
     <string name="scope_rewards_accrued_so_far">recompensas acumuladas hasta ahora</string>
     <string name="withdrawing_share_of_staked_position">%1$s de tu posición en staking</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -735,6 +735,9 @@
     <string name="signing_error_transaction_timeout">La transacción caducó por firma lenta. Inténtalo de nuevo.</string>
     <string name="hint_message_to_sign">Mensaje para firmar</string>
     <string name="verify_sign_message_message_sign">Mensaje para firmar</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">Mensaje decodificado</string>
+    <string name="verify_sign_message_message_hash">Hash del mensaje</string>
     <string name="address_book_empty_description">Mantén todas tus direcciones importantes organizadas en un solo lugar.</string>
     <string name="address_book_empty_title">Tu libreta de direcciones está vacía</string>
     <string name="check_updates_settings_title">Consultar actualizaciones</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -734,6 +734,9 @@
     <string name="signing_error_transaction_timeout">Vrijeme transakcije je isteklo zbog sporog potpisivanja. Pokušajte ponovno.</string>
     <string name="hint_message_to_sign">Poruka za potpis</string>
     <string name="verify_sign_message_message_sign">Poruka za potpis</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">Dekodirana poruka</string>
+    <string name="verify_sign_message_message_hash">Hash poruke</string>
     <string name="address_book_empty_description">Držite sve važne adrese organizirane na jednom mjestu.</string>
     <string name="address_book_empty_title">Vaš adresar je prazan</string>
     <string name="check_updates_settings_title">Provjerite Ažuriranja</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1765,6 +1765,23 @@
     <string name="done_verb_switched">Prebačeno</string>
     <string name="done_verb_placed_limit_order">Postavljen limit nalog</string>
     <string name="limit_swap_cancel_done_sent">Otkazivanje poslano</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">Vezujete</string>
+    <string name="verify_verb_unbonding">Odvezujete</string>
+    <string name="verify_verb_rebonding">Ponovno vezujete</string>
+    <string name="verify_verb_leaving">Napuštate</string>
+    <string name="verify_verb_depositing">Polažete</string>
+    <string name="verify_verb_withdrawing">Podižete</string>
+    <string name="verify_verb_switching">Prebacujete</string>
+    <string name="verify_verb_delegating">Delegirate</string>
+    <string name="verify_verb_undelegating">Poništavate delegaciju</string>
+    <string name="verify_verb_redelegating">Ponovno delegirate</string>
+    <string name="verify_verb_adding_liquidity">Dodajete likvidnost</string>
+    <string name="verify_verb_redeeming">Otkupljujete</string>
+    <string name="verify_verb_minting">Kujete</string>
+    <string name="verify_verb_merging">Spajate</string>
+    <string name="verify_verb_unmerging">Razdvajate</string>
+    <string name="verify_verb_bridging">Premošćujete</string>
     <string name="scope_your_whole_stake">cijeli vaš ulog</string>
     <string name="scope_rewards_accrued_so_far">do sada stečene nagrade</string>
     <string name="withdrawing_share_of_staked_position">%1$s vaše uložene pozicije</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -733,6 +733,9 @@
     <string name="signing_error_transaction_timeout">Timeout della transazione dovuto alla firma lenta. Riprova.</string>
     <string name="hint_message_to_sign">Messaggio da firmare</string>
     <string name="verify_sign_message_message_sign">Messaggio da firmare</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">Messaggio decodificato</string>
+    <string name="verify_sign_message_message_hash">Hash del messaggio</string>
     <string name="address_book_empty_description">Tieni tutti i tuoi indirizzi importanti organizzati in un unico posto.</string>
     <string name="address_book_empty_title">La tua rubrica è vuota</string>
     <string name="check_updates_settings_title">Controlla gli Aggiornamenti</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1758,6 +1758,23 @@
     <string name="done_verb_switched">Spostato</string>
     <string name="done_verb_placed_limit_order">Ordine limite piazzato</string>
     <string name="limit_swap_cancel_done_sent">Annullamento inviato</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">Stai vincolando</string>
+    <string name="verify_verb_unbonding">Stai svincolando</string>
+    <string name="verify_verb_rebonding">Stai rivincolando</string>
+    <string name="verify_verb_leaving">Stai uscendo</string>
+    <string name="verify_verb_depositing">Stai depositando</string>
+    <string name="verify_verb_withdrawing">Stai prelevando</string>
+    <string name="verify_verb_switching">Stai spostando</string>
+    <string name="verify_verb_delegating">Stai delegando</string>
+    <string name="verify_verb_undelegating">Stai annullando la delega</string>
+    <string name="verify_verb_redelegating">Stai ridelegando</string>
+    <string name="verify_verb_adding_liquidity">Stai aggiungendo liquidità</string>
+    <string name="verify_verb_redeeming">Stai riscattando</string>
+    <string name="verify_verb_minting">Stai coniando</string>
+    <string name="verify_verb_merging">Stai unendo</string>
+    <string name="verify_verb_unmerging">Stai separando</string>
+    <string name="verify_verb_bridging">Stai trasferendo tra catene</string>
     <string name="scope_your_whole_stake">tutto il tuo stake</string>
     <string name="scope_rewards_accrued_so_far">ricompense maturate finora</string>
     <string name="withdrawing_share_of_staked_position">%1$s della tua posizione in stake</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -557,6 +557,9 @@
     <string name="verify_sign_message_signing_method">서명 방식</string>
     <string name="hint_message_to_sign">서명할 메시지</string>
     <string name="verify_sign_message_message_sign">서명할 메시지</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">디코딩된 메시지</string>
+    <string name="verify_sign_message_message_hash">메시지 해시</string>
     <string name="sign_message_sign_screen_title">메시지 서명</string>
     <string name="vault_settings_sign_message_description">사용자 정의 메시지 서명</string>
     <string name="swap_screen_invalid_specific_and_utxo">세부 계산 실패</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1771,6 +1771,23 @@
     <string name="done_verb_switched">전환됨</string>
     <string name="done_verb_placed_limit_order">지정가 주문 생성됨</string>
     <string name="limit_swap_cancel_done_sent">취소 전송됨</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">본딩 중</string>
+    <string name="verify_verb_unbonding">언본딩 중</string>
+    <string name="verify_verb_rebonding">재본딩 중</string>
+    <string name="verify_verb_leaving">탈퇴 중</string>
+    <string name="verify_verb_depositing">입금 중</string>
+    <string name="verify_verb_withdrawing">출금 중</string>
+    <string name="verify_verb_switching">전환 중</string>
+    <string name="verify_verb_delegating">위임 중</string>
+    <string name="verify_verb_undelegating">위임 해제 중</string>
+    <string name="verify_verb_redelegating">재위임 중</string>
+    <string name="verify_verb_adding_liquidity">유동성 추가 중</string>
+    <string name="verify_verb_redeeming">상환 중</string>
+    <string name="verify_verb_minting">발행 중</string>
+    <string name="verify_verb_merging">병합 중</string>
+    <string name="verify_verb_unmerging">병합 해제 중</string>
+    <string name="verify_verb_bridging">브리지 중</string>
     <string name="scope_your_whole_stake">스테이킹 전액</string>
     <string name="scope_rewards_accrued_so_far">현재까지 누적된 보상</string>
     <string name="withdrawing_share_of_staked_position">스테이킹 포지션의 %1$s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1748,6 +1748,23 @@
     <string name="done_verb_switched">Gewisseld</string>
     <string name="done_verb_placed_limit_order">Limietorder geplaatst</string>
     <string name="limit_swap_cancel_done_sent">Annulering verzonden</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">Je bindt</string>
+    <string name="verify_verb_unbonding">Je ontbindt</string>
+    <string name="verify_verb_rebonding">Je bindt opnieuw</string>
+    <string name="verify_verb_leaving">Je verlaat</string>
+    <string name="verify_verb_depositing">Je stort</string>
+    <string name="verify_verb_withdrawing">Je neemt op</string>
+    <string name="verify_verb_switching">Je wisselt</string>
+    <string name="verify_verb_delegating">Je delegeert</string>
+    <string name="verify_verb_undelegating">Je trekt de delegatie in</string>
+    <string name="verify_verb_redelegating">Je delegeert opnieuw</string>
+    <string name="verify_verb_adding_liquidity">Je voegt liquiditeit toe</string>
+    <string name="verify_verb_redeeming">Je wisselt in</string>
+    <string name="verify_verb_minting">Je munt</string>
+    <string name="verify_verb_merging">Je voegt samen</string>
+    <string name="verify_verb_unmerging">Je splitst</string>
+    <string name="verify_verb_bridging">Je bridget</string>
     <string name="scope_your_whole_stake">je volledige stake</string>
     <string name="scope_rewards_accrued_so_far">tot nu toe opgebouwde beloningen</string>
     <string name="withdrawing_share_of_staked_position">%1$s van je gestakete positie</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -730,6 +730,9 @@
     <string name="signing_error_transaction_timeout">Transactie is verlopen vanwege trage ondertekening. Probeer het opnieuw.</string>
     <string name="hint_message_to_sign">Bericht om te ondertekenen</string>
     <string name="verify_sign_message_message_sign">Bericht om te ondertekenen</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">Gedecodeerd bericht</string>
+    <string name="verify_sign_message_message_hash">Berichthash</string>
     <string name="address_book_empty_description">Houd al uw belangrijke adressen op één plek bij elkaar.</string>
     <string name="address_book_empty_title">Uw adresboek is leeg</string>
     <string name="check_updates_settings_title">Controleer op Updates</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -731,6 +731,9 @@
     <string name="signing_error_transaction_timeout">Tempo limite da transação excedido devido à lentidão na assinatura. Por favor, tente novamente.</string>
     <string name="hint_message_to_sign">Mensagem para assinar</string>
     <string name="verify_sign_message_message_sign">Mensagem para assinar</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">Mensagem decodificada</string>
+    <string name="verify_sign_message_message_hash">Hash da mensagem</string>
     <string name="address_book_empty_description">Mantenha todos os seus endereços importantes organizados num só lugar.</string>
     <string name="address_book_empty_title">A sua agenda está vazia.</string>
     <string name="check_updates_settings_title">Verificar Atualizações</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1753,6 +1753,23 @@
     <string name="done_verb_switched">Trocado</string>
     <string name="done_verb_placed_limit_order">Ordem limite criada</string>
     <string name="limit_swap_cancel_done_sent">Cancelamento enviado</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">Você está vinculando</string>
+    <string name="verify_verb_unbonding">Você está desvinculando</string>
+    <string name="verify_verb_rebonding">Você está revinculando</string>
+    <string name="verify_verb_leaving">Você está saindo</string>
+    <string name="verify_verb_depositing">Você está depositando</string>
+    <string name="verify_verb_withdrawing">Você está sacando</string>
+    <string name="verify_verb_switching">Você está trocando</string>
+    <string name="verify_verb_delegating">Você está delegando</string>
+    <string name="verify_verb_undelegating">Você está cancelando a delegação</string>
+    <string name="verify_verb_redelegating">Você está redelegando</string>
+    <string name="verify_verb_adding_liquidity">Você está adicionando liquidez</string>
+    <string name="verify_verb_redeeming">Você está resgatando</string>
+    <string name="verify_verb_minting">Você está cunhando</string>
+    <string name="verify_verb_merging">Você está mesclando</string>
+    <string name="verify_verb_unmerging">Você está separando</string>
+    <string name="verify_verb_bridging">Você está transferindo entre cadeias</string>
     <string name="scope_your_whole_stake">todo o seu stake</string>
     <string name="scope_rewards_accrued_so_far">recompensas acumuladas até agora</string>
     <string name="withdrawing_share_of_staked_position">%1$s da sua posição em stake</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1768,6 +1768,23 @@
     <string name="done_verb_switched">Переключено</string>
     <string name="done_verb_placed_limit_order">Лимитный ордер размещён</string>
     <string name="limit_swap_cancel_done_sent">Отмена отправлена</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">Вы привязываете</string>
+    <string name="verify_verb_unbonding">Вы отвязываете</string>
+    <string name="verify_verb_rebonding">Вы перепривязываете</string>
+    <string name="verify_verb_leaving">Вы выходите</string>
+    <string name="verify_verb_depositing">Вы вносите</string>
+    <string name="verify_verb_withdrawing">Вы выводите</string>
+    <string name="verify_verb_switching">Вы переключаете</string>
+    <string name="verify_verb_delegating">Вы делегируете</string>
+    <string name="verify_verb_undelegating">Вы отменяете делегирование</string>
+    <string name="verify_verb_redelegating">Вы переделегируете</string>
+    <string name="verify_verb_adding_liquidity">Вы добавляете ликвидность</string>
+    <string name="verify_verb_redeeming">Вы выкупаете</string>
+    <string name="verify_verb_minting">Вы чеканите</string>
+    <string name="verify_verb_merging">Вы объединяете</string>
+    <string name="verify_verb_unmerging">Вы отменяете объединение</string>
+    <string name="verify_verb_bridging">Вы переводите между сетями</string>
     <string name="scope_your_whole_stake">весь ваш стейк</string>
     <string name="scope_rewards_accrued_so_far">накопленные на данный момент награды</string>
     <string name="withdrawing_share_of_staked_position">%1$s вашей стейкинг-позиции</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -734,6 +734,9 @@
     <string name="signing_error_transaction_timeout">Время транзакции истекло из-за медленного подписания. Попробуйте ещё раз.</string>
     <string name="hint_message_to_sign">Сообщение для подписи</string>
     <string name="verify_sign_message_message_sign">Сообщение для подписи</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">Расшифрованное сообщение</string>
+    <string name="verify_sign_message_message_hash">Хеш сообщения</string>
     <string name="address_book_empty_description">Храните все важные адреса в одном месте.</string>
     <string name="address_book_empty_title">Ваша адресная книга пуста.</string>
     <string name="check_updates_settings_title">Проверить Обновления</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2078,6 +2078,23 @@
     <string name="done_verb_switched">已切换</string>
     <string name="done_verb_placed_limit_order">已下限价单</string>
     <string name="limit_swap_cancel_done_sent">取消已发送</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">您正在绑定</string>
+    <string name="verify_verb_unbonding">您正在解绑</string>
+    <string name="verify_verb_rebonding">您正在重新绑定</string>
+    <string name="verify_verb_leaving">您正在退出</string>
+    <string name="verify_verb_depositing">您正在存入</string>
+    <string name="verify_verb_withdrawing">您正在提取</string>
+    <string name="verify_verb_switching">您正在切换</string>
+    <string name="verify_verb_delegating">您正在委托</string>
+    <string name="verify_verb_undelegating">您正在解除委托</string>
+    <string name="verify_verb_redelegating">您正在重新委托</string>
+    <string name="verify_verb_adding_liquidity">您正在添加流动性</string>
+    <string name="verify_verb_redeeming">您正在赎回</string>
+    <string name="verify_verb_minting">您正在铸造</string>
+    <string name="verify_verb_merging">您正在合并</string>
+    <string name="verify_verb_unmerging">您正在取消合并</string>
+    <string name="verify_verb_bridging">您正在跨链转账</string>
     <string name="scope_your_whole_stake">您的全部质押</string>
     <string name="scope_rewards_accrued_so_far">至今累积的奖励</string>
     <string name="withdrawing_share_of_staked_position">您质押仓位的 %1$s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -766,6 +766,9 @@
     <string name="signing_error_transaction_timeout">由于签名速度缓慢，交易超时。请重试。</string>
     <string name="hint_message_to_sign">要签名的消息</string>
     <string name="verify_sign_message_message_sign">要签名的消息</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">解码后的消息</string>
+    <string name="verify_sign_message_message_hash">消息哈希</string>
 
     <!-- Keygen -->
     <string name="keygen_step_preparing_vault">准备保险库</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1813,6 +1813,23 @@
     <string name="done_verb_switched">Switched</string>
     <string name="done_verb_placed_limit_order">Placed limit order</string>
     <string name="limit_swap_cancel_done_sent">Cancellation sent</string>
+    <!-- Verify screens: present-progressive operation vocabulary read from the transaction about to be signed -->
+    <string name="verify_verb_bonding">You’re bonding</string>
+    <string name="verify_verb_unbonding">You’re unbonding</string>
+    <string name="verify_verb_rebonding">You’re rebonding</string>
+    <string name="verify_verb_leaving">You’re leaving</string>
+    <string name="verify_verb_depositing">You’re depositing</string>
+    <string name="verify_verb_withdrawing">You’re withdrawing</string>
+    <string name="verify_verb_switching">You’re switching</string>
+    <string name="verify_verb_delegating">You’re delegating</string>
+    <string name="verify_verb_undelegating">You’re undelegating</string>
+    <string name="verify_verb_redelegating">You’re redelegating</string>
+    <string name="verify_verb_adding_liquidity">You’re adding liquidity</string>
+    <string name="verify_verb_redeeming">You’re redeeming</string>
+    <string name="verify_verb_minting">You’re minting</string>
+    <string name="verify_verb_merging">You’re merging</string>
+    <string name="verify_verb_unmerging">You’re unmerging</string>
+    <string name="verify_verb_bridging">You’re bridging</string>
     <string name="scope_your_whole_stake">your whole stake</string>
     <string name="scope_rewards_accrued_so_far">rewards accrued so far</string>
     <string name="withdrawing_share_of_staked_position">%1$s of your staked position</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -568,6 +568,9 @@
     <string name="verify_sign_message_signing_method">Signing method</string>
     <string name="hint_message_to_sign">Message to sign</string>
     <string name="verify_sign_message_message_sign">Message to sign</string>
+    <!-- Sign-message Verify: what the signed payload turned out to be -->
+    <string name="verify_sign_message_decoded_message">Decoded message</string>
+    <string name="verify_sign_message_message_hash">Message hash</string>
     <string name="sign_message_sign_screen_title">Sign message</string>
     <string name="vault_settings_sign_message_description">Sign custom message</string>
     <string name="swap_screen_invalid_specific_and_utxo">Specific calculation failed</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/VerifyDepositViewModelTest.kt
@@ -115,6 +115,7 @@ internal class VerifyDepositViewModelTest {
             ioDispatcher = testDispatcher,
             launchKeysign = launchKeysign,
             isVaultHasFastSignById = isVaultHasFastSignById,
+            verifyTransactionPresentation = mockk(relaxed = true),
         )
 
     /**

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -274,6 +274,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
             doneTransactionPresentation = mockk(relaxed = true),
+            ioDispatcher = testDispatcher,
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelInAppReviewTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelInAppReviewTest.kt
@@ -165,6 +165,7 @@ internal class KeysignViewModelInAppReviewTest {
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
             doneTransactionPresentation = mockk(relaxed = true),
+            ioDispatcher = testDispatcher,
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
@@ -106,6 +106,7 @@ internal class KeysignViewModelSaveTransactionHistoryTest {
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
             doneTransactionPresentation = mockk(relaxed = true),
+            ioDispatcher = testDispatcher,
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateEvmActualFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateEvmActualFeeTest.kt
@@ -148,6 +148,7 @@ internal class KeysignViewModelTryUpdateEvmActualFeeTest {
             gasFeeToEstimatedFee = gasFeeToEstimatedFee,
             pendingLimitOrderRepository = mockk(relaxed = true),
             doneTransactionPresentation = mockk(relaxed = true),
+            ioDispatcher = testDispatcher,
             awaitApprovalConfirmation = mockk(relaxed = true),
         )
 

--- a/app/src/test/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/sign/VerifySignMessageViewModelTest.kt
@@ -84,6 +84,7 @@ internal class VerifySignMessageViewModelTest {
                     mapOf(SendDst.ARG_TRANSACTION_ID to TX_ID, SendDst.ARG_VAULT_ID to VAULT_ID)
                 ),
             customMessagePayloadRepo = customMessagePayloadRepo,
+            customMessageDecoder = mockk(relaxed = true),
             vaultPasswordRepository = vaultPasswordRepository,
             launchKeysignUseCase = launchKeysign,
             isVaultHasFastSignById = isVaultHasFastSignById,

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/verify/VerifyTransactionViewModelTest.kt
@@ -150,6 +150,7 @@ internal class VerifyTransactionViewModelTest {
             tokenRepository = tokenRepository,
             json = json,
             ioDispatcher = testDispatcher,
+            verifyTransactionPresentation = mockk(relaxed = true),
         )
 
     /** Verifies checkConsentAddress sets consentAddress true. */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/SignedTransactionContent.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/SignedTransactionContent.kt
@@ -3,6 +3,8 @@ package com.vultisig.wallet.data.models.transaction_decoding
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingPayload
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingPayload
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.Transaction
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.ERC20ApprovePayload
 import com.vultisig.wallet.data.models.payload.KeysignPayload
@@ -358,3 +360,49 @@ data class InitiatingTransactionContent(
     override val hasOpaqueSignedContent: Boolean
         get() = cosmosStakingIntent != null || stakingIntent != null
 }
+
+/**
+ * The transaction type the wire discriminator carries, for the chains that set one. Read off the
+ * chain-specific block on the initiator exactly as [KeysignPayloadContent] reads it off the built
+ * payload, so both sides of a ceremony classify the same transaction the same way.
+ */
+private fun BlockChainSpecific.decodedTransactionType(): TransactionType =
+    (this as? BlockChainSpecific.Cosmos)?.transactionType
+        ?: (this as? BlockChainSpecific.THORChain)?.transactionType
+        ?: TransactionType.TRANSACTION_TYPE_UNSPECIFIED
+
+/**
+ * An initiator's send, viewed through the decoder API before a keysign payload exists. Carries no
+ * staking intent: a send that reaches this screen is a transfer or a dApp-supplied transaction, and
+ * the structured staking flows build their transactions elsewhere.
+ */
+fun Transaction.asSignedTransactionContent(): SignedTransactionContent =
+    InitiatingTransactionContent(
+        chain = token.chain,
+        isNativeCoin = token.isNativeToken,
+        rawToAddress = dstAddress,
+        rawAmount = SignedAmount.Committed(tokenValue.value),
+        rawMemo = memo?.takeIf { it.isNotEmpty() },
+        rawTransactionType = blockChainSpecific.decodedTransactionType(),
+        rawWasmPayload = null,
+        stakingIntent = null,
+        cosmosStakingIntent = null,
+    )
+
+/**
+ * An initiator's deposit — the DeFi flows: bond, stake, mint, liquidity, secured assets — viewed
+ * through the decoder API before a keysign payload exists. The structured staking intents are the
+ * ones the signer builds the signed bytes from, so they are what the reading is entitled to.
+ */
+fun DepositTransaction.asSignedTransactionContent(): SignedTransactionContent =
+    InitiatingTransactionContent(
+        chain = srcToken.chain,
+        isNativeCoin = srcToken.isNativeToken,
+        rawToAddress = dstAddress,
+        rawAmount = SignedAmount.Committed(srcTokenValue.value),
+        rawMemo = memo.takeIf { it.isNotEmpty() },
+        rawTransactionType = blockChainSpecific.decodedTransactionType(),
+        rawWasmPayload = wasmExecuteContractPayload,
+        stakingIntent = solanaStakingPayload,
+        cosmosStakingIntent = cosmosStakingPayload,
+    )


### PR DESCRIPTION
## Summary

Connects the dormant decoder foundation to every Verify surface, so a device names the operation it is about to sign instead of calling every DeFi transaction a send. Android mirror of [vultisig-ios#5218](https://github.com/vultisig/vultisig-ios/pull/5218) and its follow-up commit `a411d563` ("left-align decoded verify verbs").

Sits on the foundation (#5706) and the Done hero (#5794), which are already on `main`.

## Reviewer contract

1. **What proves the operation?** Only a structured result from a registered signed-content decoder. This slice registers none.
2. **Which surfaces can reach it?** Initiator Send Verify, initiator function-call Verify, and the co-signer's Verify for both shapes.
3. **What is deliberately refused?** Unknown content, weaker duplicate providers, both Done surfaces, swaps, and message signatures.
4. **What hero appears?** A leading-aligned verb with a truthful exact or projected amount and trusted fiat where available; otherwise the pre-existing presentation is untouched.

## Precedence

That is the substance of the change. A chain-state projection outranks a simulation, because it states a scope no figure can — "your whole stake". A simulation outranks the plain decoder, because it prices a balance change the signed bytes never state, and only borrows the decoded verb. The signed-amount reading is the last claimant.

iOS spends a whole `TransactionHeroResolver` plus a surface/provider registry encoding that. Android already expresses the rest as branch order per screen — a Blockaid or TON simulation, a limit-order title, an XRPL trust line — so this lands as one method, `VerifyHero.applyTo(existing)`. Same call the Done mirror made.

## Notable decisions

- **Device parity.** Initiator and co-signer both read through `SignedTransactionContent`, so they show the same verb for the same transaction. Two new initiator adapters — `Transaction.asSignedTransactionContent()` and `DepositTransaction.asSignedTransactionContent()` — sit beside the existing `KeysignPayload` one.
- **Verify vocabulary never reaches Done.** The decoded verify hero is written to `verifyUiModel` only. Done resolves its own past-tense verb from the same payload, and leaking the present-progressive one would put "You're staking" over a signature already on chain.
- **The deposit surface keeps its specific titles.** `depositVerifyAcceptsDecodedHero` lets the decoder displace only the generic "You're sending". A limit-order cancel, a Kamino deposit or withdraw, and an unbond keep their own title *and* the rows that belong with it — the order pair, the donated-dust warning. This is the stand-in for iOS registering its specific providers ahead of the decoder.
- **Race handling.** The reading is held `@Volatile` and reapplied by the Blockaid and TON hero jobs, so whichever of the concurrent resolutions lands second still keeps the verb.
- **Alignment.** `HeroContentView` gained `verbAlignment`. Verify passes `Start`; Done keeps the centred default. Figures stay centred on every surface, and a swap's verb stays centred — the same exception iOS makes.

## Strings

16 new `verify_verb_*` keys across all ten locales. Three staking verbs reuse `cosmos_staking_youre_*` and the two limit-order verbs reuse `verify_limit_order_title` / `verify_limit_order_cancel_title`, which already ship the exact wording everywhere — so a decoded reading and the screen a user reaches the same operation through cannot disagree. Dutch and Russian were authored against each locale's existing terminology; iOS ships neither.

## What this does not do

No chain reader is added, so `SignedTransactionDecoder`'s registry is still empty: every transaction reads `Unknown`, and every screen renders exactly what it renders today. This is the wiring. It becomes visible when the per-chain decoders (iOS #5219–#5224) land.

## Test plan

- `:app` and `:data` unit suites green; `ktfmtFormat` and `lintDebug` clean.
- Six `PreviewActivity` entries render the decoded hero shapes on both Verify surfaces without a decoder — `verify_decoded_deposit_before` / `_after` / `_projected` / `_unresolved`, and `verify_decoded_send_before` / `_after`. Captured on an emulator and checked:
  - **before** — "You're sending" over `0.00000001 RUNE`, the carrier dust that says nothing about the position being closed.
  - **after** — "You're staking" left-aligned, `1,250.5 TCY` and `$412.66` centred beneath it.
  - **projected** — "You're unstaking", `≈ 625.25 TCY`, and the scope line "50% of your staked position".
  - **unresolved** — the guard that matters: a position read that failed or timed out keeps the verb and the signed scope, and omits the estimate rather than backfilling it with the carrier dust.
  - Done previews (`send_tx_done_decoded`, `blockaid_hero_done_send`) verified unchanged.
- To exercise the wiring end to end before chain readers exist, temporarily register a stub `TransactionContentDecoder` on `SignedTransactionDecoder` and walk a deposit; the co-signer must show the same verb, and Done must still read "Staked".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9NVpxNCntotiW9wHxNhfw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification screens now show decoded transaction details, including operation, asset, amount, destination, and projected information.
  * Deposit and send verification use decoded presentation content when available.
  * Sign-message verification displays decoded text, hashes, and contract-call details.
  * Transaction hero content supports configurable alignment for improved readability.
  * Transaction failures can include additional explanatory details.

* **Localization**
  * Added operation-progress and decoded sign-message labels in multiple languages.

* **Reliability**
  * Decoding issues no longer block transaction display or signing; the interface falls back to existing information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->