### PR TITLE
feat(keysign): decode Solana staking transactions

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
@@ -26,16 +26,22 @@ import javax.inject.Singleton
 import kotlinx.coroutines.flow.first
 
 /**
+ * The vault's own coin for [coin], or null when the vault holds no match. A chain read keyed off a
+ * coin — its address, its decimals — has to run on one of these, never on the peer-supplied coin a
+ * joining co-signer was handed.
+ */
+internal fun List<Coin>.trustedCoinFor(coin: Coin): Coin? = firstOrNull {
+    it.chain == coin.chain &&
+        it.ticker.equals(coin.ticker, ignoreCase = true) &&
+        it.contractAddress.equals(coin.contractAddress, ignoreCase = true)
+}
+
+/**
  * The vault's own coin for [coin], which carries the trusted decimals and logo. Falls back to
  * [coin] itself when the vault holds no match — on a joining co-signer that coin is peer-supplied,
  * so a local match is preferred wherever one exists.
  */
-internal fun List<Coin>.trustedMatchFor(coin: Coin): Coin =
-    firstOrNull {
-        it.chain == coin.chain &&
-            it.ticker.equals(coin.ticker, ignoreCase = true) &&
-            it.contractAddress.equals(coin.contractAddress, ignoreCase = true)
-    } ?: coin
+internal fun List<Coin>.trustedMatchFor(coin: Coin): Coin = trustedCoinFor(coin) ?: coin
 
 /**
  * Converts provenance-aware readings into display content. This is the single boundary where

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
@@ -85,6 +85,10 @@ constructor(
                             ?: titleOnly
                 }
 
+            // The rent reserve has to be read live before this can be shown as stake, so the
+            // funding figure is deliberately not rendered: it is larger than what gets staked.
+            is DecodedAmount.AccountFunding -> titleOnly
+
             // Projection and localized scope arrive with fractional readers.
             is DecodedAmount.Fraction -> titleOnly
             DecodedAmount.Unstated -> titleOnly
@@ -96,7 +100,15 @@ constructor(
      * rounds-to-nothing quantity degrades to the bare verb rather than presenting a carrier amount
      * as the operation amount.
      */
-    private suspend fun sendHero(title: String, coin: Coin, raw: BigInteger): HeroContent? {
+    private suspend fun sendHero(title: String, coin: Coin, raw: BigInteger): HeroContent? =
+        heroAmount(coin, raw)?.let { HeroContent.Send(title = title, coin = it) }
+
+    /**
+     * A display amount for [raw] base units of [coin], or null when there is nothing truthful to
+     * show. Shared with the position readers, so a projected estimate is formatted and priced by
+     * exactly the same rules as a signed amount.
+     */
+    suspend fun heroAmount(coin: Coin, raw: BigInteger): HeroCoinAmount? {
         // Values wider than the precision the display formatter carries are refused rather than
         // rounded: an amount that cannot be represented exactly is not shown at all.
         if (raw.abs().toString().length > MAX_SIGNIFICANT_DIGITS) return null
@@ -111,7 +123,7 @@ constructor(
         // Only a bare "0" parses; a grouped or suffixed amount throws and is kept.
         if (runCatching { BigDecimal(amount) }.getOrNull()?.signum() == 0) return null
 
-        return HeroContent.Send(title = title, coin = heroAmount(coin, tokenValue, amount))
+        return heroAmount(coin, tokenValue, amount)
     }
 
     /**
@@ -198,7 +210,8 @@ constructor(
                 DecodedOperation.ClaimRewards -> R.string.done_verb_claimed_rewards
                 DecodedOperation.Mint -> R.string.done_verb_minted
                 DecodedOperation.Redeem -> R.string.done_verb_redeemed
-                DecodedOperation.SecuredAssetWithdraw -> R.string.done_verb_withdrew
+                DecodedOperation.SecuredAssetWithdraw,
+                DecodedOperation.WithdrawStake -> R.string.done_verb_withdrew
                 DecodedOperation.AddLiquidity -> R.string.done_verb_added_liquidity
                 DecodedOperation.RemoveLiquidity -> R.string.done_verb_removed_liquidity
                 DecodedOperation.Merge -> R.string.done_verb_merged
@@ -245,7 +258,8 @@ constructor(
                 DecodedOperation.Rebond -> R.string.verify_verb_rebonding
                 DecodedOperation.Leave -> R.string.verify_verb_leaving
                 DecodedOperation.SecuredAssetDeposit -> R.string.verify_verb_depositing
-                DecodedOperation.SecuredAssetWithdraw -> R.string.verify_verb_withdrawing
+                DecodedOperation.SecuredAssetWithdraw,
+                DecodedOperation.WithdrawStake -> R.string.verify_verb_withdrawing
                 DecodedOperation.SwitchChain -> R.string.verify_verb_switching
                 DecodedOperation.Delegate -> R.string.verify_verb_delegating
                 DecodedOperation.Undelegate -> R.string.verify_verb_undelegating

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DoneTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DoneTransactionPresentation.kt
@@ -60,11 +60,17 @@ constructor(
             DecodedTransactionPresentation.doneTitleRes(decoded.operation)?.let(context::getString)
                 ?: return null
 
-        resolvedTransactionHero.resolve(content, trustedCoins, title)?.let {
-            return it
+        // A projection reads chain state keyed off the coin, so it runs only on the vault's own
+        // coin; the fallback hero takes the peer-supplied one for its display metadata.
+        val trusted = trustedCoins.trustedCoinFor(payload.coin)
+
+        trusted?.let { coin ->
+            resolvedTransactionHero.resolve(content, coin, title)?.let {
+                return it
+            }
         }
 
-        return presentation.hero(decoded, trustedCoins.trustedMatchFor(payload.coin), title)
+        return presentation.hero(decoded, trusted ?: payload.coin, title)
     }
 
     companion object {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ProjectionCoordinator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ProjectionCoordinator.kt
@@ -45,6 +45,14 @@ constructor(@ApplicationContext private val context: Context) {
                     else -> null
                 }
 
+            // The funding is exact, but part of it stays behind as the account's rent reserve,
+            // so the scope says which part of it is actually being staked. A reader turns that
+            // into a figure; without one the sentence is still true.
+            is DecodedAmount.AccountFunding ->
+                context.getString(R.string.scope_delegated_amount_after_rent).takeIf {
+                    decoded.operation == DecodedOperation.Delegate
+                }
+
             is DecodedAmount.Units -> null
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ResolvedTransactionHero.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ResolvedTransactionHero.kt
@@ -43,17 +43,24 @@ constructor(
     private val readers: List<PositionReading> =
         listOf(solanaDelegatedAmount, solanaStakeAccountAmount)
 
-    /** Resolves through the first reader matching a trusted local coin. */
+    /**
+     * Resolves through the first reader that answers for [coin] — the vault's own coin for this
+     * transaction, which the caller already holds.
+     *
+     * The coin is passed rather than searched for: a reader claims an operation and a chain, not a
+     * particular token, so scanning the vault for the first coin a reader accepts could hand a
+     * Solana stake reading an SPL token and price the amount at that token's decimals and rate.
+     */
     suspend fun resolve(
         content: SignedTransactionContent,
-        trustedCoins: List<Coin>,
+        coin: Coin,
         title: String,
         readers: List<PositionReading> = this.readers,
     ): HeroContent? {
         val decoded = decoder.decode(content)
 
         for (reader in readers) {
-            val coin = trustedCoins.firstOrNull { reader.handles(decoded, it) } ?: continue
+            if (!reader.handles(decoded, coin)) continue
             val amount = ProjectionCoordinator.estimate { reader.amount(decoded, coin) }
             return projectionCoordinator.hero(decoded, title, amount)
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ResolvedTransactionHero.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ResolvedTransactionHero.kt
@@ -23,9 +23,8 @@ internal interface PositionReading {
  * Resolves optional chain-state amounts behind decoder-layer readers, keeping chain knowledge out
  * of the keysign view models.
  *
- * Mirrors the iOS `ResolvedTransactionHero`. The registry is empty until the per-chain signed
- * decoders land; with no reader matching, callers fall back to the signed amount the decoder
- * already read.
+ * Mirrors the iOS `ResolvedTransactionHero`. With no reader matching — or with a read that fails or
+ * times out — callers fall back to the signed amount the decoder already read.
  */
 @Singleton
 internal class ResolvedTransactionHero
@@ -33,10 +32,16 @@ internal class ResolvedTransactionHero
 constructor(
     private val decoder: SignedTransactionDecoder,
     private val projectionCoordinator: ProjectionCoordinator,
+    solanaDelegatedAmount: SolanaDelegatedAmountReader,
+    solanaStakeAccountAmount: SolanaStakeAccountAmountReader,
 ) {
 
-    /** Chain readers are registered here as their signed decoders become available. */
-    private val readers: List<PositionReading> = emptyList()
+    /**
+     * Chain readers, in the order they are asked. Each declares the operations it answers for, so
+     * the first match wins and no reader sees a transaction it did not claim.
+     */
+    private val readers: List<PositionReading> =
+        listOf(solanaDelegatedAmount, solanaStakeAccountAmount)
 
     /** Resolves through the first reader matching a trusted local coin. */
     suspend fun resolve(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/SolanaPositionReaders.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/SolanaPositionReaders.kt
@@ -1,0 +1,94 @@
+package com.vultisig.wallet.ui.models.transactiondecoding
+
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingConfig
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingService
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedCounterparty
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
+import java.math.BigInteger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Turns the exact funding of a new stake account into the stake that will actually be active.
+ *
+ * A delegation funds the account with the stake plus its rent-exempt reserve, and only the chain
+ * can say what that reserve currently is. Until it is read, the signed figure overstates the stake
+ * — which is why the decoder classifies it as [DecodedAmount.AccountFunding] and no screen renders
+ * it directly.
+ *
+ * Mirrors the iOS `SolanaDelegatedAmountReader`.
+ */
+@Singleton
+internal class SolanaDelegatedAmountReader
+@Inject
+constructor(
+    private val solanaApi: SolanaApi,
+    private val presentation: DecodedTransactionPresentation,
+) : PositionReading {
+
+    override fun handles(decoded: DecodedTransaction, coin: Coin): Boolean =
+        coin.chain == Chain.Solana &&
+            decoded.operation == DecodedOperation.Delegate &&
+            decoded.amount is DecodedAmount.AccountFunding
+
+    override suspend fun amount(decoded: DecodedTransaction, coin: Coin): HeroCoinAmount? {
+        val funding =
+            (decoded.amount as? DecodedAmount.AccountFunding)
+                ?.takeIf { it.asset == DecodedAsset.ChainNative }
+                ?.value ?: return null
+
+        // Read live, never from the bundled fallback constant. A stale reserve subtracted from an
+        // exact funding produces a wrong headline figure; showing no figure leaves the scope
+        // sentence, which is true either way.
+        val reserve =
+            solanaApi.getMinimumBalanceForRentExemption(SolanaStakingConfig.STAKE_ACCOUNT_SPACE)
+        if (reserve <= BigInteger.ZERO || funding <= reserve) return null
+
+        return presentation.heroAmount(coin, funding - reserve)
+    }
+}
+
+/**
+ * Resolves a whole-account deactivation to the lamports actually delegated in that account.
+ *
+ * Deactivation names no quantity — it cools the entire account — so the amount lives in chain
+ * state, keyed by the stake account the signed instruction names.
+ *
+ * Mirrors the iOS `SolanaStakeAccountAmountReader`.
+ */
+@Singleton
+internal class SolanaStakeAccountAmountReader
+@Inject
+constructor(
+    private val stakingService: SolanaStakingService,
+    private val presentation: DecodedTransactionPresentation,
+) : PositionReading {
+
+    override fun handles(decoded: DecodedTransaction, coin: Coin): Boolean =
+        coin.chain == Chain.Solana &&
+            decoded.operation == DecodedOperation.Unstake &&
+            decoded.counterparty is DecodedCounterparty.StakeAccount
+
+    override suspend fun amount(decoded: DecodedTransaction, coin: Coin): HeroCoinAmount? {
+        val address =
+            (decoded.counterparty as? DecodedCounterparty.StakeAccount)?.value ?: return null
+
+        // Matched on the exact account the signed instruction names, not on the owner's first or
+        // largest position: a wallet can hold several stake accounts, and describing the wrong one
+        // is worse than describing none.
+        val stake =
+            stakingService
+                .fetchStakeAccounts(coin.address)
+                .firstOrNull { it.stakePubkey == address }
+                ?.delegatedStake ?: return null
+
+        return presentation.heroAmount(coin, stake)
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/VerifyTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/VerifyTransactionPresentation.kt
@@ -74,10 +74,14 @@ constructor(
             DecodedTransactionPresentation.verifyTitleRes(decoded.operation)
                 ?.let(context::getString) ?: return null
 
+        // A projection reads chain state keyed off the coin, so it runs only on the vault's own
+        // coin; the decoded hero falls back to the peer-supplied one for its display metadata.
+        val trusted = trustedCoins.trustedCoinFor(coin)
+
         return VerifyHero(
             verb = title,
-            projected = resolvedTransactionHero.resolve(content, trustedCoins, title),
-            decoded = presentation.hero(decoded, trustedCoins.trustedMatchFor(coin), title),
+            projected = trusted?.let { resolvedTransactionHero.resolve(content, it, title) },
+            decoded = presentation.hero(decoded, trusted ?: coin, title),
         )
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1779,5 +1779,6 @@
     <string name="verify_verb_bridging">Du überträgst kettenübergreifend</string>
     <string name="scope_your_whole_stake">dein gesamter Stake</string>
     <string name="scope_rewards_accrued_so_far">bisher angefallene Belohnungen</string>
+    <string name="scope_delegated_amount_after_rent">der delegierte Betrag nach Abzug der Mietreserve</string>
     <string name="withdrawing_share_of_staked_position">%1$s deiner Stake-Position</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1778,5 +1778,6 @@
     <string name="verify_verb_bridging">Estás transfiriendo entre cadenas</string>
     <string name="scope_your_whole_stake">todo tu stake</string>
     <string name="scope_rewards_accrued_so_far">recompensas acumuladas hasta ahora</string>
+    <string name="scope_delegated_amount_after_rent">el importe delegado después de la reserva de alquiler</string>
     <string name="withdrawing_share_of_staked_position">%1$s de tu posición en staking</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1788,5 +1788,6 @@
     <string name="verify_verb_bridging">Premošćujete</string>
     <string name="scope_your_whole_stake">cijeli vaš ulog</string>
     <string name="scope_rewards_accrued_so_far">do sada stečene nagrade</string>
+    <string name="scope_delegated_amount_after_rent">delegirani iznos nakon rezerve za najam</string>
     <string name="withdrawing_share_of_staked_position">%1$s vaše uložene pozicije</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1781,5 +1781,6 @@
     <string name="verify_verb_bridging">Stai trasferendo tra catene</string>
     <string name="scope_your_whole_stake">tutto il tuo stake</string>
     <string name="scope_rewards_accrued_so_far">ricompense maturate finora</string>
+    <string name="scope_delegated_amount_after_rent">l’importo delegato dopo la riserva di affitto</string>
     <string name="withdrawing_share_of_staked_position">%1$s della tua posizione in stake</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1794,5 +1794,6 @@
     <string name="verify_verb_bridging">브리지 중</string>
     <string name="scope_your_whole_stake">스테이킹 전액</string>
     <string name="scope_rewards_accrued_so_far">현재까지 누적된 보상</string>
+    <string name="scope_delegated_amount_after_rent">임대 예치금을 제외한 위임 금액</string>
     <string name="withdrawing_share_of_staked_position">스테이킹 포지션의 %1$s</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1771,5 +1771,6 @@
     <string name="verify_verb_bridging">Je bridget</string>
     <string name="scope_your_whole_stake">je volledige stake</string>
     <string name="scope_rewards_accrued_so_far">tot nu toe opgebouwde beloningen</string>
+    <string name="scope_delegated_amount_after_rent">het gedelegeerde bedrag na de huurreserve</string>
     <string name="withdrawing_share_of_staked_position">%1$s van je gestakete positie</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1776,5 +1776,6 @@
     <string name="verify_verb_bridging">Você está transferindo entre cadeias</string>
     <string name="scope_your_whole_stake">todo o seu stake</string>
     <string name="scope_rewards_accrued_so_far">recompensas acumuladas até agora</string>
+    <string name="scope_delegated_amount_after_rent">o valor delegado após a reserva de aluguel</string>
     <string name="withdrawing_share_of_staked_position">%1$s da sua posição em stake</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1791,5 +1791,6 @@
     <string name="verify_verb_bridging">Вы переводите между сетями</string>
     <string name="scope_your_whole_stake">весь ваш стейк</string>
     <string name="scope_rewards_accrued_so_far">накопленные на данный момент награды</string>
+    <string name="scope_delegated_amount_after_rent">делегированная сумма за вычетом резерва за аренду</string>
     <string name="withdrawing_share_of_staked_position">%1$s вашей стейкинг-позиции</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2101,5 +2101,6 @@
     <string name="verify_verb_bridging">您正在跨链转账</string>
     <string name="scope_your_whole_stake">您的全部质押</string>
     <string name="scope_rewards_accrued_so_far">至今累积的奖励</string>
+    <string name="scope_delegated_amount_after_rent">扣除租金储备后的委托金额</string>
     <string name="withdrawing_share_of_staked_position">您质押仓位的 %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1836,5 +1836,6 @@
     <string name="verify_verb_bridging">You’re bridging</string>
     <string name="scope_your_whole_stake">your whole stake</string>
     <string name="scope_rewards_accrued_so_far">rewards accrued so far</string>
+    <string name="scope_delegated_amount_after_rent">the delegated amount after the rent reserve</string>
     <string name="withdrawing_share_of_staked_position">%1$s of your staked position</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1836,6 +1836,6 @@
     <string name="verify_verb_bridging">You’re bridging</string>
     <string name="scope_your_whole_stake">your whole stake</string>
     <string name="scope_rewards_accrued_so_far">rewards accrued so far</string>
-    <string name="scope_delegated_amount_after_rent">the delegated amount after the rent reserve</string>
+    <string name="scope_delegated_amount_after_rent">the delegated amount after deducting the rent reserve</string>
     <string name="withdrawing_share_of_staked_position">%1$s of your staked position</string>
 </resources>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SolanaApi.kt
@@ -26,6 +26,7 @@ import com.vultisig.wallet.data.api.models.SplTokenInfo
 import com.vultisig.wallet.data.api.models.SplTokenJson
 import com.vultisig.wallet.data.api.utils.postRpc
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaStakingConfig
+import com.vultisig.wallet.data.chains.helpers.SOLANA_MAX_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.models.SplTokenDeserialized
 import com.vultisig.wallet.data.utils.SplTokenResponseJsonSerializer
@@ -270,7 +271,7 @@ internal class SolanaApiImp(
                     ?.sorted()
                     .orEmpty()
             val median = solanaMedianPriorityFee(nonZeroFees, fallback)
-            maxOf(median, fallback).coerceAtMost(MAX_PRIORITY_FEE_PRICE.toBigInteger())
+            maxOf(median, fallback).coerceAtMost(SOLANA_MAX_PRIORITY_FEE_PRICE.toBigInteger())
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -738,9 +739,6 @@ internal class SolanaApiImp(
         // SolanaHelper.ataRentLamports, which uses this value as its only source (no live RPC
         // call).
         private const val SPL_TOKEN_ACCOUNT_RENT_EXEMPT_LAMPORTS_BOOTSTRAP = 2_039_280L
-        // 100x the floor — caps priority fee at ~0.01 SOL per tx to prevent overpayment
-        // during congestion spikes or compromised RPC proxy
-        private const val MAX_PRIORITY_FEE_PRICE = 100_000_000L
     }
 }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaStakingTransactionReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaStakingTransactionReader.kt
@@ -1,8 +1,12 @@
 package com.vultisig.wallet.data.blockchain.solana.staking
 
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoComputeBudget
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoDecodedTransaction
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoTransactionDecoder
 import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoTxInstruction
+import com.vultisig.wallet.data.chains.helpers.SOLANA_MAX_PRIORITY_FEE_PRICE
+import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
+import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.crypto.Base58Codec
 import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
 import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
@@ -57,15 +61,40 @@ object SolanaStakingTransactionReader {
 
     private const val CREATE_ACCOUNT_DATA_BYTES = 52
 
-    /** Reads one relayed transaction, or refuses it. */
-    fun read(base64Transaction: String): SolanaStakingReading? {
+    /**
+     * The compute-unit limit every staking transaction this app builds reserves.
+     * `BlockChainSpecificRepository` pins it for all of Solana, and the staking payload builder
+     * passes that through to `SolanaHelper`, so a relayed transaction reserving anything else was
+     * not built by this app.
+     */
+    private val EXPECTED_UNIT_LIMIT: BigInteger =
+        BigInteger.valueOf(SOLANA_PRIORITY_FEE_LIMIT.toLong())
+
+    /** The clamp `SolanaApi.getMedianPriorityFee` and `SolanaHelper` apply to the sampled price. */
+    private val MINIMUM_UNIT_PRICE: BigInteger = BigInteger.valueOf(SOLANA_PRIORITY_FEE_PRICE)
+
+    private val MAXIMUM_UNIT_PRICE: BigInteger = BigInteger.valueOf(SOLANA_MAX_PRIORITY_FEE_PRICE)
+
+    /**
+     * Reads one relayed transaction, or refuses it.
+     *
+     * @param signerAddress the vault's own Solana address. Everything below is read as a claim
+     *   about *this* wallet, so without it a transaction that merely names the wallet in an
+     *   authority slot would be described as the wallet's own.
+     */
+    fun read(base64Transaction: String, signerAddress: String): SolanaStakingReading? {
+        if (signerAddress.isEmpty()) return null
+
         val decoded =
             runCatching { KaminoTransactionDecoder.decode(base64Transaction) }.getOrNull()
                 ?: return null
 
-        // Compute-budget entries accompany staking without moving value, so they are ignored
-        // rather than treated as part of the sequence. Order is otherwise preserved: the shapes
-        // below are positional.
+        if (!decoded.isSignableBy(signerAddress)) return null
+        if (!decoded.carriesAnAcceptableComputeBudget()) return null
+
+        // Compute-budget entries are checked above rather than matched as part of the sequence:
+        // they move no value, and their position is WalletCore's to choose. Order is otherwise
+        // preserved — the shapes below are positional.
         val instructions =
             decoded.instructions.filterNot { it.programId == KaminoComputeBudget.PROGRAM_ID }
 
@@ -75,23 +104,74 @@ object SolanaStakingTransactionReader {
         if (instructions.any { it.namesAnUnresolvedAccount }) return null
 
         return when (instructions.size) {
-            1 -> readStandalone(instructions[0])
-            3 -> readDelegation(instructions)
+            1 -> readStandalone(instructions[0], signerAddress)
+            3 -> readDelegation(instructions, signerAddress)
             else -> null
         }
+    }
+
+    /**
+     * Whether the envelope is one this wallet alone completes.
+     *
+     * The raw-signing path splices this vault's signature into slot 0 and leaves the rest of the
+     * envelope exactly as it arrived. So the fee payer — message account key 0, not any account an
+     * instruction happens to name first — must be the wallet, one signature must be all the message
+     * declares, and every slot must still be an empty placeholder. Otherwise the wallet pays for
+     * somebody else's transaction, signs one that is broadcast incomplete, or countersigns beside a
+     * signature it never saw. These are the same three checks the Kamino raw-Solana path makes for
+     * the same reason.
+     */
+    private fun KaminoDecodedTransaction.isSignableBy(signerAddress: String): Boolean =
+        feePayer == signerAddress && requiredSignatures == 1 && isUnsigned
+
+    /**
+     * Whether the compute budget is one this app would have set.
+     *
+     * The budget is not inert: unit price times unit limit is the priority fee the runtime charges,
+     * and the screen this reading feeds describes only the staking action. So each ComputeBudget
+     * instruction has to parse, neither kind may repeat, and the values have to be the ones this
+     * app clamps to. A transaction carrying no budget at all is accepted — it pays the base fee
+     * only, which is the one direction that cannot overcharge — and the two instructions' order is
+     * not checked, since it is WalletCore's to pick on both platforms and changes nothing about
+     * what is charged.
+     */
+    private fun KaminoDecodedTransaction.carriesAnAcceptableComputeBudget(): Boolean {
+        val budget = instructions.filter { it.programId == KaminoComputeBudget.PROGRAM_ID }
+        if (budget.isEmpty()) return true
+
+        val limits = budget.mapNotNull { KaminoComputeBudget.unitLimitArgument(it.data) }
+        val prices = budget.mapNotNull { KaminoComputeBudget.unitPriceArgument(it.data) }
+
+        // Anything unparseable, duplicated, or from neither entry point leaves a budget instruction
+        // unaccounted for, and an unaccounted-for instruction is one nothing here is checking.
+        if (limits.size + prices.size != budget.size) return false
+        if (limits.size > 1 || prices.size > 1) return false
+
+        limits.singleOrNull()?.let { if (it != EXPECTED_UNIT_LIMIT) return false }
+        prices.singleOrNull()?.let {
+            if (it < MINIMUM_UNIT_PRICE || it > MAXIMUM_UNIT_PRICE) return false
+        }
+        return true
     }
 
     /**
      * Deactivate and withdraw each stand alone. A delegate never does — it only reaches this app as
      * the third instruction of a create/initialize/delegate sequence — so it is refused here.
      */
-    private fun readStandalone(instruction: KaminoTxInstruction): SolanaStakingReading? {
+    private fun readStandalone(
+        instruction: KaminoTxInstruction,
+        signerAddress: String,
+    ): SolanaStakingReading? {
         if (instruction.programId != SolanaStakingConfig.STAKE_PROGRAM_ID) return null
 
         return when (instruction.data.discriminator()) {
             STAKE_DEACTIVATE -> {
                 // Deactivation cools the whole account and names no quantity.
                 if (instruction.data.size != 4 || instruction.accounts.size != 3) return null
+
+                // Account 2 is the stake authority. A deactivation authorised by anyone else is
+                // not this wallet's to describe, whatever the envelope says about who pays.
+                if (instruction.accounts[2] != signerAddress) return null
                 SolanaStakingReading(
                     operation = DecodedOperation.Unstake,
                     amount = DecodedAmount.Unstated,
@@ -107,9 +187,10 @@ object SolanaStakingTransactionReader {
                 // A transaction can name this wallet as the authority and somebody else as the
                 // recipient, which would read as "you're withdrawing" over funds leaving for an
                 // address the screen never shows. WalletCore builds this app's withdrawals with
-                // the signer as both, so requiring that refuses the mismatch and accepts every
-                // transaction this app produces.
-                if (instruction.accounts[1] != instruction.accounts[4]) return null
+                // the signer as both, so requiring that of both refuses the mismatch and accepts
+                // every transaction this app produces.
+                if (instruction.accounts[1] != signerAddress) return null
+                if (instruction.accounts[4] != signerAddress) return null
 
                 val lamports = instruction.data.littleEndianU64(offset = 4) ?: return null
                 SolanaStakingReading(
@@ -131,7 +212,10 @@ object SolanaStakingTransactionReader {
      * could fund one account and delegate a different one, and the funding figure shown would
      * describe neither.
      */
-    private fun readDelegation(instructions: List<KaminoTxInstruction>): SolanaStakingReading? {
+    private fun readDelegation(
+        instructions: List<KaminoTxInstruction>,
+        signerAddress: String,
+    ): SolanaStakingReading? {
         val (create, initialize, delegate) =
             Triple(instructions[0], instructions[1], instructions[2])
 
@@ -143,10 +227,11 @@ object SolanaStakingTransactionReader {
         if (createdStake != initialize.accounts.getOrNull(0)) return null
         if (createdStake != delegate.accounts.getOrNull(0)) return null
 
-        // The payer must be the account the delegation is authorised by, and the account the
-        // initialize instruction names as staker. Otherwise the funds are the signer's while the
-        // stake is somebody else's.
+        // The payer must be this wallet, the account the delegation is authorised by, and the
+        // account the initialize instruction names as staker. Otherwise the funds are the signer's
+        // while the stake is somebody else's.
         val payer = create.accounts.getOrNull(0) ?: return null
+        if (payer != signerAddress) return null
         if (payer != delegate.accounts.getOrNull(5)) return null
         if (payer != initialize.authorizedStaker()) return null
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaStakingTransactionReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaStakingTransactionReader.kt
@@ -47,8 +47,13 @@ object SolanaStakingTransactionReader {
     private const val PUBLIC_KEY_BYTES = 32
     private const val MAX_SEED_BYTES = 32
 
-    /** `Initialize` carries an Authorized (2 keys) plus a Lockup (2 keys + a timestamp). */
+    /**
+     * `Initialize` is a 4-byte discriminator, an `Authorized { staker, withdrawer }` of two public
+     * keys, and a `Lockup { unix_timestamp: i64, epoch: u64, custodian }` — 4 + 64 + 48.
+     */
     private const val INITIALIZE_DATA_BYTES = 116
+
+    private const val AUTHORIZED_STAKER_OFFSET = 4
 
     private const val CREATE_ACCOUNT_DATA_BYTES = 52
 
@@ -97,6 +102,15 @@ object SolanaStakingTransactionReader {
             STAKE_WITHDRAW -> {
                 // Withdraw data carries the lamports leaving the stake account.
                 if (instruction.data.size != 12 || instruction.accounts.size != 5) return null
+
+                // Account 1 is where the lamports go and account 4 is the authority permitting it.
+                // A transaction can name this wallet as the authority and somebody else as the
+                // recipient, which would read as "you're withdrawing" over funds leaving for an
+                // address the screen never shows. WalletCore builds this app's withdrawals with
+                // the signer as both, so requiring that refuses the mismatch and accepts every
+                // transaction this app produces.
+                if (instruction.accounts[1] != instruction.accounts[4]) return null
+
                 val lamports = instruction.data.littleEndianU64(offset = 4) ?: return null
                 SolanaStakingReading(
                     operation = DecodedOperation.WithdrawStake,
@@ -135,6 +149,11 @@ object SolanaStakingTransactionReader {
         val payer = create.accounts.getOrNull(0) ?: return null
         if (payer != delegate.accounts.getOrNull(5)) return null
         if (payer != initialize.authorizedStaker()) return null
+
+        // The withdrawer matters more than the staker: it is the authority that can take the
+        // lamports back out. Left unchecked, a transaction could name this wallet as staker while
+        // handing withdrawal to someone else — the wallet funds the account and cannot empty it.
+        if (payer != initialize.authorizedWithdrawer()) return null
 
         val vote = delegate.accounts.getOrNull(1) ?: return null
 
@@ -208,9 +227,17 @@ object SolanaStakingTransactionReader {
             data.size == 4 &&
             data.discriminator() == STAKE_DELEGATE
 
-    /** The staker `Initialize` authorises, which must be the account paying for the stake. */
+    /**
+     * `Initialize` carries `Authorized { staker, withdrawer }` straight after the discriminator, so
+     * the staker is the first key and the withdrawer the second.
+     */
     private fun KaminoTxInstruction.authorizedStaker(): String? =
-        data.takeIf { it.size == INITIALIZE_DATA_BYTES }?.base58(offset = 4)
+        data.takeIf { it.size == INITIALIZE_DATA_BYTES }?.base58(offset = AUTHORIZED_STAKER_OFFSET)
+
+    private fun KaminoTxInstruction.authorizedWithdrawer(): String? =
+        data
+            .takeIf { it.size == INITIALIZE_DATA_BYTES }
+            ?.base58(offset = AUTHORIZED_STAKER_OFFSET + PUBLIC_KEY_BYTES)
 
     /** True when any account this instruction names came from an unresolved lookup table. */
     private val KaminoTxInstruction.namesAnUnresolvedAccount: Boolean

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaStakingTransactionReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaStakingTransactionReader.kt
@@ -1,0 +1,252 @@
+package com.vultisig.wallet.data.blockchain.solana.staking
+
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoComputeBudget
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoTransactionDecoder
+import com.vultisig.wallet.data.blockchain.solana.kamino.KaminoTxInstruction
+import com.vultisig.wallet.data.crypto.Base58Codec
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedCounterparty
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import java.math.BigInteger
+
+/** What one relayed Solana transaction proves it does. */
+data class SolanaStakingReading(
+    val operation: DecodedOperation,
+    val amount: DecodedAmount,
+    val counterparty: DecodedCounterparty?,
+)
+
+/**
+ * Reads self-contained Solana staking transactions out of the bytes a co-signer receives.
+ *
+ * Mirrors the iOS `SolanaTransactionReader`, but does not re-implement its hand-written message
+ * parser: Android already decodes Solana transactions through WalletCore's `TransactionDecoder`
+ * (see [KaminoTransactionDecoder]), which handles legacy and v0 messages and resolves the static
+ * account keys. What is ported is the part that matters — the refusals, and the requirement that a
+ * whole instruction sequence match, so an unrelated transfer cannot ride along beside a recognised
+ * staking instruction and go undescribed.
+ *
+ * Everything unrecognised is refused rather than guessed at. A co-signer that cannot read a
+ * transaction is better served by the screen it already had than by a confident wrong verb.
+ */
+object SolanaStakingTransactionReader {
+
+    /** Little-endian stake-program instruction discriminators. */
+    private const val STAKE_INITIALIZE = 0
+    private const val STAKE_DELEGATE = 2
+    private const val STAKE_WITHDRAW = 4
+    private const val STAKE_DEACTIVATE = 5
+
+    /** Little-endian system-program instruction discriminators. */
+    private const val SYSTEM_CREATE_ACCOUNT = 0
+    private const val SYSTEM_CREATE_ACCOUNT_WITH_SEED = 3
+
+    private const val SYSTEM_PROGRAM_ID = "11111111111111111111111111111111"
+
+    private const val PUBLIC_KEY_BYTES = 32
+    private const val MAX_SEED_BYTES = 32
+
+    /** `Initialize` carries an Authorized (2 keys) plus a Lockup (2 keys + a timestamp). */
+    private const val INITIALIZE_DATA_BYTES = 116
+
+    private const val CREATE_ACCOUNT_DATA_BYTES = 52
+
+    /** Reads one relayed transaction, or refuses it. */
+    fun read(base64Transaction: String): SolanaStakingReading? {
+        val decoded =
+            runCatching { KaminoTransactionDecoder.decode(base64Transaction) }.getOrNull()
+                ?: return null
+
+        // Compute-budget entries accompany staking without moving value, so they are ignored
+        // rather than treated as part of the sequence. Order is otherwise preserved: the shapes
+        // below are positional.
+        val instructions =
+            decoded.instructions.filterNot { it.programId == KaminoComputeBudget.PROGRAM_ID }
+
+        // An account the decoder could not name came from an address lookup table, which needs
+        // network state this read deliberately does not have. Refused rather than compared, since
+        // two unresolved accounts would otherwise look like the same account.
+        if (instructions.any { it.namesAnUnresolvedAccount }) return null
+
+        return when (instructions.size) {
+            1 -> readStandalone(instructions[0])
+            3 -> readDelegation(instructions)
+            else -> null
+        }
+    }
+
+    /**
+     * Deactivate and withdraw each stand alone. A delegate never does — it only reaches this app as
+     * the third instruction of a create/initialize/delegate sequence — so it is refused here.
+     */
+    private fun readStandalone(instruction: KaminoTxInstruction): SolanaStakingReading? {
+        if (instruction.programId != SolanaStakingConfig.STAKE_PROGRAM_ID) return null
+
+        return when (instruction.data.discriminator()) {
+            STAKE_DEACTIVATE -> {
+                // Deactivation cools the whole account and names no quantity.
+                if (instruction.data.size != 4 || instruction.accounts.size != 3) return null
+                SolanaStakingReading(
+                    operation = DecodedOperation.Unstake,
+                    amount = DecodedAmount.Unstated,
+                    counterparty = DecodedCounterparty.StakeAccount(instruction.accounts[0]),
+                )
+            }
+
+            STAKE_WITHDRAW -> {
+                // Withdraw data carries the lamports leaving the stake account.
+                if (instruction.data.size != 12 || instruction.accounts.size != 5) return null
+                val lamports = instruction.data.littleEndianU64(offset = 4) ?: return null
+                SolanaStakingReading(
+                    operation = DecodedOperation.WithdrawStake,
+                    // Stake accounts hold chain-native SOL.
+                    amount = DecodedAmount.Units(lamports, DecodedAsset.ChainNative),
+                    counterparty = DecodedCounterparty.StakeAccount(instruction.accounts[0]),
+                )
+            }
+
+            else -> null
+        }
+    }
+
+    /**
+     * The delegation shape this app builds: create the stake account, initialize it, delegate it.
+     *
+     * Every account identity is checked across the three instructions. Without that, a transaction
+     * could fund one account and delegate a different one, and the funding figure shown would
+     * describe neither.
+     */
+    private fun readDelegation(instructions: List<KaminoTxInstruction>): SolanaStakingReading? {
+        val (create, initialize, delegate) =
+            Triple(instructions[0], instructions[1], instructions[2])
+
+        val funding = create.stakeAccountFunding() ?: return null
+        if (!initialize.isStakeInitialize() || !delegate.isStakeDelegate()) return null
+
+        // The created, initialized and delegated stake account must be one account.
+        val createdStake = create.accounts.getOrNull(1) ?: return null
+        if (createdStake != initialize.accounts.getOrNull(0)) return null
+        if (createdStake != delegate.accounts.getOrNull(0)) return null
+
+        // The payer must be the account the delegation is authorised by, and the account the
+        // initialize instruction names as staker. Otherwise the funds are the signer's while the
+        // stake is somebody else's.
+        val payer = create.accounts.getOrNull(0) ?: return null
+        if (payer != delegate.accounts.getOrNull(5)) return null
+        if (payer != initialize.authorizedStaker()) return null
+
+        val vote = delegate.accounts.getOrNull(1) ?: return null
+
+        return SolanaStakingReading(
+            operation = DecodedOperation.Delegate,
+            // Funding, not stake: the rent reserve stays in the account.
+            amount = DecodedAmount.AccountFunding(funding, DecodedAsset.ChainNative),
+            counterparty = DecodedCounterparty.Validator(vote),
+        )
+    }
+
+    /**
+     * The lamports a system-program instruction funds a new stake account with, or null when it is
+     * not creating one. Both shapes WalletCore emits are accepted, and both are checked to be
+     * creating a stake-program-owned account of the stake-account size — otherwise this would read
+     * the funding of an ordinary account creation as a delegation.
+     */
+    private fun KaminoTxInstruction.stakeAccountFunding(): BigInteger? {
+        if (programId != SYSTEM_PROGRAM_ID) return null
+
+        val payer = accounts.getOrNull(0) ?: return null
+        val createdStake = accounts.getOrNull(1) ?: return null
+        if (payer == createdStake) return null
+
+        return when (data.discriminator()) {
+            SYSTEM_CREATE_ACCOUNT -> {
+                if (accounts.size != 2 || data.size != CREATE_ACCOUNT_DATA_BYTES) return null
+                val lamports = data.littleEndianU64(offset = 4) ?: return null
+                if (lamports <= BigInteger.ZERO) return null
+                if (data.littleEndianU64(offset = 12) != STAKE_ACCOUNT_SPACE) return null
+                if (!data.holdsStakeProgramId(offset = 20)) return null
+                lamports
+            }
+
+            SYSTEM_CREATE_ACCOUNT_WITH_SEED -> {
+                if (accounts.size != 3) return null
+                val seedLength = data.littleEndianU64(offset = 36) ?: return null
+                if (seedLength > BigInteger.valueOf(MAX_SEED_BYTES.toLong())) return null
+
+                val lamportsOffset = 44 + seedLength.toInt()
+                val spaceOffset = lamportsOffset + 8
+                val ownerOffset = spaceOffset + 8
+                if (data.size != ownerOffset + PUBLIC_KEY_BYTES) return null
+
+                val lamports = data.littleEndianU64(lamportsOffset) ?: return null
+                if (lamports <= BigInteger.ZERO) return null
+                if (data.littleEndianU64(spaceOffset) != STAKE_ACCOUNT_SPACE) return null
+                if (!data.holdsStakeProgramId(ownerOffset)) return null
+
+                // The seed's base must be the payer, and must be the base the data names.
+                val base = accounts.getOrNull(2) ?: return null
+                if (base != payer) return null
+                if (data.base58(offset = 4) != base) return null
+
+                lamports
+            }
+
+            else -> null
+        }
+    }
+
+    private fun KaminoTxInstruction.isStakeInitialize(): Boolean =
+        programId == SolanaStakingConfig.STAKE_PROGRAM_ID &&
+            accounts.size == 2 &&
+            data.size == INITIALIZE_DATA_BYTES &&
+            data.discriminator() == STAKE_INITIALIZE
+
+    private fun KaminoTxInstruction.isStakeDelegate(): Boolean =
+        programId == SolanaStakingConfig.STAKE_PROGRAM_ID &&
+            accounts.size == 6 &&
+            data.size == 4 &&
+            data.discriminator() == STAKE_DELEGATE
+
+    /** The staker `Initialize` authorises, which must be the account paying for the stake. */
+    private fun KaminoTxInstruction.authorizedStaker(): String? =
+        data.takeIf { it.size == INITIALIZE_DATA_BYTES }?.base58(offset = 4)
+
+    /** True when any account this instruction names came from an unresolved lookup table. */
+    private val KaminoTxInstruction.namesAnUnresolvedAccount: Boolean
+        get() =
+            programId == KaminoTransactionDecoder.UNKNOWN_ACCOUNT ||
+                accounts.any { it == KaminoTransactionDecoder.UNKNOWN_ACCOUNT }
+
+    /** The four-byte little-endian instruction discriminator, or null when the data is shorter. */
+    private fun ByteArray.discriminator(): Int? {
+        if (size < 4) return null
+        var value = 0
+        for (offset in 0 until 4) {
+            value = value or ((this[offset].toInt() and 0xFF) shl (8 * offset))
+        }
+        return value
+    }
+
+    /** A little-endian `u64` read as an unsigned value, or null when it does not fit. */
+    private fun ByteArray.littleEndianU64(offset: Int): BigInteger? {
+        if (offset < 0 || size < offset + 8) return null
+        var value = BigInteger.ZERO
+        for (byte in 7 downTo 0) {
+            value =
+                value.shiftLeft(8).or(BigInteger.valueOf((this[offset + byte].toLong() and 0xFF)))
+        }
+        return value
+    }
+
+    private fun ByteArray.base58(offset: Int): String? {
+        if (offset < 0 || size < offset + PUBLIC_KEY_BYTES) return null
+        return Base58Codec.encode(copyOfRange(offset, offset + PUBLIC_KEY_BYTES))
+    }
+
+    private fun ByteArray.holdsStakeProgramId(offset: Int): Boolean =
+        base58(offset) == SolanaStakingConfig.STAKE_PROGRAM_ID
+
+    private val STAKE_ACCOUNT_SPACE: BigInteger =
+        BigInteger.valueOf(SolanaStakingConfig.STAKE_ACCOUNT_SPACE.toLong())
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaTransactionDecoder.kt
@@ -34,7 +34,9 @@ class SolanaTransactionDecoder @Inject constructor() : TransactionContentDecoder
         // Several relayed transactions have no single operation between them, so naming one would
         // describe only part of what is being signed.
         val raw = solana.rawTransactions.singleOrNull() ?: return null
-        val reading = SolanaStakingTransactionReader.read(raw) ?: return null
+        val reading =
+            SolanaStakingTransactionReader.read(raw, signerAddress = tx.signerAddress)
+                ?: return null
 
         return DecodedTransaction(
             operation = reading.operation,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/solana/staking/SolanaTransactionDecoder.kt
@@ -1,0 +1,94 @@
+package com.vultisig.wallet.data.blockchain.solana.staking
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedCounterparty
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedEvidence
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.data.models.transaction_decoding.OpaqueSignedContent
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
+import com.vultisig.wallet.data.models.transaction_decoding.TransactionContentDecoder
+import javax.inject.Inject
+
+/**
+ * Reads Solana staking operations from the initiator's pre-image or, on a joining device, from the
+ * opaque transaction bytes it was relayed. The payload's flat sidecars are never consulted for a
+ * relayed transaction: they are peer-supplied, and the bytes are what gets signed.
+ *
+ * Mirrors the iOS `SolanaTransactionDecoder`.
+ */
+class SolanaTransactionDecoder @Inject constructor() : TransactionContentDecoder {
+
+    override val handles: Set<Chain> = setOf(Chain.Solana)
+
+    override fun decode(tx: SignedTransactionContent): DecodedTransaction? {
+        // An initiator holds the intent it will build from; a co-signer holds its encoded bytes.
+        tx.stakingIntent?.let {
+            return read(it)
+        }
+
+        val solana = tx.signedData as? OpaqueSignedContent.SolanaSignature ?: return null
+
+        // Several relayed transactions have no single operation between them, so naming one would
+        // describe only part of what is being signed.
+        val raw = solana.rawTransactions.singleOrNull() ?: return null
+        val reading = SolanaStakingTransactionReader.read(raw) ?: return null
+
+        return DecodedTransaction(
+            operation = reading.operation,
+            amount = reading.amount,
+            counterparty = reading.counterparty,
+            evidence = DecodedEvidence.SignedData,
+        )
+    }
+
+    /** The operation an initiator's staking intent commits to. */
+    private fun read(intent: SolanaStakingPayload): DecodedTransaction =
+        when (intent.opType) {
+            SolanaStakingOpType.Delegate ->
+                DecodedTransaction(
+                    operation = DecodedOperation.Delegate,
+                    amount =
+                        when {
+                            // A "Finish Move" re-delegates an account that already holds its
+                            // lamports on-chain. `SolanaHelper` leaves the built value at 0
+                            // precisely so nothing reads it as an amount to move, so neither does
+                            // this: the payload's lamports fund nothing here, and presenting them
+                            // as funding would put a rent-reserve subtraction on a transaction
+                            // that pays no rent.
+                            !intent.stakeAccount.isNullOrEmpty() -> DecodedAmount.Unstated
+
+                            // A fresh delegation funds a new account: the rent reserve stays
+                            // behind, so this is funding rather than stake.
+                            else ->
+                                intent.lamports?.let {
+                                    DecodedAmount.AccountFunding(it, DecodedAsset.ChainNative)
+                                } ?: DecodedAmount.Unstated
+                        },
+                    counterparty = intent.votePubkey?.let(DecodedCounterparty::Validator),
+                    evidence = DecodedEvidence.StructuredPayload,
+                )
+
+            SolanaStakingOpType.Unstake ->
+                DecodedTransaction(
+                    operation = DecodedOperation.Unstake,
+                    // Deactivation cools the account; the funds move only on the later withdrawal.
+                    amount = DecodedAmount.Unstated,
+                    counterparty = intent.stakeAccount?.let(DecodedCounterparty::StakeAccount),
+                    evidence = DecodedEvidence.StructuredPayload,
+                )
+
+            SolanaStakingOpType.Withdraw ->
+                DecodedTransaction(
+                    operation = DecodedOperation.WithdrawStake,
+                    // The withdrawn lamports are the committed quantity.
+                    amount =
+                        intent.lamports?.let { DecodedAmount.Units(it, DecodedAsset.ChainNative) }
+                            ?: DecodedAmount.Unstated,
+                    counterparty = intent.stakeAccount?.let(DecodedCounterparty::StakeAccount),
+                    evidence = DecodedEvidence.StructuredPayload,
+                )
+        }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/SolanaHelper.kt
@@ -27,6 +27,14 @@ import wallet.core.jni.proto.Solana
 internal const val SOLANA_PRIORITY_FEE_PRICE = 1000000L
 internal const val SOLANA_PRIORITY_FEE_LIMIT = 100000
 
+/**
+ * Ceiling on the micro-lamports-per-compute-unit price, 100x the floor — about 0.01 SOL of priority
+ * fee at [SOLANA_PRIORITY_FEE_LIMIT] units. Every price this app signs is clamped into
+ * `[SOLANA_PRIORITY_FEE_PRICE, SOLANA_MAX_PRIORITY_FEE_PRICE]` when it is sampled, so the same
+ * range is what a co-signer holds a relayed transaction's compute budget to.
+ */
+internal const val SOLANA_MAX_PRIORITY_FEE_PRICE = 100_000_000L
+
 const val SOLANA_DEFAULT_CONTRACT_ADDRESS = "So11111111111111111111111111111111111111112"
 
 /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/DecodedTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/DecodedTransaction.kt
@@ -19,6 +19,13 @@ sealed class DecodedAmount {
     /** Base units exactly as the signed content carries them. */
     data class Units(val value: BigInteger, val asset: DecodedAsset) : DecodedAmount()
 
+    /**
+     * Exact funding of a newly created account. Distinct from [Units] because it is not the
+     * operation's amount: part of it stays behind as the account's rent reserve, so what actually
+     * gets staked is lower and only chain state can say by how much.
+     */
+    data class AccountFunding(val value: BigInteger, val asset: DecodedAsset) : DecodedAmount()
+
     /** A signed share in basis points; resolving the position is enrichment. */
     data class Fraction(val basisPoints: Int, val asset: DecodedAsset) : DecodedAmount()
 
@@ -43,6 +50,12 @@ enum class DecodedOperation {
     ClaimRewards,
     Mint,
     Redeem,
+
+    /**
+     * Withdrawing lamports out of a Solana stake account, which is a separate step from [Unstake] —
+     * deactivation cools the account, and the funds move only on this.
+     */
+    WithdrawStake,
     AddLiquidity,
     RemoveLiquidity,
     Merge,
@@ -62,6 +75,9 @@ enum class DecodedOperation {
 sealed class DecodedCounterparty {
     /** A network node. */
     data class Node(val value: String) : DecodedCounterparty()
+
+    /** A Solana stake account, which holds one delegation. */
+    data class StakeAccount(val value: String) : DecodedCounterparty()
 
     /** A validator. */
     data class Validator(val value: String) : DecodedCounterparty()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/SignedTransactionContent.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/SignedTransactionContent.kt
@@ -126,6 +126,16 @@ interface SignedTransactionContent {
     /** Whether the chain settles the moved asset as its native coin. */
     val isNativeCoin: Boolean
 
+    /**
+     * The signing account's own address on [chain] — the vault's address, the same on both devices.
+     *
+     * A decoder that reads opaque signed bytes needs it to tell "this transaction is ours" from
+     * "this transaction merely names us somewhere": a relayed transaction can put the wallet in an
+     * authority slot while paying its fee from, or sending its proceeds to, an account the wallet
+     * does not control.
+     */
+    val signerAddress: String
+
     // MARK: Ungated fields
     // Decoders should prefer `corroborated`; `raw` access requires explicit proof.
 
@@ -227,6 +237,9 @@ private data class KeysignPayloadContent(val payload: KeysignPayload) : SignedTr
 
     override val isNativeCoin: Boolean
         get() = payload.coin.isNativeToken
+
+    override val signerAddress: String
+        get() = payload.coin.address
 
     override val rawToAddress: String
         get() = payload.toAddress
@@ -341,6 +354,7 @@ private data class KeysignPayloadContent(val payload: KeysignPayload) : SignedTr
 data class InitiatingTransactionContent(
     override val chain: Chain,
     override val isNativeCoin: Boolean,
+    override val signerAddress: String,
     override val rawToAddress: String,
     override val rawAmount: SignedAmount,
     override val rawMemo: String?,
@@ -380,6 +394,7 @@ fun Transaction.asSignedTransactionContent(): SignedTransactionContent =
     InitiatingTransactionContent(
         chain = token.chain,
         isNativeCoin = token.isNativeToken,
+        signerAddress = token.address,
         rawToAddress = dstAddress,
         rawAmount = SignedAmount.Committed(tokenValue.value),
         rawMemo = memo?.takeIf { it.isNotEmpty() },
@@ -398,6 +413,7 @@ fun DepositTransaction.asSignedTransactionContent(): SignedTransactionContent =
     InitiatingTransactionContent(
         chain = srcToken.chain,
         isNativeCoin = srcToken.isNativeToken,
+        signerAddress = srcToken.address,
         rawToAddress = dstAddress,
         rawAmount = SignedAmount.Committed(srcTokenValue.value),
         rawMemo = memo.takeIf { it.isNotEmpty() },

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/SignedTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/SignedTransactionDecoder.kt
@@ -2,8 +2,6 @@ package com.vultisig.wallet.data.models.transaction_decoding
 
 import com.vultisig.wallet.data.models.Chain
 import java.util.concurrent.CopyOnWriteArrayList
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
 
 /**
@@ -27,18 +25,18 @@ interface TransactionContentDecoder {
 
 /**
  * Reads operations from content that will actually be signed. Maintains an ordered registry of
- * chain-family decoders and attempts each in precedence order. The foundation registers no chain
- * readers, so every transaction remains unreadable.
+ * chain-family decoders and attempts each in precedence order. A transaction no registered reader
+ * can prove an operation for stays unreadable, and every surface keeps its own presentation.
  *
- * Scoped as [Singleton] for true app-level shared instance across the app. All decoder
- * registrations are visible to any consumer, ensuring consistent provenance verification.
+ * Constructed through [TransactionDecodingModule], which is where the registered readers and their
+ * precedence live. It is a single app-level instance, so those registrations are visible to every
+ * consumer and both devices in a ceremony read the same transaction the same way.
  *
  * The registry is thread-safe: concurrent calls to register, unregister, and clear are safe due to
  * the use of CopyOnWriteArrayList, which prevents ConcurrentModificationException during iteration
  * in [decode].
  */
-@Singleton
-class SignedTransactionDecoder @Inject constructor() {
+class SignedTransactionDecoder {
 
     /** Registered readers in precedence order. Thread-safe for concurrent access. */
     private val decoders: CopyOnWriteArrayList<TransactionContentDecoder> = CopyOnWriteArrayList()

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
@@ -1,0 +1,27 @@
+package com.vultisig.wallet.data.models.transaction_decoding
+
+import com.vultisig.wallet.data.blockchain.solana.staking.SolanaTransactionDecoder
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Where the chain readers are registered, and the one place their precedence is expressed.
+ *
+ * Registration order is precedence order: [SignedTransactionDecoder] tries each eligible reader
+ * until one proves an operation. Readers are eligible only for the chains they declare, so ordering
+ * matters only between readers that overlap — but it is explicit here rather than emergent, because
+ * a reader added in the wrong position changes what a user is told they are signing.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal object TransactionDecodingModule {
+
+    @Provides
+    @Singleton
+    fun provideSignedTransactionDecoder(
+        solana: SolanaTransactionDecoder
+    ): SignedTransactionDecoder = SignedTransactionDecoder().apply { register(solana) }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/transaction_decoding/SignedTransactionDecoderFoundationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/transaction_decoding/SignedTransactionDecoderFoundationTest.kt
@@ -266,6 +266,7 @@ class SignedTransactionDecoderFoundationTest {
     ) : SignedTransactionContent {
         override val chain: Chain = contentChain
         override val isNativeCoin = true
+        override val signerAddress = "signer"
         override val rawToAddress = "destination"
         override val rawAmount = SignedAmount.Committed(42.toBigInteger())
         override val signedData: OpaqueSignedContent? = null


### PR DESCRIPTION
## Summary

The first chain reader on the decoder registry, so the decoder-driven Verify and Done heroes stop being inert. Android mirror of [vultisig-ios#5220](https://github.com/vultisig/vultisig-ios/pull/5220).

Reads delegate, deactivate, and stake-account withdrawal from either the initiator's staking intent or, on a joining device, the relayed transaction bytes.

## Reviewer contract

1. **What proves the operation?** The signed Solana transaction bytes and a recognised staking instruction sequence, or the initiator pre-image that produces those bytes. Never the payload's flat sidecars, which are peer-supplied.
2. **Which surfaces can reach it?** Initiator Verify and co-signer Keysign confirmation, through the same registry and the same position readers.
3. **What is deliberately refused?** Multiple relayed transactions, unrecognised instructions, partial sequences, mismatched accounts, and any account the decoder could not name.
4. **What hero appears?** Delegating, Unstaking, or Withdrawing with a truthful exact or projected SOL amount. A failed read never exposes account funding or a carrier value as stake.

## Funding is not stake

A delegation funds a new account with the stake **plus** its rent-exempt reserve, so the signed figure overstates what actually gets staked, and only the chain can say by how much. That is why it is classified as `AccountFunding` rather than `Units`: no screen renders it directly. A reader subtracts the live reserve to produce an approximate figure, and the scope line — "the delegated amount after the rent reserve" — stays true when the read fails and no figure appears at all.

A whole-account deactivate names no quantity, so it resolves against the exact stake account the instruction names — not the owner's first or largest position, because describing the wrong one is worse than describing none.

## Two deliberate departures from iOS

**The 407-line hand-written message parser is not ported.** Android already decodes Solana transactions through WalletCore's `TransactionDecoder`, and that path is what Kamino validation has been using. What *is* ported is the part that carries the safety: the refusals, and the requirement that a whole instruction sequence match, so an unrelated transfer cannot ride along beside a recognised staking instruction and go undescribed. Accounts the decoder cannot name came from an address lookup table and are refused rather than compared — two unresolved accounts would otherwise look like the same account.

**A "Finish Move" re-delegate reads no amount.** It re-delegates an account that already holds its lamports on-chain, and `SolanaHelper` leaves the built value at `0` specifically so nothing reads it as an amount to move. iOS reads the payload's lamports as funding regardless, which puts a rent-reserve subtraction on a transaction that pays no rent.

## Also

The decoder registry moves into a Hilt module, which is now the single place the registered readers and their precedence live. `SignedTransactionDecoder` keeps its `register`/`unregister`/`clear` API and its existing coverage.

## Test plan

- `:app` and `:data` unit suites green; ktfmt and `lintDebug` clean.
- Instruction shapes were verified against the builder that produces them — `SolanaStakingSignDataResolver` and `SolanaHelper.getStakingPreSignedInputData` — rather than against assumptions: fresh delegate emits create + initialize + delegate in one transaction, deactivate and withdraw stand alone, and every one of them carries compute-budget instructions that the reader ignores.

**Not yet verified against a real relayed transaction.** The byte-level reader has no fixture behind it, so the account-position and data-length checks are reasoned from the builder rather than exercised. Worth a co-signed delegate/unstake/withdraw on devices before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9NVpxNCntotiW9wHxNhfw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for decoding Solana staking, unstaking, and stake-account withdrawal transactions.
  - Delegated amounts now reflect the live rent reserve when available.
  - Added clearer transaction details distinguishing stake withdrawals from unstaking.
  - Improved recognition of stake accounts and transaction counterparties.

- **Bug Fixes**
  - Account-funding transactions no longer display misleading amounts when the live rent reserve is unavailable.
  - Unsupported or incomplete transaction data now falls back safely without displaying invalid amounts.

- **Localization**
  - Added translated text describing delegated amounts after the rent reserve across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->