### PR TITLE
fix(cardano): carry native-token data through the keysign payload

### DIFF
--- a/app/src/androidTest/assets/cardano.json
+++ b/app/src/androidTest/assets/cardano.json
@@ -68,5 +68,48 @@
       "lib_type": "DKLS"
     },
     "expected_image_hash": ["c2a0b05a7a8cc1746555b54d136810f10d4c1609c6897f70a009a1807fc7c9b9"]
+  },
+  {
+    "name": "Send SNEK - native token",
+    "keysign_payload": {
+      "coin": {
+        "chain": "Cardano",
+        "ticker": "SNEK",
+        "address": "addr1v9g9wnzsutrxt7vcg4efdfwhagwh3x2f6hjwykk7acdpsfgyt4h2j",
+        "decimals": 0,
+        "price_provider_id": "snek",
+        "contract_address": "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f.534e454b",
+        "is_native_token": false,
+        "hex_public_key": "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5",
+        "logo": "snek.png"
+      },
+      "to_address": "addr1v9g9wnzsutrxt7vcg4efdfwhagwh3x2f6hjwykk7acdpsfgyt4h2j",
+      "to_amount": "1000000",
+      "BlockchainSpecific": {
+        "CardanoSpecific": {
+          "byte_fee": 200000,
+          "send_max_amount": false,
+          "ttl": 190000000
+        }
+      },
+      "utxo_info": [
+        {
+          "hash": "f074134aabbfb13b8aec7cf5465b1e5a862d1cadc175d431c1d9339150db8a1d",
+          "amount": 10000000,
+          "index": 0,
+          "cardano_tokens": [
+            {
+              "policy_id": "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f",
+              "asset_name_hex": "534e454b",
+              "amount": "2500000"
+            }
+          ]
+        }
+      ],
+      "SwapPayload": null,
+      "vault_public_key_ecdsa": "75be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf4ecd1ed9e645d5",
+      "lib_type": "DKLS"
+    },
+    "expected_image_hash": ["5ad62be071e80c4e617487831d35be6f1fc0fff46aeca43b41164ccc36190c8a"]
   }
 ]

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModelExtension.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModelExtension.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.blockchain
 
+// Explicit imports win over the same-package corpus models of the same name.
 import BlockchainSpecific
 import Coin
 import KeysignPayload
@@ -16,6 +17,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
 import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.models.proto.v1.SignDirectProto
 import com.vultisig.wallet.data.models.proto.v1.SignSolanaProto
@@ -41,8 +43,20 @@ fun KeysignPayload.toInternalKeySignPayload():
         toAmount = this.toAmount.toBigInteger(),
         blockChainSpecific = this.blockchainSpecific.toBlockChainSpecific(coin, this.toAddress),
         utxos =
-            this.utxoInfo?.map {
-                UtxoInfo(hash = it.hash, amount = it.amount, index = it.index.toUInt())
+            this.utxoInfo?.map { utxo ->
+                UtxoInfo(
+                    hash = utxo.hash,
+                    amount = utxo.amount,
+                    index = utxo.index.toUInt(),
+                    cardanoTokens =
+                        utxo.cardanoTokens.orEmpty().map { asset ->
+                            CardanoTokenAsset(
+                                policyId = asset.policyId,
+                                assetNameHex = asset.assetNameHex,
+                                amount = asset.amount.toBigInteger(),
+                            )
+                        },
+                )
             } ?: emptyList(),
         signAmino =
             this.signData?.signAmino?.let {

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModels.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelperModels.kt
@@ -214,7 +214,21 @@ data class IbcDenomTrace(
     val height: String,
 )
 
-@Serializable data class UtxoInfo(val hash: String, val index: Long, val amount: Long)
+@Serializable
+data class UtxoInfo(
+    val hash: String,
+    val index: Long,
+    val amount: Long,
+    /** Cardano-only native assets on this UTxO; absent for every other UTXO chain. */
+    @SerialName("cardano_tokens") val cardanoTokens: List<CardanoTokenAsset>? = null,
+)
+
+@Serializable
+data class CardanoTokenAsset(
+    @SerialName("policy_id") val policyId: String,
+    @SerialName("asset_name_hex") val assetNameHex: String,
+    val amount: String,
+)
 
 @Serializable
 data class SignData(

--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -45,6 +45,7 @@ import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
 import vultisig.keysign.v1.SignSui
 import vultisig.keysign.v1.SignTon
@@ -885,9 +886,9 @@ class ChainHelpersTest {
             // fee: it must cover Cardano's fixed minimum (minFeeB = 155_381 lovelace).
             val derivedFee =
                 CardanoHelper.estimateFee(
-                    toAmount = internalPayload.toAmount.toLong(),
+                    coin = internalPayload.coin,
+                    toAmount = internalPayload.toAmount,
                     toAddress = internalPayload.toAddress,
-                    changeAddress = internalPayload.coin.address,
                     sendMaxAmount = cardano.sendMaxAmount,
                     ttl = cardano.ttl.toLong(),
                     utxos = internalPayload.utxos,
@@ -899,6 +900,40 @@ class ChainHelpersTest {
                 derivedFee >= 155_381,
             )
         }
+    }
+
+    /**
+     * The native-asset bundle has to land in the signed bytes, not merely on the payload. Changing
+     * the token quantity must move the sighash; a body that hashed the same either dropped the
+     * bundle or planned the send as plain ADA, which is what would move ADA under the token's
+     * label.
+     */
+    @Test
+    fun cardanoTokenBundleReachesTheSighash() {
+        val transactions: List<TransactionData> = loadTransactionData(CARDANO_JSON_FILE)
+        val tokenPayload =
+            transactions
+                .map { it.keysignPayload.toInternalKeySignPayload() }
+                .firstOrNull { !it.coin.isNativeToken }
+        if (tokenPayload == null) {
+            fail("cardano.json carries no native-token case")
+            return
+        }
+
+        // The input the planner spends declares what it holds, so the body can conserve it.
+        assertTrue(tokenPayload.utxos.any { it.cardanoTokens.isNotEmpty() })
+
+        val hash = CardanoHelper.getPreSignedImageHash(tokenPayload)
+        assertTrue(
+            "Expected 64-char hex hash but got: ${hash[0]}",
+            hash[0].matches(Regex("[0-9a-f]{64}")),
+        )
+
+        val doubled =
+            CardanoHelper.getPreSignedImageHash(
+                tokenPayload.copy(toAmount = tokenPayload.toAmount * BigInteger.valueOf(2))
+            )
+        assertNotEquals(hash, doubled)
     }
 
     @Test
@@ -1135,7 +1170,7 @@ class ChainHelpersTest {
         // preserving the cross-signer agreement required by #5421 and vultisig-sdk#1585.
         // -3: kujira.json, dropped with the chain — the other corpora still carry it, so the sync
         // check reports it as missing here rather than as a hash disagreement.
-        private const val EXPECTED_CASE_COUNT = 85
+        private const val EXPECTED_CASE_COUNT = 86
 
         private const val HEX_PUBLIC_KEY =
             "023e4b76861289ad4528b33c2fd21b3a5160cd37b3294234914e21efb6ed4a452b"

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -261,18 +261,6 @@ internal class DefaultSendStrategy(
                         }
                     }
 
-                    if (chain == Chain.Cardano && !selectedToken.isNativeToken) {
-                        // A CNT send needs a native-asset bundle in the signing input, which
-                        // CardanoHelper does not build yet (#5713). Without this the transfer
-                        // would be planned as plain ADA and move ADA under the token's label.
-                        throw InvalidTransactionDataException(
-                            UiText.FormattedText(
-                                R.string.send_error_cardano_native_token_unsupported,
-                                listOf(selectedToken.ticker),
-                            )
-                        )
-                    }
-
                     val isThorchainRouterDeposit =
                         defiTypeProvider() == DeFiNavActions.ADD_LP &&
                             !selectedToken.isNativeToken &&

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -416,10 +416,16 @@ internal class DefaultSendStrategy(
                             // broadcast. A Cardano native-token send also pins its recipient
                             // output to CardanoHelper.MIN_LOVELACE_ON_TOKEN_OUTPUT, so that floor
                             // must be reserved on top of the fee or WalletCore's planner rejects
-                            // the plan mid-keysign instead of here.
+                            // the plan mid-keysign instead of here. Cardano's fee is read from
+                            // `specific`, not `spendableGasFee`: it was just re-planned by
+                            // getSpecific() for this exact send and can differ from the earlier
+                            // validation-step estimate.
                             val requiredNativeValue =
                                 if (chain == Chain.Cardano) {
-                                    spendableGasFee.value +
+                                    val cardanoByteFee =
+                                        (specific.blockChainSpecific as? BlockChainSpecific.Cardano)
+                                            ?.byteFee ?: error("Cardano-specific fee is missing")
+                                    BigInteger.valueOf(cardanoByteFee) +
                                         BigInteger.valueOf(
                                             CardanoHelper.MIN_LOVELACE_ON_TOKEN_OUTPUT
                                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.snapshots.Snapshot
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.blockchain.cosmos.TerraClassicTax
 import com.vultisig.wallet.data.blockchain.tron.TRON_STAKING_MEMO_REGEX
+import com.vultisig.wallet.data.chains.helpers.CardanoHelper
 import com.vultisig.wallet.data.chains.helpers.RippleDestinationTag
 import com.vultisig.wallet.data.models.Account
 import com.vultisig.wallet.data.models.Chain
@@ -407,18 +408,32 @@ internal class DefaultSendStrategy(
                                     listOf(selectedToken.ticker),
                                 )
                             )
-                        } else if (nativeTokenValue < spendableGasFee.value) {
+                        } else {
                             // Gate on the fee this send actually pays, not the base gas fee:
                             // raised Advanced Gas Settings are what an ERC-20 transfer reserves,
                             // so checking the unraised value would let a native balance that
                             // cannot cover them through to a full MPC keysign that only fails at
-                            // broadcast.
-                            throw InvalidTransactionDataException(
-                                UiText.FormattedText(
-                                    R.string.insufficient_native_token,
-                                    listOf(nativeTokenAccount.token.ticker),
+                            // broadcast. A Cardano native-token send also pins its recipient
+                            // output to CardanoHelper.MIN_LOVELACE_ON_TOKEN_OUTPUT, so that floor
+                            // must be reserved on top of the fee or WalletCore's planner rejects
+                            // the plan mid-keysign instead of here.
+                            val requiredNativeValue =
+                                if (chain == Chain.Cardano) {
+                                    spendableGasFee.value +
+                                        BigInteger.valueOf(
+                                            CardanoHelper.MIN_LOVELACE_ON_TOKEN_OUTPUT
+                                        )
+                                } else {
+                                    spendableGasFee.value
+                                }
+                            if (nativeTokenValue < requiredNativeValue) {
+                                throw InvalidTransactionDataException(
+                                    UiText.FormattedText(
+                                        R.string.insufficient_native_token,
+                                        listOf(nativeTokenAccount.token.ticker),
+                                    )
                                 )
-                            )
+                            }
                         }
                     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -887,7 +887,6 @@
     <string name="tx_done_transaction_details_collapse">Reduzieren</string>
     <string name="vault_confirmation_vault_upgraded">Tresor aktualisiert</string>
     <string name="this_amount_would_leave_too_little_change">Bei diesem Betrag bleibt zu wenig Wechselgeld übrig. 💡 Versuchen Sie „Max. senden“ (%1$s ADA), um dieses Problem zu vermeiden.</string>
-    <string name="send_error_cardano_native_token_unsupported">Das Senden von %1$s wird noch nicht unterstützt. Cardano-Native-Tokens können gehalten und verfolgt, aber nicht gesendet werden.</string>
     <string name="swap_form_native">Native</string>
     <string name="swap_transaction_overview_approval_tx_hash">Genehmigungs-Tx-Hash</string>
     <string name="swap_transaction_overview_track">Tracking</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -885,7 +885,6 @@
     <string name="tx_done_transaction_details_collapse">Contraer</string>
     <string name="vault_confirmation_vault_upgraded">Bóveda mejorada</string>
     <string name="this_amount_would_leave_too_little_change">Con este importe, quedaría muy poco cambio. 💡 Prueba \"Enviar Máximo\" (%1$s ADA) para evitar este problema.</string>
-    <string name="send_error_cardano_native_token_unsupported">El envío de %1$s aún no está soportado. Los tokens nativos de Cardano se pueden mantener y seguir, pero no enviar.</string>
     <string name="swap_form_native">Nativo</string>
     <string name="swap_transaction_overview_approval_tx_hash">Hash de transacción de aprobación</string>
     <string name="swap_transaction_overview_track">Seguimiento</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -888,7 +888,6 @@
     <string name="tx_done_transaction_details_collapse">Sažmi</string>
     <string name="vault_confirmation_vault_upgraded">Trezor nadograđen</string>
     <string name="this_amount_would_leave_too_little_change">Ovaj iznos bi ostavio premalo kusura. 💡 Pokušajte s \'Pošalji maksimum\' (%1$s ADA) kako biste izbjegli ovaj problem.</string>
-    <string name="send_error_cardano_native_token_unsupported">Slanje %1$s još nije podržano. Cardano izvorni tokeni mogu se držati i pratiti, ali ne i slati.</string>
     <string name="swap_form_native">Izvorno</string>
     <string name="swap_transaction_overview_approval_tx_hash">Odobrenje Tx Hash</string>
     <string name="swap_transaction_overview_track">Praćenje</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -885,7 +885,6 @@
     <string name="tx_done_transaction_details_collapse">Riduci</string>
     <string name="vault_confirmation_vault_upgraded">Vault aggiornato</string>
     <string name="this_amount_would_leave_too_little_change">Questo importo lascerebbe troppo poco resto. 💡 Prova \"Invia Massimo\" (%1$s ADA) per evitare questo problema.</string>
-    <string name="send_error_cardano_native_token_unsupported">L\'invio di %1$s non è ancora supportato. I token nativi di Cardano possono essere detenuti e monitorati, ma non inviati.</string>
     <string name="swap_form_native">Nativo</string>
     <string name="swap_transaction_overview_approval_tx_hash">Hash di approvazione</string>
     <string name="swap_transaction_overview_track">Traccia</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1244,7 +1244,6 @@
     <string name="insufficient_balance_try_send">잔액이 부족합니다. \'최대 보내기\'로 %1$s ADA를 보내보세요.</string>
     <string name="insufficient_balance_ada">잔액 부족 (%1$s ADA). 이 거래를 완료하려면 더 많은 ADA가 필요합니다.</string>
     <string name="this_amount_would_leave_too_little_change">이 금액은 거스름돈이 너무 적게 남습니다. \'최대 보내기\' (%1$s ADA)를 사용해 보세요.</string>
-    <string name="send_error_cardano_native_token_unsupported">%1$s 전송은 아직 지원되지 않습니다. Cardano 네이티브 토큰은 보유 및 추적만 가능하며 전송할 수 없습니다.</string>
     <string name="swap_form_native">네이티브</string>
     <string name="swap_transaction_overview_approval_tx_hash">승인 Tx 해시</string>
     <string name="swap_transaction_overview_track">추적</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -882,7 +882,6 @@
     <string name="tx_done_transaction_details_collapse">Samenvouwen</string>
     <string name="vault_confirmation_vault_upgraded">Vault geüpgraded</string>
     <string name="this_amount_would_leave_too_little_change">Dit bedrag zou te weinig wisselgeld opleveren. 💡 Probeer \'Send Max\' (%1$s ADA) om dit probleem te voorkomen.</string>
-    <string name="send_error_cardano_native_token_unsupported">Het verzenden van %1$s wordt nog niet ondersteund. Cardano native tokens kunnen worden aangehouden en gevolgd, maar niet verzonden.</string>
     <string name="swap_form_native">Native</string>
     <string name="swap_transaction_overview_approval_tx_hash">Goedkeuring Tx Hash</string>
     <string name="swap_transaction_overview_track">Spoor</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -884,7 +884,6 @@
     <string name="tx_done_transaction_details_collapse">Recolher</string>
     <string name="vault_confirmation_vault_upgraded">Cofre atualizado</string>
     <string name="this_amount_would_leave_too_little_change">Este valor deixaria muito pouco troco. 💡 Experimente \"Enviar Máximo\" (%1$s ADA) para evitar este problema.</string>
-    <string name="send_error_cardano_native_token_unsupported">O envio de %1$s ainda não é suportado. Os tokens nativos de Cardano podem ser mantidos e acompanhados, mas não enviados.</string>
     <string name="swap_form_native">Nativo</string>
     <string name="swap_transaction_overview_approval_tx_hash">Hash de Transação de Aprovação</string>
     <string name="swap_transaction_overview_track">Rastrear</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -886,7 +886,6 @@
     <string name="tx_done_transaction_details_collapse">Свернуть</string>
     <string name="vault_confirmation_vault_upgraded">Хранилище обновлено</string>
     <string name="this_amount_would_leave_too_little_change">С этой суммы сдачи будет слишком мало. 💡 Попробуйте «Отправить максимум» (%1$s ADA), чтобы избежать этой проблемы.</string>
-    <string name="send_error_cardano_native_token_unsupported">Отправка %1$s пока не поддерживается. Нативные токены Cardano можно хранить и отслеживать, но не отправлять.</string>
     <string name="swap_form_native">Нативное</string>
     <string name="swap_transaction_overview_approval_tx_hash">Хеш транзакции подтверждения</string>
     <string name="swap_transaction_overview_track">Отслеживание</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1008,7 +1008,6 @@
     <string name="insufficient_balance_try_send">余额不足。尝试"发送最大"以发送 %1$s ADA。</string>
     <string name="insufficient_balance_ada">余额不足（%1$s ADA）。您需要更多 ADA 来完成此交易。</string>
     <string name="this_amount_would_leave_too_little_change">此金额将留下太少的找零。💡 尝试"发送最大"（%1$s ADA）以避免此问题。</string>
-    <string name="send_error_cardano_native_token_unsupported">暂不支持发送 %1$s。Cardano 原生代币可以持有和查看，但无法发送。</string>
 
     <!-- Referral -->
     <string name="must_be_enabled_before_proceeding">在继续之前必须启用 %1$s。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1274,7 +1274,6 @@
     <string name="insufficient_balance_try_send">Insufficient balance. Try \'Send Max\' to send %1$s ADA instead.</string>
     <string name="insufficient_balance_ada">Insufficient balance (%1$s ADA). You need more ADA to complete this transaction.</string>
     <string name="this_amount_would_leave_too_little_change">This amount would leave too little change. 💡 Try \'Send Max\' (%1$s ADA) to avoid this issue.</string>
-    <string name="send_error_cardano_native_token_unsupported">Sending %1$s isn\'t supported yet. Cardano native tokens can be held and tracked, but not sent.</string>
     <string name="swap_form_native">Native</string>
     <string name="swap_transaction_overview_approval_tx_hash">Approval Tx Hash</string>
     <string name="swap_transaction_overview_track">Track</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
@@ -1860,82 +1860,93 @@ internal class DefaultSendStrategyTest {
     }
 
     /**
-     * A Cardano native token cannot be signed yet (CardanoHelper builds no asset bundle), so the
-     * send must be refused before planning — not left to the signer, which would only fail after
-     * the transaction was staged and the Verify screen shown.
+     * A Cardano native-token send builds a real asset bundle now, so submit must plan and stage it
+     * like any other token rather than refusing it up front. The staged amount stays in the token's
+     * own base units — the lovelace floor the recipient output needs is the signer's business, and
+     * folding it in here would send the wrong number of tokens.
      */
     @Test
-    fun `submit rejects a Cardano native-token send before planning`() = runTest {
-        val snekCoin = snekCoin()
-        val adaCoin = adaCoin()
-        val account =
-            Account(
-                token = snekCoin,
-                tokenValue = TokenValue(BigInteger.valueOf(1_000_000L), snekCoin),
-                fiatValue = null,
-                price = null,
-            )
-        vaultId = "vault-1"
-        selectedAccount = account
-        addressFieldState.setTextAndPlaceCursorAtEnd("addr1dest")
-        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1")
-        coEvery { accountValidator.validate() } returns
-            ValidatedAccount(
-                vaultId = "vault-1",
-                selectedAccount = account,
-                chain = Chain.Cardano,
-                gasFee = TokenValue(BigInteger.valueOf(180_000L), adaCoin),
-                dstAddress = "addr1dest",
-            )
-        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
-        every { amountManager.currentMaxAmount } returns BigDecimal.ZERO
+    fun `submit stages a Cardano native-token send in the token's own units`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val snekCoin = snekCoin()
+            val adaCoin = adaCoin()
+            val account =
+                Account(
+                    token = snekCoin,
+                    tokenValue = TokenValue(BigInteger.valueOf(1_000_000L), snekCoin),
+                    fiatValue = null,
+                    price = null,
+                )
+            vaultId = "vault-1"
+            selectedAccount = account
+            // A token send pays its fee in ADA, so the native account has to be on hand.
+            accounts.value =
+                listOf(
+                    account,
+                    Account(
+                        token = adaCoin,
+                        tokenValue = TokenValue(BigInteger.valueOf(10_000_000L), adaCoin),
+                        fiatValue = null,
+                        price = null,
+                    ),
+                )
+            addressFieldState.setTextAndPlaceCursorAtEnd("addr1dest")
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1000")
+            coEvery { accountValidator.validate() } returns
+                ValidatedAccount(
+                    vaultId = "vault-1",
+                    selectedAccount = account,
+                    chain = Chain.Cardano,
+                    gasFee = TokenValue(BigInteger.valueOf(180_000L), adaCoin),
+                    dstAddress = "addr1dest",
+                )
+            coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            coEvery {
+                blockChainSpecificRepository.getSpecific(
+                    chain = any(),
+                    address = any(),
+                    token = any(),
+                    gasFee = any(),
+                    isSwap = any(),
+                    isMaxAmountEnabled = any(),
+                    isDeposit = any(),
+                    dstAddress = any(),
+                    tokenAmountValue = any(),
+                    memo = any(),
+                    isThorchainRouterDeposit = any(),
+                )
+            } returns
+                BlockChainSpecificAndUtxo(
+                    BlockChainSpecific.Cardano(
+                        byteFee = 180_000L,
+                        sendMaxAmount = false,
+                        ttl = 1_000UL,
+                    )
+                )
+            every { amountManager.currentMaxAmount } returns BigDecimal.ZERO
+            coEvery { getAvailableTokenBalance(any(), any()) } returns
+                TokenValue(BigInteger.valueOf(1_000_000L), snekCoin)
+            coEvery { gasFeeToEstimatedFee(any()) } returns
+                EstimatedGasFee(
+                    formattedFiatValue = "$0.10",
+                    formattedTokenValue = "0.18 ADA",
+                    tokenValue = TokenValue(BigInteger.valueOf(180_000L), adaCoin),
+                    fiatValue = mockk(relaxed = true),
+                )
+            val captured = slot<Transaction>()
+            coEvery { transactionRepository.addTransaction(capture(captured)) } returns Unit
 
-        build(this).submit()
-        advanceUntilIdle()
+            build(this).submit()
+            advanceUntilIdle()
 
-        assertEquals(
-            UiText.FormattedText(
-                R.string.send_error_cardano_native_token_unsupported,
-                listOf("SNEK"),
-            ),
-            lastError,
-        )
-    }
-
-    /**
-     * The same refusal seen from the other side: nothing is staged, so the Verify screen the
-     * strategy routes to on success is never reached.
-     */
-    @Test
-    fun `submit stages no transaction for a Cardano native token`() = runTest {
-        val snekCoin = snekCoin()
-        val adaCoin = adaCoin()
-        val account =
-            Account(
-                token = snekCoin,
-                tokenValue = TokenValue(BigInteger.valueOf(1_000_000L), snekCoin),
-                fiatValue = null,
-                price = null,
-            )
-        vaultId = "vault-1"
-        selectedAccount = account
-        addressFieldState.setTextAndPlaceCursorAtEnd("addr1dest")
-        tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1")
-        coEvery { accountValidator.validate() } returns
-            ValidatedAccount(
-                vaultId = "vault-1",
-                selectedAccount = account,
-                chain = Chain.Cardano,
-                gasFee = TokenValue(BigInteger.valueOf(180_000L), adaCoin),
-                dstAddress = "addr1dest",
-            )
-        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
-        every { amountManager.currentMaxAmount } returns BigDecimal.ZERO
-
-        build(this).submit()
-        advanceUntilIdle()
-
-        coVerify(exactly = 0) { transactionRepository.addTransaction(any()) }
+            assertNull(lastError, "Expected no error; got $lastError")
+            assertEquals(BigInteger.valueOf(1_000L), captured.captured.tokenValue.value)
+            assertEquals("SNEK", captured.captured.tokenValue.unit)
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
     }
 
     private fun snekCoin(): Coin =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
@@ -1949,6 +1949,88 @@ internal class DefaultSendStrategyTest {
         }
     }
 
+    /**
+     * ADA held covers the byte fee (180,000 lovelace) but not the extra
+     * `CardanoHelper.MIN_LOVELACE_ON_TOKEN_OUTPUT` (1.5 ADA) the token's recipient output pins.
+     * Submit must reject this up front rather than staging a keysign that WalletCore's planner
+     * would only refuse once signing has started.
+     */
+    @Test
+    fun `submit rejects a Cardano native-token send when ADA covers the fee but not the token output floor`() =
+        runTest {
+            mockkStatic(Dispatchers::class)
+            every { Dispatchers.IO } returns mainDispatcher
+            try {
+                val snekCoin = snekCoin()
+                val adaCoin = adaCoin()
+                val account =
+                    Account(
+                        token = snekCoin,
+                        tokenValue = TokenValue(BigInteger.valueOf(1_000_000L), snekCoin),
+                        fiatValue = null,
+                        price = null,
+                    )
+                vaultId = "vault-1"
+                selectedAccount = account
+                accounts.value =
+                    listOf(
+                        account,
+                        Account(
+                            token = adaCoin,
+                            tokenValue = TokenValue(BigInteger.valueOf(200_000L), adaCoin),
+                            fiatValue = null,
+                            price = null,
+                        ),
+                    )
+                addressFieldState.setTextAndPlaceCursorAtEnd("addr1dest")
+                tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1000")
+                coEvery { accountValidator.validate() } returns
+                    ValidatedAccount(
+                        vaultId = "vault-1",
+                        selectedAccount = account,
+                        chain = Chain.Cardano,
+                        gasFee = TokenValue(BigInteger.valueOf(180_000L), adaCoin),
+                        dstAddress = "addr1dest",
+                    )
+                coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+                coEvery {
+                    blockChainSpecificRepository.getSpecific(
+                        chain = any(),
+                        address = any(),
+                        token = any(),
+                        gasFee = any(),
+                        isSwap = any(),
+                        isMaxAmountEnabled = any(),
+                        isDeposit = any(),
+                        dstAddress = any(),
+                        tokenAmountValue = any(),
+                        memo = any(),
+                        isThorchainRouterDeposit = any(),
+                    )
+                } returns
+                    BlockChainSpecificAndUtxo(
+                        BlockChainSpecific.Cardano(
+                            byteFee = 180_000L,
+                            sendMaxAmount = false,
+                            ttl = 1_000UL,
+                        )
+                    )
+                every { amountManager.currentMaxAmount } returns BigDecimal.ZERO
+                coEvery { getAvailableTokenBalance(any(), any()) } returns
+                    TokenValue(BigInteger.valueOf(1_000_000L), snekCoin)
+
+                build(this).submit()
+                advanceUntilIdle()
+
+                assertEquals(
+                    R.string.insufficient_native_token,
+                    (lastError as UiText.FormattedText).resId,
+                )
+            } finally {
+                unmockkStatic(Dispatchers::class)
+            }
+        }
+
     private fun snekCoin(): Coin =
         Coin(
             chain = Chain.Cardano,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.api.models.cardano.OgmiosError
 import com.vultisig.wallet.data.api.models.cardano.OgmiosTransactionResponse
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.cardanoAssetId
+import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
 import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
@@ -137,7 +138,7 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
     }
 
     override suspend fun getUTXOs(coin: Coin): List<UtxoInfo> {
-        val requestBody = CardanoUtxoRequestJson(listOf(coin.address))
+        val requestBody = CardanoUtxoRequestJson(addresses = listOf(coin.address), extended = true)
         val response =
             httpClient.post(url) {
                 url { path(apiV1Path, "address_utxos") }
@@ -153,11 +154,43 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
         }
     }
 
-    private fun List<CardanoUtxoResponseJson>.toUtxos() = map { utxo ->
-        UtxoInfo(
-            hash = utxo.txHash ?: "",
-            amount = utxo.value?.toLong() ?: 0L,
-            index = utxo.txIndex?.toUInt() ?: 0u,
+    /**
+     * Maps Koios rows to [UtxoInfo], ordered by `(hash, index)`.
+     *
+     * The order is part of the signed bytes: WalletCore's planner consumes the inputs as given, and
+     * the payload this produces is what every co-signer reads. Koios does not promise a stable
+     * order, so pinning one here keeps a re-fetch from producing a different keysign session for
+     * the same wallet state.
+     */
+    private fun List<CardanoUtxoResponseJson>.toUtxos(): List<UtxoInfo> =
+        mapNotNull { utxo ->
+                val assets = utxo.assetList.orEmpty()
+                val tokens = assets.mapNotNull { it.toTokenAsset() }
+                if (tokens.size != assets.size) {
+                    // A half-read UTxO would understate its bundle, and signing that builds a body
+                    // that does not conserve the assets it spends. Drop the whole UTxO instead.
+                    Timber.w("Dropping Cardano UTxO %s: unparseable asset row", utxo.txHash)
+                    return@mapNotNull null
+                }
+                UtxoInfo(
+                    hash = utxo.txHash ?: "",
+                    amount = utxo.value?.toLong() ?: 0L,
+                    index = utxo.txIndex?.toUInt() ?: 0u,
+                    // Sorted so the proto serialises identically however Koios ordered the row.
+                    cardanoTokens =
+                        tokens.sortedWith(compareBy({ it.policyId }, { it.assetNameHex })),
+                )
+            }
+            .sortedWith(compareBy({ it.hash }, { it.index }))
+
+    private fun CardanoAssetResponseJson.toTokenAsset(): CardanoTokenAsset? {
+        val policyId = policyId?.lowercase() ?: return null
+        val amount = quantity?.toBigIntegerOrNull() ?: return null
+        if (amount.signum() < 0) return null
+        return CardanoTokenAsset(
+            policyId = policyId,
+            assetNameHex = assetName.orEmpty().lowercase(),
+            amount = amount,
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.api.models.cardano.OgmiosError
 import com.vultisig.wallet.data.api.models.cardano.OgmiosTransactionResponse
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.cardanoAssetId
+import com.vultisig.wallet.data.models.parseCardanoAssetId
 import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
 import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.utils.bodyOrThrow
@@ -184,12 +185,17 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
             .sortedWith(compareBy({ it.hash }, { it.index }))
 
     private fun CardanoAssetResponseJson.toTokenAsset(): CardanoTokenAsset? {
-        val policyId = policyId?.lowercase() ?: return null
         val amount = quantity?.toBigIntegerOrNull() ?: return null
         if (amount.signum() < 0) return null
+        // Validates hex format and length, same contract as the id read back off a Coin's
+        // contractAddress — an id this loose would push malformed hex straight into the signing
+        // input's TokenAmount.
+        val assetId =
+            parseCardanoAssetId(cardanoAssetId(policyId ?: return null, assetName.orEmpty()))
+                ?: return null
         return CardanoTokenAsset(
-            policyId = policyId,
-            assetNameHex = assetName.orEmpty().lowercase(),
+            policyId = assetId.policyId,
+            assetNameHex = assetId.assetNameHex,
             amount = amount,
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoUtxoRequestJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoUtxoRequestJson.kt
@@ -3,5 +3,16 @@ package com.vultisig.wallet.data.api.models.cardano
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/**
+ * Koios `address_utxos` request.
+ *
+ * [extended] is what makes the response carry `asset_list`; without it Koios returns the lovelace
+ * value alone and a token-bearing UTxO is indistinguishable from an ADA-only one. It deliberately
+ * carries no default: the client serializes with `encodeDefaults = false`, which would drop a
+ * property sitting on its declared default and silently ask for the plain form.
+ */
 @Serializable
-data class CardanoUtxoRequestJson(@SerialName("_addresses") val addresses: List<String>)
+data class CardanoUtxoRequestJson(
+    @SerialName("_addresses") val addresses: List<String>,
+    @SerialName("_extended") val extended: Boolean,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoUtxoResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoUtxoResponseJson.kt
@@ -8,4 +8,6 @@ data class CardanoUtxoResponseJson(
     @SerialName("tx_hash") val txHash: String? = null,
     @SerialName("tx_index") val txIndex: Long? = null,
     @SerialName("value") val value: String? = null,
+    /** Native assets on this UTxO. Only populated when the request asks for the extended form. */
+    @SerialName("asset_list") val assetList: List<CardanoAssetResponseJson>? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
@@ -5,13 +5,17 @@ import com.vultisig.wallet.data.crypto.CardanoCIP20
 import com.vultisig.wallet.data.crypto.CardanoUtils
 import com.vultisig.wallet.data.crypto.checkError
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.SignedTransactionResult
+import com.vultisig.wallet.data.models.parseCardanoAssetId
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.tss.getSignature
 import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.Numeric.hexStringToByteArray
+import java.math.BigInteger
 import timber.log.Timber
 import wallet.core.java.AnySigner
 import wallet.core.jni.CoinType
@@ -27,14 +31,27 @@ import wallet.core.jni.proto.Common.SigningError
 object CardanoHelper {
 
     /**
+     * Lovelace attached to the recipient output of a native-token send.
+     *
+     * Cardano requires every output to carry a minimum ADA value that scales with the output's CBOR
+     * size; a single-asset output is typically ~0.85 ADA. The fixed 1.5 ADA leaves headroom and is
+     * the value iOS and the SDK send, so the three platforms build byte-identical bodies. Deriving
+     * it dynamically (`Cardano.outputMinAdaAmount`) would be tighter but would put a per-device
+     * value into the signed body, which is exactly what breaks a mixed-platform ceremony.
+     */
+    private const val MIN_LOVELACE_ON_TOKEN_OUTPUT = 1_500_000L
+
+    /**
      * Assembles a [Cardano.SigningInput.Builder] from raw transaction parameters.
      *
      * [forceFee] pins the body fee: a positive value forces that exact fee (used when signing so
      * the MPC sighash matches the fee transmitted by the initiator); `0` leaves the fee unset so
      * WalletCore's planner derives it from the transaction size (used for fee estimation).
+     *
+     * [tokenBundle] is the native assets the recipient output carries, or `null` for an ADA send.
      */
     private fun buildSigningInput(
-        toAmount: Long,
+        toAmount: BigInteger,
         toAddress: String,
         changeAddress: String,
         sendMaxAmount: Boolean,
@@ -42,18 +59,30 @@ object CardanoHelper {
         utxos: List<UtxoInfo>,
         forceFee: Long,
         memo: String?,
+        tokenBundle: Cardano.TokenBundle?,
     ): Cardano.SigningInput.Builder {
-        val input =
-            Cardano.SigningInput.newBuilder()
-                .setTransferMessage(
-                    Cardano.Transfer.newBuilder()
-                        .setAmount(toAmount)
-                        .setToAddress(toAddress)
-                        .setUseMaxAmount(sendMaxAmount)
-                        .setChangeAddress(changeAddress)
-                        .setForceFee(forceFee)
-                )
-                .setTtl(ttl)
+        // `transferMessage.amount` is the recipient output's lovelace. On an ADA send that is the
+        // typed amount; on a token send the typed amount counts the token's own base units, so
+        // passing it here would size the output in lovelace and the ledger would reject it as
+        // insufficiently funded. The token rides in [tokenBundle] and the output takes the floor.
+        val recipientLovelace =
+            if (tokenBundle == null) toAmount.toLong() else MIN_LOVELACE_ON_TOKEN_OUTPUT
+
+        val transfer =
+            Cardano.Transfer.newBuilder()
+                .setAmount(recipientLovelace)
+                .setToAddress(toAddress)
+                // `useMaxAmount` drains every input lovelace into the recipient output. On a token
+                // send "max" means all of the token while the lovelace stays pinned at the floor
+                // above, so the flag must never be set there.
+                .setUseMaxAmount(sendMaxAmount && tokenBundle == null)
+                .setChangeAddress(changeAddress)
+                .setForceFee(forceFee)
+        if (tokenBundle != null) {
+            transfer.setTokenAmount(tokenBundle)
+        }
+
+        val input = Cardano.SigningInput.newBuilder().setTransferMessage(transfer).setTtl(ttl)
 
         // CIP-20 memo (label 674). When present, WalletCore commits
         // blake2b-256(auxDataCbor) into the body at map key 7 and embeds the aux
@@ -62,7 +91,11 @@ object CardanoHelper {
         // sighash.
         cip20AuxData(memo)?.let { input.setAuxiliaryData(ByteString.copyFrom(it)) }
 
-        // Add UTXOs to the input
+        // Add UTXOs to the input. Per-UTxO token data rides on the wire
+        // (`UtxoInfo.cardanoTokens`), populated by the initiator before keysign, so every
+        // co-signer reads the same inputs without its own Koios call. Declaring it also lets the
+        // planner conserve the assets a spent input carries — omit it and the body either trips
+        // `errorLowBalance` on a token send or silently drops assets on an ADA send.
         for (inputUtxo in utxos) {
             val utxo =
                 Cardano.TxInput.newBuilder()
@@ -74,6 +107,7 @@ object CardanoHelper {
                     )
                     .setAmount(inputUtxo.amount.toLong())
                     .setAddress(changeAddress)
+                    .addAllTokenAmount(inputUtxo.cardanoTokens.map { it.toTokenAmount() })
                     .build()
             input.addUtxos(utxo)
         }
@@ -90,19 +124,13 @@ object CardanoHelper {
         keysignPayload: KeysignPayload
     ): Cardano.SigningInput.Builder {
         require(keysignPayload.coin.chain == Chain.Cardano) { "Coin is not ada" }
-        // Backstop for the send-form guard: [buildSigningInput] emits only a `Cardano.Transfer`
-        // amount, which the ledger reads as lovelace. Signing a native-asset payload here would
-        // move ADA under that token's label, so refuse until the asset bundle lands (#5713).
-        require(keysignPayload.coin.isNativeToken) {
-            "Cardano native-token sends are not supported yet: ${keysignPayload.coin.ticker}"
-        }
 
         val (byteFee, sendMaxAmount, ttl) =
             keysignPayload.blockChainSpecific as? BlockChainSpecific.Cardano
                 ?: error("fail to get Cardano chain specific parameters")
 
         return buildSigningInput(
-            toAmount = keysignPayload.toAmount.toLong(),
+            toAmount = keysignPayload.toAmount,
             toAddress = keysignPayload.toAddress,
             changeAddress = keysignPayload.coin.address,
             sendMaxAmount = sendMaxAmount,
@@ -110,8 +138,41 @@ object CardanoHelper {
             utxos = keysignPayload.utxos,
             forceFee = byteFee,
             memo = keysignPayload.memo,
+            tokenBundle = tokenBundle(keysignPayload.coin, keysignPayload.toAmount),
         )
     }
+
+    /**
+     * The recipient output's native-asset bundle for a Cardano token send, or `null` when [coin] is
+     * ADA itself.
+     *
+     * The asset id is read from `Coin.contractAddress`, the `<policy_id>.<asset_name_hex>` form the
+     * curated catalog and every discovery path store.
+     */
+    private fun tokenBundle(coin: Coin, amount: BigInteger): Cardano.TokenBundle? {
+        if (coin.isNativeToken) return null
+
+        val assetId =
+            parseCardanoAssetId(coin.contractAddress)
+                ?: error("Cardano token ${coin.ticker} has a malformed asset id")
+        require(amount.signum() >= 0) { "Cardano token ${coin.ticker} amount is negative" }
+
+        return Cardano.TokenBundle.newBuilder()
+            .addToken(
+                Cardano.TokenAmount.newBuilder()
+                    .setPolicyId(assetId.policyId)
+                    .setAssetNameHex(assetId.assetNameHex)
+                    .setAmount(ByteString.copyFrom(CardanoUtils.tokenAmountBytes(amount)))
+            )
+            .build()
+    }
+
+    private fun CardanoTokenAsset.toTokenAmount(): Cardano.TokenAmount =
+        Cardano.TokenAmount.newBuilder()
+            .setPolicyId(policyId)
+            .setAssetNameHex(assetNameHex)
+            .setAmount(ByteString.copyFrom(CardanoUtils.tokenAmountBytes(amount)))
+            .build()
 
     /**
      * Canonical CIP-20 auxiliary-data CBOR (label 674) for the payload [memo], or `null` when there
@@ -151,11 +212,13 @@ object CardanoHelper {
      * Derives the size-based Cardano fee for a prospective transaction by running WalletCore's
      * planner with no forced fee. Used by the initiator to seed `byteFee` before signing; the
      * derived value is then transmitted and forced on every device.
+     *
+     * [toAmount] is lovelace when [coin] is ADA and the token's own base units otherwise.
      */
     fun estimateFee(
-        toAmount: Long,
+        coin: Coin,
+        toAmount: BigInteger,
         toAddress: String,
-        changeAddress: String,
         sendMaxAmount: Boolean,
         ttl: Long,
         utxos: List<UtxoInfo>,
@@ -165,12 +228,15 @@ object CardanoHelper {
             buildSigningInput(
                     toAmount = toAmount,
                     toAddress = toAddress,
-                    changeAddress = changeAddress,
+                    changeAddress = coin.address,
                     sendMaxAmount = sendMaxAmount,
                     ttl = ttl,
                     utxos = utxos,
                     forceFee = 0,
                     memo = memo,
+                    // The bundle changes the body's size and output count, so a token send has to
+                    // be priced on the shape that will actually be signed.
+                    tokenBundle = tokenBundle(coin, toAmount),
                 )
                 .build()
         return plan(signingInput).fee

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CardanoHelper.kt
@@ -39,7 +39,7 @@ object CardanoHelper {
      * it dynamically (`Cardano.outputMinAdaAmount`) would be tighter but would put a per-device
      * value into the signed body, which is exactly what breaks a mixed-platform ceremony.
      */
-    private const val MIN_LOVELACE_ON_TOKEN_OUTPUT = 1_500_000L
+    const val MIN_LOVELACE_ON_TOKEN_OUTPUT = 1_500_000L
 
     /**
      * Assembles a [Cardano.SigningInput.Builder] from raw transaction parameters.

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.crypto
 
 import com.vultisig.wallet.data.common.Utils
 import com.vultisig.wallet.data.utils.Numeric
+import java.math.BigInteger
 import kotlin.experimental.and
 import timber.log.Timber
 import wallet.core.jni.Bech32
@@ -10,6 +11,26 @@ import wallet.core.jni.Hash
 object CardanoUtils {
 
     private const val KEY_SIZE = 32
+
+    /**
+     * Encodes a native-token quantity the way WalletCore's Cardano signer reads
+     * `TokenAmount.amount`: minimal big-endian magnitude bytes, a single `0x00` for zero.
+     *
+     * [BigInteger.toByteArray] is two's-complement, so it prefixes a `0x00` sign byte whenever the
+     * top bit of the leading magnitude byte is set — 255 encodes as `00 ff`. Leaving that byte in
+     * would change the serialized signing input and therefore the sighash, against iOS
+     * (`BigUInt.serialize()`) and the SDK (`amountToBytes`), which both emit the magnitude alone.
+     */
+    fun tokenAmountBytes(amount: BigInteger): ByteArray {
+        require(amount.signum() >= 0) { "Cardano token amount must not be negative" }
+        val bytes = amount.toByteArray()
+        // toByteArray() never emits more than one leading sign byte for a non-negative value.
+        return if (bytes.size > 1 && bytes[0] == 0.toByte()) {
+            bytes.copyOfRange(1, bytes.size)
+        } else {
+            bytes
+        }
+    }
 
     fun createExtendedKey(spendingKeyHex: String, chainCodeHex: String): ByteArray {
         val spendingKeyData = Numeric.hexStringToByteArray(spendingKeyHex)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.THORChainSwapPayload
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
 import com.vultisig.wallet.data.models.payload.DAppMetadata
 import com.vultisig.wallet.data.models.payload.ERC20ApprovePayload
 import com.vultisig.wallet.data.models.payload.KeysignPayload
@@ -39,7 +40,14 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                 from.utxoInfo
                     .asSequence()
                     .filterNotNull()
-                    .map { UtxoInfo(hash = it.hash, amount = it.amount, index = it.index) }
+                    .map {
+                        UtxoInfo(
+                            hash = it.hash,
+                            amount = it.amount,
+                            index = it.index,
+                            cardanoTokens = it.cardanoTokens.toCardanoTokenAssets(),
+                        )
+                    }
                     .toList(),
             approvePayload =
                 from.erc20ApprovePayload?.let {
@@ -329,6 +337,24 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
             logo = logo,
             isNativeToken = isNativeToken,
         )
+
+    /**
+     * Reads the Cardano native assets an initiator attached to a UTxO.
+     *
+     * A malformed quantity is refused rather than dropped: signing on a bundle that silently lost a
+     * row would move assets the payload does not describe.
+     */
+    private fun List<vultisig.keysign.v1.CardanoTokenAsset?>.toCardanoTokenAssets():
+        List<CardanoTokenAsset> =
+        filterNotNull().map { asset ->
+            CardanoTokenAsset(
+                policyId = asset.policyId,
+                assetNameHex = asset.assetNameHex,
+                amount =
+                    asset.amount.toBigIntegerOrNull()
+                        ?: error("Cardano token ${asset.policyId} has a malformed amount"),
+            )
+        }
 
     private fun ThorChainSwapPayloadProto.toThorChainSwapPayload() =
         THORChainSwapPayload(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -9,6 +9,8 @@ import com.vultisig.wallet.data.models.EVMSwapPayloadJson
 import com.vultisig.wallet.data.models.SigningLibType
 import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.THORChainSwapPayload
+import com.vultisig.wallet.data.models.cardanoAssetId
+import com.vultisig.wallet.data.models.parseCardanoAssetId
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
 import com.vultisig.wallet.data.models.payload.DAppMetadata
@@ -341,20 +343,25 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
     /**
      * Reads the Cardano native assets an initiator attached to a UTxO.
      *
-     * A malformed quantity is refused rather than dropped: signing on a bundle that silently lost a
-     * row would move assets the payload does not describe.
+     * A malformed row is refused rather than dropped: signing on a bundle that silently lost or
+     * loosened a row would move assets the payload does not describe, or push identifiers a
+     * co-signer never agreed to into the signing input's TokenAmount.
      */
     private fun List<vultisig.keysign.v1.CardanoTokenAsset?>.toCardanoTokenAssets():
-        List<CardanoTokenAsset> =
-        filterNotNull().map { asset ->
-            CardanoTokenAsset(
-                policyId = asset.policyId,
-                assetNameHex = asset.assetNameHex,
-                amount =
-                    asset.amount.toBigIntegerOrNull()
-                        ?: error("Cardano token ${asset.policyId} has a malformed amount"),
-            )
-        }
+        List<CardanoTokenAsset> = map { asset ->
+        val proto = asset ?: error("Cardano token asset row is missing")
+        val assetId =
+            parseCardanoAssetId(cardanoAssetId(proto.policyId, proto.assetNameHex))
+                ?: error("Cardano token ${proto.policyId} has a malformed asset id")
+        val amount =
+            proto.amount.toBigIntegerOrNull()?.takeIf { it.signum() >= 0 }
+                ?: error("Cardano token ${proto.policyId} has a malformed amount")
+        CardanoTokenAsset(
+            policyId = assetId.policyId,
+            assetNameHex = assetId.assetNameHex,
+            amount = amount,
+        )
+    }
 
     private fun ThorChainSwapPayloadProto.toThorChainSwapPayload() =
         THORChainSwapPayload(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -56,6 +56,14 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         hash = it.hash,
                         amount = it.amount,
                         index = it.index,
+                        cardanoTokens =
+                            it.cardanoTokens.map { asset ->
+                                vultisig.keysign.v1.CardanoTokenAsset(
+                                    policyId = asset.policyId,
+                                    assetNameHex = asset.assetNameHex,
+                                    amount = asset.amount.toString(),
+                                )
+                            },
                     )
                 },
             ethereumSpecific =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
@@ -3,6 +3,12 @@ package com.vultisig.wallet.data.models
 /** The separator between a Cardano asset's policy id and its asset name. */
 private const val CARDANO_ASSET_ID_SEPARATOR = "."
 
+/** A minting policy is a 28-byte script hash. */
+private const val CARDANO_POLICY_ID_HEX_LENGTH = 56
+
+/** CIP-14 caps an asset name at 32 bytes. */
+private const val CARDANO_ASSET_NAME_MAX_HEX_LENGTH = 64
+
 /**
  * A Cardano native token's `<policy_id>.<asset_name_hex>` asset id, lowercase hex.
  *
@@ -17,6 +23,33 @@ private const val CARDANO_ASSET_ID_SEPARATOR = "."
  */
 fun cardanoAssetId(policyId: String, assetNameHex: String): String =
     "${policyId.lowercase()}$CARDANO_ASSET_ID_SEPARATOR${assetNameHex.lowercase()}"
+
+/** The two halves of a Cardano asset id, lowercase hex. */
+data class CardanoAssetId(val policyId: String, val assetNameHex: String)
+
+/**
+ * Splits a `<policy_id>.<asset_name_hex>` [Coin.contractAddress] back into its halves, or `null`
+ * when the id is malformed.
+ *
+ * The halves are pushed into a Cardano signing input as raw hex, so an id that is not well-formed
+ * hex of the right length would produce a transaction body the ledger rejects. Validating here
+ * keeps that failure at the point the id is read rather than at broadcast. Mirrors iOS
+ * `CardanoAssetId.parse`.
+ */
+fun parseCardanoAssetId(assetId: String): CardanoAssetId? {
+    val policyId = assetId.substringBefore(CARDANO_ASSET_ID_SEPARATOR, missingDelimiterValue = "")
+    if (policyId.length != CARDANO_POLICY_ID_HEX_LENGTH || !policyId.isLowercaseHex()) return null
+
+    // An asset name encodes raw bytes, so its hex is even-length; empty is legal (a policy's
+    // unnamed asset).
+    val assetNameHex = assetId.substringAfter(CARDANO_ASSET_ID_SEPARATOR)
+    if (assetNameHex.length > CARDANO_ASSET_NAME_MAX_HEX_LENGTH) return null
+    if (assetNameHex.length % 2 != 0 || !assetNameHex.isLowercaseHex()) return null
+
+    return CardanoAssetId(policyId = policyId, assetNameHex = assetNameHex)
+}
+
+private fun String.isLowercaseHex(): Boolean = all { it in '0'..'9' || it in 'a'..'f' }
 
 object Coins {
     object Akash {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/UtxoInfo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/payload/UtxoInfo.kt
@@ -1,3 +1,32 @@
 package com.vultisig.wallet.data.models.payload
 
-data class UtxoInfo(val hash: String, val amount: Long, val index: UInt)
+import java.math.BigInteger
+
+/**
+ * A Cardano native asset carried by a single UTxO, as it crosses the keysign wire
+ * (`vultisig.keysign.v1.CardanoTokenAsset`).
+ *
+ * Only the initiator queries Koios; every co-signer reads these values verbatim off the payload, so
+ * the two devices feed WalletCore identical inputs and derive the same sighash. Both hex fields are
+ * lowercase — the wire carries the canonical form so no peer has to normalize.
+ */
+data class CardanoTokenAsset(
+    val policyId: String,
+    val assetNameHex: String,
+    val amount: BigInteger,
+)
+
+data class UtxoInfo(
+    val hash: String,
+    val amount: Long,
+    val index: UInt,
+    /**
+     * Cardano-only: the native assets this UTxO carries. Empty for every other UTXO chain and for
+     * ADA-only UTxOs.
+     *
+     * Cardano's ledger conserves value per asset, so a transaction that spends a token-bearing
+     * input has to declare those tokens or the body is rejected. WalletCore can only do that if the
+     * input says what it holds.
+     */
+    val cardanoTokens: List<CardanoTokenAsset> = emptyList(),
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -272,9 +272,9 @@ constructor(
                         if (dstAddress != null && tokenAmountValue != null) {
                             try {
                                 CardanoHelper.estimateFee(
-                                    toAmount = tokenAmountValue.toLong(),
+                                    coin = token,
+                                    toAmount = tokenAmountValue,
                                     toAddress = dstAddress,
-                                    changeAddress = address,
                                     sendMaxAmount = isMaxAmountEnabled,
                                     ttl = ttl.toLong(),
                                     utxos = utxos,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiUtxoAssetsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiUtxoAssetsTest.kt
@@ -1,0 +1,234 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import io.ktor.http.HttpStatusCode
+import java.math.BigInteger
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * A Cardano transaction has to declare the native assets its inputs carry or the ledger rejects the
+ * body for not conserving value, so `address_utxos` has to be read in its extended form and the
+ * assets carried onto [com.vultisig.wallet.data.models.payload.UtxoInfo].
+ *
+ * Ordering is load-bearing too: only the initiator queries Koios and the result is serialized into
+ * the keysign payload every co-signer reads, so an unstable order would produce a different session
+ * for the same wallet state.
+ */
+class CardanoApiUtxoAssetsTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private val ada = Coins.Cardano.ADA.copy(address = "addr1test")
+
+    private val snekPolicyId = "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f"
+    private val snekAssetNameHex = "534e454b"
+    private val usdmPolicyId = "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad"
+    private val usdmAssetNameHex = "0014df105553444d"
+
+    private fun utxoRow(hash: String, index: Int, value: String, assetList: String? = null) =
+        buildString {
+            append("""{"tx_hash":"$hash","tx_index":$index,"value":"$value"""")
+            if (assetList != null) append(""","asset_list":$assetList""")
+            append("}")
+        }
+
+    private fun assetRow(policyId: String, assetName: String, quantity: String) =
+        """{"policy_id":"$policyId","asset_name":"$assetName","quantity":"$quantity"}"""
+
+    @Test
+    fun `getUTXOs asks Koios for the extended form`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.capturingRequest(
+                        status = HttpStatusCode.OK,
+                        body = "[${utxoRow("aa", 0, "1000000")}]",
+                        capture = capture,
+                        jsonFormat = json,
+                    ),
+                json = json,
+            )
+
+        api.getUTXOs(ada)
+
+        // Without `_extended` Koios omits asset_list entirely and every UTxO looks ADA-only.
+        assertTrue(
+            capture.bodies.single().contains("\"_extended\":true"),
+            "Expected an extended address_utxos request, got ${capture.bodies.single()}",
+        )
+    }
+
+    @Test
+    fun `getUTXOs carries native assets onto the UTxO`() = runTest {
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWith(
+                        status = HttpStatusCode.OK,
+                        body =
+                            "[${utxoRow(
+                            hash = "aa",
+                            index = 0,
+                            value = "1000000",
+                            assetList = "[${assetRow(snekPolicyId, snekAssetNameHex, "2500000")}]",
+                        )}]",
+                        jsonFormat = json,
+                    ),
+                json = json,
+            )
+
+        val asset = api.getUTXOs(ada).single().cardanoTokens.single()
+
+        assertEquals(snekPolicyId, asset.policyId)
+        assertEquals(snekAssetNameHex, asset.assetNameHex)
+        assertEquals(BigInteger("2500000"), asset.amount)
+    }
+
+    @Test
+    fun `getUTXOs lowercases the asset id halves`() = runTest {
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWith(
+                        status = HttpStatusCode.OK,
+                        body =
+                            "[${utxoRow(
+                            hash = "aa",
+                            index = 0,
+                            value = "1000000",
+                            assetList =
+                                "[${assetRow(
+                                    snekPolicyId.uppercase(),
+                                    snekAssetNameHex.uppercase(),
+                                    "1",
+                                )}]",
+                        )}]",
+                        jsonFormat = json,
+                    ),
+                json = json,
+            )
+
+        val asset = api.getUTXOs(ada).single().cardanoTokens.single()
+
+        // The curated catalog stores lowercase ids; a mixed-case wire value would both miss a
+        // catalog match and change the bytes a co-signer hashes.
+        assertEquals(snekPolicyId, asset.policyId)
+        assertEquals(snekAssetNameHex, asset.assetNameHex)
+    }
+
+    @Test
+    fun `getUTXOs orders UTxOs by hash then index`() = runTest {
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWith(
+                        status = HttpStatusCode.OK,
+                        body =
+                            listOf(
+                                    utxoRow("bb", 0, "1"),
+                                    utxoRow("aa", 2, "1"),
+                                    utxoRow("aa", 1, "1"),
+                                )
+                                .joinToString(prefix = "[", separator = ",", postfix = "]"),
+                        jsonFormat = json,
+                    ),
+                json = json,
+            )
+
+        assertEquals(
+            listOf("aa" to 1u, "aa" to 2u, "bb" to 0u),
+            api.getUTXOs(ada).map { it.hash to it.index },
+        )
+    }
+
+    @Test
+    fun `getUTXOs orders assets within a UTxO by policy id then asset name`() = runTest {
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWith(
+                        status = HttpStatusCode.OK,
+                        body =
+                            "[${utxoRow(
+                            hash = "aa",
+                            index = 0,
+                            value = "1000000",
+                            assetList =
+                                listOf(
+                                        assetRow(snekPolicyId, snekAssetNameHex, "1"),
+                                        assetRow(usdmPolicyId, usdmAssetNameHex, "2"),
+                                        assetRow(usdmPolicyId, "", "3"),
+                                    )
+                                    .joinToString(prefix = "[", separator = ",", postfix = "]"),
+                        )}]",
+                        jsonFormat = json,
+                    ),
+                json = json,
+            )
+
+        // Koios does not promise an order; the proto has to serialise the same way regardless.
+        assertEquals(
+            listOf(
+                snekPolicyId to snekAssetNameHex,
+                usdmPolicyId to "",
+                usdmPolicyId to usdmAssetNameHex,
+            ),
+            api.getUTXOs(ada).single().cardanoTokens.map { it.policyId to it.assetNameHex },
+        )
+    }
+
+    @Test
+    fun `getUTXOs drops a UTxO whose asset row cannot be read`() = runTest {
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWith(
+                        status = HttpStatusCode.OK,
+                        body =
+                            listOf(
+                                    utxoRow(
+                                        hash = "aa",
+                                        index = 0,
+                                        value = "1000000",
+                                        assetList =
+                                            """[{"policy_id":"$snekPolicyId","asset_name":"$snekAssetNameHex","quantity":"not-a-number"}]""",
+                                    ),
+                                    utxoRow("bb", 0, "2000000"),
+                                )
+                                .joinToString(prefix = "[", separator = ",", postfix = "]"),
+                        jsonFormat = json,
+                    ),
+                json = json,
+            )
+
+        // Spending a UTxO whose bundle was only half read would build a body that silently drops
+        // the assets it could not parse, so the whole UTxO is left out of the selection.
+        assertEquals(listOf("bb"), api.getUTXOs(ada).map { it.hash })
+    }
+
+    @Test
+    fun `getUTXOs leaves an ADA-only UTxO with no assets`() = runTest {
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWith(
+                        status = HttpStatusCode.OK,
+                        body = "[${utxoRow("aa", 0, "1000000", assetList = "[]")}]",
+                        jsonFormat = json,
+                    ),
+                json = json,
+            )
+
+        assertEquals(emptyList<CardanoTokenAsset>(), api.getUTXOs(ada).single().cardanoTokens)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/crypto/CardanoUtilsTest.kt
@@ -1,5 +1,8 @@
 package com.vultisig.wallet.data.crypto
 
+import java.math.BigInteger
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -138,5 +141,43 @@ class CardanoUtilsTest {
         assertEquals(0x84.toByte(), upgraded[0])
         assertEquals(0xF5.toByte(), upgraded[upgraded.size - 2]) // is_valid spliced before aux
         assertEquals(0xF6.toByte(), upgraded[upgraded.size - 1])
+    }
+
+    /**
+     * WalletCore reads `TokenAmount.amount` as an unsigned big-endian magnitude. iOS
+     * (`BigUInt.serialize()`) and the SDK (`amountToBytes`) both emit exactly that, so a stray
+     * two's-complement sign byte here would change the serialized signing input and split the
+     * sighash across platforms.
+     */
+    @Test
+    fun `tokenAmountBytes encodes zero as a single zero byte`() {
+        assertContentEquals(byteArrayOf(0), CardanoUtils.tokenAmountBytes(BigInteger.ZERO))
+    }
+
+    @Test
+    fun `tokenAmountBytes strips the two's-complement sign byte`() {
+        // 255 is 0x00FF as two's complement; the wire carries 0xFF alone.
+        assertContentEquals(hex("ff"), CardanoUtils.tokenAmountBytes(BigInteger.valueOf(255)))
+        assertContentEquals(hex("ffff"), CardanoUtils.tokenAmountBytes(BigInteger.valueOf(65535)))
+    }
+
+    @Test
+    fun `tokenAmountBytes keeps a leading byte that is real magnitude`() {
+        // 256 is 0x0100 — the leading 0x01 is magnitude, not a sign byte.
+        assertContentEquals(hex("0100"), CardanoUtils.tokenAmountBytes(BigInteger.valueOf(256)))
+        assertContentEquals(hex("01"), CardanoUtils.tokenAmountBytes(BigInteger.ONE))
+    }
+
+    @Test
+    fun `tokenAmountBytes handles a quantity past Long range`() {
+        val huge = BigInteger("18446744073709551616") // 2^64
+        assertContentEquals(hex("010000000000000000"), CardanoUtils.tokenAmountBytes(huge))
+    }
+
+    @Test
+    fun `tokenAmountBytes refuses a negative quantity`() {
+        assertFailsWith<IllegalArgumentException> {
+            CardanoUtils.tokenAmountBytes(BigInteger.valueOf(-1))
+        }
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperCardanoTokensTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperCardanoTokensTest.kt
@@ -1,0 +1,143 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.payload.UtxoInfo
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * `UtxoInfo.cardano_tokens` is what tells a co-signer which native assets the inputs carry. Only
+ * the initiator queries Koios, so a mapper that drops the field leaves the peer building a
+ * different `Cardano.SigningInput` for the same send — a different sighash, and a ceremony that
+ * cannot complete.
+ */
+class KeysignPayloadProtoMapperCardanoTokensTest {
+
+    private val outbound = PayloadToProtoMapperImpl()
+    private val inbound = KeysignPayloadProtoMapperImpl()
+
+    @Test
+    fun `native assets survive the KeysignPayload to proto round-trip`() {
+        val restored = inbound(requireNotNull(outbound(payload(UTXO_WITH_TOKENS))))
+
+        assertEquals(listOf(UTXO_WITH_TOKENS), restored.utxos)
+    }
+
+    @Test
+    fun `a quantity outside Long range survives intact`() {
+        // The wire carries a decimal string precisely so a supply past 2^63 is representable.
+        val huge = BigInteger("340282366920938463463374607431768211455")
+        val utxo = UTXO_WITH_TOKENS.copy(cardanoTokens = listOf(SNEK.copy(amount = huge)))
+
+        val restored = inbound(requireNotNull(outbound(payload(utxo))))
+
+        assertEquals(huge, restored.utxos.single().cardanoTokens.single().amount)
+    }
+
+    @Test
+    fun `the wire order of the assets is preserved`() {
+        // The initiator sorts before sending; a mapper that reordered would change the bytes the
+        // peer hashes even though both hold the same assets.
+        val utxo = UTXO_WITH_TOKENS.copy(cardanoTokens = listOf(USDM, SNEK))
+
+        val proto = requireNotNull(outbound(payload(utxo)))
+
+        assertEquals(
+            listOf(USDM.policyId, SNEK.policyId),
+            proto.utxoInfo.single()?.cardanoTokens?.map { it?.policyId },
+        )
+        assertEquals(listOf(USDM, SNEK), inbound(proto).utxos.single().cardanoTokens)
+    }
+
+    @Test
+    fun `an ADA-only UTxO carries no assets in either direction`() {
+        val adaOnly = UTXO_WITH_TOKENS.copy(cardanoTokens = emptyList())
+
+        val proto = requireNotNull(outbound(payload(adaOnly)))
+
+        assertTrue(proto.utxoInfo.single()?.cardanoTokens.isNullOrEmpty())
+        assertEquals(emptyList<CardanoTokenAsset>(), inbound(proto).utxos.single().cardanoTokens)
+    }
+
+    @Test
+    fun `a malformed quantity is refused rather than silently dropped`() {
+        val proto = requireNotNull(outbound(payload(UTXO_WITH_TOKENS)))
+        val corrupted =
+            proto.copy(
+                utxoInfo =
+                    proto.utxoInfo.map { utxo ->
+                        utxo?.copy(
+                            cardanoTokens = utxo.cardanoTokens.map { it?.copy(amount = "??") }
+                        )
+                    }
+            )
+
+        // Signing a bundle that quietly lost a row would move assets the payload does not
+        // describe, so the read fails instead.
+        assertThrows(IllegalStateException::class.java) { inbound(corrupted) }
+    }
+
+    private fun payload(utxo: UtxoInfo) =
+        KeysignPayload(
+            coin = SNEK_COIN,
+            toAddress = "addr1v9g9wnzsutrxt7vcg4efdfwhagwh3x2f6hjwykk7acdpsfgyt4h2j",
+            toAmount = BigInteger("1000000"),
+            blockChainSpecific =
+                BlockChainSpecific.Cardano(
+                    byteFee = 200_000L,
+                    sendMaxAmount = false,
+                    ttl = 1_000UL,
+                ),
+            memo = null,
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "local",
+            libType = null,
+            wasmExecuteContractPayload = null,
+            utxos = listOf(utxo),
+        )
+
+    private companion object {
+        val SNEK =
+            CardanoTokenAsset(
+                policyId = "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f",
+                assetNameHex = "534e454b",
+                amount = BigInteger("2500000"),
+            )
+
+        val USDM =
+            CardanoTokenAsset(
+                policyId = "c48cbb3d5e57ed56e276bc45f99ab39abe94e6cd7ac39fb402da47ad",
+                assetNameHex = "0014df105553444d",
+                amount = BigInteger("665000"),
+            )
+
+        val UTXO_WITH_TOKENS =
+            UtxoInfo(
+                hash = "f074134aabbfb13b8aec7cf5465b1e5a862d1cadc175d431c1d9339150db8a1d",
+                amount = 10_000_000L,
+                index = 0u,
+                cardanoTokens = listOf(SNEK, USDM),
+            )
+
+        val SNEK_COIN =
+            Coin(
+                chain = Chain.Cardano,
+                ticker = "SNEK",
+                logo = "snek",
+                address = "addr1v9g9wnzsutrxt7vcg4efdfwhagwh3x2f6hjwykk7acdpsfgyt4h2j",
+                decimal = 0,
+                hexPublicKey = "pub",
+                priceProviderID = "snek",
+                contractAddress =
+                    "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f.534e454b",
+                isNativeToken = false,
+            )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CardanoAssetIdParseTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CardanoAssetIdParseTest.kt
@@ -1,0 +1,71 @@
+package com.vultisig.wallet.data.models
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * The halves of a `Coin.contractAddress` are pushed into a Cardano signing input as raw hex, so a
+ * malformed id has to be caught before it reaches a body the ledger would reject. Mirrors iOS
+ * `CardanoAssetIdTests`.
+ */
+class CardanoAssetIdParseTest {
+
+    private val policyId = "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f"
+
+    @Test
+    fun `round-trips an id the catalog builds`() {
+        val id = cardanoAssetId(policyId = policyId, assetNameHex = "534E454B")
+
+        assertEquals(CardanoAssetId(policyId, "534e454b"), parseCardanoAssetId(id))
+    }
+
+    @Test
+    fun `accepts a policy's unnamed asset`() {
+        assertEquals(CardanoAssetId(policyId, ""), parseCardanoAssetId("$policyId."))
+    }
+
+    @Test
+    fun `accepts the longest asset name CIP-14 allows`() {
+        val name = "ab".repeat(32)
+
+        assertEquals(CardanoAssetId(policyId, name), parseCardanoAssetId("$policyId.$name"))
+    }
+
+    @Test
+    fun `rejects an id with no separator`() {
+        assertNull(parseCardanoAssetId(policyId))
+    }
+
+    @Test
+    fun `rejects a policy id of the wrong length`() {
+        assertNull(parseCardanoAssetId("${policyId.dropLast(2)}.534e454b"))
+    }
+
+    @Test
+    fun `rejects a non-hex policy id`() {
+        assertNull(parseCardanoAssetId("${policyId.dropLast(1)}z.534e454b"))
+    }
+
+    @Test
+    fun `rejects an uppercase policy id`() {
+        // The catalog and every discovery path store lowercase; an uppercase id here would mean
+        // the caller skipped normalization and would put different bytes on the wire.
+        assertNull(parseCardanoAssetId("${policyId.uppercase()}.534e454b"))
+    }
+
+    @Test
+    fun `rejects an odd-length asset name`() {
+        assertNull(parseCardanoAssetId("$policyId.534e454"))
+    }
+
+    @Test
+    fun `rejects an asset name past the CIP-14 ceiling`() {
+        assertNull(parseCardanoAssetId("$policyId.${"ab".repeat(33)}"))
+    }
+
+    @Test
+    fun `rejects an empty id`() {
+        assertNull(parseCardanoAssetId(""))
+    }
+}


### PR DESCRIPTION
Closes #5713

## Transaction hash

https://cardanoscan.io/transaction/13b9a51d8fa3959d3765cc6dfe755f76c7f972b713770c695aee93950f358359


## Problem

`UtxoInfo.cardano_tokens` has been part of the keysign wire format all along and iOS both writes and reads it. Android dropped it at every layer — the provider's asset list never left deserialization, the domain model had no field for it, neither proto mapper touched it, and the signer never declared an asset bundle. A shared vault therefore built two different `Cardano.SigningInput` values for the same native-token send.



Since #5809 the symptom is not a silent divergence: that PR added a send-form refusal and a `CardanoHelper` backstop, both naming this issue, so Cardano tokens are visible and held but cannot be sent. This change is what those guards were waiting for, so it removes them too.

## What changed

**Payload** — `asset_list` is parsed off Koios, carried on `UtxoInfo.cardanoTokens`, and written and read by both proto mappers.

**Signing** — `CardanoHelper` sets `TokenBundle` on the recipient output and `tokenAmount` on every input, encodes quantities as minimal big-endian unsigned bytes, and never sets `useMaxAmount` on a token send. The fee estimate is derived from the bundle-carrying shape, so the transmitted `byteFee` covers the body that is actually signed.

**Send form** — the "not supported yet" refusal and its string are gone from all 10 locales.

## Two decisions worth reviewing

**The min-ADA floor is the fixed 1.5 ADA, not `Cardano.outputMinAdaAmount`.** The issue prescribes the dynamic value. iOS deliberately does not use it — `Cardano.swift:58` pins `minLovelaceOnTokenOutput = 1_500_000` and calls dynamic derivation a future enhancement. A per-device floor puts a per-device value in the signed body, which is precisely the mixed-platform sighash split this issue exists to close. Tightening it later is a three-repo change, not an Android one.

**Ordering is part of the signed bytes.** Only the initiator queries Koios, and its result is what every peer hashes. UTxOs are sorted by `(hash, index)` and each UTxO's assets by `(policy id, asset name)`, matching iOS, so a re-fetch cannot produce a different keysign session for the same wallet state.

## Two things the issue does not mention

The scope in the issue covers the input side only, but the guards citing it expect a working send. Four further pieces were needed for that: the output `TokenBundle`, the `useMaxAmount` rule, the amount encoding (the wire carries a decimal string, WalletCore wants bytes), and the canonical sort.

Separately, `_extended` has to be declared with **no default value**. Koios only returns `asset_list` for the extended form, and the client serializes with `encodeDefaults = false` — a property sitting on its declared default never reaches the wire. Declared with `= true` it read correctly and shipped nothing; a test asserting on the request body is what caught it.

## Also fixed incidentally

`BlockChainSpecificRepository` hands WalletCore every UTxO with its lovelace value. Before this change, an ADA-only send from an address that had ever received an airdrop built a body spending a token-bearing input without declaring the tokens, which does not conserve value. Inputs now declare their assets on every Cardano send, ADA included.

## Test plan

- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — 3568 + 2374 tests, 0 failures. 22 new tests: asset parsing and both orderings, the proto round-trip including a quantity past `Long` range and a refused malformed one, the amount encoding, the asset-id parser, and a token send reaching the transaction it stages.
- `./gradlew :app:connectedDebugAndroidTest :data:connectedDebugAndroidTest` — 37/37 and 50/50 on an emulator. The corpus gains "Send SNEK - native token" pinned from that run, and a test asserting the bundle moves the sighash.
- **The two existing ADA pins are unchanged** — that is the evidence ADA-only sighashes did not move.
- `./gradlew :app:lintDebug` clean.

`scripts/check_golden_corpus_sync.py` warns that the new case is missing on ios and sdk. Those repos need the same case name and hash before the check compares rather than warns.

Manual, on a Cardano vault holding a curated token:

1. Enable SNEK, send some to another address you control — previously refused at Continue, now reaches Verify and broadcasts. The recipient gets the token plus ~1.5 ADA.
2. Tap Max on that send — fills the whole token balance, and Verify still shows the 1.5 ADA floor rather than a swept balance.
3. Send plain ADA from the same token-holding address — this is the case that could previously fail at broadcast; the token balance is unchanged afterwards.
4. On a shared vault, run a token send in both directions with iOS: iOS initiator with an Android co-signer, then the reverse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sending Cardano native tokens alongside ADA.
  * Preserved token details throughout transaction planning and signing.
  * Added support for large token quantities and validated asset identifiers.
  * Included native assets in Cardano UTXO information.

* **Bug Fixes**
  * Improved fee estimation for Cardano token transactions.
  * Invalid token quantities and asset identifiers are now rejected safely.

* **Tests**
  * Added coverage for transfers, parsing, ordering, serialization, and fee estimation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->