### PR TITLE
fix(maya): node-scoped Unbond data and LP-unit ceilings

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -76,6 +76,22 @@ internal enum class DepositOption {
     RemoveLiquidity,
 }
 
+/**
+ * The LP-unit ceiling an Unbond may spend, carrying the position it was measured for.
+ *
+ * MayaChain applies `UNBOND` against one node's bond-provider record, so the figure only means
+ * anything alongside the node and pool it was read from. The node address is a live field — it can
+ * be typed or pasted after the units were fetched, and the memo is built from the field — so a bare
+ * number could not tell "this much is bonded on the node in the field" from "on the node that was
+ * in the field a moment ago". This can, and [unbondLpUnitsCeiling] refuses the second.
+ */
+@Immutable
+internal data class BondedUnitsCeiling(
+    val nodeAddress: String,
+    val asset: String,
+    val units: String,
+)
+
 @Immutable
 internal data class DepositFormUiModel(
     val selectedToken: Coin = Coins.ThorChain.RUNE,
@@ -116,6 +132,12 @@ internal data class DepositFormUiModel(
     val bondableAssets: List<String> = emptyList(),
     val selectedBondAsset: String = "",
     val availableLpUnits: String? = null,
+    // Unbond's ceiling is node-scoped and so cannot share availableLpUnits, which Bond fills with
+    // an address-wide surplus.
+    val bondedUnitsCeiling: BondedUnitsCeiling? = null,
+    // Distinguishes "this node holds nothing for you" from "we could not find out": both leave the
+    // asset list empty, and only the second is worth a retry.
+    val bondAssetsLoadFailed: Boolean = false,
     // For Maya: total LP units in the pool. For THORChain remove-LP, this stores the user's own
     // units (the calculator divides by it so that selectedUnits/userUnits gives the redeem
     // fraction).
@@ -143,6 +165,37 @@ internal data class DepositFormUiModel(
     // removeLpPoolDepth is for the RUNE side.
     val removeLpAssetRedeemBase: BigInteger = BigInteger.ZERO,
 )
+
+/**
+ * The LP units this vault may still bond, or `null` when no position has been loaded.
+ *
+ * MayaChain rejects an over-ceiling BOND/UNBOND outright — it neither clamps nor partially applies
+ * — and refunds the deposit minus the network fee, so the figure is worth catching before a keysign
+ * ceremony is spent on a memo the chain will not apply. Bond measures its ceiling address-wide (the
+ * surplus not yet bonded anywhere), so it holds for whichever node the memo names.
+ */
+internal fun DepositFormUiModel.bondLpUnitsCeiling(): BigInteger? =
+    if (depositChain != Chain.MayaChain) null else availableLpUnits?.toBigIntegerOrNull()
+
+/**
+ * The LP units this vault has bonded to [nodeAddress] in pool [asset], or `null` when no ceiling is
+ * known for that exact position.
+ *
+ * Unbond spends against one node's bond-provider record, so its ceiling answers only for the node
+ * and pool it was measured on. Both are passed in from the fields the memo itself is built from,
+ * rather than read off the state: once either moves on, this reports nothing rather than a limit
+ * belonging to a position the memo no longer names.
+ */
+internal fun DepositFormUiModel.unbondLpUnitsCeiling(
+    nodeAddress: String,
+    asset: String,
+): BigInteger? =
+    if (depositChain != Chain.MayaChain) null
+    else
+        bondedUnitsCeiling
+            ?.takeIf { it.nodeAddress == nodeAddress && it.asset == asset }
+            ?.units
+            ?.toBigIntegerOrNull()
 
 @HiltViewModel
 internal class DepositFormViewModel
@@ -397,11 +450,18 @@ constructor(
     }
 
     fun selectBondAsset(asset: String) {
-        val pool = liquidityDataLoader.bondPoolFor(asset)
+        // Each option carries its own ceiling: Bond the address-wide surplus for the pool, Unbond
+        // the units this vault has bonded to the node in the address field. Switching pool replaces
+        // one and must leave no trace of the other, or the field would be measured against a
+        // position the memo does not name.
+        val isUnbond = state.value.depositOption == DepositOption.Unbond
+        val pool = if (isUnbond) null else liquidityDataLoader.bondPoolFor(asset)
         _state.update {
             it.copy(
                 selectedBondAsset = asset,
                 availableLpUnits = pool?.availableUnits,
+                bondedUnitsCeiling =
+                    if (isUnbond) liquidityDataLoader.bondedCeilingFor(asset) else null,
                 removeLpUnitsDivisor = pool?.totalPoolLpUnits?.toBigInteger() ?: BigInteger.ZERO,
                 removeLpPoolDepth = pool?.poolCacaoDepth?.toBigInteger() ?: BigInteger.ZERO,
                 lpUnitsError = null,
@@ -414,6 +474,14 @@ constructor(
     fun setMaxLpUnits() {
         liquidityDataLoader.setMaxLpUnits()
     }
+
+    /**
+     * Re-runs the MayaChain bondable / bonded asset fetch for the option on screen.
+     *
+     * Exposed so a transient failure is recoverable in place: Unbond is the get-my-money-out
+     * direction, and without a loaded position it now refuses to submit at all.
+     */
+    fun retryLoadBondAssets() = depositOptionCoordinator.retryLoadMayaBondAssets()
 
     fun setRemoveLpPercent(percent: Float) {
         liquidityDataLoader.setRemoveLpPercent(percent)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModel.kt
@@ -92,6 +92,35 @@ internal data class BondedUnitsCeiling(
     val units: String,
 )
 
+/**
+ * How far the MayaChain bond-asset fetch behind the Bond / Unbond form has got.
+ *
+ * The list of pools it produces cannot answer this on its own: empty means "this node holds nothing
+ * for you", "we have not asked yet", "we are asking" and "we could not find out" all at once, and
+ * only the last is worth a Retry while none of the others may claim the node is empty.
+ */
+internal sealed interface BondAssetsState {
+    /** Nothing has been asked for — the Unbond form has no node address to scope a fetch to. */
+    data object Idle : BondAssetsState
+
+    /** A fetch is in flight; the form may not yet say the node holds nothing. */
+    data object Loading : BondAssetsState
+
+    /** The fetch failed. Distinct from an empty result, and the only state worth a retry. */
+    data object Failed : BondAssetsState
+
+    /**
+     * The fetch landed. [ceiling] is Unbond's limit for the selected pool on the node it was read
+     * from; Bond leaves it null, its ceiling being the address-wide
+     * [DepositFormUiModel.availableLpUnits].
+     */
+    data class Loaded(val ceiling: BondedUnitsCeiling? = null) : BondAssetsState
+}
+
+/** Unbond's node- and pool-scoped ceiling, once loaded. */
+internal val DepositFormUiModel.bondedUnitsCeiling: BondedUnitsCeiling?
+    get() = (bondAssetsState as? BondAssetsState.Loaded)?.ceiling
+
 @Immutable
 internal data class DepositFormUiModel(
     val selectedToken: Coin = Coins.ThorChain.RUNE,
@@ -133,11 +162,9 @@ internal data class DepositFormUiModel(
     val selectedBondAsset: String = "",
     val availableLpUnits: String? = null,
     // Unbond's ceiling is node-scoped and so cannot share availableLpUnits, which Bond fills with
-    // an address-wide surplus.
-    val bondedUnitsCeiling: BondedUnitsCeiling? = null,
-    // Distinguishes "this node holds nothing for you" from "we could not find out": both leave the
-    // asset list empty, and only the second is worth a retry.
-    val bondAssetsLoadFailed: Boolean = false,
+    // an address-wide surplus. It rides on the load state because it is only meaningful once that
+    // load has landed.
+    val bondAssetsState: BondAssetsState = BondAssetsState.Idle,
     // For Maya: total LP units in the pool. For THORChain remove-LP, this stores the user's own
     // units (the calculator divides by it so that selectedUnits/userUnits gives the redeem
     // fraction).
@@ -460,8 +487,10 @@ constructor(
             it.copy(
                 selectedBondAsset = asset,
                 availableLpUnits = pool?.availableUnits,
-                bondedUnitsCeiling =
-                    if (isUnbond) liquidityDataLoader.bondedCeilingFor(asset) else null,
+                bondAssetsState =
+                    if (isUnbond)
+                        BondAssetsState.Loaded(liquidityDataLoader.bondedCeilingFor(asset))
+                    else it.bondAssetsState,
                 removeLpUnitsDivisor = pool?.totalPoolLpUnits?.toBigInteger() ?: BigInteger.ZERO,
                 removeLpPoolDepth = pool?.poolCacaoDepth?.toBigInteger() ?: BigInteger.ZERO,
                 lpUnitsError = null,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/DepositFieldInputCoordinator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/DepositFieldInputCoordinator.kt
@@ -10,6 +10,8 @@ import com.vultisig.wallet.ui.models.deposit.DepositFieldStates
 import com.vultisig.wallet.ui.models.deposit.DepositFieldValidator
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositOption
+import com.vultisig.wallet.ui.models.deposit.bondLpUnitsCeiling
+import com.vultisig.wallet.ui.models.deposit.unbondLpUnitsCeiling
 import com.vultisig.wallet.ui.utils.UiText
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -180,16 +182,39 @@ constructor(
         }
     }
 
-    /** Validates the LP-units field, surfacing inline errors. */
+    /**
+     * Validates the LP-units field: the character check, then the ceiling the loaded MayaChain
+     * position allows.
+     *
+     * MayaChain rejects an over-ceiling BOND/UNBOND rather than clamping it, refunding the deposit
+     * minus the network fee — so the figure has to be caught here, before the user spends a
+     * multi-device keysign ceremony on a memo the chain will not apply.
+     */
     fun validateLpUnits() {
         val lpUnits = fields.lpUnitsFieldState.text.toString()
-        state.update {
-            it.copy(
-                lpUnitsError =
-                    if (!fieldValidator.isLpUnitCharsValid(lpUnits))
-                        UiText.StringResource(R.string.deposit_error_invalid_lpunits)
-                    else null
-            )
+        state.update { it.copy(lpUnitsError = lpUnitsErrorOrNull(lpUnits, it)) }
+    }
+
+    private fun lpUnitsErrorOrNull(lpUnits: String, current: DepositFormUiModel): UiText? {
+        if (!fieldValidator.isLpUnitCharsValid(lpUnits)) {
+            return UiText.StringResource(R.string.deposit_error_invalid_lpunits)
+        }
+        val ceiling =
+            when (current.depositOption) {
+                DepositOption.Bond -> current.bondLpUnitsCeiling()
+                DepositOption.Unbond ->
+                    current.unbondLpUnitsCeiling(
+                        nodeAddress = fields.nodeAddressFieldState.text.toString(),
+                        asset = fields.assetsFieldState.text.toString(),
+                    )
+                else -> null
+            } ?: return null
+        val entered = lpUnits.toBigIntegerOrNull() ?: return null
+        if (entered <= ceiling) return null
+        return if (current.depositOption == DepositOption.Unbond) {
+            UiText.StringResource(R.string.deposit_error_lpunits_exceeds_bonded)
+        } else {
+            UiText.StringResource(R.string.deposit_error_lpunits_exceeds_available)
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/DepositOptionCoordinator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/DepositOptionCoordinator.kt
@@ -187,10 +187,10 @@ constructor(
      * Keeps the Unbond asset list and its LP-unit ceiling tied to the node in the address field.
      *
      * The node cannot be read once and kept: the field is editable, and the route only prefills it.
-     * Every edit re-scopes what is bonded, hence what is unbondable — so the ceiling is dropped on
-     * the first keystroke rather than when the replacement lands. In between, the field already
-     * names the new node while the figure still describes the previous one, and the memo is built
-     * from the field.
+     * Every edit re-scopes what is bonded, hence what is unbondable — so the whole position is
+     * dropped on the keystroke rather than when the replacement lands. In between, the field
+     * already names the new node while the pools, the ceiling and the units would still describe
+     * the previous one, and the memo is built from the field.
      */
     private fun watchNodeAddressForUnbond() {
         nodeAddressWatchJob =
@@ -200,7 +200,7 @@ constructor(
                     .map { it.toString() }
                     .distinctUntilChanged()
                     .collectLatest { nodeAddress ->
-                        state.update { it.copy(bondedUnitsCeiling = null) }
+                        liquidityDataLoader.clearBondedAssets()
                         delay(NODE_ADDRESS_DEBOUNCE_MS)
                         liquidityDataLoader.loadMayaBondedAssets(nodeAddress)
                     }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/DepositOptionCoordinator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/DepositOptionCoordinator.kt
@@ -20,16 +20,21 @@ import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
+import com.vultisig.wallet.ui.utils.textAsFlow
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -87,6 +92,7 @@ constructor(
     }
 
     private var withdrawSecuredAssetJob: Job? = null
+    private var nodeAddressWatchJob: Job? = null
 
     /**
      * Switches the active deposit form to [option], resetting the form fields and running the
@@ -99,6 +105,8 @@ constructor(
         // Stop the previous WithdrawSecuredAsset address collector so re-selecting the option does
         // not leak an additional permanent collector running handleWithdrawSecuredAsset.
         withdrawSecuredAssetJob?.cancel()
+        // Likewise the Unbond node-address watcher: it belongs to the option being left.
+        nodeAddressWatchJob?.cancel()
         scope.launch {
             resetTextFields()
             state.update { it.copy(depositOption = option) }
@@ -113,9 +121,9 @@ constructor(
                     state.update {
                         it.copy(selectedToken = defaultBondToken, unstakableAmount = null)
                     }
-                    if (chain == Chain.MayaChain) {
-                        liquidityDataLoader.loadMayaBondableAssets()
-                    }
+                    // The Maya asset load runs after the node-address prefill below: Unbond is
+                    // scoped to that node, and reading the field before it is filled would ask
+                    // about no node at all.
                 }
 
                 DepositOption.Leave -> {
@@ -164,6 +172,51 @@ constructor(
             if (!bondAddress.isNullOrEmpty()) {
                 fields.nodeAddressFieldState.setTextAndPlaceCursorAtEnd(bondAddress)
             }
+
+            if (chain == Chain.MayaChain) {
+                when (option) {
+                    DepositOption.Bond -> liquidityDataLoader.loadMayaBondableAssets()
+                    DepositOption.Unbond -> watchNodeAddressForUnbond()
+                    else -> Unit
+                }
+            }
+        }
+    }
+
+    /**
+     * Keeps the Unbond asset list and its LP-unit ceiling tied to the node in the address field.
+     *
+     * The node cannot be read once and kept: the field is editable, and the route only prefills it.
+     * Every edit re-scopes what is bonded, hence what is unbondable — so the ceiling is dropped on
+     * the first keystroke rather than when the replacement lands. In between, the field already
+     * names the new node while the figure still describes the previous one, and the memo is built
+     * from the field.
+     */
+    private fun watchNodeAddressForUnbond() {
+        nodeAddressWatchJob =
+            scope.launch {
+                fields.nodeAddressFieldState
+                    .textAsFlow()
+                    .map { it.toString() }
+                    .distinctUntilChanged()
+                    .collectLatest { nodeAddress ->
+                        state.update { it.copy(bondedUnitsCeiling = null) }
+                        delay(NODE_ADDRESS_DEBOUNCE_MS)
+                        liquidityDataLoader.loadMayaBondedAssets(nodeAddress)
+                    }
+            }
+    }
+
+    /** Re-runs the MayaChain asset load for the option on screen, after a failed fetch. */
+    fun retryLoadMayaBondAssets() {
+        if (chainProvider() != Chain.MayaChain) return
+        when (state.value.depositOption) {
+            DepositOption.Bond -> liquidityDataLoader.loadMayaBondableAssets()
+            DepositOption.Unbond ->
+                liquidityDataLoader.loadMayaBondedAssets(
+                    fields.nodeAddressFieldState.text.toString()
+                )
+            else -> Unit
         }
     }
 
@@ -268,5 +321,11 @@ constructor(
                 providerError = null,
             )
         }
+    }
+
+    companion object {
+        // Long enough that typing a node address does not fire a request per keystroke, short
+        // enough that a paste is answered before the user reaches the units field.
+        private const val NODE_ADDRESS_DEBOUNCE_MS = 300L
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
@@ -12,7 +12,9 @@ import com.vultisig.wallet.data.repositories.MayachainBondRepository
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.defi.parseThorChainPool
+import com.vultisig.wallet.ui.models.deposit.BondedUnitsCeiling
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
+import com.vultisig.wallet.ui.models.deposit.DepositOption
 import com.vultisig.wallet.ui.models.deposit.RemoveLpCalculator
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
@@ -30,6 +32,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
 
 /**
  * Owns LP / liquidity-pool data loading extracted from `DepositFormViewModel` so the Maya bondable
@@ -77,11 +80,26 @@ constructor(
     }
 
     private var lpBondPoolMap: Map<String, LpBondablePool> = emptyMap()
+    private var bondedUnitsByPool: Map<String, Long> = emptyMap()
+    private var bondedUnitsNodeAddress: String = ""
     private var loadMayaBondableAssetsJob: Job? = null
     private var loadLpJob: Job? = null
 
     /** Returns the bondable pool previously loaded for [asset], or `null` if not loaded. */
     fun bondPoolFor(asset: String): LpBondablePool? = lpBondPoolMap[asset]
+
+    /**
+     * The unbond ceiling for [asset] on the node the bonded units were last loaded for, or `null`
+     * when that node holds nothing in that pool for this vault.
+     */
+    fun bondedCeilingFor(asset: String): BondedUnitsCeiling? =
+        bondedUnitsByPool[asset]?.let {
+            BondedUnitsCeiling(
+                nodeAddress = bondedUnitsNodeAddress,
+                asset = asset,
+                units = it.toString(),
+            )
+        }
 
     /** Cancels any in-flight remove-LP fetch so it can't write stale state into a new option. */
     fun cancelLoad() {
@@ -93,18 +111,21 @@ constructor(
     fun loadMayaBondableAssets() {
         loadMayaBondableAssetsJob?.cancel()
         lpBondPoolMap = emptyMap()
+        clearBondedUnits()
         state.update {
             it.copy(
                 bondableAssets = emptyList(),
                 selectedBondAsset = "",
                 availableLpUnits = null,
+                bondedUnitsCeiling = null,
+                bondAssetsLoadFailed = false,
                 removeLpUnitsDivisor = BigInteger.ZERO,
                 removeLpPoolDepth = BigInteger.ZERO,
             )
         }
         assetsFieldState.clearText()
         loadMayaBondableAssetsJob =
-            scope.safeLaunch {
+            scope.safeLaunch(onError = ::onBondAssetsLoadFailed) {
                 val userAddress =
                     withTimeoutOrNull(ADDRESS_AWAIT_TIMEOUT_MS) { address.filterNotNull().first() }
                         ?.address
@@ -140,6 +161,80 @@ constructor(
                     assetsFieldState.setTextAndPlaceCursorAtEnd(firstAsset)
                 }
             }
+    }
+
+    /**
+     * Loads the Maya pools [nodeAddress] holds LP units for on behalf of this vault (Unbond).
+     *
+     * Deliberately not the bondable-asset load: that one is address-wide and reports the surplus
+     * *not* yet bonded, so it hides exactly the pools a fully-bonded user came here to unbond.
+     *
+     * A blank [nodeAddress] is not a failure — the field is simply not filled in yet — so it clears
+     * the list and stops. Anything that did fail is recorded on the state, because an empty list on
+     * its own would otherwise claim the node holds nothing when we never found out.
+     */
+    fun loadMayaBondedAssets(nodeAddress: String) {
+        loadMayaBondableAssetsJob?.cancel()
+        lpBondPoolMap = emptyMap()
+        clearBondedUnits()
+        state.update {
+            it.copy(
+                bondableAssets = emptyList(),
+                selectedBondAsset = "",
+                availableLpUnits = null,
+                bondedUnitsCeiling = null,
+                bondAssetsLoadFailed = false,
+                lpUnitsError = null,
+                removeLpUnitsDivisor = BigInteger.ZERO,
+                removeLpPoolDepth = BigInteger.ZERO,
+            )
+        }
+        assetsFieldState.clearText()
+        if (nodeAddress.isBlank()) return
+        loadMayaBondableAssetsJob =
+            scope.safeLaunch(onError = ::onBondAssetsLoadFailed) {
+                val bondAddress =
+                    withTimeoutOrNull(ADDRESS_AWAIT_TIMEOUT_MS) { address.filterNotNull().first() }
+                        ?.address
+                        ?: run {
+                            // Not knowing our own address is a load failure like any other: the
+                            // node may well hold a position, we just cannot ask about it.
+                            state.update { it.copy(bondAssetsLoadFailed = true) }
+                            return@safeLaunch
+                        }
+                val bondedByPool =
+                    withContext(Dispatchers.IO) {
+                        mayachainBondRepository.getBondedLpUnitsOnNode(
+                            nodeAddress = nodeAddress,
+                            bondAddress = bondAddress,
+                        )
+                    }
+                bondedUnitsByPool = bondedByPool
+                bondedUnitsNodeAddress = nodeAddress
+                val assets = bondedByPool.keys.toList()
+                val firstAsset = assets.firstOrNull() ?: ""
+                state.update {
+                    it.copy(
+                        bondableAssets = assets,
+                        selectedBondAsset = firstAsset,
+                        bondedUnitsCeiling = bondedCeilingFor(firstAsset),
+                    )
+                }
+                if (firstAsset.isNotEmpty()) {
+                    assetsFieldState.setTextAndPlaceCursorAtEnd(firstAsset)
+                }
+            }
+    }
+
+    /** Forgets the loaded unbond position so no ceiling can outlive the node it was read from. */
+    private fun clearBondedUnits() {
+        bondedUnitsByPool = emptyMap()
+        bondedUnitsNodeAddress = ""
+    }
+
+    private fun onBondAssetsLoadFailed(error: Throwable) {
+        Timber.e(error, "Error loading Maya bond assets")
+        state.update { it.copy(bondAssetsLoadFailed = true) }
     }
 
     /**
@@ -396,8 +491,14 @@ constructor(
 
     /** Fills the LP-units field with the full available units for the loaded position. */
     fun setMaxLpUnits() {
-        val units = state.value.availableLpUnits ?: return
+        val current = state.value
+        val units =
+            when (current.depositOption) {
+                DepositOption.Unbond -> current.bondedUnitsCeiling?.units
+                else -> current.availableLpUnits
+            } ?: return
         lpUnitsFieldState.setTextAndPlaceCursorAtEnd(units)
+        state.update { it.copy(lpUnitsError = null) }
     }
 
     /** Applies a slider [percent] (0f..1f) to compute the selected units and redeem display. */

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoader.kt
@@ -12,10 +12,12 @@ import com.vultisig.wallet.data.repositories.MayachainBondRepository
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
 import com.vultisig.wallet.ui.models.defi.parseThorChainPool
+import com.vultisig.wallet.ui.models.deposit.BondAssetsState
 import com.vultisig.wallet.ui.models.deposit.BondedUnitsCeiling
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositOption
 import com.vultisig.wallet.ui.models.deposit.RemoveLpCalculator
+import com.vultisig.wallet.ui.models.deposit.bondedUnitsCeiling
 import com.vultisig.wallet.ui.utils.UiText
 import com.vultisig.wallet.ui.utils.asUiText
 import dagger.assisted.Assisted
@@ -117,8 +119,7 @@ constructor(
                 bondableAssets = emptyList(),
                 selectedBondAsset = "",
                 availableLpUnits = null,
-                bondedUnitsCeiling = null,
-                bondAssetsLoadFailed = false,
+                bondAssetsState = BondAssetsState.Loading,
                 removeLpUnitsDivisor = BigInteger.ZERO,
                 removeLpPoolDepth = BigInteger.ZERO,
             )
@@ -132,8 +133,9 @@ constructor(
                         ?: run {
                             state.update {
                                 it.copy(
+                                    bondAssetsState = BondAssetsState.Failed,
                                     errorText =
-                                        UiText.StringResource(R.string.dialog_default_error_body)
+                                        UiText.StringResource(R.string.dialog_default_error_body),
                                 )
                             }
                             return@safeLaunch
@@ -151,6 +153,7 @@ constructor(
                         bondableAssets = assets,
                         selectedBondAsset = firstAsset,
                         availableLpUnits = firstPool?.availableUnits,
+                        bondAssetsState = BondAssetsState.Loaded(),
                         removeLpUnitsDivisor =
                             firstPool?.totalPoolLpUnits?.toBigInteger() ?: BigInteger.ZERO,
                         removeLpPoolDepth =
@@ -174,23 +177,9 @@ constructor(
      * its own would otherwise claim the node holds nothing when we never found out.
      */
     fun loadMayaBondedAssets(nodeAddress: String) {
-        loadMayaBondableAssetsJob?.cancel()
-        lpBondPoolMap = emptyMap()
-        clearBondedUnits()
-        state.update {
-            it.copy(
-                bondableAssets = emptyList(),
-                selectedBondAsset = "",
-                availableLpUnits = null,
-                bondedUnitsCeiling = null,
-                bondAssetsLoadFailed = false,
-                lpUnitsError = null,
-                removeLpUnitsDivisor = BigInteger.ZERO,
-                removeLpPoolDepth = BigInteger.ZERO,
-            )
-        }
-        assetsFieldState.clearText()
+        clearBondedAssets()
         if (nodeAddress.isBlank()) return
+        state.update { it.copy(bondAssetsState = BondAssetsState.Loading) }
         loadMayaBondableAssetsJob =
             scope.safeLaunch(onError = ::onBondAssetsLoadFailed) {
                 val bondAddress =
@@ -199,7 +188,7 @@ constructor(
                         ?: run {
                             // Not knowing our own address is a load failure like any other: the
                             // node may well hold a position, we just cannot ask about it.
-                            state.update { it.copy(bondAssetsLoadFailed = true) }
+                            state.update { it.copy(bondAssetsState = BondAssetsState.Failed) }
                             return@safeLaunch
                         }
                 val bondedByPool =
@@ -217,13 +206,42 @@ constructor(
                     it.copy(
                         bondableAssets = assets,
                         selectedBondAsset = firstAsset,
-                        bondedUnitsCeiling = bondedCeilingFor(firstAsset),
+                        bondAssetsState = BondAssetsState.Loaded(bondedCeilingFor(firstAsset)),
                     )
                 }
                 if (firstAsset.isNotEmpty()) {
                     assetsFieldState.setTextAndPlaceCursorAtEnd(firstAsset)
                 }
             }
+    }
+
+    /**
+     * Drops everything the Unbond form holds for one node: the cached position, the asset list and
+     * selection, and the two fields they are read back through.
+     *
+     * The node-address watcher calls this on the keystroke, ahead of its debounce, and not only
+     * [loadMayaBondedAssets] once the replacement load starts. Dropping the ceiling alone would
+     * leave the previous node's pools in the picker for the whole debounce, and selecting one
+     * restores that node's ceiling through [bondedCeilingFor] — a figure the form would then show,
+     * and Max would fill, for a node it no longer names.
+     */
+    fun clearBondedAssets() {
+        loadMayaBondableAssetsJob?.cancel()
+        lpBondPoolMap = emptyMap()
+        clearBondedUnits()
+        state.update {
+            it.copy(
+                bondableAssets = emptyList(),
+                selectedBondAsset = "",
+                availableLpUnits = null,
+                bondAssetsState = BondAssetsState.Idle,
+                lpUnitsError = null,
+                removeLpUnitsDivisor = BigInteger.ZERO,
+                removeLpPoolDepth = BigInteger.ZERO,
+            )
+        }
+        assetsFieldState.clearText()
+        lpUnitsFieldState.clearText()
     }
 
     /** Forgets the loaded unbond position so no ceiling can outlive the node it was read from. */
@@ -234,7 +252,7 @@ constructor(
 
     private fun onBondAssetsLoadFailed(error: Throwable) {
         Timber.e(error, "Error loading Maya bond assets")
-        state.update { it.copy(bondAssetsLoadFailed = true) }
+        state.update { it.copy(bondAssetsState = BondAssetsState.Failed) }
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/BondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/BondStrategy.kt
@@ -16,6 +16,7 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
+import com.vultisig.wallet.ui.models.deposit.bondLpUnitsCeiling
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.utils.UiText
 import java.math.BigInteger
@@ -87,6 +88,19 @@ internal class BondStrategy(
         if (depositChain == Chain.MayaChain && !isLpUnitCharsValid(lpUnits)) {
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.deposit_error_invalid_lpunits)
+            )
+        }
+
+        // Enforced when a surplus was loaded, not required the way Unbond requires its ceiling:
+        // Bond still accepts a typed asset when the pool list comes back empty, and that path has
+        // no figure to measure against.
+        val bondableUnits = state.bondLpUnitsCeiling()
+        if (
+            bondableUnits != null &&
+                (lpUnits.toBigIntegerOrNull() ?: BigInteger.ZERO) > bondableUnits
+        ) {
+            throw InvalidTransactionDataException(
+                UiText.StringResource(R.string.deposit_error_lpunits_exceeds_available)
             )
         }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/UnbondStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/deposit/submit/UnbondStrategy.kt
@@ -14,6 +14,7 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
+import com.vultisig.wallet.ui.models.deposit.unbondLpUnitsCeiling
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.utils.UiText
 import java.math.BigDecimal
@@ -23,10 +24,10 @@ import java.util.UUID
 /**
  * Builds an Unbond [DepositTransaction] for THORChain or MayaChain.
  *
- * Known gap: unlike the deleted Send-form path (`AccountsLoader.publishUnbond`) and the iOS/Windows
- * clients, this does not cap the amount to the specific node's bonded balance — only to the
- * wallet's combined RUNE balance via the displayed max. A follow-up should port that per-node
- * ceiling here.
+ * On MayaChain the LP units are capped at what this vault has bonded to the node named in the memo,
+ * read back through [unbondLpUnitsCeiling]. Known gap: THORChain's leg still caps only at the
+ * wallet's combined RUNE balance via the displayed max, not at the node's bonded balance the way
+ * the deleted Send-form path (`AccountsLoader.publishUnbond`) and the iOS/Windows clients do.
  */
 internal class UnbondStrategy(
     private val vaultIdProvider: () -> String?,
@@ -83,6 +84,23 @@ internal class UnbondStrategy(
             throw InvalidTransactionDataException(
                 UiText.StringResource(R.string.deposit_error_invalid_lpunits)
             )
+        }
+
+        if (depositChain == Chain.MayaChain) {
+            // A ceiling is required, not merely respected when present. It carries the node and
+            // pool it was measured for, so demanding one here is what rules out a figure fetched
+            // for a different node: the memo is assembled from the live address field, while the
+            // fetch that refreshes the ceiling is debounced behind it.
+            val ceiling =
+                state.unbondLpUnitsCeiling(nodeAddress = nodeAddress, asset = assets)
+                    ?: throw InvalidTransactionDataException(
+                        UiText.StringResource(R.string.deposit_form_bonded_assets_load_failed)
+                    )
+            if ((lpUnits.toBigIntegerOrNull() ?: BigInteger.ZERO) > ceiling) {
+                throw InvalidTransactionDataException(
+                    UiText.StringResource(R.string.deposit_error_lpunits_exceeds_bonded)
+                )
+            }
         }
 
         val tokenAmount = tokenAmountFieldState.text.toString().toBigDecimalOrNull()

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
@@ -39,11 +39,13 @@ import com.vultisig.wallet.ui.components.library.form.FormTextFieldCard
 import com.vultisig.wallet.ui.components.library.form.SelectionCard
 import com.vultisig.wallet.ui.components.v2.containers.ContainerType
 import com.vultisig.wallet.ui.components.v2.containers.V2Container
+import com.vultisig.wallet.ui.models.deposit.BondAssetsState
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositFormViewModel
 import com.vultisig.wallet.ui.models.deposit.DepositOption
 import com.vultisig.wallet.ui.models.deposit.TokenMergeInfo
 import com.vultisig.wallet.ui.models.deposit.TokenWithdrawSecureAsset
+import com.vultisig.wallet.ui.models.deposit.bondedUnitsCeiling
 import com.vultisig.wallet.ui.screens.function.TransferIbcFunctionScreen
 import com.vultisig.wallet.ui.theme.Theme
 import com.vultisig.wallet.ui.utils.asString
@@ -382,27 +384,44 @@ internal fun DepositFormScreen(
                                 // Unbond lists what one node holds for this vault, so an empty
                                 // list is an answer and a failed fetch is not: neither may fall
                                 // back to free text, which would let the user sign an UNBOND for
-                                // a pool they hold nothing in on this node.
+                                // a pool they hold nothing in on this node. Which of the two this
+                                // is — and whether it is neither, the fetch still being in flight
+                                // — only the load state can say.
                                 isUnbond ->
-                                    BondAssetsMessage(
-                                        message =
-                                            stringResource(
-                                                if (state.bondAssetsLoadFailed)
-                                                    R.string.deposit_form_bonded_assets_load_failed
-                                                else R.string.deposit_form_no_bonded_assets_on_node
-                                            ),
-                                        actionText =
-                                            stringResource(R.string.retry).takeIf {
-                                                state.bondAssetsLoadFailed
-                                            },
-                                        onAction = onRetryLoadBondAssets,
-                                    )
+                                    when (state.bondAssetsState) {
+                                        BondAssetsState.Idle -> Unit
+                                        BondAssetsState.Loading ->
+                                            BondAssetsMessage(
+                                                message =
+                                                    stringResource(
+                                                        R.string.deposit_form_bonded_assets_loading
+                                                    )
+                                            )
+                                        BondAssetsState.Failed ->
+                                            BondAssetsMessage(
+                                                message =
+                                                    stringResource(
+                                                        R.string
+                                                            .deposit_form_bonded_assets_load_failed
+                                                    ),
+                                                actionText = stringResource(R.string.retry),
+                                                onAction = onRetryLoadBondAssets,
+                                            )
+                                        is BondAssetsState.Loaded ->
+                                            BondAssetsMessage(
+                                                message =
+                                                    stringResource(
+                                                        R.string
+                                                            .deposit_form_no_bonded_assets_on_node
+                                                    )
+                                            )
+                                    }
 
                                 // Bond keeps its typed-asset fallback — the surplus list can be
                                 // legitimately empty — but no longer swallows the failure that
                                 // produced this branch.
                                 else -> {
-                                    if (state.bondAssetsLoadFailed) {
+                                    if (state.bondAssetsState == BondAssetsState.Failed) {
                                         BondAssetsMessage(
                                             message =
                                                 stringResource(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/deposit/DepositFormScreen.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.screens.deposit
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -31,6 +32,7 @@ import com.vultisig.wallet.ui.components.UiAlertDialog
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
+import com.vultisig.wallet.ui.components.clickOnce
 import com.vultisig.wallet.ui.components.library.form.FormCard
 import com.vultisig.wallet.ui.components.library.form.FormSelection
 import com.vultisig.wallet.ui.components.library.form.FormTextFieldCard
@@ -99,6 +101,8 @@ internal fun DepositFormScreen(
         onOpenSelectToken = model::selectToken,
         onSelectSecureAsset = model::onSelectSecureAsset,
         onSelectBondAsset = model::selectBondAsset,
+        onSetMaxLpUnits = model::setMaxLpUnits,
+        onRetryLoadBondAssets = model::retryLoadBondAssets,
     )
 }
 
@@ -143,6 +147,8 @@ internal fun DepositFormScreen(
     onOpenSelectToken: () -> Unit = {},
     onSelectSecureAsset: (TokenWithdrawSecureAsset) -> Unit = {},
     onSelectBondAsset: (String) -> Unit = {},
+    onSetMaxLpUnits: () -> Unit = {},
+    onRetryLoadBondAssets: () -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
     val errorText = state.errorText
@@ -342,35 +348,80 @@ internal fun DepositFormScreen(
                     }
 
                     if (depositOption in listOf(DepositOption.Bond, DepositOption.Unbond)) {
-                        FormTextFieldCard(
-                            title = stringResource(R.string.deposit_form_provider_title),
-                            hint = stringResource(R.string.deposit_form_provider_hint),
-                            keyboardType = KeyboardType.Text,
-                            textFieldState = providerFieldState,
-                            onLostFocus = onProviderLostFocus,
-                            error = state.providerError,
-                        ) {
-                            PasteIcon(onPaste = onSetProvider)
-                            UiSpacer(size = 8.dp)
+                        val isMayaBond =
+                            depositChain == Chain.MayaChain && depositOption == DepositOption.Bond
+                        // MayaChain rejects a bond memo that carries both an asset and a provider
+                        // ("cannot set provider address or operator fee when bonding with an
+                        // asset"), and this form always emits the asset — so the field cannot be
+                        // offered here.
+                        if (!isMayaBond) {
+                            FormTextFieldCard(
+                                title = stringResource(R.string.deposit_form_provider_title),
+                                hint = stringResource(R.string.deposit_form_provider_hint),
+                                keyboardType = KeyboardType.Text,
+                                textFieldState = providerFieldState,
+                                onLostFocus = onProviderLostFocus,
+                                error = state.providerError,
+                            ) {
+                                PasteIcon(onPaste = onSetProvider)
+                                UiSpacer(size = 8.dp)
+                            }
                         }
 
                         if (depositChain == Chain.MayaChain) {
-                            if (state.bondableAssets.isNotEmpty()) {
-                                FormSelection(
-                                    selected = state.selectedBondAsset,
-                                    options = state.bondableAssets,
-                                    onSelectOption = onSelectBondAsset,
-                                    mapTypeToString = { it },
-                                )
-                            } else {
-                                FormTextFieldCard(
-                                    title = stringResource(R.string.deposit_form_screen_assets),
-                                    hint = stringResource(R.string.deposit_form_enter_asset_hint),
-                                    keyboardType = KeyboardType.Text,
-                                    textFieldState = assetsFieldState,
-                                    onLostFocus = onAssetsLostFocus,
-                                    error = state.assetsError,
-                                )
+                            val isUnbond = depositOption == DepositOption.Unbond
+                            when {
+                                state.bondableAssets.isNotEmpty() ->
+                                    FormSelection(
+                                        selected = state.selectedBondAsset,
+                                        options = state.bondableAssets,
+                                        onSelectOption = onSelectBondAsset,
+                                        mapTypeToString = { it },
+                                    )
+
+                                // Unbond lists what one node holds for this vault, so an empty
+                                // list is an answer and a failed fetch is not: neither may fall
+                                // back to free text, which would let the user sign an UNBOND for
+                                // a pool they hold nothing in on this node.
+                                isUnbond ->
+                                    BondAssetsMessage(
+                                        message =
+                                            stringResource(
+                                                if (state.bondAssetsLoadFailed)
+                                                    R.string.deposit_form_bonded_assets_load_failed
+                                                else R.string.deposit_form_no_bonded_assets_on_node
+                                            ),
+                                        actionText =
+                                            stringResource(R.string.retry).takeIf {
+                                                state.bondAssetsLoadFailed
+                                            },
+                                        onAction = onRetryLoadBondAssets,
+                                    )
+
+                                // Bond keeps its typed-asset fallback — the surplus list can be
+                                // legitimately empty — but no longer swallows the failure that
+                                // produced this branch.
+                                else -> {
+                                    if (state.bondAssetsLoadFailed) {
+                                        BondAssetsMessage(
+                                            message =
+                                                stringResource(
+                                                    R.string.deposit_form_bonded_assets_load_failed
+                                                ),
+                                            actionText = stringResource(R.string.retry),
+                                            onAction = onRetryLoadBondAssets,
+                                        )
+                                    }
+                                    FormTextFieldCard(
+                                        title = stringResource(R.string.deposit_form_screen_assets),
+                                        hint =
+                                            stringResource(R.string.deposit_form_enter_asset_hint),
+                                        keyboardType = KeyboardType.Text,
+                                        textFieldState = assetsFieldState,
+                                        onLostFocus = onAssetsLostFocus,
+                                        error = state.assetsError,
+                                    )
+                                }
                             }
 
                             FormTextFieldCard(
@@ -381,6 +432,21 @@ internal fun DepositFormScreen(
                                 onLostFocus = onLpUnitsLostFocus,
                                 error = state.lpUnitsError,
                             )
+
+                            val ceiling =
+                                if (isUnbond) state.bondedUnitsCeiling?.units
+                                else state.availableLpUnits
+                            if (ceiling != null) {
+                                LpUnitsCeilingRow(
+                                    label =
+                                        stringResource(
+                                            if (isUnbond) R.string.deposit_form_bonded_lp_units
+                                            else R.string.deposit_form_available_lp_units
+                                        ),
+                                    units = ceiling,
+                                    onSetMax = onSetMaxLpUnits,
+                                )
+                            }
                         }
                     }
 
@@ -527,6 +593,67 @@ internal fun DepositFormScreen(
                 else VsButtonState.Enabled,
             modifier = Modifier.fillMaxWidth().align(Alignment.BottomCenter).padding(all = 16.dp),
         )
+    }
+}
+
+/** Explains why no asset picker is shown, with an optional action such as retrying the load. */
+@Composable
+private fun BondAssetsMessage(
+    message: String,
+    actionText: String? = null,
+    onAction: () -> Unit = {},
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = message,
+            style = Theme.brockmann.supplementary.footnote,
+            color = Theme.v2.colors.text.tertiary,
+            modifier = Modifier.weight(1f),
+        )
+        if (actionText != null) {
+            Text(
+                text = actionText,
+                style = Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.primary.accent4,
+                modifier = Modifier.clickOnce(onClick = onAction),
+            )
+        }
+    }
+}
+
+/** Shows the LP-unit ceiling for the selected pool, with a max affordance that fills it exactly. */
+@Composable
+private fun LpUnitsCeilingRow(label: String, units: String, onSetMax: () -> Unit) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(
+            text = label,
+            style = Theme.brockmann.supplementary.footnote,
+            color = Theme.v2.colors.text.tertiary,
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = units,
+                style = Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.text.tertiary,
+            )
+            Text(
+                text = stringResource(R.string.send_screen_max).lowercase(),
+                style = Theme.brockmann.supplementary.footnote,
+                color = Theme.v2.colors.primary.accent4,
+                modifier = Modifier.clickOnce(onClick = onSetMax),
+            )
+        }
     }
 }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -381,6 +381,8 @@
     <string name="no_barcodes_found">Keine Barcodes gefunden</string>
     <string name="reshare_start_join_reshare_button">Reshare beitreten</string>
     <string name="deposit_error_invalid_lpunits">LP-Einheiten sind ungültig</string>
+    <string name="deposit_error_lpunits_exceeds_available">Übersteigt Ihre verfügbaren LP-Einheiten</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">Übersteigt die an diese Node gebundenen LP-Einheiten</string>
     <string name="deposit_error_invalid_assets">Assets ist ungültig</string>
     <string name="deposit_error_chain_not_enabled">Aktivieren Sie %1$s in diesem Tresor, um %2$s abzuheben</string>
     <string name="deposit_error_has_not_reached_maturity">Diese Einlage hat ihre Fälligkeit noch nicht erreicht.</string>
@@ -393,6 +395,9 @@
     <string name="deposit_form_screen_asset_selection">Anlagenauswahl</string>
     <string name="deposit_form_screen_lpunits">LP-Einheiten</string>
     <string name="deposit_form_available_lp_units">Verfügbare LP-Einheiten</string>
+    <string name="deposit_form_bonded_lp_units">Gebundene LP-Einheiten</string>
+    <string name="deposit_form_no_bonded_assets_on_node">Keine gebundenen Vermögenswerte auf dieser Node gefunden</string>
+    <string name="deposit_form_bonded_assets_load_failed">Gebundene Vermögenswerte für diese Node konnten nicht geladen werden</string>
     <string name="deposit_form_estimated_bond_value">Geschätzter Bondwert</string>
     <string name="join_keysign_error_wrong_vault_share">Dieselbe Tresorfreigabe. Bitte ändern Sie die Freigabe zum Signieren</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Tresor ändern</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -398,6 +398,7 @@
     <string name="deposit_form_bonded_lp_units">Gebundene LP-Einheiten</string>
     <string name="deposit_form_no_bonded_assets_on_node">Keine gebundenen Vermögenswerte auf dieser Node gefunden</string>
     <string name="deposit_form_bonded_assets_load_failed">Gebundene Vermögenswerte für diese Node konnten nicht geladen werden</string>
+    <string name="deposit_form_bonded_assets_loading">Gebundene Vermögenswerte werden geladen…</string>
     <string name="deposit_form_estimated_bond_value">Geschätzter Bondwert</string>
     <string name="join_keysign_error_wrong_vault_share">Dieselbe Tresorfreigabe. Bitte ändern Sie die Freigabe zum Signieren</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Tresor ändern</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -381,6 +381,8 @@
     <string name="no_barcodes_found">No se encontraron códigos de barras.</string>
     <string name="reshare_start_join_reshare_button">Únase a Reshare</string>
     <string name="deposit_error_invalid_lpunits">Las unidades LP no son válidas</string>
+    <string name="deposit_error_lpunits_exceeds_available">Supera las unidades LP disponibles</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">Supera las unidades LP vinculadas a este nodo</string>
     <string name="deposit_error_invalid_assets">Los activos no son válidos</string>
     <string name="deposit_error_chain_not_enabled">Habilita %1$s en esta bóveda para retirar %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Este depósito aún no ha alcanzado su período de vencimiento.</string>
@@ -393,6 +395,9 @@
     <string name="deposit_form_screen_asset_selection">Selección de activos</string>
     <string name="deposit_form_screen_lpunits">Unidades LP</string>
     <string name="deposit_form_available_lp_units">Unidades LP disponibles</string>
+    <string name="deposit_form_bonded_lp_units">Unidades LP vinculadas</string>
+    <string name="deposit_form_no_bonded_assets_on_node">No se encontraron activos vinculados en este nodo</string>
+    <string name="deposit_form_bonded_assets_load_failed">No se pudieron cargar los activos vinculados de este nodo</string>
     <string name="deposit_form_estimated_bond_value">Valor estimado del bono</string>
     <string name="join_keysign_error_wrong_vault_share">Misma bóveda compartida. Cambie la compartición para iniciar sesión</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Cambiar bóveda</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -398,6 +398,7 @@
     <string name="deposit_form_bonded_lp_units">Unidades LP vinculadas</string>
     <string name="deposit_form_no_bonded_assets_on_node">No se encontraron activos vinculados en este nodo</string>
     <string name="deposit_form_bonded_assets_load_failed">No se pudieron cargar los activos vinculados de este nodo</string>
+    <string name="deposit_form_bonded_assets_loading">Cargando activos vinculados…</string>
     <string name="deposit_form_estimated_bond_value">Valor estimado del bono</string>
     <string name="join_keysign_error_wrong_vault_share">Misma bóveda compartida. Cambie la compartición para iniciar sesión</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Cambiar bóveda</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -398,6 +398,7 @@
     <string name="deposit_form_bonded_lp_units">Vezane LP jedinice</string>
     <string name="deposit_form_no_bonded_assets_on_node">Nema vezane imovine na ovom čvoru</string>
     <string name="deposit_form_bonded_assets_load_failed">Nije moguće učitati vezanu imovinu za ovaj čvor</string>
+    <string name="deposit_form_bonded_assets_loading">Učitavanje vezane imovine…</string>
     <string name="deposit_form_estimated_bond_value">Procijenjeni iznos zaloga</string>
     <string name="join_keysign_error_wrong_vault_share">Isti dio trezora. Molimo promijenite dionicu za potpis</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Promjena trezora</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -381,6 +381,8 @@
     <string name="no_barcodes_found">Nisu pronađeni barkodovi</string>
     <string name="reshare_start_join_reshare_button">Pridružite se ponovnom dijeljenju</string>
     <string name="deposit_error_invalid_lpunits">LP jedinice nisu važeće</string>
+    <string name="deposit_error_lpunits_exceeds_available">Premašuje dostupne LP jedinice</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">Premašuje LP jedinice vezane uz ovaj čvor</string>
     <string name="deposit_error_invalid_assets">Sredstva su nevažeća</string>
     <string name="deposit_error_chain_not_enabled">Omogućite %1$s u ovom trezoru za povlačenje %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Ovaj depozit još nije dostigao rok dospijeća</string>
@@ -393,6 +395,9 @@
     <string name="deposit_form_screen_asset_selection">Odabir imovine</string>
     <string name="deposit_form_screen_lpunits">LP jedinice</string>
     <string name="deposit_form_available_lp_units">Dostupne LP jedinice</string>
+    <string name="deposit_form_bonded_lp_units">Vezane LP jedinice</string>
+    <string name="deposit_form_no_bonded_assets_on_node">Nema vezane imovine na ovom čvoru</string>
+    <string name="deposit_form_bonded_assets_load_failed">Nije moguće učitati vezanu imovinu za ovaj čvor</string>
     <string name="deposit_form_estimated_bond_value">Procijenjeni iznos zaloga</string>
     <string name="join_keysign_error_wrong_vault_share">Isti dio trezora. Molimo promijenite dionicu za potpis</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Promjena trezora</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -381,6 +381,8 @@
     <string name="no_barcodes_found">Nessun codice a barre trovato</string>
     <string name="reshare_start_join_reshare_button">Unisciti a Reshare</string>
     <string name="deposit_error_invalid_lpunits">Le unità LP non sono valide</string>
+    <string name="deposit_error_lpunits_exceeds_available">Supera le unità LP disponibili</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">Supera le unità LP vincolate a questo nodo</string>
     <string name="deposit_error_invalid_assets">Le risorse non sono valide</string>
     <string name="deposit_error_chain_not_enabled">Abilita %1$s in questo vault per prelevare %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Questo deposito non ha ancora raggiunto il suo periodo di scadenza</string>
@@ -393,6 +395,9 @@
     <string name="deposit_form_screen_asset_selection">Selezione asset</string>
     <string name="deposit_form_screen_lpunits">Unità LP</string>
     <string name="deposit_form_available_lp_units">Unità LP disponibili</string>
+    <string name="deposit_form_bonded_lp_units">Unità LP vincolate</string>
+    <string name="deposit_form_no_bonded_assets_on_node">Nessuna attività vincolata trovata su questo nodo</string>
+    <string name="deposit_form_bonded_assets_load_failed">Impossibile caricare le attività vincolate per questo nodo</string>
     <string name="deposit_form_estimated_bond_value">Valore stimato del bond</string>
     <string name="join_keysign_error_wrong_vault_share">Stessa condivisione del vault. Modifica la condivisione per firmare</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Cambia Vault</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -398,6 +398,7 @@
     <string name="deposit_form_bonded_lp_units">Unità LP vincolate</string>
     <string name="deposit_form_no_bonded_assets_on_node">Nessuna attività vincolata trovata su questo nodo</string>
     <string name="deposit_form_bonded_assets_load_failed">Impossibile caricare le attività vincolate per questo nodo</string>
+    <string name="deposit_form_bonded_assets_loading">Caricamento attività vincolate…</string>
     <string name="deposit_form_estimated_bond_value">Valore stimato del bond</string>
     <string name="join_keysign_error_wrong_vault_share">Stessa condivisione del vault. Modifica la condivisione per firmare</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Cambia Vault</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -511,6 +511,7 @@
     <string name="deposit_form_bonded_lp_units">본딩된 LP 유닛</string>
     <string name="deposit_form_no_bonded_assets_on_node">이 노드에 본딩된 자산이 없습니다</string>
     <string name="deposit_form_bonded_assets_load_failed">이 노드의 본딩된 자산을 불러오지 못했습니다</string>
+    <string name="deposit_form_bonded_assets_loading">본딩된 자산 로드 중…</string>
     <string name="deposit_form_estimated_bond_value">예상 본드 가치</string>
     <string name="join_keysign_error_wrong_vault_share">동일한 볼트 공유입니다. 서명할 공유를 변경해 주세요</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">볼트 변경</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -494,6 +494,8 @@
     <string name="no_barcodes_found">바코드를 찾을 수 없습니다</string>
     <string name="reshare_start_join_reshare_button">재공유 참여</string>
     <string name="deposit_error_invalid_lpunits">LP 유닛이 유효하지 않습니다</string>
+    <string name="deposit_error_lpunits_exceeds_available">사용 가능한 LP 유닛을 초과합니다</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">이 노드에 본딩된 LP 유닛을 초과합니다</string>
     <string name="deposit_error_invalid_assets">자산이 유효하지 않습니다</string>
     <string name="deposit_error_chain_not_enabled">%2$s을(를) 출금하려면 이 볼트에서 %1$s을(를) 활성화하세요</string>
     <string name="deposit_error_has_not_reached_maturity">이 예치는 아직 만기에 도달하지 않았습니다</string>
@@ -506,6 +508,9 @@
     <string name="deposit_form_screen_asset_selection">자산 선택</string>
     <string name="deposit_form_screen_lpunits">LP 유닛</string>
     <string name="deposit_form_available_lp_units">사용 가능한 LP 유닛</string>
+    <string name="deposit_form_bonded_lp_units">본딩된 LP 유닛</string>
+    <string name="deposit_form_no_bonded_assets_on_node">이 노드에 본딩된 자산이 없습니다</string>
+    <string name="deposit_form_bonded_assets_load_failed">이 노드의 본딩된 자산을 불러오지 못했습니다</string>
     <string name="deposit_form_estimated_bond_value">예상 본드 가치</string>
     <string name="join_keysign_error_wrong_vault_share">동일한 볼트 공유입니다. 서명할 공유를 변경해 주세요</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">볼트 변경</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -397,6 +397,7 @@
     <string name="deposit_form_bonded_lp_units">Gebonden LP-eenheden</string>
     <string name="deposit_form_no_bonded_assets_on_node">Geen gebonden activa gevonden op deze node</string>
     <string name="deposit_form_bonded_assets_load_failed">Kan uw gebonden activa voor deze node niet laden</string>
+    <string name="deposit_form_bonded_assets_loading">Gebonden activa laden…</string>
     <string name="deposit_form_estimated_bond_value">Geschatte bondwaarde</string>
     <string name="join_keysign_error_wrong_vault_share">Zelfde kluisshare. Verander de share naar sign</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Wijzig kluis</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -380,6 +380,8 @@
     <string name="no_barcodes_found">Geen barcodes gevonden</string>
     <string name="reshare_start_join_reshare_button">Word lid van Reshare</string>
     <string name="deposit_error_invalid_lpunits">LP-eenheden zijn ongeldig</string>
+    <string name="deposit_error_lpunits_exceeds_available">Overschrijdt uw beschikbare LP-eenheden</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">Overschrijdt de aan deze node gebonden LP-eenheden</string>
     <string name="deposit_error_invalid_assets">Activa zijn ongeldig</string>
     <string name="deposit_error_chain_not_enabled">Schakel %1$s in deze kluis in om %2$s op te nemen</string>
     <string name="deposit_error_has_not_reached_maturity">Deze deposito heeft de vervaldatum nog niet bereikt</string>
@@ -392,6 +394,9 @@
     <string name="deposit_form_screen_asset_selection">Activaselectie</string>
     <string name="deposit_form_screen_lpunits">LP-eenheden</string>
     <string name="deposit_form_available_lp_units">Beschikbare LP-eenheden</string>
+    <string name="deposit_form_bonded_lp_units">Gebonden LP-eenheden</string>
+    <string name="deposit_form_no_bonded_assets_on_node">Geen gebonden activa gevonden op deze node</string>
+    <string name="deposit_form_bonded_assets_load_failed">Kan uw gebonden activa voor deze node niet laden</string>
     <string name="deposit_form_estimated_bond_value">Geschatte bondwaarde</string>
     <string name="join_keysign_error_wrong_vault_share">Zelfde kluisshare. Verander de share naar sign</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Wijzig kluis</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -398,6 +398,7 @@
     <string name="deposit_form_bonded_lp_units">Unidades LP vinculadas</string>
     <string name="deposit_form_no_bonded_assets_on_node">Nenhum ativo vinculado encontrado neste nó</string>
     <string name="deposit_form_bonded_assets_load_failed">Não foi possível carregar os ativos vinculados deste nó</string>
+    <string name="deposit_form_bonded_assets_loading">Carregando ativos vinculados…</string>
     <string name="deposit_form_estimated_bond_value">Valor estimado do bond</string>
     <string name="join_keysign_error_wrong_vault_share">A mesma partilha do cofre. Por favor, altere a partilha para assinar</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Alterar cofre</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -381,6 +381,8 @@
     <string name="no_barcodes_found">Nenhum código de barras encontrado</string>
     <string name="reshare_start_join_reshare_button">Junte-se a partilhar novamente</string>
     <string name="deposit_error_invalid_lpunits">As unidades LP são inválidas</string>
+    <string name="deposit_error_lpunits_exceeds_available">Excede as unidades LP disponíveis</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">Excede as unidades LP vinculadas a este nó</string>
     <string name="deposit_error_invalid_assets">Os recursos são inválidos</string>
     <string name="deposit_error_chain_not_enabled">Ative %1$s neste cofre para retirar %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Este depósito ainda não atingiu o seu prazo de vencimento.</string>
@@ -393,6 +395,9 @@
     <string name="deposit_form_screen_asset_selection">Seleção de ativos</string>
     <string name="deposit_form_screen_lpunits">Unidades LP</string>
     <string name="deposit_form_available_lp_units">Unidades LP disponíveis</string>
+    <string name="deposit_form_bonded_lp_units">Unidades LP vinculadas</string>
+    <string name="deposit_form_no_bonded_assets_on_node">Nenhum ativo vinculado encontrado neste nó</string>
+    <string name="deposit_form_bonded_assets_load_failed">Não foi possível carregar os ativos vinculados deste nó</string>
     <string name="deposit_form_estimated_bond_value">Valor estimado do bond</string>
     <string name="join_keysign_error_wrong_vault_share">A mesma partilha do cofre. Por favor, altere a partilha para assinar</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Alterar cofre</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -397,6 +397,7 @@
     <string name="deposit_form_bonded_lp_units">Связанные единицы LP</string>
     <string name="deposit_form_no_bonded_assets_on_node">На этом узле нет связанных активов</string>
     <string name="deposit_form_bonded_assets_load_failed">Не удалось загрузить связанные активы для этого узла</string>
+    <string name="deposit_form_bonded_assets_loading">Загрузка связанных активов…</string>
     <string name="deposit_form_estimated_bond_value">Оценочная стоимость залога</string>
     <string name="join_keysign_error_wrong_vault_share">Тот же общий доступ к хранилищу. Пожалуйста, измените общий доступ для подписи</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Изменить хранилище</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -380,6 +380,8 @@
     <string name="no_barcodes_found">Штрих-коды не найдены.</string>
     <string name="reshare_start_join_reshare_button">Присоединиться к перераспределению</string>
     <string name="deposit_error_invalid_lpunits">Единицы LP недействительны</string>
+    <string name="deposit_error_lpunits_exceeds_available">Превышает доступные единицы LP</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">Превышает единицы LP, связанные с этим узлом</string>
     <string name="deposit_error_invalid_assets">Активы недействительны</string>
     <string name="deposit_error_chain_not_enabled">Включите %1$s в этом хранилище, чтобы вывести %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">Срок действия этого депозита еще не наступил.</string>
@@ -392,6 +394,9 @@
     <string name="deposit_form_screen_asset_selection">Выбор актива</string>
     <string name="deposit_form_screen_lpunits">Единицы LP</string>
     <string name="deposit_form_available_lp_units">Доступные единицы LP</string>
+    <string name="deposit_form_bonded_lp_units">Связанные единицы LP</string>
+    <string name="deposit_form_no_bonded_assets_on_node">На этом узле нет связанных активов</string>
+    <string name="deposit_form_bonded_assets_load_failed">Не удалось загрузить связанные активы для этого узла</string>
     <string name="deposit_form_estimated_bond_value">Оценочная стоимость залога</string>
     <string name="join_keysign_error_wrong_vault_share">Тот же общий доступ к хранилищу. Пожалуйста, измените общий доступ для подписи</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Изменить хранилище</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -683,6 +683,7 @@
     <string name="deposit_form_bonded_lp_units">已绑定 LP 单位</string>
     <string name="deposit_form_no_bonded_assets_on_node">在此节点上未找到已绑定资产</string>
     <string name="deposit_form_bonded_assets_load_failed">无法加载此节点的已绑定资产</string>
+    <string name="deposit_form_bonded_assets_loading">正在加载已绑定资产…</string>
     <string name="deposit_form_estimated_bond_value">预计质押价值</string>
 
     <!-- Join Keysign Error -->

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -664,6 +664,8 @@
 
     <!-- Deposit Errors -->
     <string name="deposit_error_invalid_lpunits">LP 单位无效</string>
+    <string name="deposit_error_lpunits_exceeds_available">超出可用 LP 单位</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">超出绑定到此节点的 LP 单位</string>
     <string name="deposit_error_invalid_assets">资产无效</string>
     <string name="deposit_error_chain_not_enabled">请在此保险库中启用 %1$s 以提取 %2$s</string>
 
@@ -678,6 +680,9 @@
     <string name="deposit_form_screen_asset_selection">选择资产</string>
     <string name="deposit_form_screen_lpunits">LP 单位</string>
     <string name="deposit_form_available_lp_units">可用 LP 单位</string>
+    <string name="deposit_form_bonded_lp_units">已绑定 LP 单位</string>
+    <string name="deposit_form_no_bonded_assets_on_node">在此节点上未找到已绑定资产</string>
+    <string name="deposit_form_bonded_assets_load_failed">无法加载此节点的已绑定资产</string>
     <string name="deposit_form_estimated_bond_value">预计质押价值</string>
 
     <!-- Join Keysign Error -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -522,6 +522,7 @@
     <string name="deposit_form_bonded_lp_units">Bonded LP Units</string>
     <string name="deposit_form_no_bonded_assets_on_node">No bonded assets found on this node</string>
     <string name="deposit_form_bonded_assets_load_failed">Couldn\'t load your bonded assets for this node</string>
+    <string name="deposit_form_bonded_assets_loading">Loading bonded assets…</string>
     <string name="deposit_form_estimated_bond_value">Estimated Bond Value</string>
     <string name="join_keysign_error_wrong_vault_share">Same vault share. Please change the share to sign</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Change Vault</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -505,6 +505,8 @@
     <string name="no_barcodes_found">No barcodes found</string>
     <string name="reshare_start_join_reshare_button">Join Reshare</string>
     <string name="deposit_error_invalid_lpunits">LP units are invalid</string>
+    <string name="deposit_error_lpunits_exceeds_available">Exceeds your available LP units</string>
+    <string name="deposit_error_lpunits_exceeds_bonded">Exceeds the LP units bonded to this node</string>
     <string name="deposit_error_invalid_assets">Assets are invalid</string>
     <string name="deposit_error_chain_not_enabled">Enable %1$s in this vault to withdraw %2$s</string>
     <string name="deposit_error_has_not_reached_maturity">This deposit has not reached its maturity period yet</string>
@@ -517,6 +519,9 @@
     <string name="deposit_form_screen_asset_selection">Asset selection</string>
     <string name="deposit_form_screen_lpunits">LP Units</string>
     <string name="deposit_form_available_lp_units">Available LP Units</string>
+    <string name="deposit_form_bonded_lp_units">Bonded LP Units</string>
+    <string name="deposit_form_no_bonded_assets_on_node">No bonded assets found on this node</string>
+    <string name="deposit_form_bonded_assets_load_failed">Couldn\'t load your bonded assets for this node</string>
     <string name="deposit_form_estimated_bond_value">Estimated Bond Value</string>
     <string name="join_keysign_error_wrong_vault_share">Same vault share. Please change the share to sign</string>
     <string name="join_keysign_error_wrong_vault_share_try_again_button">Change Vault</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -50,12 +50,14 @@ import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.SendDst
 import com.vultisig.wallet.ui.utils.UiText
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -501,9 +503,9 @@ internal class DepositFormViewModelTest {
             advanceUntilIdle()
             val loaded = vm.state.first { it.bondableAssets.isNotEmpty() }
 
-            assertEquals(listOf("MAYA.CACAO"), loaded.bondableAssets)
-            assertEquals("500000", loaded.bondedUnitsCeiling?.units)
-            assertEquals(MAYA_NODE, loaded.bondedUnitsCeiling?.nodeAddress)
+            loaded.bondableAssets shouldBe listOf("MAYA.CACAO")
+            loaded.bondedUnitsCeiling?.units shouldBe "500000"
+            loaded.bondedUnitsCeiling?.nodeAddress shouldBe MAYA_NODE
         }
 
     @Test
@@ -520,11 +522,11 @@ internal class DepositFormViewModelTest {
 
         vm.lpUnitsFieldState.setTextAndPlaceCursorAtEnd("500001")
         vm.validateLpUnits()
-        assertNotNull(vm.state.value.lpUnitsError)
+        vm.state.value.lpUnitsError.shouldNotBeNull()
 
         vm.lpUnitsFieldState.setTextAndPlaceCursorAtEnd("500000")
         vm.validateLpUnits()
-        assertEquals(null, vm.state.value.lpUnitsError)
+        vm.state.value.lpUnitsError shouldBe null
     }
 
     @Test
@@ -538,10 +540,10 @@ internal class DepositFormViewModelTest {
 
             vm.loadData("vault1", Chain.MayaChain.raw, "unbond", MAYA_NODE)
             advanceUntilIdle()
-            val loaded = vm.state.first { it.bondAssetsLoadFailed }
+            val loaded = vm.state.first { it.bondAssetsState == BondAssetsState.Failed }
 
-            assertTrue(loaded.bondableAssets.isEmpty())
-            assertNull(loaded.bondedUnitsCeiling)
+            loaded.bondableAssets.shouldBeEmpty()
+            loaded.bondedUnitsCeiling shouldBe null
         }
 
     private fun givenMayaVaultAddress() {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/DepositFormViewModelTest.kt
@@ -55,6 +55,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -62,6 +63,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -484,6 +486,81 @@ internal class DepositFormViewModelTest {
             R.string.deposit_error_lp_paused_pool,
             (errorText as UiText.FormattedText).resId,
         )
+    }
+
+    @Test
+    fun `Maya Unbond loads the pools bonded to the routed node, including a full position`() =
+        runTest {
+            val vm = buildViewModel()
+            givenMayaVaultAddress()
+            coEvery {
+                mayachainBondRepository.getBondedLpUnitsOnNode(MAYA_NODE, MAYA_VAULT_ADDRESS)
+            } returns mapOf("MAYA.CACAO" to 500_000L)
+
+            vm.loadData("vault1", Chain.MayaChain.raw, "unbond", MAYA_NODE)
+            advanceUntilIdle()
+            val loaded = vm.state.first { it.bondableAssets.isNotEmpty() }
+
+            assertEquals(listOf("MAYA.CACAO"), loaded.bondableAssets)
+            assertEquals("500000", loaded.bondedUnitsCeiling?.units)
+            assertEquals(MAYA_NODE, loaded.bondedUnitsCeiling?.nodeAddress)
+        }
+
+    @Test
+    fun `Maya Unbond rejects more LP units than the node has bonded`() = runTest {
+        val vm = buildViewModel()
+        givenMayaVaultAddress()
+        coEvery {
+            mayachainBondRepository.getBondedLpUnitsOnNode(MAYA_NODE, MAYA_VAULT_ADDRESS)
+        } returns mapOf("MAYA.CACAO" to 500_000L)
+
+        vm.loadData("vault1", Chain.MayaChain.raw, "unbond", MAYA_NODE)
+        advanceUntilIdle()
+        vm.state.first { it.bondableAssets.isNotEmpty() }
+
+        vm.lpUnitsFieldState.setTextAndPlaceCursorAtEnd("500001")
+        vm.validateLpUnits()
+        assertNotNull(vm.state.value.lpUnitsError)
+
+        vm.lpUnitsFieldState.setTextAndPlaceCursorAtEnd("500000")
+        vm.validateLpUnits()
+        assertEquals(null, vm.state.value.lpUnitsError)
+    }
+
+    @Test
+    fun `Maya Unbond flags a failed bonded-asset fetch instead of showing an empty node`() =
+        runTest {
+            val vm = buildViewModel()
+            givenMayaVaultAddress()
+            coEvery {
+                mayachainBondRepository.getBondedLpUnitsOnNode(MAYA_NODE, MAYA_VAULT_ADDRESS)
+            } throws RuntimeException("node api down")
+
+            vm.loadData("vault1", Chain.MayaChain.raw, "unbond", MAYA_NODE)
+            advanceUntilIdle()
+            val loaded = vm.state.first { it.bondAssetsLoadFailed }
+
+            assertTrue(loaded.bondableAssets.isEmpty())
+            assertNull(loaded.bondedUnitsCeiling)
+        }
+
+    private fun givenMayaVaultAddress() {
+        coEvery { accountsRepository.loadAddress("vault1", Chain.MayaChain) } returns
+            flowOf(
+                Address(
+                    chain = Chain.MayaChain,
+                    address = MAYA_VAULT_ADDRESS,
+                    accounts =
+                        listOf(
+                            Account(
+                                token = Coins.MayaChain.CACAO,
+                                tokenValue = null,
+                                fiatValue = null,
+                                price = null,
+                            )
+                        ),
+                )
+            )
     }
 
     @Test
@@ -1002,5 +1079,10 @@ internal class DepositFormViewModelTest {
         vm.validateLpUnits()
 
         assertEquals(null, vm.state.value.lpUnitsError)
+    }
+
+    private companion object {
+        const val MAYA_NODE = "mayaNode1"
+        const val MAYA_VAULT_ADDRESS = "maya1someaddress"
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoaderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoaderTest.kt
@@ -8,16 +8,17 @@ import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.repositories.MayachainBondRepository
 import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
+import com.vultisig.wallet.ui.models.deposit.BondAssetsState
 import com.vultisig.wallet.ui.models.deposit.BondedUnitsCeiling
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositOption
+import com.vultisig.wallet.ui.models.deposit.bondedUnitsCeiling
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertNull
-import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -77,14 +78,13 @@ internal class LiquidityDataLoaderTest {
             awaitLoad()
 
             val current = state.value
-            assertEquals(listOf("MAYA.CACAO", "ETH.ETH"), current.bondableAssets)
-            assertEquals("MAYA.CACAO", current.selectedBondAsset)
-            assertEquals(
-                BondedUnitsCeiling(nodeAddress = NODE, asset = "MAYA.CACAO", units = "500000"),
-                current.bondedUnitsCeiling,
-            )
-            assertEquals("MAYA.CACAO", assetsField.text.toString())
-            assertFalse(current.bondAssetsLoadFailed)
+            current.bondableAssets shouldBe listOf("MAYA.CACAO", "ETH.ETH")
+            current.selectedBondAsset shouldBe "MAYA.CACAO"
+            current.bondAssetsState shouldBe
+                BondAssetsState.Loaded(
+                    BondedUnitsCeiling(nodeAddress = NODE, asset = "MAYA.CACAO", units = "500000")
+                )
+            assetsField.text.toString() shouldBe "MAYA.CACAO"
         }
 
     @Test
@@ -95,8 +95,8 @@ internal class LiquidityDataLoaderTest {
         loader.loadMayaBondedAssets(NODE)
         awaitLoad()
 
-        assertEquals(listOf("MAYA.CACAO"), state.value.bondableAssets)
-        assertEquals("500000", state.value.bondedUnitsCeiling?.units)
+        state.value.bondableAssets shouldBe listOf("MAYA.CACAO")
+        state.value.bondedUnitsCeiling?.units shouldBe "500000"
     }
 
     @Test
@@ -107,9 +107,9 @@ internal class LiquidityDataLoaderTest {
         awaitLoad()
 
         val current = state.value
-        assertTrue(current.bondableAssets.isEmpty())
-        assertNull(current.bondedUnitsCeiling)
-        assertFalse(current.bondAssetsLoadFailed)
+        current.bondableAssets.shouldBeEmpty()
+        // Loaded, not Failed: the node was asked and answered that it holds nothing.
+        current.bondAssetsState shouldBe BondAssetsState.Loaded()
     }
 
     @Test
@@ -122,10 +122,30 @@ internal class LiquidityDataLoaderTest {
             awaitLoad()
 
             val current = state.value
-            assertTrue(current.bondableAssets.isEmpty())
-            assertNull(current.bondedUnitsCeiling)
-            assertTrue(current.bondAssetsLoadFailed)
+            current.bondableAssets.shouldBeEmpty()
+            current.bondAssetsState shouldBe BondAssetsState.Failed
         }
+
+    @Test
+    fun `loadMayaBondedAssets reports loading before it can claim the node is empty`() = runTest {
+        val fetch = CompletableDeferred<Map<String, Long>>()
+        coEvery { bondRepository.getBondedLpUnitsOnNode(NODE, VAULT_ADDRESS) } coAnswers
+            {
+                fetch.await()
+            }
+
+        loader.loadMayaBondedAssets(NODE)
+
+        // The pool list is empty in flight exactly as it is on an empty node, so only the state
+        // stops the form from telling the user this node holds nothing before it has been asked.
+        state.value.bondableAssets.shouldBeEmpty()
+        state.value.bondAssetsState shouldBe BondAssetsState.Loading
+
+        fetch.complete(mapOf("MAYA.CACAO" to 500_000L))
+        awaitLoad()
+
+        state.value.bondedUnitsCeiling?.units shouldBe "500000"
+    }
 
     @Test
     fun `loadMayaBondedAssets asks nothing while the node address is blank`() = runTest {
@@ -133,8 +153,9 @@ internal class LiquidityDataLoaderTest {
         awaitLoad()
 
         coVerify(exactly = 0) { bondRepository.getBondedLpUnitsOnNode(any(), any()) }
-        assertTrue(state.value.bondableAssets.isEmpty())
-        assertFalse(state.value.bondAssetsLoadFailed)
+        state.value.bondableAssets.shouldBeEmpty()
+        // Idle, not Failed: a form with no node named yet has nothing to retry.
+        state.value.bondAssetsState shouldBe BondAssetsState.Idle
     }
 
     @Test
@@ -148,8 +169,27 @@ internal class LiquidityDataLoaderTest {
         loader.loadMayaBondedAssets("otherNode")
         awaitLoad()
 
-        assertNull(state.value.bondedUnitsCeiling)
-        assertTrue(state.value.bondableAssets.isEmpty())
+        state.value.bondedUnitsCeiling shouldBe null
+        state.value.bondableAssets.shouldBeEmpty()
+    }
+
+    @Test
+    fun `clearBondedAssets leaves no pool of the previous node selectable`() = runTest {
+        givenBonded(mapOf("MAYA.CACAO" to 500_000L))
+        loader.loadMayaBondedAssets(NODE)
+        awaitLoad()
+        lpUnitsField.setTextAndPlaceCursorAtEnd("500000")
+
+        loader.clearBondedAssets()
+
+        // The picker runs off bondableAssets and selecting one reads bondedCeilingFor, so both
+        // have to be empty for the debounce window to hold no ceiling from the previous node.
+        state.value.bondableAssets.shouldBeEmpty()
+        state.value.selectedBondAsset shouldBe ""
+        loader.bondedCeilingFor("MAYA.CACAO") shouldBe null
+        state.value.bondAssetsState shouldBe BondAssetsState.Idle
+        assetsField.text.toString() shouldBe ""
+        lpUnitsField.text.toString() shouldBe ""
     }
 
     @Test
@@ -159,8 +199,8 @@ internal class LiquidityDataLoaderTest {
         loader.loadMayaBondedAssets(NODE)
         awaitLoad()
 
-        assertEquals("500000", loader.bondedCeilingFor("MAYA.CACAO")?.units)
-        assertNull(loader.bondedCeilingFor("ETH.ETH"))
+        loader.bondedCeilingFor("MAYA.CACAO")?.units shouldBe "500000"
+        loader.bondedCeilingFor("ETH.ETH") shouldBe null
     }
 
     @Test
@@ -172,7 +212,7 @@ internal class LiquidityDataLoaderTest {
 
         loader.setMaxLpUnits()
 
-        assertEquals("500000", lpUnitsField.text.toString())
+        lpUnitsField.text.toString() shouldBe "500000"
     }
 
     private fun givenBonded(pools: Map<String, Long>) {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoaderTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/load/LiquidityDataLoaderTest.kt
@@ -1,0 +1,186 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.deposit.load
+
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import com.vultisig.wallet.data.models.Address
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.repositories.MayachainBondRepository
+import com.vultisig.wallet.data.usecases.GetThorChainLpPositionUseCase
+import com.vultisig.wallet.ui.models.deposit.BondedUnitsCeiling
+import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
+import com.vultisig.wallet.ui.models.deposit.DepositOption
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/** Covers the node-scoped Unbond load: what it publishes, and how it reports having failed. */
+internal class LiquidityDataLoaderTest {
+
+    private val scheduler = TestCoroutineScheduler()
+    private val dispatcher = UnconfinedTestDispatcher(scheduler)
+    private val scopeJob = Job()
+    private val scope = CoroutineScope(dispatcher + scopeJob)
+
+    private val bondRepository: MayachainBondRepository = mockk()
+    private val thorLpPosition: GetThorChainLpPositionUseCase = mockk(relaxed = true)
+
+    private val state =
+        MutableStateFlow(
+            DepositFormUiModel(depositChain = Chain.MayaChain, depositOption = DepositOption.Unbond)
+        )
+    private val address =
+        MutableStateFlow<Address?>(
+            Address(chain = Chain.MayaChain, address = VAULT_ADDRESS, accounts = emptyList())
+        )
+    private val assetsField = TextFieldState()
+    private val lpUnitsField = TextFieldState()
+
+    private val loader =
+        LiquidityDataLoader(
+            mayachainBondRepository = bondRepository,
+            getThorChainLpPositionUseCase = thorLpPosition,
+            scope = scope,
+            state = state,
+            address = address,
+            assetsFieldState = assetsField,
+            lpUnitsFieldState = lpUnitsField,
+            vaultId = { "vault-1" },
+            lpPoolId = { null },
+            resolvePairedAddress = { _, _, _ -> null },
+        )
+
+    /** Waits for the load coroutine, whose repository call hops off the test dispatcher. */
+    private suspend fun awaitLoad() {
+        scopeJob.children.forEach { it.join() }
+    }
+
+    @Test
+    fun `loadMayaBondedAssets lists the node's bonded pools and takes its ceiling from the first`() =
+        runTest {
+            givenBonded(mapOf("MAYA.CACAO" to 500_000L, "ETH.ETH" to 250_000L))
+
+            loader.loadMayaBondedAssets(NODE)
+            awaitLoad()
+
+            val current = state.value
+            assertEquals(listOf("MAYA.CACAO", "ETH.ETH"), current.bondableAssets)
+            assertEquals("MAYA.CACAO", current.selectedBondAsset)
+            assertEquals(
+                BondedUnitsCeiling(nodeAddress = NODE, asset = "MAYA.CACAO", units = "500000"),
+                current.bondedUnitsCeiling,
+            )
+            assertEquals("MAYA.CACAO", assetsField.text.toString())
+            assertFalse(current.bondAssetsLoadFailed)
+        }
+
+    @Test
+    fun `loadMayaBondedAssets includes a pool the vault is fully bonded to`() = runTest {
+        // The Bond loader filters these out as having no surplus; Unbond exists to spend them.
+        givenBonded(mapOf("MAYA.CACAO" to 500_000L))
+
+        loader.loadMayaBondedAssets(NODE)
+        awaitLoad()
+
+        assertEquals(listOf("MAYA.CACAO"), state.value.bondableAssets)
+        assertEquals("500000", state.value.bondedUnitsCeiling?.units)
+    }
+
+    @Test
+    fun `loadMayaBondedAssets reports an empty node without calling it a failure`() = runTest {
+        givenBonded(emptyMap())
+
+        loader.loadMayaBondedAssets(NODE)
+        awaitLoad()
+
+        val current = state.value
+        assertTrue(current.bondableAssets.isEmpty())
+        assertNull(current.bondedUnitsCeiling)
+        assertFalse(current.bondAssetsLoadFailed)
+    }
+
+    @Test
+    fun `loadMayaBondedAssets flags a failed fetch rather than reporting an empty node`() =
+        runTest {
+            coEvery { bondRepository.getBondedLpUnitsOnNode(NODE, VAULT_ADDRESS) } throws
+                RuntimeException("node api down")
+
+            loader.loadMayaBondedAssets(NODE)
+            awaitLoad()
+
+            val current = state.value
+            assertTrue(current.bondableAssets.isEmpty())
+            assertNull(current.bondedUnitsCeiling)
+            assertTrue(current.bondAssetsLoadFailed)
+        }
+
+    @Test
+    fun `loadMayaBondedAssets asks nothing while the node address is blank`() = runTest {
+        loader.loadMayaBondedAssets("")
+        awaitLoad()
+
+        coVerify(exactly = 0) { bondRepository.getBondedLpUnitsOnNode(any(), any()) }
+        assertTrue(state.value.bondableAssets.isEmpty())
+        assertFalse(state.value.bondAssetsLoadFailed)
+    }
+
+    @Test
+    fun `loadMayaBondedAssets drops the ceiling loaded for a previous node`() = runTest {
+        givenBonded(mapOf("MAYA.CACAO" to 500_000L))
+        loader.loadMayaBondedAssets(NODE)
+        awaitLoad()
+
+        coEvery { bondRepository.getBondedLpUnitsOnNode("otherNode", VAULT_ADDRESS) } returns
+            emptyMap()
+        loader.loadMayaBondedAssets("otherNode")
+        awaitLoad()
+
+        assertNull(state.value.bondedUnitsCeiling)
+        assertTrue(state.value.bondableAssets.isEmpty())
+    }
+
+    @Test
+    fun `bondedCeilingFor answers only for the pools the loaded node holds`() = runTest {
+        givenBonded(mapOf("MAYA.CACAO" to 500_000L))
+
+        loader.loadMayaBondedAssets(NODE)
+        awaitLoad()
+
+        assertEquals("500000", loader.bondedCeilingFor("MAYA.CACAO")?.units)
+        assertNull(loader.bondedCeilingFor("ETH.ETH"))
+    }
+
+    @Test
+    fun `setMaxLpUnits fills the bonded ceiling when unbonding`() = runTest {
+        givenBonded(mapOf("MAYA.CACAO" to 500_000L))
+        loader.loadMayaBondedAssets(NODE)
+        awaitLoad()
+        lpUnitsField.setTextAndPlaceCursorAtEnd("1")
+
+        loader.setMaxLpUnits()
+
+        assertEquals("500000", lpUnitsField.text.toString())
+    }
+
+    private fun givenBonded(pools: Map<String, Long>) {
+        coEvery { bondRepository.getBondedLpUnitsOnNode(NODE, VAULT_ADDRESS) } returns pools
+    }
+
+    private companion object {
+        const val NODE = "mayaNode"
+        const val VAULT_ADDRESS = "vaultMayaAddress"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/BondStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/BondStrategyTest.kt
@@ -18,6 +18,8 @@ import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import com.vultisig.wallet.ui.utils.UiText
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -91,7 +93,7 @@ internal class BondStrategyTest {
         assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
         lpUnits.setTextAndPlaceCursorAtEnd("501")
 
-        assertFailsWith<InvalidTransactionDataException> {
+        shouldThrow<InvalidTransactionDataException> {
             build(Chain.MayaChain, availableLpUnits = "500").build()
         }
     }
@@ -109,7 +111,7 @@ internal class BondStrategyTest {
 
         val tx = build(Chain.MayaChain).build()
 
-        assertEquals("BOND:MAYA.CACAO:9999:mayaNode", tx.memo)
+        tx.memo shouldBe "BOND:MAYA.CACAO:9999:mayaNode"
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/BondStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/BondStrategyTest.kt
@@ -84,6 +84,35 @@ internal class BondStrategyTest {
     }
 
     @Test
+    fun `Maya bond throws when the entered units exceed the bondable surplus`() = runTest {
+        coEvery { chainRepo.isValid(Chain.MayaChain, "mayaNode") } returns true
+        every { assetsValidator.invoke("MAYA.CACAO") } returns true
+        nodeAddress.setTextAndPlaceCursorAtEnd("mayaNode")
+        assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
+        lpUnits.setTextAndPlaceCursorAtEnd("501")
+
+        assertFailsWith<InvalidTransactionDataException> {
+            build(Chain.MayaChain, availableLpUnits = "500").build()
+        }
+    }
+
+    @Test
+    fun `Maya bond builds when no surplus was loaded`() = runTest {
+        // Bond still accepts a typed asset when the pool list comes back empty, and that path has
+        // no figure to measure against — unlike Unbond, which requires its node-scoped ceiling.
+        coEvery { chainRepo.isValid(Chain.MayaChain, "mayaNode") } returns true
+        every { assetsValidator.invoke("MAYA.CACAO") } returns true
+        givenSpecific()
+        nodeAddress.setTextAndPlaceCursorAtEnd("mayaNode")
+        assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
+        lpUnits.setTextAndPlaceCursorAtEnd("9999")
+
+        val tx = build(Chain.MayaChain).build()
+
+        assertEquals("BOND:MAYA.CACAO:9999:mayaNode", tx.memo)
+    }
+
+    @Test
     fun `Thor bond throws when token amount is missing or zero`() = runTest {
         coEvery { chainRepo.isValid(Chain.ThorChain, "thorNode") } returns true
         nodeAddress.setTextAndPlaceCursorAtEnd("thorNode")
@@ -101,12 +130,20 @@ internal class BondStrategyTest {
         }
     }
 
-    private fun build(chain: Chain, isWhitelistFailed: Boolean = false) =
+    private fun build(
+        chain: Chain,
+        isWhitelistFailed: Boolean = false,
+        availableLpUnits: String? = null,
+    ) =
         BondStrategy(
             vaultIdProvider = { "vault-1" },
             chainProvider = { chain },
             stateProvider = {
-                DepositFormUiModel(depositChain = chain, isWhitelistFailed = isWhitelistFailed)
+                DepositFormUiModel(
+                    depositChain = chain,
+                    isWhitelistFailed = isWhitelistFailed,
+                    availableLpUnits = availableLpUnits,
+                )
             },
             selectedTokenProvider = { runeCoin() },
             selectedAccountProvider = { mockk(relaxed = true) },

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/UnbondStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/UnbondStrategyTest.kt
@@ -14,10 +14,13 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
+import com.vultisig.wallet.ui.models.deposit.BondAssetsState
 import com.vultisig.wallet.ui.models.deposit.BondedUnitsCeiling
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
 import com.vultisig.wallet.ui.models.deposit.DepositOption
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -92,7 +95,7 @@ internal class UnbondStrategyTest {
                 )
                 .build()
 
-        assertEquals("UNBOND:MAYA.CACAO:1000:mayaNode", tx.memo)
+        tx.memo shouldBe "UNBOND:MAYA.CACAO:1000:mayaNode"
     }
 
     @Test
@@ -103,7 +106,7 @@ internal class UnbondStrategyTest {
         assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
         lpUnits.setTextAndPlaceCursorAtEnd("1001")
 
-        assertFailsWith<InvalidTransactionDataException> {
+        shouldThrow<InvalidTransactionDataException> {
             build(
                     Chain.MayaChain,
                     selectedTokenChain = Chain.MayaChain,
@@ -123,7 +126,7 @@ internal class UnbondStrategyTest {
         assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
         lpUnits.setTextAndPlaceCursorAtEnd("500")
 
-        assertFailsWith<InvalidTransactionDataException> {
+        shouldThrow<InvalidTransactionDataException> {
             build(
                     Chain.MayaChain,
                     selectedTokenChain = Chain.MayaChain,
@@ -141,7 +144,7 @@ internal class UnbondStrategyTest {
         assets.setTextAndPlaceCursorAtEnd("ETH.ETH")
         lpUnits.setTextAndPlaceCursorAtEnd("500")
 
-        assertFailsWith<InvalidTransactionDataException> {
+        shouldThrow<InvalidTransactionDataException> {
             build(
                     Chain.MayaChain,
                     selectedTokenChain = Chain.MayaChain,
@@ -159,7 +162,7 @@ internal class UnbondStrategyTest {
         assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
         lpUnits.setTextAndPlaceCursorAtEnd("1000")
 
-        assertFailsWith<InvalidTransactionDataException> {
+        shouldThrow<InvalidTransactionDataException> {
             build(Chain.MayaChain, selectedTokenChain = Chain.MayaChain).build()
         }
     }
@@ -173,8 +176,10 @@ internal class UnbondStrategyTest {
             depositChain = Chain.MayaChain,
             depositOption = DepositOption.Unbond,
             selectedBondAsset = asset,
-            bondedUnitsCeiling =
-                BondedUnitsCeiling(nodeAddress = node, asset = asset, units = units),
+            bondAssetsState =
+                BondAssetsState.Loaded(
+                    BondedUnitsCeiling(nodeAddress = node, asset = asset, units = units)
+                ),
         )
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/UnbondStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/deposit/submit/UnbondStrategyTest.kt
@@ -14,7 +14,9 @@ import com.vultisig.wallet.data.repositories.BlockChainSpecificAndUtxo
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepository
 import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
 import com.vultisig.wallet.data.usecases.DepositMemoAssetsValidatorUseCase
+import com.vultisig.wallet.ui.models.deposit.BondedUnitsCeiling
 import com.vultisig.wallet.ui.models.deposit.DepositFormUiModel
+import com.vultisig.wallet.ui.models.deposit.DepositOption
 import com.vultisig.wallet.ui.models.send.InvalidTransactionDataException
 import io.mockk.coEvery
 import io.mockk.every
@@ -61,11 +63,119 @@ internal class UnbondStrategyTest {
         assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
         lpUnits.setTextAndPlaceCursorAtEnd("1000")
 
-        val tx = build(Chain.MayaChain, selectedTokenChain = Chain.MayaChain).build()
+        val tx =
+            build(
+                    Chain.MayaChain,
+                    selectedTokenChain = Chain.MayaChain,
+                    state = mayaUnbondState(units = "1000"),
+                )
+                .build()
 
         assertEquals("UNBOND:MAYA.CACAO:1000:mayaNode", tx.memo)
         assertEquals(BigInteger.ONE, tx.srcTokenValue.value)
     }
+
+    @Test
+    fun `Maya unbond builds when the entered units equal the bonded ceiling`() = runTest {
+        coEvery { chainRepo.isValid(Chain.MayaChain, "mayaNode") } returns true
+        every { assetsValidator.invoke("MAYA.CACAO") } returns true
+        givenSpecific()
+        nodeAddress.setTextAndPlaceCursorAtEnd("mayaNode")
+        assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
+        lpUnits.setTextAndPlaceCursorAtEnd("1000")
+
+        val tx =
+            build(
+                    Chain.MayaChain,
+                    selectedTokenChain = Chain.MayaChain,
+                    state = mayaUnbondState(units = "1000"),
+                )
+                .build()
+
+        assertEquals("UNBOND:MAYA.CACAO:1000:mayaNode", tx.memo)
+    }
+
+    @Test
+    fun `Maya unbond throws when the entered units exceed what is bonded to the node`() = runTest {
+        coEvery { chainRepo.isValid(Chain.MayaChain, "mayaNode") } returns true
+        every { assetsValidator.invoke("MAYA.CACAO") } returns true
+        nodeAddress.setTextAndPlaceCursorAtEnd("mayaNode")
+        assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
+        lpUnits.setTextAndPlaceCursorAtEnd("1001")
+
+        assertFailsWith<InvalidTransactionDataException> {
+            build(
+                    Chain.MayaChain,
+                    selectedTokenChain = Chain.MayaChain,
+                    state = mayaUnbondState(units = "1000"),
+                )
+                .build()
+        }
+    }
+
+    @Test
+    fun `Maya unbond throws when the ceiling was measured on a different node`() = runTest {
+        // The address field can be re-typed after the units were fetched, and the memo is built
+        // from the field: a ceiling from the previous node must not authorise this one.
+        coEvery { chainRepo.isValid(Chain.MayaChain, "otherNode") } returns true
+        every { assetsValidator.invoke("MAYA.CACAO") } returns true
+        nodeAddress.setTextAndPlaceCursorAtEnd("otherNode")
+        assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
+        lpUnits.setTextAndPlaceCursorAtEnd("500")
+
+        assertFailsWith<InvalidTransactionDataException> {
+            build(
+                    Chain.MayaChain,
+                    selectedTokenChain = Chain.MayaChain,
+                    state = mayaUnbondState(units = "1000"),
+                )
+                .build()
+        }
+    }
+
+    @Test
+    fun `Maya unbond throws when the ceiling belongs to another pool`() = runTest {
+        coEvery { chainRepo.isValid(Chain.MayaChain, "mayaNode") } returns true
+        every { assetsValidator.invoke("ETH.ETH") } returns true
+        nodeAddress.setTextAndPlaceCursorAtEnd("mayaNode")
+        assets.setTextAndPlaceCursorAtEnd("ETH.ETH")
+        lpUnits.setTextAndPlaceCursorAtEnd("500")
+
+        assertFailsWith<InvalidTransactionDataException> {
+            build(
+                    Chain.MayaChain,
+                    selectedTokenChain = Chain.MayaChain,
+                    state = mayaUnbondState(units = "1000"),
+                )
+                .build()
+        }
+    }
+
+    @Test
+    fun `Maya unbond throws when no bonded position was loaded`() = runTest {
+        coEvery { chainRepo.isValid(Chain.MayaChain, "mayaNode") } returns true
+        every { assetsValidator.invoke("MAYA.CACAO") } returns true
+        nodeAddress.setTextAndPlaceCursorAtEnd("mayaNode")
+        assets.setTextAndPlaceCursorAtEnd("MAYA.CACAO")
+        lpUnits.setTextAndPlaceCursorAtEnd("1000")
+
+        assertFailsWith<InvalidTransactionDataException> {
+            build(Chain.MayaChain, selectedTokenChain = Chain.MayaChain).build()
+        }
+    }
+
+    private fun mayaUnbondState(
+        units: String,
+        node: String = "mayaNode",
+        asset: String = "MAYA.CACAO",
+    ) =
+        DepositFormUiModel(
+            depositChain = Chain.MayaChain,
+            depositOption = DepositOption.Unbond,
+            selectedBondAsset = asset,
+            bondedUnitsCeiling =
+                BondedUnitsCeiling(nodeAddress = node, asset = asset, units = units),
+        )
 
     @Test
     fun `Thor unbond throws when amount is zero`() = runTest {
@@ -76,11 +186,15 @@ internal class UnbondStrategyTest {
         assertFailsWith<InvalidTransactionDataException> { build(Chain.ThorChain).build() }
     }
 
-    private fun build(chain: Chain, selectedTokenChain: Chain = Chain.ThorChain) =
+    private fun build(
+        chain: Chain,
+        selectedTokenChain: Chain = Chain.ThorChain,
+        state: DepositFormUiModel = DepositFormUiModel(depositChain = chain),
+    ) =
         UnbondStrategy(
             vaultIdProvider = { "vault-1" },
             chainProvider = { chain },
-            stateProvider = { DepositFormUiModel(depositChain = chain) },
+            stateProvider = { state },
             selectedTokenProvider = { coin(selectedTokenChain) },
             nodeAddressFieldState = nodeAddress,
             tokenAmountFieldState = tokenAmount,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/MayachainBondRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/MayachainBondRepository.kt
@@ -155,17 +155,7 @@ class MayachainBondRepositoryImpl @Inject constructor(private val mayaChainApi: 
                     .associate { it.pool to (it.liquidityUnits.toLongOrNull() ?: 0L) }
             if (memberPools.isEmpty()) return emptyMap()
 
-            val bondedByPool = mutableMapOf<String, Long>()
-            for (node in getAllNodes()) {
-                for (provider in node.bondProviders.providers) {
-                    if (provider.bondAddress == address) {
-                        for ((pool, units) in provider.pools) {
-                            bondedByPool[pool] =
-                                (bondedByPool[pool] ?: 0L) + (units.toLongOrNull() ?: 0L)
-                        }
-                    }
-                }
-            }
+            val bondedByPool = bondedUnitsByPool(getAllNodes(), address)
 
             memberPools
                 .mapValues { (pool, total) -> maxOf(0L, total - (bondedByPool[pool] ?: 0L)) }
@@ -190,16 +180,11 @@ class MayachainBondRepositoryImpl @Inject constructor(private val mayaChainApi: 
         bondAddress: String,
     ): Map<String, Long> {
         return try {
-            val bondedByPool = mutableMapOf<String, Long>()
-            for (provider in getNodeDetails(nodeAddress).bondProviders.providers) {
-                if (provider.bondAddress != bondAddress) continue
-                for ((pool, units) in provider.pools) {
-                    bondedByPool[pool] = (bondedByPool[pool] ?: 0L) + (units.toLongOrNull() ?: 0L)
-                }
-            }
             // A pool listed at zero is not a position, and offering it would let the form build an
             // UNBOND memo the node has nothing to apply it against.
-            bondedByPool.filterValues { it > 0L }
+            bondedUnitsByPool(listOf(getNodeDetails(nodeAddress)), bondAddress).filterValues {
+                it > 0L
+            }
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e(
@@ -210,6 +195,29 @@ class MayachainBondRepositoryImpl @Inject constructor(private val mayaChainApi: 
             )
             throw e
         }
+    }
+
+    /**
+     * The LP units [bondAddress] has bonded across [nodes], summed per pool.
+     *
+     * One address can hold a provider record on several nodes, and both the address-wide surplus
+     * and the position on a single node are read off those same records, so they are added up the
+     * same way here.
+     */
+    private fun bondedUnitsByPool(
+        nodes: List<MayaNodeInfo>,
+        bondAddress: String,
+    ): Map<String, Long> {
+        val bondedByPool = mutableMapOf<String, Long>()
+        for (node in nodes) {
+            for (provider in node.bondProviders.providers) {
+                if (provider.bondAddress != bondAddress) continue
+                for ((pool, units) in provider.pools) {
+                    bondedByPool[pool] = (bondedByPool[pool] ?: 0L) + (units.toLongOrNull() ?: 0L)
+                }
+            }
+        }
+        return bondedByPool
     }
 
     override suspend fun getMemberDetails(address: String): MayaMemberDetails {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/MayachainBondRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/MayachainBondRepository.kt
@@ -35,6 +35,16 @@ interface MayachainBondRepository {
 
     suspend fun getLpBondableAssetsWithUnits(address: String): Map<String, LpBondablePool>
 
+    /**
+     * The LP units [bondAddress] has bonded to [nodeAddress], keyed by pool.
+     *
+     * Unbonding is per node: `UNBOND:{asset}:{units}:{node}` spends against that one node's
+     * bond-provider record, so the address-wide surplus [getLpBondableAssetsWithUnits] reports
+     * cannot say what is unbondable here — least of all for a pool bonded in full, which that
+     * surplus excludes by design. An empty map means this address holds nothing on this node.
+     */
+    suspend fun getBondedLpUnitsOnNode(nodeAddress: String, bondAddress: String): Map<String, Long>
+
     suspend fun getMemberDetails(address: String): MayaMemberDetails
 
     suspend fun getLpPoolStats(): List<MayaLpPoolStats>
@@ -171,6 +181,33 @@ class MayachainBondRepositoryImpl @Inject constructor(private val mayaChainApi: 
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e(e, "Error fetching LP bondable assets with units for address: $address")
+            throw e
+        }
+    }
+
+    override suspend fun getBondedLpUnitsOnNode(
+        nodeAddress: String,
+        bondAddress: String,
+    ): Map<String, Long> {
+        return try {
+            val bondedByPool = mutableMapOf<String, Long>()
+            for (provider in getNodeDetails(nodeAddress).bondProviders.providers) {
+                if (provider.bondAddress != bondAddress) continue
+                for ((pool, units) in provider.pools) {
+                    bondedByPool[pool] = (bondedByPool[pool] ?: 0L) + (units.toLongOrNull() ?: 0L)
+                }
+            }
+            // A pool listed at zero is not a position, and offering it would let the form build an
+            // UNBOND memo the node has nothing to apply it against.
+            bondedByPool.filterValues { it > 0L }
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            Timber.e(
+                e,
+                "Error fetching bonded LP units on node %s for %s",
+                nodeAddress,
+                bondAddress,
+            )
             throw e
         }
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/MayachainBondRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/MayachainBondRepositoryImplTest.kt
@@ -244,6 +244,110 @@ internal class MayachainBondRepositoryImplTest {
         assertTrue(result.isEmpty())
     }
 
+    private fun nodeWithProviders(nodeAddress: String, vararg providers: MayaBondProvider) =
+        MayaNodeInfo(
+            nodeAddress = nodeAddress,
+            status = "Active",
+            bondProviders = MayaBondProviders(nodeOperatorFee = "0", providers = providers.toList()),
+        )
+
+    @Test
+    fun `getBondedLpUnitsOnNode returns a pool the vault is fully bonded to`() = runTest {
+        // The case getLpBondableAssetsWithUnits filters out by design: committing the whole LP
+        // position to one node leaves no surplus, and is the standard bonding pattern.
+        coEvery { api.getNodeDetails("node1") } returns
+            nodeWithProviders(
+                "node1",
+                MayaBondProvider(
+                    bondAddress = "addr1",
+                    bonded = true,
+                    pools = mapOf("MAYA.CACAO" to "500000"),
+                ),
+            )
+
+        val result = repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
+
+        assertEquals(mapOf("MAYA.CACAO" to 500000L), result)
+    }
+
+    @Test
+    fun `getBondedLpUnitsOnNode reads only the node it was asked about`() = runTest {
+        coEvery { api.getNodeDetails("node1") } returns
+            nodeWithProviders(
+                "node1",
+                MayaBondProvider(
+                    bondAddress = "addr1",
+                    bonded = true,
+                    pools = mapOf("MAYA.CACAO" to "500000"),
+                ),
+            )
+        coEvery { api.getNodeDetails("node2") } returns
+            nodeWithProviders(
+                "node2",
+                MayaBondProvider(
+                    bondAddress = "addr1",
+                    bonded = true,
+                    pools = mapOf("ETH.ETH" to "700000"),
+                ),
+            )
+
+        val result = repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
+
+        assertEquals(mapOf("MAYA.CACAO" to 500000L), result)
+    }
+
+    @Test
+    fun `getBondedLpUnitsOnNode returns empty when the vault is not a provider on the node`() =
+        runTest {
+            coEvery { api.getNodeDetails("node1") } returns
+                nodeWithProviders(
+                    "node1",
+                    MayaBondProvider(
+                        bondAddress = "someoneElse",
+                        bonded = true,
+                        pools = mapOf("MAYA.CACAO" to "500000"),
+                    ),
+                )
+
+            val result =
+                repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
+
+            assertTrue(result.isEmpty())
+        }
+
+    @Test
+    fun `getBondedLpUnitsOnNode sums duplicate provider entries and drops empty pools`() = runTest {
+        coEvery { api.getNodeDetails("node1") } returns
+            nodeWithProviders(
+                "node1",
+                MayaBondProvider(
+                    bondAddress = "addr1",
+                    bonded = true,
+                    pools = mapOf("MAYA.CACAO" to "200000", "ETH.ETH" to "0"),
+                ),
+                MayaBondProvider(
+                    bondAddress = "addr1",
+                    bonded = true,
+                    pools = mapOf("MAYA.CACAO" to "300000"),
+                ),
+            )
+
+        val result = repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
+
+        assertEquals(mapOf("MAYA.CACAO" to 500000L), result)
+    }
+
+    @Test
+    fun `getBondedLpUnitsOnNode propagates exception from getNodeDetails`() = runTest {
+        coEvery { api.getNodeDetails("node1") } throws RuntimeException("Node API failure")
+
+        val thrown =
+            assertFailsWith<RuntimeException> {
+                repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
+            }
+        assertEquals("Node API failure", thrown.message)
+    }
+
     @Test
     fun `getLpBondableAssetsWithUnits propagates exception from getAllNodes`() = runTest {
         coEvery { api.getMayaNodePools() } returns

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/MayachainBondRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/MayachainBondRepositoryImplTest.kt
@@ -7,6 +7,9 @@ import com.vultisig.wallet.data.api.MayaMemberDetails
 import com.vultisig.wallet.data.api.MayaMemberPool
 import com.vultisig.wallet.data.api.MayaNodeInfo
 import com.vultisig.wallet.data.api.MayaNodePool
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlin.test.assertEquals
@@ -267,7 +270,7 @@ internal class MayachainBondRepositoryImplTest {
 
         val result = repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
 
-        assertEquals(mapOf("MAYA.CACAO" to 500000L), result)
+        result shouldBe mapOf("MAYA.CACAO" to 500000L)
     }
 
     @Test
@@ -293,7 +296,7 @@ internal class MayachainBondRepositoryImplTest {
 
         val result = repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
 
-        assertEquals(mapOf("MAYA.CACAO" to 500000L), result)
+        result shouldBe mapOf("MAYA.CACAO" to 500000L)
     }
 
     @Test
@@ -312,7 +315,7 @@ internal class MayachainBondRepositoryImplTest {
             val result =
                 repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
 
-            assertTrue(result.isEmpty())
+            result.shouldBeEmpty()
         }
 
     @Test
@@ -334,7 +337,7 @@ internal class MayachainBondRepositoryImplTest {
 
         val result = repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
 
-        assertEquals(mapOf("MAYA.CACAO" to 500000L), result)
+        result shouldBe mapOf("MAYA.CACAO" to 500000L)
     }
 
     @Test
@@ -342,10 +345,10 @@ internal class MayachainBondRepositoryImplTest {
         coEvery { api.getNodeDetails("node1") } throws RuntimeException("Node API failure")
 
         val thrown =
-            assertFailsWith<RuntimeException> {
+            shouldThrow<RuntimeException> {
                 repository.getBondedLpUnitsOnNode(nodeAddress = "node1", bondAddress = "addr1")
             }
-        assertEquals("Node API failure", thrown.message)
+        thrown.message shouldBe "Node API failure"
     }
 
     @Test


### PR DESCRIPTION
Closes #5759

## Tranaction hash
https://www.explorer.mayachain.info/tx/81516AF4B2A9E84848930BDBD56277A32089D2119D64A27EFDD1AEE86F79C54C

## Problem

MayaChain unbonding is per node — `UNBOND:{asset}:{units}:{node}` is applied against that one node's bond-provider record — but the Unbond form was fed the Bond form's data source. `DepositOptionCoordinator` put both options in one `when` arm and called `getLpBondableAssetsWithUnits(vaultAddress)`, which sums bonds across *all* nodes and then keeps only pools with `available > 0`.

That filter is right for Bond and wrong for Unbond: it removes exactly the pools a fully-bonded user came to unbond, and committing a whole LP position to one node is the standard bonding pattern. With the list empty the form silently swapped in a free-text "Asset" field, so a typo produced a signed, broadcastable, wrong memo — and a genuine API failure landed in that same branch, indistinguishable from "you have nothing bonded here". Neither side capped the LP units, though MayaChain's `validateV129` rejects an over-limit BOND/UNBOND outright (`refundTx`: the deposit comes back minus 0.2 CACAO, after a completed multi-device keysign that achieved nothing).

## What changed

**Node-scoped Unbond source.** New `MayachainBondRepository.getBondedLpUnitsOnNode(nodeAddress, bondAddress)` reads that node's provider entry and returns its per-pool `pools` map — no new endpoint, `getNodeDetails` already existed. `LiquidityDataLoader.loadMayaBondedAssets(node)` wires it to `DepositOption.Unbond`; Bond keeps `loadMayaBondableAssets()` and its math unchanged, and `MayachainBondRepositoryImplTest` passes unmodified.

**The ceiling carries its position.** `BondedUnitsCeiling(nodeAddress, asset, units)` — because the node address is an editable field, and the memo is built from that field. A bare number can't tell "this much is bonded on the node on screen" from "on the node that was there a moment ago", so `unbondLpUnitsCeiling(node, asset)` answers only when both still match, and the submit path *requires* a match rather than trusting a validation flag. The field watcher drops the ceiling on the first keystroke, not when the refetch lands, and re-scopes the list after a 300 ms debounce (matching iOS, which does the same for the same reason).

**Ceilings enforced on both sides**, in `validateLpUnits()` and again in the submit strategies. Unbond requires a ceiling; Bond enforces one only when a surplus was loaded, since its typed-asset fallback stays and that path has no figure to measure against. The units field now shows `Bonded LP Units` / `Available LP Units` with a `max` affordance, which the Deposit form never had.

**Empty vs failed.** Unbond states "No bonded assets found on this node" when the node holds nothing, and offers a retry when the fetch failed — the loader no longer swallows that error into the default Timber-only handler. Bond keeps its typed-asset fallback but now surfaces the failure above it.

**Provider field** is no longer offered for a MayaChain *bond*: this form always emits an asset, and the chain rejects a memo carrying both.

## Judgment calls worth a look

- The issue offered re-routing the Maya Bond entry point to `BondFormScreen` as an alternative. I gave the shared block the ceiling and max instead, so no entry point moves and `Route.BondForm` behaviour is untouched.
- Provider is hidden for Maya **Bond** only. Maya's reject rule is about bonding with an asset; the `UNBOND` memo still accepts a provider (an operator path), so that field stays.
- Unbond now refuses to submit without a loaded ceiling. That is stricter than before — deliberately, since it is the only way to guarantee the cap — and is why the retry exists.

## Test plan

- `./gradlew :data:testDebugUnitTest :app:testDebugUnitTest` — green. New: 5 repository tests (fully-bonded pool returned, other node not read, non-provider empty, duplicate providers summed / zero pools dropped, error propagated), 8 `LiquidityDataLoaderTest` cases (empty node vs failed fetch, ceiling scoping, blank node, max), 3 `DepositFormViewModelTest` cases end-to-end from the route, plus ceiling cases in both strategy tests.
- `./gradlew assembleDebug` and `:app:compileDebugAndroidTestKotlin` — green.
- Manual: DeFi → Bonded → node → **Unbond** lists the pools that node holds (including a 100%-bonded one), shows the bonded units with `max`, blocks a larger figure, and on a node holding nothing says so instead of offering a text field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added node- and pool-specific bonded LP-unit tracking for MayaChain unbonding.
- Added bonded-asset loading states, retry support, and maximum-unit actions.
- Updated the deposit form to display LP-unit limits and bonded assets.

## Bug Fixes
- Prevented Bond and Unbond submissions from exceeding available or bonded LP units.
- Bonded assets now refresh when the selected node changes.
- Added validation for mismatched nodes and pools during MayaChain unbonding.

## Localization
- Added translated messages for LP-unit limits, bonded assets, loading, and error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->