### PR TITLE
fix(swap): explain min-output reverts in transaction history

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionFailureExplanation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionFailureExplanation.kt
@@ -1,0 +1,62 @@
+package com.vultisig.wallet.ui.models
+
+import androidx.annotation.StringRes
+import com.vultisig.wallet.R
+import java.util.Locale
+
+/**
+ * Actionable copy for an on-chain failure the app recognises from the reason stored against the
+ * transaction.
+ *
+ * A revert reason is router text, not user copy: "Insufficient output" describes a min-output check
+ * to whoever wrote the router, and describes nothing at all to the person who just paid gas for it.
+ * Matching the reason to an explanation is what lets history say the price moved and the slippage
+ * tolerance needs raising, instead of leaving a retry — and another gas payment — as the only
+ * obvious move (#5802).
+ *
+ * A reason that matches nothing maps to null and stays out of the UI. Everything the wallet stores
+ * in that field is internal text ("Transaction reverted", "SwapKit failed: reverted", a raw router
+ * string), so showing it unrecognised would trade one unhelpful message for another.
+ */
+enum class TransactionFailureExplanation(
+    @StringRes val labelRes: Int,
+    @StringRes val descriptionRes: Int,
+    private val signatures: List<String>,
+) {
+    /**
+     * An aggregator's minimum-output check rejected the swap: between the quote being signed and
+     * the transaction landing, the price moved far enough that the payout would have fallen below
+     * the floor built into the calldata.
+     *
+     * The first two signatures are the ones the receipts in #5802 carry (LI.FI and 1inch/Kyber);
+     * the rest are the same check worded by other routers.
+     */
+    MIN_OUTPUT_SLIPPAGE(
+        labelRes = R.string.transaction_status_failed_slippage_label,
+        descriptionRes = R.string.transaction_status_failed_slippage_description,
+        signatures =
+            listOf(
+                "insufficient output",
+                "return amount is not enough",
+                "insufficient_output_amount",
+                "too little received",
+            ),
+    );
+
+    companion object {
+        /**
+         * The explanation for [rawReason], or null when nothing recognises it.
+         *
+         * Matched as a case-insensitive substring: nodes wrap the reason in their own prose
+         * ("execution reverted: Insufficient output"), and routers prefix theirs with a contract
+         * name ("UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT").
+         */
+        fun from(rawReason: String?): TransactionFailureExplanation? {
+            val normalized =
+                rawReason?.lowercase(Locale.ROOT)?.takeIf { it.isNotBlank() } ?: return null
+            return entries.firstOrNull { explanation ->
+                explanation.signatures.any { it in normalized }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -90,7 +90,13 @@ sealed interface TransactionStatusUiModel {
 
     data object Confirmed : TransactionStatusUiModel
 
-    data class Failed(val reason: UiText?) : TransactionStatusUiModel
+    /**
+     * @param reason the raw on-chain / provider text, kept for diagnostics.
+     * @param explanation what that reason means for the user, when the app recognises it. Null
+     *   leaves the row reporting a bare failure, as it always has.
+     */
+    data class Failed(val reason: UiText?, val explanation: TransactionFailureExplanation? = null) :
+        TransactionStatusUiModel
 
     /**
      * THORChain/MayaChain inbound tx that the network refunded (paused pool, unmet swap limit,
@@ -657,7 +663,10 @@ constructor(
 
                 TransactionStatus.CONFIRMED -> TransactionStatusUiModel.Confirmed
                 TransactionStatus.FAILED ->
-                    TransactionStatusUiModel.Failed(UiText.DynamicString(failureReason.orEmpty()))
+                    TransactionStatusUiModel.Failed(
+                        reason = UiText.DynamicString(failureReason.orEmpty()),
+                        explanation = TransactionFailureExplanation.from(failureReason),
+                    )
                 TransactionStatus.REFUNDED ->
                     TransactionStatusUiModel.Refunded(UiText.DynamicString(failureReason.orEmpty()))
                 // NotFound is transient — the indexer has not seen the tx yet. Render as Pending.

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -67,6 +67,7 @@ import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.components.hero.retitled
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
+import com.vultisig.wallet.ui.models.TransactionFailureExplanation
 import com.vultisig.wallet.ui.models.deposit.DepositTransactionUiModel
 import com.vultisig.wallet.ui.models.sign.SignMessageTransactionUiModel
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
@@ -227,8 +228,16 @@ sealed interface TransactionStatus {
     /** Transaction has been confirmed on-chain. */
     data object Confirmed : TransactionStatus
 
-    /** Transaction failed or was rejected. */
-    data class Failed(val cause: UiText) : TransactionStatus
+    /**
+     * Transaction failed or was rejected.
+     *
+     * @param cause the raw provider / on-chain text, kept for diagnostics.
+     * @param explanation what that cause means for the user, when the app recognises it. This is
+     *   the screen the user decides whether to retry on, so a failure it can explain is explained
+     *   here and not only in history (#5802).
+     */
+    data class Failed(val cause: UiText, val explanation: TransactionFailureExplanation? = null) :
+        TransactionStatus
 
     /**
      * Transaction was accepted by the chain but refunded by the protocol (e.g. THORChain/Maya `type
@@ -1223,7 +1232,11 @@ constructor(
     private fun TransactionResult.toTransactionStatus() =
         when (this) {
             TransactionResult.Confirmed -> TransactionStatus.Confirmed
-            is TransactionResult.Failed -> TransactionStatus.Failed(this.reason.asUiText())
+            is TransactionResult.Failed ->
+                TransactionStatus.Failed(
+                    cause = this.reason.asUiText(),
+                    explanation = TransactionFailureExplanation.from(this.reason),
+                )
             is TransactionResult.Refunded -> TransactionStatus.Refunded(this.reason.asUiText())
             TransactionResult.TimedOut -> TransactionStatus.StillConfirming
             TransactionResult.NotFound,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCard.kt
@@ -28,6 +28,7 @@ import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.v2.containers.ContainerBorderType
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
+import com.vultisig.wallet.ui.models.TransactionFailureExplanation
 import com.vultisig.wallet.ui.models.TransactionHistoryItemUiModel
 import com.vultisig.wallet.ui.models.TransactionStatusUiModel
 import com.vultisig.wallet.ui.models.TransactionStatusUiModel.Broadcasted
@@ -40,6 +41,7 @@ import com.vultisig.wallet.ui.screens.transaction.components.TransactionStatusWi
 import com.vultisig.wallet.ui.screens.transaction.components.TypeBadge
 import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
 import com.vultisig.wallet.ui.theme.Theme
+import com.vultisig.wallet.ui.utils.UiText
 
 @Composable
 internal fun SwapTransactionCard(
@@ -56,7 +58,7 @@ internal fun SwapTransactionCard(
         borderType = ContainerBorderType.Bordered(),
     ) {
         Box {
-            Column(modifier = Modifier.padding(16.dp)) {
+            Column(modifier = Modifier.padding(swapCardPadding)) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceBetween,
@@ -129,6 +131,22 @@ internal fun SwapTransactionCard(
                             SendAmountText(amount = item.fromAmount, token = item.fromToken)
                         }
                     }
+
+                    val explanation = (item.status as? TransactionStatusUiModel.Failed)?.explanation
+                    if (explanation != null) {
+                        UiSpacer(size = 8.dp)
+                        Text(
+                            text = stringResource(explanation.labelRes),
+                            style = Theme.brockmann.supplementary.caption,
+                            color = Theme.v2.colors.alerts.error,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                        // The provider badge is anchored over this corner and overhangs the card's
+                        // own bottom padding, so a last flow child would be printed underneath it.
+                        if (item.provider.isNotEmpty()) {
+                            UiSpacer(size = viaBadgeClearance)
+                        }
+                    }
                 }
             }
 
@@ -170,6 +188,23 @@ private fun SwapAmountText(amount: String, token: String, modifier: Modifier = M
     )
 }
 
+private val viaBadgeVerticalPadding = 8.dp
+
+/** The provider logo — the tallest thing the badge ever holds, so it sets the badge's height. */
+private const val VIA_BADGE_CONTENT_SIZE = 16
+
+private val swapCardPadding = 16.dp
+
+private val failureLineGap = 8.dp
+
+/**
+ * How far the failure line has to be lifted to clear the provider badge. Derived from the badge's
+ * own geometry rather than eyeballed, so the two cannot drift apart: the badge is absolutely
+ * positioned over the card's bottom-end corner and stands taller than the padding it overhangs.
+ */
+private val viaBadgeClearance =
+    viaBadgeVerticalPadding * 2 + VIA_BADGE_CONTENT_SIZE.dp - swapCardPadding + failureLineGap
+
 @Composable
 private fun ViaBadge(provider: String, providerLogo: ImageModel?, modifier: Modifier = Modifier) {
     // The badge is anchored to the card's bottom-end corner, so its outer corner is not its own
@@ -189,10 +224,15 @@ private fun ViaBadge(provider: String, providerLogo: ImageModel?, modifier: Modi
             modifier
                 .background(color = Theme.v2.colors.backgrounds.tertiary_2, shape = shape)
                 .border(width = 1.dp, color = Theme.v2.colors.border.light, shape = shape)
-                .padding(start = 8.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+                .padding(
+                    start = 8.dp,
+                    end = 16.dp,
+                    top = viaBadgeVerticalPadding,
+                    bottom = viaBadgeVerticalPadding,
+                ),
     ) {
         if (providerLogo != null) {
-            TokenCircle(logo = providerLogo, ticker = provider, size = 16)
+            TokenCircle(logo = providerLogo, ticker = provider, size = VIA_BADGE_CONTENT_SIZE)
         }
         Text(
             text =
@@ -252,6 +292,42 @@ private fun PreviewSwapCardPending() {
                 previewSwapItem.copy(
                     status = Pending,
                     timestamp = System.currentTimeMillis() - 5_000L,
+                ),
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF02122B)
+@Composable
+private fun PreviewSwapCardFailedOnSlippage() {
+    OnBoardingComposeTheme {
+        SwapTransactionCard(
+            item =
+                previewSwapItem.copy(
+                    status =
+                        TransactionStatusUiModel.Failed(
+                            reason = UiText.DynamicString("Insufficient output"),
+                            explanation = TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE,
+                        ),
+                    provider = "LI.FI",
+                ),
+            modifier = Modifier.fillMaxWidth().padding(16.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFF02122B)
+@Composable
+private fun PreviewSwapCardFailedWithoutExplanation() {
+    OnBoardingComposeTheme {
+        SwapTransactionCard(
+            item =
+                previewSwapItem.copy(
+                    status =
+                        TransactionStatusUiModel.Failed(
+                            reason = UiText.DynamicString("Transaction reverted")
+                        )
                 ),
             modifier = Modifier.fillMaxWidth().padding(16.dp),
         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionDetailBottomSheet.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TransactionDetailBottomSheet.kt
@@ -119,7 +119,19 @@ internal fun TransactionDetailBottomSheet(
                 val refundReason = refunded?.reason?.asString()?.takeIf { it.isNotBlank() }
                 if (refundReason != null) {
                     UiSpacer(size = 16.dp)
-                    RefundReasonBanner(reason = refundReason)
+                    ReasonBanner(reason = refundReason, tint = Theme.v2.colors.alerts.warning)
+                }
+
+                // The row itself only ever says "Error". The sheet is where there is room to say
+                // what the user can do about it, for the failures the app can recognise (#5802).
+                val failureExplanation =
+                    (item.status as? TransactionStatusUiModel.Failed)?.explanation
+                if (failureExplanation != null) {
+                    UiSpacer(size = 16.dp)
+                    ReasonBanner(
+                        reason = stringResource(failureExplanation.descriptionRes),
+                        tint = Theme.v2.colors.alerts.error,
+                    )
                 }
 
                 UiSpacer(size = 24.dp)
@@ -397,27 +409,23 @@ private fun DetailInfoRows(
 }
 
 /**
- * Banner used in the transaction detail sheet to expose the THORChain/MayaChain refund reason
- * returned by Midgard. Sits alongside the explorer link so the user can both read the reason and
- * inspect the on-chain refund.
+ * Banner used in the transaction detail sheet to explain an outcome the row can only label: the
+ * THORChain/MayaChain refund reason returned by Midgard, or why a swap failed. Sits alongside the
+ * explorer link so the user can both read the reason and inspect the transaction on-chain.
+ *
+ * [tint] carries the severity — warning for a refund, which returned the funds, and error for a
+ * failure, which did not.
  */
 @Composable
-internal fun RefundReasonBanner(reason: String) {
+internal fun ReasonBanner(reason: String, tint: Color) {
     Text(
         text = reason.replaceFirstChar { ch -> ch.titlecase(Locale.ROOT) },
         style = Theme.brockmann.supplementary.footnote,
-        color = Theme.v2.colors.alerts.warning,
+        color = tint,
         modifier =
             Modifier.fillMaxWidth()
-                .border(
-                    width = 1.dp,
-                    color = Theme.v2.colors.alerts.warning.copy(alpha = 0.4f),
-                    shape = Theme.v2.radius.md,
-                )
-                .background(
-                    color = Theme.v2.colors.alerts.warning.copy(alpha = 0.10f),
-                    shape = Theme.v2.radius.md,
-                )
+                .border(width = 1.dp, color = tint.copy(alpha = 0.4f), shape = Theme.v2.radius.md)
+                .background(color = tint.copy(alpha = 0.10f), shape = Theme.v2.radius.md)
                 .padding(horizontal = 16.dp, vertical = 12.dp),
     )
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/TxDoneScaffold.kt
@@ -272,15 +272,24 @@ private fun SuccessTransaction(
         // Surface the protocol's refund reason (paused pool, slip exceeded, etc.) on the done
         // screen. Kept outside the collapsed block above so it stays visible when the user expands
         // Transaction Details. Only Refunded carries a clean Midgard reason; Failed.cause is a raw
-        // provider error string (JSON blob, untranslated timeout literal) and is not shown here.
+        // provider error string (JSON blob, untranslated timeout literal) and is not shown here —
+        // a recognised failure is explained through its own banner below instead.
         (transactionStatus as? TransactionStatus.Refunded)
             ?.reason
             ?.asString()
             ?.takeIf { it.isNotBlank() }
             ?.let { reason ->
-                RefundReasonBanner(reason = reason)
+                ReasonBanner(reason = reason, tint = Theme.v2.colors.alerts.warning)
                 UiSpacer(8.dp)
             }
+
+        (transactionStatus as? TransactionStatus.Failed)?.explanation?.let { explanation ->
+            ReasonBanner(
+                reason = stringResource(explanation.descriptionRes),
+                tint = Theme.v2.colors.alerts.error,
+            )
+            UiSpacer(8.dp)
+        }
 
         dappMetadata
             ?.takeUnless { it.isEmpty }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1407,6 +1407,8 @@
     <string name="transaction_status_confirmed_label">Erfolgreich</string>
     <string name="transaction_status_failed_label">Fehler</string>
     <string name="transaction_status_refunded_label">Erstattet</string>
+    <string name="transaction_status_failed_slippage_label">Preis hat die Slippage-Toleranz überschritten</string>
+    <string name="transaction_status_failed_slippage_description">Der Preis hat sich geändert, bevor dieser Tausch ausgeführt wurde. Die Auszahlung wäre geringer ausgefallen, als Ihre Slippage-Toleranz erlaubt, und das Netzwerk hat ihn rückgängig gemacht. Erhöhen Sie Ihre Slippage-Toleranz oder versuchen Sie es erneut.</string>
     <string name="transaction_status_in_progress_label">In Bearbeitung…</string>
     <string name="transaction_status_signed_label">Signiert</string>
     <string name="transaction_history_to_label">An</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1406,6 +1406,8 @@
     <string name="transaction_status_confirmed_label">Confirmada</string>
     <string name="transaction_status_failed_label">Fallida</string>
     <string name="transaction_status_refunded_label">Reembolsada</string>
+    <string name="transaction_status_failed_slippage_label">El precio superó la tolerancia de deslizamiento</string>
+    <string name="transaction_status_failed_slippage_description">El precio cambió antes de que se ejecutara este intercambio, por lo que el pago habría sido inferior a lo permitido por su tolerancia de deslizamiento y la red lo revirtió. Aumente la tolerancia de deslizamiento o inténtelo de nuevo.</string>
     <string name="transaction_status_in_progress_label">En progreso…</string>
     <string name="transaction_status_signed_label">Firmada</string>
     <string name="transaction_history_to_label">Para</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1412,6 +1412,8 @@
     <string name="transaction_status_confirmed_label">Potvrđeno</string>
     <string name="transaction_status_failed_label">Neuspješno</string>
     <string name="transaction_status_refunded_label">Vraćeno</string>
+    <string name="transaction_status_failed_slippage_label">Cijena je premašila toleranciju proklizavanja</string>
+    <string name="transaction_status_failed_slippage_description">Cijena se promijenila prije nego što je ova zamjena izvršena, pa bi isplata bila manja od one koju dopušta vaša tolerancija proklizavanja i mreža ju je poništila. Povećajte toleranciju proklizavanja ili pokušajte ponovno.</string>
     <string name="transaction_status_in_progress_label">U tijeku…</string>
     <string name="transaction_status_signed_label">Potpisano</string>
     <string name="transaction_history_to_label">Za</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1408,6 +1408,8 @@
     <string name="transaction_status_confirmed_label">Riuscita</string>
     <string name="transaction_status_failed_label">Errore</string>
     <string name="transaction_status_refunded_label">Rimborsata</string>
+    <string name="transaction_status_failed_slippage_label">Il prezzo ha superato la tolleranza di slippage</string>
+    <string name="transaction_status_failed_slippage_description">Il prezzo è cambiato prima che questo scambio venisse eseguito, quindi il pagamento sarebbe stato inferiore a quanto consentito dalla tua tolleranza di slippage e la rete lo ha annullato. Aumenta la tolleranza di slippage o riprova.</string>
     <string name="transaction_status_in_progress_label">In corso…</string>
     <string name="transaction_status_signed_label">Firmata</string>
     <string name="transaction_history_to_label">A</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1434,6 +1434,8 @@
     <string name="transaction_status_confirmed_label">성공</string>
     <string name="transaction_status_failed_label">오류</string>
     <string name="transaction_status_refunded_label">환불됨</string>
+    <string name="transaction_status_failed_slippage_label">가격이 슬리피지 허용 범위를 벗어났습니다</string>
+    <string name="transaction_status_failed_slippage_description">이 스왑이 실행되기 전에 가격이 변동되어 슬리피지 허용 범위보다 적은 금액을 받게 되므로 네트워크가 거래를 되돌렸습니다. 슬리피지 허용 범위를 높이거나 다시 시도하세요.</string>
     <string name="transaction_status_in_progress_label">진행 중…</string>
     <string name="transaction_status_signed_label">서명됨</string>
     <string name="transaction_history_to_label">수신</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1402,6 +1402,8 @@
     <string name="transaction_status_confirmed_label">Geslaagd</string>
     <string name="transaction_status_failed_label">Fout</string>
     <string name="transaction_status_refunded_label">Terugbetaald</string>
+    <string name="transaction_status_failed_slippage_label">Prijs ging voorbij de slippage-tolerantie</string>
+    <string name="transaction_status_failed_slippage_description">De prijs veranderde voordat deze wissel werd uitgevoerd, waardoor de uitbetaling lager zou zijn dan uw slippage-tolerantie toestaat en het netwerk hem heeft teruggedraaid. Verhoog uw slippage-tolerantie of probeer het opnieuw.</string>
     <string name="transaction_status_in_progress_label">Bezig…</string>
     <string name="transaction_status_signed_label">Ondertekend</string>
     <string name="transaction_history_to_label">Aan</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1407,6 +1407,8 @@
     <string name="transaction_status_confirmed_label">Bem-sucedida</string>
     <string name="transaction_status_failed_label">Erro</string>
     <string name="transaction_status_refunded_label">Reembolsada</string>
+    <string name="transaction_status_failed_slippage_label">O preço ultrapassou a tolerância de derrapagem</string>
+    <string name="transaction_status_failed_slippage_description">O preço mudou antes de esta troca ser executada, portanto o pagamento teria sido inferior ao permitido pela sua tolerância de derrapagem e a rede reverteu-a. Aumente a tolerância de derrapagem ou tente novamente.</string>
     <string name="transaction_status_in_progress_label">Em andamento…</string>
     <string name="transaction_status_signed_label">Assinada</string>
     <string name="transaction_history_to_label">Para</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1414,6 +1414,8 @@
     <string name="transaction_status_confirmed_label">Успешно</string>
     <string name="transaction_status_failed_label">Ошибка</string>
     <string name="transaction_status_refunded_label">Возвращено</string>
+    <string name="transaction_status_failed_slippage_label">Цена вышла за допустимое проскальзывание</string>
+    <string name="transaction_status_failed_slippage_description">Цена изменилась до исполнения этого обмена, поэтому выплата оказалась бы меньше, чем допускает ваше проскальзывание, и сеть отменила транзакцию. Увеличьте допустимое проскальзывание или попробуйте снова.</string>
     <string name="transaction_status_in_progress_label">В процессе…</string>
     <string name="transaction_status_signed_label">Подписано</string>
     <string name="transaction_history_to_label">На</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1736,6 +1736,8 @@
     <string name="transaction_status_confirmed_label">成功</string>
     <string name="transaction_status_failed_label">错误</string>
     <string name="transaction_status_refunded_label">已退款</string>
+    <string name="transaction_status_failed_slippage_label">价格超出滑点容差</string>
+    <string name="transaction_status_failed_slippage_description">此次交换执行前价格发生变动，支付金额将低于您的滑点容差允许的范围，网络已撤销该交易。请提高滑点容差或重试。</string>
     <string name="transaction_status_in_progress_label">进行中…</string>
     <string name="transaction_status_signed_label">已签名</string>
     <string name="transaction_history_to_label">至</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1491,6 +1491,8 @@
     <string name="transaction_status_confirmed_label">Successful</string>
     <string name="transaction_status_failed_label">Error</string>
     <string name="transaction_status_refunded_label">Refunded</string>
+    <string name="transaction_status_failed_slippage_label">Price moved past slippage tolerance</string>
+    <string name="transaction_status_failed_slippage_description">The price moved before this swap landed, so it would have paid out less than your slippage tolerance allowed and the network reverted it. Raise your slippage tolerance or try again.</string>
     <string name="transaction_status_in_progress_label">In progress…</string>
     <string name="transaction_status_signed_label">Signed</string>
     <string name="transaction_history_to_label">To</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/transaction/TransactionFailureExplanationTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/transaction/TransactionFailureExplanationTest.kt
@@ -1,0 +1,76 @@
+package com.vultisig.wallet.ui.models.transaction
+
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.models.TransactionFailureExplanation
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins which stored failure reasons history is willing to explain (#5802).
+ *
+ * The two signatures from the issue's receipts must be recognised through whatever wrapping the
+ * node or router put around them, and everything else must stay unrecognised — the reason column
+ * also holds the app's own internal text, which is no more useful to a user than "Error" is.
+ */
+class TransactionFailureExplanationTest {
+
+    @Test
+    fun `recognises the LI_FI min-output revert`() {
+        TransactionFailureExplanation.from("Insufficient output") shouldBe
+            TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE
+    }
+
+    @Test
+    fun `recognises the 1inch and Kyber min-return revert`() {
+        TransactionFailureExplanation.from("Return amount is not enough") shouldBe
+            TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE
+    }
+
+    @Test
+    fun `matches through node wrapping and casing`() {
+        TransactionFailureExplanation.from("execution reverted: INSUFFICIENT OUTPUT") shouldBe
+            TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE
+        TransactionFailureExplanation.from(
+            "RPC error: Return Amount Is Not Enough [code 3]"
+        ) shouldBe TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE
+    }
+
+    @Test
+    fun `matches a router that prefixes its own contract name`() {
+        TransactionFailureExplanation.from("UniswapV2Router: INSUFFICIENT_OUTPUT_AMOUNT") shouldBe
+            TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE
+    }
+
+    @Test
+    fun `the explanation points at the slippage copy`() {
+        with(TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE) {
+            labelRes shouldBe R.string.transaction_status_failed_slippage_label
+            descriptionRes shouldBe R.string.transaction_status_failed_slippage_description
+        }
+    }
+
+    /**
+     * These are the strings the wallet itself stores when it cannot learn a reason. Explaining them
+     * would be inventing a cause, so they stay unrecognised and the row keeps saying only "Error".
+     */
+    @Test
+    fun `the app's own placeholder reasons stay unexplained`() {
+        TransactionFailureExplanation.from("Transaction reverted").shouldBeNull()
+        TransactionFailureExplanation.from("SwapKit failed: reverted").shouldBeNull()
+        TransactionFailureExplanation.from("Unknown chain: fantom").shouldBeNull()
+    }
+
+    @Test
+    fun `an unrelated revert stays unexplained`() {
+        TransactionFailureExplanation.from("ERC20: transfer amount exceeds balance").shouldBeNull()
+        TransactionFailureExplanation.from("ERC20InsufficientAllowance").shouldBeNull()
+    }
+
+    @Test
+    fun `null and blank reasons stay unexplained`() {
+        TransactionFailureExplanation.from(null).shouldBeNull()
+        TransactionFailureExplanation.from("").shouldBeNull()
+        TransactionFailureExplanation.from("   ").shouldBeNull()
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/transaction/TransactionHistoryViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/transaction/TransactionHistoryViewModelTest.kt
@@ -25,6 +25,7 @@ import com.vultisig.wallet.data.repositories.swap.LimitSwapConfig
 import com.vultisig.wallet.data.usecases.RefreshLimitOrdersUseCase
 import com.vultisig.wallet.data.usecases.RefreshPendingTransactionsUseCase
 import com.vultisig.wallet.ui.models.TransactionAssetUiModel
+import com.vultisig.wallet.ui.models.TransactionFailureExplanation
 import com.vultisig.wallet.ui.models.TransactionHistoryItemUiModel
 import com.vultisig.wallet.ui.models.TransactionHistoryTab
 import com.vultisig.wallet.ui.models.TransactionHistoryViewModel
@@ -313,6 +314,56 @@ internal class TransactionHistoryViewModelTest {
         testScope.runCurrent()
 
         coVerify(exactly = 2) { refreshPendingTransactions(VAULT_ID) }
+    }
+
+    /**
+     * A failed row must reach the UI carrying an explanation the screen can show, not just the raw
+     * router text — that text is what history used to have and could say nothing useful about
+     * (#5802).
+     */
+    @Test
+    fun `a min-output revert reaches the UI as a slippage explanation`() {
+        every { transactionHistoryRepository.observeTransactions(any(), any(), any()) } returns
+            flowOf(
+                listOf(
+                    inFlightEntity()
+                        .copy(
+                            status = TransactionStatus.FAILED,
+                            failureReason = "execution reverted: Insufficient output",
+                        )
+                )
+            )
+
+        val vm = createViewModel()
+        testScope.runCurrent()
+
+        val status =
+            vm.uiState.value.groups.single().transactions.single().status
+                as TransactionStatusUiModel.Failed
+        status.explanation shouldBe TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE
+    }
+
+    /** An unrecognised reason leaves the row exactly as it was: labelled "Error", nothing more. */
+    @Test
+    fun `an unrecognised failure reason produces no explanation`() {
+        every { transactionHistoryRepository.observeTransactions(any(), any(), any()) } returns
+            flowOf(
+                listOf(
+                    inFlightEntity()
+                        .copy(
+                            status = TransactionStatus.FAILED,
+                            failureReason = "Transaction reverted",
+                        )
+                )
+            )
+
+        val vm = createViewModel()
+        testScope.runCurrent()
+
+        val status =
+            vm.uiState.value.groups.single().transactions.single().status
+                as TransactionStatusUiModel.Failed
+        status.explanation.shouldBeNull()
     }
 
     /** Leaving the screen stops the timer: a backgrounded history screen must not keep polling. */

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -865,8 +865,10 @@ class EvmApiImp(
         } catch (e: CancellationException) {
             throw e
         } catch (e: NetworkException) {
-            // A node that answers a revert with a non-2xx still states the reason in the body, and
-            // NetworkException carries the extracted message.
+            // bodyOrThrow only extracts the error message for 2xx-with-bad-body cases; a non-2xx
+            // response carries the raw body text here, which usually won't match decode()'s known
+            // prefixes/shapes. That's fine — decode() returns null and the caller falls back to a
+            // generic error message.
             EvmRevertReason.decode(e.message, data = null)
         } catch (e: Exception) {
             Timber.d("revert reason: replay failed for %s — %s", txHash, e.message)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/EvmApi.kt
@@ -2,14 +2,17 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.CustomTokenResponse
 import com.vultisig.wallet.data.api.models.EvmBaseFeeJson
+import com.vultisig.wallet.data.api.models.EvmCallResponseJson
 import com.vultisig.wallet.data.api.models.EvmFeeHistoryResponseJson
 import com.vultisig.wallet.data.api.models.EvmRpcResponseJson
+import com.vultisig.wallet.data.api.models.EvmTxByHashJson
 import com.vultisig.wallet.data.api.models.EvmTxStatusJson
 import com.vultisig.wallet.data.api.models.RpcPayload
 import com.vultisig.wallet.data.api.models.RpcResponse
 import com.vultisig.wallet.data.api.models.RpcResponseJson
 import com.vultisig.wallet.data.api.models.SendTransactionJson
 import com.vultisig.wallet.data.api.models.ZkGasFee
+import com.vultisig.wallet.data.api.txstatus.EvmRevertReason
 import com.vultisig.wallet.data.chains.helpers.EthereumFunction
 import com.vultisig.wallet.data.chains.helpers.EthereumRlpEncoder
 import com.vultisig.wallet.data.chains.helpers.Multicall3
@@ -29,6 +32,7 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import java.math.BigInteger
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -100,6 +104,16 @@ interface EvmApi {
     ): Map<String, BigInteger>
 
     suspend fun getTxStatus(txHash: String): EvmRpcResponseJson<EvmTxStatusJson>?
+
+    /**
+     * Replays a mined transaction with `eth_call` and returns the revert reason the node reports,
+     * or null when it reports none — the receipt only carries a pass/fail bit, so this is the only
+     * way to learn *why* a swap failed.
+     *
+     * Best called soon after the failure: the replay needs the state at the transaction's block,
+     * which a non-archive node keeps for a limited window and then discards.
+     */
+    suspend fun getRevertReason(txHash: String): String?
 
     /**
      * Prices the L1 data-availability fee of an OP-stack L2 transaction via the `GasPriceOracle`
@@ -804,6 +818,60 @@ class EvmApiImp(
                 null
             }
         return rpcResp
+    }
+
+    override suspend fun getRevertReason(txHash: String): String? {
+        val tx =
+            try {
+                fetch<EvmRpcResponseJson<EvmTxByHashJson>>(
+                        method = "eth_getTransactionByHash",
+                        params = buildJsonArray { add(txHash) },
+                    )
+                    .result
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.d("revert reason: cannot read tx %s — %s", txHash, e.message)
+                null
+            } ?: return null
+
+        // A contract creation has no callee to replay against, and a transaction still in the
+        // mempool has no block to replay at.
+        val to = tx.to?.takeIf { it.isNotBlank() } ?: return null
+        val blockNumber = tx.blockNumber?.takeIf { it.isNotBlank() } ?: return null
+
+        return try {
+            val response =
+                fetch<EvmCallResponseJson>(
+                    method = "eth_call",
+                    params =
+                        buildJsonArray {
+                            addJsonObject {
+                                put("from", tx.from)
+                                put("to", to)
+                                tx.input?.let { put("data", it) }
+                                tx.value?.let { put("value", it) }
+                                tx.gas?.let { put("gas", it) }
+                            }
+                            // The transaction's own block, not its predecessor: a swap whose
+                            // approval leg landed in the same block would otherwise replay without
+                            // that approval and report an allowance failure instead of the real
+                            // reason. The transaction reverted, so it left no state of its own for
+                            // the replay to trip over.
+                            add(blockNumber)
+                        },
+                )
+            EvmRevertReason.decode(response.error?.message, response.error?.data)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: NetworkException) {
+            // A node that answers a revert with a non-2xx still states the reason in the body, and
+            // NetworkException carries the extracted message.
+            EvmRevertReason.decode(e.message, data = null)
+        } catch (e: Exception) {
+            Timber.d("revert reason: replay failed for %s — %s", txHash, e.message)
+            null
+        }
     }
 
     companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/EvmJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/EvmJson.kt
@@ -4,6 +4,7 @@ import java.math.BigInteger
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
 
 @Serializable
 data class RpcPayload(
@@ -63,6 +64,39 @@ data class RpcResponseResultJson(
 
 @Serializable
 data class RpcError(@SerialName("code") val code: Int, @SerialName("message") val message: String)
+
+/**
+ * The subset of `eth_getTransactionByHash` needed to replay a mined transaction with `eth_call`.
+ * Every field but `from` is optional: a contract creation has no `to`, and a node that omits
+ * `blockNumber` is still reporting a pending transaction, which cannot be replayed at a block.
+ */
+@Serializable
+data class EvmTxByHashJson(
+    @SerialName("from") val from: String,
+    @SerialName("to") val to: String? = null,
+    @SerialName("input") val input: String? = null,
+    @SerialName("value") val value: String? = null,
+    @SerialName("gas") val gas: String? = null,
+    @SerialName("blockNumber") val blockNumber: String? = null,
+)
+
+/**
+ * An `eth_call` error, kept separate from [RpcError] because a revert's payload arrives under
+ * `data` in a shape the node chooses — a hex string on most, a nested object on some — so it is
+ * modelled as a raw [JsonElement] and narrowed at the point of decoding.
+ */
+@Serializable
+data class EvmCallErrorJson(
+    @SerialName("code") val code: Int? = null,
+    @SerialName("message") val message: String? = null,
+    @SerialName("data") val data: JsonElement? = null,
+)
+
+@Serializable
+data class EvmCallResponseJson(
+    @SerialName("result") val result: String? = null,
+    @SerialName("error") val error: EvmCallErrorJson? = null,
+)
 
 @Serializable data class ErrorSendTransactionJson(@SerialName("message") val message: String)
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/EvmRevertReason.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/EvmRevertReason.kt
@@ -1,0 +1,143 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * Decodes the human-readable reason an EVM node reports when a reverted transaction is replayed
+ * with `eth_call`.
+ *
+ * Nodes disagree on where that reason goes. Geth and most hosted RPCs put the ABI-encoded revert
+ * payload in `error.data` and a summary in `error.message`; others send only one of the two, and
+ * some wrap the payload one level deeper (`error.data.data`, `error.data.originalError.data`). Both
+ * carriers are read here so the reason survives whichever node the wallet is pointed at.
+ *
+ * Only `Error(string)` — the `require(cond, "reason")` encoding every aggregator's min-output check
+ * uses — is decoded. A custom error or `Panic(uint256)` carries no string to recover, so the
+ * message carrier is used instead and, failing that, the reason stays unknown.
+ */
+internal object EvmRevertReason {
+
+    /** `keccak("Error(string)")[0..3]` — the selector prefixing a `require`/`revert` string. */
+    private const val ERROR_STRING_SELECTOR = "08c379a0"
+
+    /** One ABI word is 32 bytes, i.e. 64 hex characters. */
+    private const val WORD_HEX_LENGTH = 64
+
+    /** Longest reason kept — a runaway payload is a decode gone wrong, not a message for a user. */
+    private const val MAX_REASON_LENGTH = 200
+
+    /**
+     * Node boilerplate wrapping a revert reason, longest form of each family first so the more
+     * specific prefix wins. A message is only read as a reason when it carries one of these: an
+     * `eth_call` that fails for an unrelated reason (a node without archive state for the block, a
+     * rate limit) also arrives as `error.message`, and storing that as "why the swap reverted"
+     * would be a lie.
+     */
+    private val MESSAGE_PREFIXES =
+        listOf(
+            "vm exception while processing transaction: reverted with reason string",
+            "vm exception while processing transaction: revert",
+            "error: transaction reverted:",
+            "transaction reverted:",
+            "execution reverted:",
+            "execution reverted",
+            "reverted:",
+            "revert:",
+        )
+
+    /**
+     * The revert reason carried by an `eth_call` error, or null when neither carrier holds one.
+     *
+     * @param message the node's `error.message`.
+     * @param data the node's `error.data`, in any of the shapes described on this object.
+     */
+    fun decode(message: String?, data: JsonElement?): String? =
+        decodeErrorString(extractRevertPayload(data)) ?: fromMessage(message)
+
+    /**
+     * Pulls the `0x…`-encoded revert payload out of an `error.data` value that may be the hex
+     * string itself, or an object holding it under `data` or `originalError.data`.
+     */
+    private fun extractRevertPayload(data: JsonElement?): String? =
+        when (data) {
+            is JsonPrimitive -> data.contentOrNull
+            is JsonObject ->
+                (data["data"] as? JsonPrimitive)?.contentOrNull
+                    ?: ((data["originalError"] as? JsonObject)?.get("data") as? JsonPrimitive)
+                        ?.contentOrNull
+
+            else -> null
+        }
+
+    /**
+     * Decodes `Error(string)` calldata: the selector, then a word of offset, a word of length, and
+     * the UTF-8 bytes right-padded to a word boundary. Every declared length is trusted only as far
+     * as the payload actually reaches, so a truncated response yields null rather than throwing.
+     */
+    private fun decodeErrorString(payload: String?): String? {
+        val body =
+            payload
+                ?.removePrefix("0x")
+                ?.takeIf { it.startsWith(ERROR_STRING_SELECTOR, ignoreCase = true) }
+                ?.drop(ERROR_STRING_SELECTOR.length) ?: return null
+        if (body.length < WORD_HEX_LENGTH * 2) return null
+
+        // The offset word is honoured rather than assumed: it is 0x20 for every encoder seen in the
+        // wild, but reading it costs nothing and a non-standard one would otherwise decode to
+        // garbage.
+        val lengthStart = (body.take(WORD_HEX_LENGTH).hexToIntOrNull() ?: return null) * 2
+        val stringStart = lengthStart + WORD_HEX_LENGTH
+        if (stringStart > body.length) return null
+
+        val length =
+            body.substring(lengthStart, stringStart).hexToIntOrNull()?.takeIf { it > 0 }
+                ?: return null
+        val end = stringStart + length * 2
+        if (end > body.length) return null
+
+        return body
+            .substring(stringStart, end)
+            .hexToBytesOrNull()
+            ?.toString(Charsets.UTF_8)
+            ?.sanitize()
+    }
+
+    /**
+     * The reason a node states in its message, with the node's own boilerplate stripped. Some nodes
+     * put the ABI payload here rather than in `error.data`, so what is left after the prefix is
+     * offered to the decoder before being taken as prose.
+     */
+    private fun fromMessage(message: String?): String? {
+        val trimmed = message?.trim() ?: return null
+        val prefix =
+            MESSAGE_PREFIXES.firstOrNull { trimmed.startsWith(it, ignoreCase = true) }
+                ?: return null
+        val rest = trimmed.drop(prefix.length).trim()
+        return decodeErrorString(rest) ?: rest.sanitize()
+    }
+
+    /**
+     * Trims a decoded reason and rejects the ones that carry no information: an empty string, a
+     * payload longer than any genuine `require` message, or one holding control characters — which
+     * means the bytes were never UTF-8 text to begin with.
+     */
+    private fun String.sanitize(): String? =
+        trim()
+            .trim(':', '.', ' ')
+            .takeIf { it.isNotEmpty() && it.length <= MAX_REASON_LENGTH }
+            ?.takeIf { text -> text.none(Char::isISOControl) }
+
+    /** Parses a hex word as a non-negative Int, rejecting anything that cannot index a payload. */
+    private fun String.hexToIntOrNull(): Int? =
+        toLongOrNull(radix = 16)?.takeIf { it in 0..Int.MAX_VALUE.toLong() }?.toInt()
+
+    private fun String.hexToBytesOrNull(): ByteArray? {
+        if (length % 2 != 0) return null
+        return ByteArray(length / 2) { index ->
+            (substring(index * 2, index * 2 + 2).toIntOrNull(radix = 16) ?: return null).toByte()
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/EvmStatusProvider.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/EvmStatusProvider.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.api.txstatus
 
+import com.vultisig.wallet.data.api.EvmApi
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
@@ -13,10 +14,15 @@ class EvmStatusProvider @Inject constructor(private val evmApiFactory: EvmApiFac
 
     override suspend fun checkStatus(txHash: String, chain: Chain): TransactionResult =
         try {
-            val evmJson = evmApiFactory.createEvmApi(chain).getTxStatus(txHash)
-            when (evmJson?.result?.status) {
+            val api = evmApiFactory.createEvmApi(chain)
+            when (api.getTxStatus(txHash)?.result?.status) {
                 "0x1" -> TransactionResult.Confirmed
-                "0x0" -> TransactionResult.Failed("Transaction reverted")
+                // The receipt says only that it failed. Ask the chain why while the block is still
+                // fresh enough for a node to replay it — this is the one moment the answer is
+                // reliably available, and it is what lets history explain a slippage revert
+                // instead of reporting a bare failure (#5802).
+                "0x0" -> TransactionResult.Failed(api.revertReason(txHash) ?: GENERIC_REVERT_REASON)
+
                 else -> TransactionResult.Pending
             }
         } catch (e: CancellationException) {
@@ -25,4 +31,23 @@ class EvmStatusProvider @Inject constructor(private val evmApiFactory: EvmApiFac
             Timber.w(e, "EVM status check failed for %s on %s", txHash, chain)
             TransactionResult.Pending
         }
+
+    /**
+     * The revert reason, or null if it cannot be established. Contained so a failing lookup can
+     * only cost the explanation: letting it escape would turn a settled failure back into a pending
+     * row, which would then be polled forever.
+     */
+    private suspend fun EvmApi.revertReason(txHash: String): String? =
+        try {
+            getRevertReason(txHash)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.d(e, "revert reason lookup failed for %s", txHash)
+            null
+        }
+
+    private companion object {
+        const val GENERIC_REVERT_REASON = "Transaction reverted"
+    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingService.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.api.txstatus
 
+import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.api.chains.ton.TonApi
 import com.vultisig.wallet.data.api.chains.ton.tonUserFriendlyAddress
 import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackRequest
@@ -7,6 +8,7 @@ import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackResponseJson
 import com.vultisig.wallet.data.api.swapAggregators.SwapKitApi
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SwapTransactionHistoryData
+import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import java.math.BigDecimal
@@ -49,6 +51,7 @@ internal class SwapKitTrackingServiceImpl
 constructor(
     private val api: SwapKitApi,
     private val tonApi: TonApi,
+    private val evmApiFactory: EvmApiFactory,
     private val transactionHistoryRepository: TransactionHistoryRepository,
 ) : SwapKitTrackingService {
 
@@ -75,6 +78,12 @@ constructor(
                     response.fromAsset == response.toAsset
             ) {
                 resolveTonSettlement(response, broadcastHash, chain)
+            } else if (result is TransactionResult.Failed) {
+                // Layer 2: `/track` names the leg that failed, never why. On EVM the deposit tx
+                // itself can say — an aggregator's min-output check reverts with a reason — so the
+                // chain is asked before the row is retired, since a terminal row is never polled
+                // again and the block ages out of a non-archive node's state.
+                withEvmRevertReason(result, broadcastHash, chain)
             } else {
                 result
             }
@@ -84,6 +93,29 @@ constructor(
             Timber.w(e, "SwapKit /track check failed for %s on %s", broadcastHash, chain.raw)
             TransactionResult.Pending
         }
+    }
+
+    /**
+     * Replaces `/track`'s generic failure text with the deposit transaction's own revert reason
+     * when the source chain is EVM and the node still states one. A non-EVM chain, or a replay that
+     * answers nothing, leaves [failure] exactly as `/track` reported it.
+     */
+    private suspend fun withEvmRevertReason(
+        failure: TransactionResult.Failed,
+        broadcastHash: String,
+        chain: Chain,
+    ): TransactionResult {
+        if (chain.standard != TokenStandard.EVM) return failure
+        val reason =
+            try {
+                evmApiFactory.createEvmApi(chain).getRevertReason(broadcastHash)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.d(e, "revert reason lookup failed for %s on %s", broadcastHash, chain.raw)
+                null
+            }
+        return reason?.let(TransactionResult::Failed) ?: failure
     }
 
     /**

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiRevertReasonTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/EvmApiRevertReasonTest.kt
@@ -1,0 +1,159 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import io.ktor.http.HttpStatusCode
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers the `eth_call` replay behind [EvmApi.getRevertReason] (#5802).
+ *
+ * A receipt only carries a pass/fail bit, so the reason a swap reverted has to be read back by
+ * replaying the transaction. These tests pin what the replay sends — the transaction's own fields,
+ * at its own block — and that a node with nothing useful to say leaves the reason unknown rather
+ * than inventing one.
+ */
+class EvmApiRevertReasonTest {
+
+    private val txHash = "0x7d71f95c095a79b26aae0dd1b602c5d62b848959976233d2a5b7717891fe2b13"
+    private val sender = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1"
+    private val router = "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE"
+
+    /** `Error(string)` carrying LI.FI's min-output revert, as the LiFiDiamond emits it. */
+    private val insufficientOutput =
+        "0x08c379a0" +
+            "0000000000000000000000000000000000000000000000000000000000000020" +
+            "0000000000000000000000000000000000000000000000000000000000000013" +
+            "496e73756666696369656e74206f757470757400000000000000000000000000"
+
+    private val minedTx =
+        """
+        {"jsonrpc":"2.0","id":1,"result":{
+          "from":"$sender","to":"$router","input":"0x12aa3caf","value":"0x0",
+          "gas":"0x53e2b","blockNumber":"0x18a5f0d"
+        }}
+        """
+            .trimIndent()
+
+    private fun api(client: io.ktor.client.HttpClient) =
+        EvmApiImp(client, "https://api.vultisig.com/eth/", Chain.Ethereum)
+
+    @Test
+    fun `decodes the revert reason a replay reports`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val client =
+            MockHttpClient.capturingRequestSequence(
+                capture,
+                HttpStatusCode.OK to minedTx,
+                HttpStatusCode.OK to
+                    """{"jsonrpc":"2.0","id":1,"error":{"code":3,
+                       "message":"execution reverted","data":"$insufficientOutput"}}""",
+            )
+
+        assertEquals("Insufficient output", api(client).getRevertReason(txHash))
+    }
+
+    @Test
+    fun `replays the transaction's own fields at its own block`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val client =
+            MockHttpClient.capturingRequestSequence(
+                capture,
+                HttpStatusCode.OK to minedTx,
+                HttpStatusCode.OK to
+                    """{"jsonrpc":"2.0","id":1,"error":{"code":3,
+                       "message":"execution reverted: Insufficient output"}}""",
+            )
+
+        api(client).getRevertReason(txHash)
+
+        val lookup = capture.bodies.first()
+        assertTrue(lookup.contains("eth_getTransactionByHash"), lookup)
+        assertTrue(lookup.contains(txHash), lookup)
+
+        val replay = capture.bodies.last()
+        assertTrue(replay.contains("eth_call"), replay)
+        assertTrue(replay.contains(sender), replay)
+        assertTrue(replay.contains(router), replay)
+        assertTrue(replay.contains("0x12aa3caf"), replay)
+        assertTrue(replay.contains("0x53e2b"), replay)
+        // The block that mined it, not its predecessor: an approval in the same block has to be
+        // visible or the replay reports an allowance failure instead of the real reason.
+        assertTrue(replay.contains("0x18a5f0d"), replay)
+    }
+
+    @Test
+    fun `a node that only says it reverted yields no reason`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val client =
+            MockHttpClient.capturingRequestSequence(
+                capture,
+                HttpStatusCode.OK to minedTx,
+                HttpStatusCode.OK to
+                    """{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"execution reverted"}}""",
+            )
+
+        assertNull(api(client).getRevertReason(txHash))
+    }
+
+    @Test
+    fun `a replay that succeeds yields no reason`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val client =
+            MockHttpClient.capturingRequestSequence(
+                capture,
+                HttpStatusCode.OK to minedTx,
+                HttpStatusCode.OK to """{"jsonrpc":"2.0","id":1,"result":"0x"}""",
+            )
+
+        assertNull(api(client).getRevertReason(txHash))
+    }
+
+    /**
+     * A node too far behind to hold the block's state has no reason to give — and must not throw.
+     */
+    @Test
+    fun `a replay the node refuses yields no reason`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val client =
+            MockHttpClient.capturingRequestSequence(
+                capture,
+                HttpStatusCode.OK to minedTx,
+                HttpStatusCode.InternalServerError to
+                    """{"jsonrpc":"2.0","id":1,"error":{"code":-32000,
+                       "message":"missing trie node"}}""",
+            )
+
+        assertNull(api(client).getRevertReason(txHash))
+    }
+
+    @Test
+    fun `a transaction still in the mempool is not replayed`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val client =
+            MockHttpClient.capturingRequestSequence(
+                capture,
+                HttpStatusCode.OK to
+                    """{"jsonrpc":"2.0","id":1,"result":{
+                       "from":"$sender","to":"$router","input":"0x12aa3caf","blockNumber":null}}""",
+            )
+
+        assertNull(api(client).getRevertReason(txHash))
+        assertEquals(1, capture.bodies.size)
+    }
+
+    @Test
+    fun `an unknown transaction hash yields no reason`() = runTest {
+        val client =
+            MockHttpClient.respondingWith(
+                HttpStatusCode.OK,
+                """{"jsonrpc":"2.0","id":1,"result":null}""",
+            )
+
+        assertNull(api(client).getRevertReason(txHash))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/EvmRevertReasonTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/EvmRevertReasonTest.kt
@@ -1,0 +1,167 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the revert-reason decoder against the shapes real nodes answer an `eth_call` replay with.
+ *
+ * The payloads are genuine `Error(string)` encodings — selector, offset word, length word, then the
+ * UTF-8 bytes right-padded to a word — for the two reverts #5802 is about: LI.FI's "Insufficient
+ * output" and 1inch/Kyber's "Return amount is not enough".
+ */
+class EvmRevertReasonTest {
+
+    /** Wraps a bare hex payload the way a node's `error.data` carries it. */
+    private fun decode(message: String?, data: String? = null): String? =
+        EvmRevertReason.decode(message, data?.let(::JsonPrimitive))
+
+    private val insufficientOutput =
+        "0x08c379a0" +
+            "0000000000000000000000000000000000000000000000000000000000000020" +
+            "0000000000000000000000000000000000000000000000000000000000000013" +
+            "496e73756666696369656e74206f757470757400000000000000000000000000"
+
+    private val returnAmountNotEnough =
+        "0x08c379a0" +
+            "0000000000000000000000000000000000000000000000000000000000000020" +
+            "000000000000000000000000000000000000000000000000000000000000001b" +
+            "52657475726e20616d6f756e74206973206e6f7420656e6f7567680000000000"
+
+    @Test
+    fun `decodes an Error(string) payload from error data`() {
+        assertEquals(
+            "Insufficient output",
+            decode(message = "execution reverted", data = insufficientOutput),
+        )
+    }
+
+    @Test
+    fun `decodes the 1inch min-return payload`() {
+        assertEquals(
+            "Return amount is not enough",
+            decode(message = null, data = returnAmountNotEnough),
+        )
+    }
+
+    @Test
+    fun `reads the payload out of a nested error data object`() {
+        val nested = Json.parseToJsonElement("""{"data":"$insufficientOutput","code":3}""")
+
+        assertEquals("Insufficient output", EvmRevertReason.decode(message = null, data = nested))
+    }
+
+    @Test
+    fun `reads the payload out of a wrapped originalError`() {
+        val wrapped =
+            Json.parseToJsonElement("""{"originalError":{"data":"$insufficientOutput"}}""")
+
+        assertEquals("Insufficient output", EvmRevertReason.decode(message = null, data = wrapped))
+    }
+
+    @Test
+    fun `falls back to the message when the node sends no payload`() {
+        assertEquals(
+            "Insufficient output",
+            decode(message = "execution reverted: Insufficient output", data = null),
+        )
+    }
+
+    @Test
+    fun `decodes a payload the node put in the message instead of the data`() {
+        assertEquals(
+            "Insufficient output",
+            decode(message = "execution reverted: $insufficientOutput", data = null),
+        )
+    }
+
+    @Test
+    fun `strips a ganache-style revert prefix`() {
+        assertEquals(
+            "Return amount is not enough",
+            decode(
+                message =
+                    "VM Exception while processing transaction: revert Return amount is not enough",
+                data = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `a payload beats a message that only says it reverted`() {
+        assertEquals(
+            "Insufficient output",
+            EvmRevertReason.decode(
+                message = "execution reverted",
+                data = JsonPrimitive(insufficientOutput),
+            ),
+        )
+    }
+
+    @Test
+    fun `a bare execution reverted carries no reason`() {
+        assertNull(decode(message = "execution reverted", data = null))
+        assertNull(decode(message = "execution reverted:", data = null))
+    }
+
+    /**
+     * An `eth_call` that fails for its own reasons — no archive state for the block, a rate limit —
+     * is not a revert reason. Storing one would put "missing trie node" where an explanation of the
+     * user's failed swap belongs.
+     */
+    @Test
+    fun `an unrelated RPC error is not read as a revert reason`() {
+        assertNull(
+            decode(
+                message = "missing trie node 0xabc (path ) state 0xdef is not available",
+                data = null,
+            )
+        )
+        assertNull(decode(message = "rate limit exceeded", data = null))
+    }
+
+    @Test
+    fun `null and blank inputs decode to null`() {
+        assertNull(decode(message = null, data = null))
+        assertNull(decode(message = "   ", data = ""))
+    }
+
+    @Test
+    fun `a non-Error selector is left alone`() {
+        // Panic(uint256) with code 0x11 (arithmetic overflow) — no string to recover.
+        val panic =
+            "0x4e487b71" + "0000000000000000000000000000000000000000000000000000000000000011"
+
+        assertNull(decode(message = "execution reverted", data = panic))
+    }
+
+    @Test
+    fun `a truncated payload decodes to null rather than throwing`() {
+        assertNull(decode(message = "execution reverted", data = insufficientOutput.take(40)))
+    }
+
+    @Test
+    fun `a length longer than the payload decodes to null`() {
+        val overlong =
+            "0x08c379a0" +
+                "0000000000000000000000000000000000000000000000000000000000000020" +
+                "00000000000000000000000000000000000000000000000000000000000000ff" +
+                "496e73756666696369656e74206f757470757400000000000000000000000000"
+
+        assertNull(decode(message = null, data = overlong))
+    }
+
+    @Test
+    fun `bytes that are not text decode to null`() {
+        val binary =
+            "0x08c379a0" +
+                "0000000000000000000000000000000000000000000000000000000000000020" +
+                "0000000000000000000000000000000000000000000000000000000000000004" +
+                "0001020300000000000000000000000000000000000000000000000000000000"
+
+        assertNull(decode(message = null, data = binary))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/EvmStatusProviderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/EvmStatusProviderTest.kt
@@ -1,0 +1,88 @@
+package com.vultisig.wallet.data.api.txstatus
+
+import com.vultisig.wallet.data.api.EvmApi
+import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.api.models.EvmRpcResponseJson
+import com.vultisig.wallet.data.api.models.EvmTxStatusJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * A reverted EVM receipt has to arrive at history carrying *why* it reverted, not just that it did
+ * (#5802) — the reason is what later lets a min-output failure be explained as a price move rather
+ * than reported as a bare error.
+ */
+class EvmStatusProviderTest {
+
+    private val evmApi: EvmApi = mockk()
+    private val factory: EvmApiFactory = mockk { every { createEvmApi(any()) } returns evmApi }
+    private val provider = EvmStatusProvider(factory)
+
+    private fun stubReceipt(status: String?) {
+        coEvery { evmApi.getTxStatus(any()) } returns
+            EvmRpcResponseJson(
+                id = 1,
+                result = status?.let { EvmTxStatusJson(status = it) },
+                error = null,
+            )
+    }
+
+    @Test
+    fun `a successful receipt is Confirmed and asks for no reason`() = runTest {
+        stubReceipt("0x1")
+
+        assertEquals(TransactionResult.Confirmed, provider.checkStatus("0xh", Chain.Ethereum))
+        coVerify(exactly = 0) { evmApi.getRevertReason(any()) }
+    }
+
+    @Test
+    fun `a reverted receipt carries the reason read back from the chain`() = runTest {
+        stubReceipt("0x0")
+        coEvery { evmApi.getRevertReason("0xh") } returns "Insufficient output"
+
+        assertEquals(
+            TransactionResult.Failed("Insufficient output"),
+            provider.checkStatus("0xh", Chain.Ethereum),
+        )
+    }
+
+    @Test
+    fun `a reverted receipt the node will not explain keeps the generic reason`() = runTest {
+        stubReceipt("0x0")
+        coEvery { evmApi.getRevertReason("0xh") } returns null
+
+        assertEquals(
+            TransactionResult.Failed("Transaction reverted"),
+            provider.checkStatus("0xh", Chain.Ethereum),
+        )
+    }
+
+    @Test
+    fun `a receipt the node has not seen yet stays Pending`() = runTest {
+        stubReceipt(null)
+
+        assertEquals(TransactionResult.Pending, provider.checkStatus("0xh", Chain.Ethereum))
+    }
+
+    /**
+     * A reason lookup that blows up must cost only the explanation. Letting it escape would turn a
+     * settled failure back into a pending row, which the poller would then never stop retrying.
+     */
+    @Test
+    fun `a failing reason lookup still reports the revert`() = runTest {
+        stubReceipt("0x0")
+        coEvery { evmApi.getRevertReason("0xh") } throws RuntimeException("boom")
+
+        assertEquals(
+            TransactionResult.Failed("Transaction reverted"),
+            provider.checkStatus("0xh", Chain.Ethereum),
+        )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/txstatus/SwapKitTrackingServiceTest.kt
@@ -1,5 +1,7 @@
 package com.vultisig.wallet.data.api.txstatus
 
+import com.vultisig.wallet.data.api.EvmApi
+import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.api.chains.ton.TonApi
 import com.vultisig.wallet.data.api.chains.ton.TonJettonTransfer
 import com.vultisig.wallet.data.api.models.quotes.SwapKitTrackRequest
@@ -16,6 +18,8 @@ import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import java.math.BigInteger
@@ -34,10 +38,14 @@ class SwapKitTrackingServiceTest {
 
     private val api: SwapKitApi = mockk()
     private val tonApi: TonApi = mockk()
+    private val evmApi: EvmApi = mockk()
+    private val evmApiFactory: EvmApiFactory = mockk {
+        every { createEvmApi(any()) } returns evmApi
+    }
     private val transactionHistoryRepository: TransactionHistoryRepository = mockk()
 
     private fun service(): SwapKitTrackingService =
-        SwapKitTrackingServiceImpl(api, tonApi, transactionHistoryRepository)
+        SwapKitTrackingServiceImpl(api, tonApi, evmApiFactory, transactionHistoryRepository)
 
     private val userAddress = "UQuser000000000000000000000000000000000000000000user"
     private val escrow = "EQAbWJ3Y1HgIIvcMq1prG1anlDC0T3cZlAU7luPT6LmTpvbJ"
@@ -146,6 +154,44 @@ class SwapKitTrackingServiceTest {
     fun `untrackable chain returns Pending without hitting the API`() = runTest {
         service().checkSettlementStatus("0xbroadcast", Chain.Polkadot) shouldBe
             TransactionResult.Pending
+    }
+
+    @Test
+    fun `an EVM failure is explained with the deposit transaction's own revert reason`() = runTest {
+        coEvery { api.track(any()) } returns SwapKitTrackResponseJson(trackingStatus = "reverted")
+        coEvery { evmApi.getRevertReason("0xbroadcast") } returns "Insufficient output"
+
+        service().checkSettlementStatus("0xbroadcast", Chain.Ethereum) shouldBe
+            TransactionResult.Failed("Insufficient output")
+    }
+
+    /** `/track` said it failed; the chain has nothing to add. The row keeps what `/track` said. */
+    @Test
+    fun `an unexplained EVM failure keeps the tracking reason`() = runTest {
+        coEvery { api.track(any()) } returns SwapKitTrackResponseJson(trackingStatus = "reverted")
+        coEvery { evmApi.getRevertReason("0xbroadcast") } returns null
+
+        service().checkSettlementStatus("0xbroadcast", Chain.Ethereum) shouldBe
+            TransactionResult.Failed("SwapKit failed: reverted")
+    }
+
+    @Test
+    fun `a reason lookup that throws leaves the failure intact`() = runTest {
+        coEvery { api.track(any()) } returns SwapKitTrackResponseJson(trackingStatus = "reverted")
+        coEvery { evmApi.getRevertReason(any()) } throws RuntimeException("boom")
+
+        service().checkSettlementStatus("0xbroadcast", Chain.Ethereum) shouldBe
+            TransactionResult.Failed("SwapKit failed: reverted")
+    }
+
+    /** Only an EVM deposit can be replayed; a Solana failure must not reach for an EVM node. */
+    @Test
+    fun `a non-EVM failure is left alone`() = runTest {
+        coEvery { api.track(any()) } returns SwapKitTrackResponseJson(trackingStatus = "failed")
+
+        service().checkSettlementStatus("sig", Chain.Solana) shouldBe
+            TransactionResult.Failed("SwapKit failed: failed")
+        coVerify(exactly = 0) { evmApi.getRevertReason(any()) }
     }
 
     @Test


### PR DESCRIPTION
## Problem

A swap that reverts on-chain reaches history as a bare **Error**. That says nothing the user can act on — and the distinction matters: a minimum-output revert means the price moved and the swap is worth retrying with more slippage, while most other failures are not fixed by retrying at all. In #5728 the user retried three times and paid gas each time.

## Root cause

Android had no reason to explain from. A reverted EVM receipt was stored as the literal string `"Transaction reverted"`, and a SwapKit-routed one as `"SwapKit failed: reverted"` — neither is the chain's answer. The `failureReason` column was also never rendered anywhere: `TransactionStatusUiModel.Failed` carried it, but only `Refunded` had a surface that showed it.

So unlike iOS (ios#5314), which only needed a presentation mapping, Android needed the reason captured first.

## Implementation

**Read the reason back.** A receipt carries only a pass/fail bit, so `EvmApi.getRevertReason` replays the transaction with `eth_call` and decodes the `Error(string)` payload. Two details that are not incidental:

- The replay runs **at the transaction's own block**, not its predecessor. A swap whose approval leg landed in the same block would otherwise replay without that approval and report an allowance failure instead of the real reason.
- It runs **at the moment the row goes terminal**, while a non-archive node still holds that block's state. Verified the hard way: replaying the receipt from #5728 today returns *"Archive requests require a personal token."*

`EvmRevertReason` handles the shapes real nodes answer with — the payload in `error.data` as a hex string, nested under `data`, or under `originalError.data`; and the prose forms in `error.message`. It refuses to read an unrelated RPC error (`missing trie node`, a rate limit) as a revert reason.

**Both status paths are covered:** `EvmStatusProvider` for direct routes, and `SwapKitTrackingService` for `/track`-gated ones — the latter being the path the #5728 LI.FI receipt actually takes.

**Explain it.** `TransactionFailureExplanation` maps the reason to copy, rendered on the history card, in the detail sheet, and on the keysign done screen. The done screen is included deliberately: it is where the retry decision is made, so explaining the failure only in history would leave the reported loop intact.

An unrecognised reason is **not** shown raw. That column also holds the app's own internal text, which is no more useful to a user than "Error" already is.

Strings added to all 10 locales, each using that locale's established slippage term (`proklizavanje` in hr, `슬리피지 허용 범위` in ko) rather than a literal translation.

## Known limitation

SwapKit's 1inch route calls **SKWrapGeneric** (`0x9025b8ff…`), which swallows the router's revert and re-reverts with a generic `"Swap failed"`. Confirmed on a live receipt during testing — that string is absent from SKWrapGeneric's own bytecode, so it is bubbled up from the contract it calls, with the original cause gone.

`"Swap failed"` carries no evidence of slippage — it also covers allowance problems, expired deadlines and dead routes — so it is deliberately left unexplained. Claiming otherwise would send the user to raise slippage for a failure that is not slippage, which is the exact harm this issue is about. Those swaps still improve: the row now stores the chain's own words instead of `"SwapKit failed: reverted"`.

Explaining that path needs a different signal (comparing the quote's `minAmountOut` against the realised price) and is worth its own ticket.

## Design note

The Figma file has **no failed/error state** for the transaction history card — the component set covers only *Successful* and *In progress…*. The existing "Error" label is already beyond the design. This follows the shipped iOS/Windows behaviour and Android's own error tokens. On the card the failure line is lifted clear of the provider badge by a clearance derived from that badge's own geometry, since the badge is anchored over the card's bottom-end corner and overhangs its padding.

## Test plan

- `:data:testDebugUnitTest` — 3541 tests, 39 skipped, **0 failures**
- `:app:testDebugUnitTest` — 2375 tests, 8 skipped, **0 failures**
- New coverage, verified from the XML reports rather than the build result (JUnit 5 silently skips a non-`Unit` `@Test`): `EvmRevertReasonTest` 15, `SwapKitTrackingServiceTest` 17, `EvmApiRevertReasonTest` 7, `EvmStatusProviderTest` 5, `TransactionFailureExplanationTest` 8, `TransactionHistoryViewModelTest` 26 — **78 tests, 0 skipped**
- `:app:lintDebug` clean, `ktfmtCheck` clean, `compileDebugAndroidTestKotlin` green in both modules
- Decoder verified against a live receipt: a Base swap that reverted in testing was replayed through the exact `eth_call` this PR makes, and the payload decoded to the chain's actual string

One behaviour worth a reviewer's eye: a reason lookup that throws must not downgrade a settled failure back to `Pending`, or the poller would retry it forever. `EvmStatusProviderTest` pins this.

Closes #5802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Failed transactions now display clearer explanations, including slippage-related guidance.
  * EVM transaction failures can show the underlying on-chain revert reason when available.
  * Refund and failure messages use consistent, color-coded banners.
  * Added localized slippage-failure messaging across supported languages.

* **Bug Fixes**
  * Failed transactions now retain meaningful failure details instead of relying solely on generic messages.

* **Tests**
  * Added coverage for revert-reason detection, failure explanations, fallbacks, and transaction status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->