### PR TITLE
feat(keysign): decode Cosmos signed operations

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingVerifyViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/cosmosstaking/CosmosStakingVerifyViewModel.kt
@@ -9,12 +9,17 @@ import com.vultisig.wallet.data.IoDispatcher
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingPayload
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingService
 import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosValidator
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.DepositTransaction
+import com.vultisig.wallet.data.models.transaction_decoding.asSignedTransactionContent
 import com.vultisig.wallet.data.repositories.DepositTransactionRepository
 import com.vultisig.wallet.data.repositories.VaultPasswordRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.IsVaultHasFastSignByIdUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
+import com.vultisig.wallet.ui.components.hero.HeroContent
 import com.vultisig.wallet.ui.models.keysign.KeysignInitType
+import com.vultisig.wallet.ui.models.transactiondecoding.VerifyTransactionPresentation
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
@@ -41,6 +46,12 @@ internal data class CosmosStakingVerifyValidatorRow(val labelRes: Int, val value
 
 internal data class CosmosStakingVerifyUiState(
     val headlineRes: Int = R.string.cosmos_staking_youre_staking,
+    /**
+     * What the transaction proves it does, read from the intent the signer will encode. Replaces
+     * the headline and the amount together, because a claim states its scope ("rewards accrued so
+     * far") in place of a figure. Null until the read lands, and on any read that fails.
+     */
+    val heroContent: HeroContent? = null,
     val amount: String = "",
     val ticker: String = "",
     val coinLogo: String = "",
@@ -74,6 +85,7 @@ constructor(
     private val vaultPasswordRepository: VaultPasswordRepository,
     private val isVaultHasFastSignById: IsVaultHasFastSignByIdUseCase,
     private val launchKeysign: LaunchKeysignUseCase,
+    private val verifyTransactionPresentation: VerifyTransactionPresentation,
     private val navigator: Navigator<Destination>,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
@@ -151,6 +163,8 @@ constructor(
                 )
             }
 
+            loadDecodedHero(tx, vault?.coins.orEmpty())
+
             val byAddress =
                 withContext(ioDispatcher) {
                     runCatching { cosmosStakingService.fetchValidators(coin.chain) }
@@ -160,6 +174,30 @@ constructor(
             if (byAddress.isNotEmpty()) {
                 _state.update { it.copy(validatorRows = buildValidatorRows(payload, byAddress)) }
             }
+        }
+    }
+
+    /**
+     * Reads the staking intent through the shared decoder, so this screen and a joining co-signer's
+     * keysign confirmation name the same operation for the same transaction.
+     *
+     * Best-effort and never a signing dependency: a failed read leaves the screen's own headline
+     * and amount exactly as they are.
+     */
+    private fun loadDecodedHero(tx: DepositTransaction, trustedCoins: List<Coin>) {
+        viewModelScope.safeLaunch(
+            onError = { Timber.w(it, "Failed to resolve the decoded staking verify hero") }
+        ) {
+            val hero =
+                withContext(ioDispatcher) {
+                    verifyTransactionPresentation.resolve(
+                        content = tx.asSignedTransactionContent(),
+                        coin = tx.srcToken,
+                        trustedCoins = trustedCoins,
+                    )
+                } ?: return@safeLaunch
+
+            _state.update { it.copy(heroContent = hero.applyTo(it.heroContent)) }
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/cosmosstaking/CosmosStakingVerifyScreen.kt
@@ -36,6 +36,7 @@ import com.vultisig.wallet.ui.components.buttons.FastSignPairedButtons
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
 import com.vultisig.wallet.ui.components.buttons.VsButtonVariant
+import com.vultisig.wallet.ui.components.hero.HeroContentView
 import com.vultisig.wallet.ui.components.launchBiometricPrompt
 import com.vultisig.wallet.ui.components.v2.scaffold.V2Scaffold
 import com.vultisig.wallet.ui.models.cosmosstaking.CosmosStakingVerifyUiState
@@ -142,30 +143,38 @@ private fun SummaryCard(state: CosmosStakingVerifyUiState) {
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         // Hero: headline + amount.
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            Text(
-                text = stringResource(state.headlineRes),
-                style = Theme.brockmann.body.m.medium,
-                color = Theme.v2.colors.text.secondary,
-            )
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                AsyncImage(
-                    model = getCoinLogo(state.coinLogo),
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp).clip(CircleShape),
-                )
-                UiSpacer(size = 8.dp)
+        val hero = state.heroContent
+        if (hero != null) {
+            // What the staking intent proves it does, read from what will be signed. It replaces
+            // the headline and the amount together, because a claim states its scope ("rewards
+            // accrued so far") in place of a figure.
+            HeroContentView(content = hero, verbAlignment = Alignment.Start)
+        } else {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text(
-                    text = state.amount,
-                    style = Theme.brockmann.body.l.medium,
-                    color = Theme.v2.colors.text.primary,
+                    text = stringResource(state.headlineRes),
+                    style = Theme.brockmann.body.m.medium,
+                    color = Theme.v2.colors.text.secondary,
                 )
-                UiSpacer(size = 4.dp)
-                Text(
-                    text = state.ticker,
-                    style = Theme.brockmann.body.l.medium,
-                    color = Theme.v2.colors.text.tertiary,
-                )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    AsyncImage(
+                        model = getCoinLogo(state.coinLogo),
+                        contentDescription = null,
+                        modifier = Modifier.size(24.dp).clip(CircleShape),
+                    )
+                    UiSpacer(size = 8.dp)
+                    Text(
+                        text = state.amount,
+                        style = Theme.brockmann.body.l.medium,
+                        color = Theme.v2.colors.text.primary,
+                    )
+                    UiSpacer(size = 4.dp)
+                    Text(
+                        text = state.ticker,
+                        style = Theme.brockmann.body.l.medium,
+                        color = Theme.v2.colors.text.tertiary,
+                    )
+                }
             }
         }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosMemoReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosMemoReader.kt
@@ -1,0 +1,54 @@
+package com.vultisig.wallet.data.blockchain.cosmos
+
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+
+/**
+ * The Cosmos memo grammar, read once for both the sidecar memo an initiator holds and the
+ * `TxBody.memo` a co-signer receives inside the signed body.
+ *
+ * The two arrive by different routes but are the same string with the same meaning, and a grammar
+ * that lived in only one of them would name an operation on one device and not on the other.
+ */
+internal object CosmosMemoReader {
+
+    /** What a memo names, and whether the quantity the transaction moves belongs to that verb. */
+    data class Reading(val operation: DecodedOperation, val movesTheCarriedAmount: Boolean)
+
+    /**
+     * Matches a memo against its whole documented layout. A memo carrying fields this grammar
+     * cannot account for is one the reader does not recognise, and naming it anyway would present
+     * an ambiguous string as a verified action.
+     */
+    fun read(memo: String): Reading? {
+        val fields = memo.split(":")
+        val head = fields.firstOrNull() ?: return null
+
+        // The chain matches these heads case-insensitively.
+        return when (head.uppercase()) {
+            // `SWITCH:<address>` moves the asset to the sender's THORChain address.
+            "SWITCH" -> {
+                if (fields.size != SWITCH_FIELDS) return null
+                if (fields[SWITCH_ADDRESS_FIELD].isEmpty()) return null
+                Reading(DecodedOperation.SwitchChain, movesTheCarriedAmount = true)
+            }
+
+            // `<CHAIN>_VOTE:<option>:<proposal>` moves no quantity. `QBTC_VOTE` is what this app
+            // builds; `DYDX_VOTE` is the same grammar from an iOS initiator, and a co-signer has
+            // to read both.
+            "QBTC_VOTE",
+            "DYDX_VOTE" -> {
+                if (fields.size != VOTE_FIELDS) return null
+                if (fields.drop(1).any { it.isEmpty() }) return null
+                Reading(DecodedOperation.Vote, movesTheCarriedAmount = false)
+            }
+
+            else -> null
+        }
+    }
+
+    private const val SWITCH_FIELDS = 2
+    private const val SWITCH_ADDRESS_FIELD = 1
+
+    /** The head, the option, and the proposal id — `GovernanceViewModel` writes exactly three. */
+    private const val VOTE_FIELDS = 3
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosMemoReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosMemoReader.kt
@@ -11,8 +11,29 @@ import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
  */
 internal object CosmosMemoReader {
 
-    /** What a memo names, and whether the quantity the transaction moves belongs to that verb. */
-    data class Reading(val operation: DecodedOperation, val movesTheCarriedAmount: Boolean)
+    /**
+     * The message a memo-named operation rides on.
+     *
+     * A memo is not evidence on its own — it is a string beside a message, and only the message
+     * says what the chain will do. Naming the carrier is what lets a reader check that the two
+     * agree before it presents the memo's verb.
+     */
+    enum class Carrier {
+        /**
+         * A `MsgSend`: the memo says what the transfer is for, and the send's own coin is the
+         * quantity it moves.
+         */
+        Transfer,
+
+        /**
+         * The memo travels beside a message that states the operation itself — a vote is a
+         * `MsgVote` — so the memo describes rather than proves, and moves nothing of its own.
+         */
+        OwnMessage,
+    }
+
+    /** What a memo names, and the message that would have to carry it. */
+    data class Reading(val operation: DecodedOperation, val carrier: Carrier)
 
     /**
      * Matches a memo against its whole documented layout. A memo carrying fields this grammar
@@ -25,21 +46,23 @@ internal object CosmosMemoReader {
 
         // The chain matches these heads case-insensitively.
         return when (head.uppercase()) {
-            // `SWITCH:<address>` moves the asset to the sender's THORChain address.
+            // `SWITCH:<address>` moves the asset to the sender's THORChain address. The send is
+            // the operation; the memo is what makes it a switch rather than a payment.
             "SWITCH" -> {
                 if (fields.size != SWITCH_FIELDS) return null
                 if (fields[SWITCH_ADDRESS_FIELD].isEmpty()) return null
-                Reading(DecodedOperation.SwitchChain, movesTheCarriedAmount = true)
+                Reading(DecodedOperation.SwitchChain, Carrier.Transfer)
             }
 
-            // `<CHAIN>_VOTE:<option>:<proposal>` moves no quantity. `QBTC_VOTE` is what this app
-            // builds; `DYDX_VOTE` is the same grammar from an iOS initiator, and a co-signer has
-            // to read both.
+            // `<CHAIN>_VOTE:<option>:<proposal>` moves no quantity, and is signed as a `MsgVote`
+            // by every path that builds one — `QBTCTransactionHelper` here, `DydxHelperStruct` on
+            // iOS. `QBTC_VOTE` is what this app builds; `DYDX_VOTE` is the same grammar from an
+            // iOS initiator, and a co-signer has to read both.
             "QBTC_VOTE",
             "DYDX_VOTE" -> {
                 if (fields.size != VOTE_FIELDS) return null
                 if (fields.drop(1).any { it.isEmpty() }) return null
-                Reading(DecodedOperation.Vote, movesTheCarriedAmount = false)
+                Reading(DecodedOperation.Vote, Carrier.OwnMessage)
             }
 
             else -> null

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocDecoder.kt
@@ -1,0 +1,127 @@
+package com.vultisig.wallet.data.blockchain.cosmos
+
+import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingConfig
+import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingPayload
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedCounterparty
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedEvidence
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.data.models.transaction_decoding.OpaqueSignedContent
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
+import com.vultisig.wallet.data.models.transaction_decoding.TransactionContentDecoder
+import java.math.BigInteger
+import javax.inject.Inject
+
+/**
+ * Reads the initiator's Cosmos staking pre-image, or the active SignDoc body a co-signer was sent.
+ * Adjacent flat sidecars are never consulted for a SignDoc-driven transaction: they are
+ * peer-supplied, and the body is what gets signed.
+ *
+ * Mirrors the iOS `CosmosSignDocDecoder`.
+ */
+class CosmosSignDocDecoder @Inject constructor() : TransactionContentDecoder {
+
+    /** Only chains whose signing paths consume Cosmos SignDocs. */
+    override val handles: Set<Chain> =
+        Chain.entries.filter { it.standard == TokenStandard.COSMOS }.toSet()
+
+    override fun decode(tx: SignedTransactionContent): DecodedTransaction? {
+        // An initiator holds the intent its signer will encode; a co-signer holds the encoded body.
+        tx.cosmosStakingIntent?.let {
+            return decode(it, tx.chain)
+        }
+
+        if (!tx.signedDataBodyIsActive) return null
+        val direct = tx.signedData as? OpaqueSignedContent.CosmosSignDirect ?: return null
+        val reading = CosmosSignDocReader.read(direct.bodyBytes) ?: return null
+
+        return DecodedTransaction(
+            operation = reading.operation,
+            amount = reading.amount,
+            counterparty = reading.counterparty,
+            evidence = DecodedEvidence.SignedData,
+        )
+    }
+
+    /**
+     * Maps a validated initiator pre-image into the same vocabulary the body produces, so both
+     * devices in a ceremony name the operation identically.
+     *
+     * ⚠️ The bond denom comes from [CosmosStakingConfig], not from the payload — unlike iOS, where
+     * it rides on `CosmosStakingPayload`. That is the same source
+     * [com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingSignDataResolver] encodes
+     * the `Coin` from, so the initiator reads the denom its own signer is about to write. A chain
+     * with no staking entry has no denom to name and is refused rather than guessed at.
+     */
+    private fun decode(intent: CosmosStakingPayload, chain: Chain): DecodedTransaction? {
+        val denom = runCatching { CosmosStakingConfig.entryFor(chain).bondDenom }.getOrNull()
+
+        fun amount(text: String): DecodedAmount? {
+            if (denom.isNullOrEmpty()) return null
+            val value = runCatching { BigInteger(text) }.getOrNull() ?: return null
+            if (value.signum() < 0) return null
+            return DecodedAmount.Units(value, DecodedAsset.Denom(denom))
+        }
+
+        return when (intent) {
+            is CosmosStakingPayload.Delegate -> {
+                if (intent.validatorAddress.isEmpty()) return null
+                DecodedTransaction(
+                    operation = DecodedOperation.Delegate,
+                    amount = amount(intent.amount) ?: return null,
+                    counterparty = DecodedCounterparty.Validator(intent.validatorAddress),
+                    evidence = DecodedEvidence.StructuredPayload,
+                )
+            }
+
+            is CosmosStakingPayload.Undelegate -> {
+                if (intent.validatorAddress.isEmpty()) return null
+                DecodedTransaction(
+                    operation = DecodedOperation.Undelegate,
+                    amount = amount(intent.amount) ?: return null,
+                    counterparty = DecodedCounterparty.Validator(intent.validatorAddress),
+                    evidence = DecodedEvidence.StructuredPayload,
+                )
+            }
+
+            is CosmosStakingPayload.Redelegate -> {
+                if (intent.validatorSrcAddress.isEmpty() || intent.validatorDstAddress.isEmpty()) {
+                    return null
+                }
+                DecodedTransaction(
+                    operation = DecodedOperation.Redelegate,
+                    amount = amount(intent.amount) ?: return null,
+                    // The destination is where the stake lands; the source is left behind.
+                    counterparty = DecodedCounterparty.Validator(intent.validatorDstAddress),
+                    evidence = DecodedEvidence.StructuredPayload,
+                )
+            }
+
+            is CosmosStakingPayload.WithdrawRewards -> {
+                val validators = intent.validators
+                if (validators.isEmpty() || validators.size > MAX_CLAIM_VALIDATORS) return null
+                if (validators.any { it.isEmpty() }) return null
+                DecodedTransaction(
+                    operation = DecodedOperation.ClaimRewards,
+                    // The chain settles what has accrued; the intent names no quantity.
+                    amount = DecodedAmount.Unstated,
+                    // A batch across validators has no single counterparty to name.
+                    counterparty = validators.singleOrNull()?.let(DecodedCounterparty::Validator),
+                    evidence = DecodedEvidence.StructuredPayload,
+                )
+            }
+        }
+    }
+
+    private companion object {
+        /**
+         * Matches the batch ceiling the SignDoc reader enforces on the co-signer side, so an intent
+         * that could not have produced a readable body is refused on the initiator too.
+         */
+        const val MAX_CLAIM_VALIDATORS = 64
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocDecoder.kt
@@ -40,28 +40,31 @@ class CosmosSignDocDecoder @Inject constructor() : TransactionContentDecoder {
         val body = CosmosSignDocReader.read(direct.bodyBytes) ?: return null
 
         // An active SignDoc withholds the sidecar memo, so `CosmosTransactionDecoder` never reaches
-        // a switch or a governance vote here — and the body's own memo is the signed one anyway.
-        // It outranks a bare transfer, which is the message a memo-driven operation rides on: a
-        // switch is a `MsgSend` wearing a memo, and describing it as a send names the wrong verb.
-        val messages = body.reading
-        if (messages == null || messages.operation == DecodedOperation.Transfer) {
-            body.memo?.let(CosmosMemoReader::read)?.let { memo ->
-                return DecodedTransaction(
-                    operation = memo.operation,
-                    // The figure is the one the message commits to, when the verb moves it at all.
-                    amount =
-                        if (memo.movesTheCarriedAmount) messages?.amount ?: DecodedAmount.Unstated
-                        else DecodedAmount.Unstated,
-                    // The memo names the operation, not who it settles with; the address the send
-                    // carries is a module or vault account rather than the counterparty.
-                    counterparty = null,
-                    evidence = DecodedEvidence.SignedData,
-                )
-            }
+        // a switch here — and the body's own memo is the signed one anyway. A switch is a `MsgSend`
+        // wearing a memo, so the memo says what the transfer is for and describing it as a send
+        // names the wrong verb.
+        //
+        // The memo speaks only over the transfer it rides on, and only for a verb a transfer can
+        // carry. It never speaks for a message this could not read — that body is already refused —
+        // nor over a message that states its own operation, where the memo would be a peer-supplied
+        // string outranking the bytes the chain will act on.
+        val reading = body.reading
+        if (reading.operation == DecodedOperation.Transfer) {
+            body.memo
+                ?.let(CosmosMemoReader::read)
+                ?.takeIf { it.carrier == CosmosMemoReader.Carrier.Transfer }
+                ?.let { memo ->
+                    return DecodedTransaction(
+                        operation = memo.operation,
+                        // The figure is the one the send itself commits to.
+                        amount = reading.amount,
+                        // The memo names the operation, not who it settles with; the address the
+                        // send carries is a module or vault account rather than a counterparty.
+                        counterparty = null,
+                        evidence = DecodedEvidence.SignedData,
+                    )
+                }
         }
-
-        // Messages of no type this names, and no memo to fall back on, name nothing.
-        val reading = messages ?: return null
 
         return DecodedTransaction(
             operation = reading.operation,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocDecoder.kt
@@ -37,7 +37,31 @@ class CosmosSignDocDecoder @Inject constructor() : TransactionContentDecoder {
 
         if (!tx.signedDataBodyIsActive) return null
         val direct = tx.signedData as? OpaqueSignedContent.CosmosSignDirect ?: return null
-        val reading = CosmosSignDocReader.read(direct.bodyBytes) ?: return null
+        val body = CosmosSignDocReader.read(direct.bodyBytes) ?: return null
+
+        // An active SignDoc withholds the sidecar memo, so `CosmosTransactionDecoder` never reaches
+        // a switch or a governance vote here — and the body's own memo is the signed one anyway.
+        // It outranks a bare transfer, which is the message a memo-driven operation rides on: a
+        // switch is a `MsgSend` wearing a memo, and describing it as a send names the wrong verb.
+        val messages = body.reading
+        if (messages == null || messages.operation == DecodedOperation.Transfer) {
+            body.memo?.let(CosmosMemoReader::read)?.let { memo ->
+                return DecodedTransaction(
+                    operation = memo.operation,
+                    // The figure is the one the message commits to, when the verb moves it at all.
+                    amount =
+                        if (memo.movesTheCarriedAmount) messages?.amount ?: DecodedAmount.Unstated
+                        else DecodedAmount.Unstated,
+                    // The memo names the operation, not who it settles with; the address the send
+                    // carries is a module or vault account rather than the counterparty.
+                    counterparty = null,
+                    evidence = DecodedEvidence.SignedData,
+                )
+            }
+        }
+
+        // Messages of no type this names, and no memo to fall back on, name nothing.
+        val reading = messages ?: return null
 
         return DecodedTransaction(
             operation = reading.operation,
@@ -119,9 +143,9 @@ class CosmosSignDocDecoder @Inject constructor() : TransactionContentDecoder {
 
     private companion object {
         /**
-         * Matches the batch ceiling the SignDoc reader enforces on the co-signer side, so an intent
-         * that could not have produced a readable body is refused on the initiator too.
+         * The batch ceiling the SignDoc reader enforces on the co-signer side, so an intent that
+         * could not have produced a readable body is refused on the initiator too.
          */
-        const val MAX_CLAIM_VALIDATORS = 64
+        const val MAX_CLAIM_VALIDATORS = CosmosSignDocReader.MAX_MESSAGES
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocReader.kt
@@ -1,0 +1,357 @@
+package com.vultisig.wallet.data.blockchain.cosmos
+
+import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingHelper
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedCounterparty
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import java.math.BigInteger
+
+/**
+ * Reads operation, amount, and counterparty out of the protobuf `TxBody` a co-signer receives.
+ *
+ * Mirrors the iOS `CosmosSignDocReader`. Malformed, mixed, partial, or oversized bodies are refused
+ * as a whole rather than partially described: every length and varint here is peer-supplied, and a
+ * body this cannot read completely is one the co-signer is better served by the screen it already
+ * had than by a confident wrong verb.
+ *
+ * A hand-written reader rather than a generated one because the Cosmos message set is not in
+ * `commondata` — and because the refusals, not the parsing, are what this exists for.
+ */
+internal object CosmosSignDocReader {
+
+    /** What a SignDoc body turned out to be. */
+    data class Reading(
+        val operation: DecodedOperation,
+        val amount: DecodedAmount,
+        val counterparty: DecodedCounterparty?,
+    )
+
+    // MARK: - Refusal limits
+
+    /** Real staking bodies are well below this. */
+    private const val MAX_BODY_BYTES = 64 * 1024
+
+    /** Messages in one body. A batched rewards claim sends one per validator. */
+    private const val MAX_MESSAGES = 64
+
+    /** Bounds unknown-field scans. */
+    private const val MAX_FIELDS = 512
+
+    /** `cosmos.bank.v1beta1.MsgSend`, the one non-staking message this names. */
+    private const val MSG_SEND_TYPE_URL = "/cosmos.bank.v1beta1.MsgSend"
+
+    /**
+     * Reads one complete SignDoc body, or refuses it.
+     *
+     * @param body the decoded `SignDirect.bodyBytes` — already base64-decoded by
+     *   [com.vultisig.wallet.data.models.transaction_decoding.OpaqueSignedContent.CosmosSignDirect].
+     */
+    fun read(body: ByteArray): Reading? {
+        if (body.isEmpty() || body.size > MAX_BODY_BYTES) return null
+
+        val messages = messageBodies(body)?.takeIf { it.isNotEmpty() } ?: return null
+
+        // Every message must decode, and they must agree on one operation. A body that mixes verbs
+        // has no single one to name, and naming either would describe only part of what is signed.
+        val readings = ArrayList<Reading>(messages.size)
+        for (message in messages) {
+            readings.add(read(message) ?: return null)
+        }
+
+        val first = readings.first()
+        if (readings.any { it.operation != first.operation }) return null
+
+        // A homogeneous batch has one verb but no single amount or counterparty.
+        if (readings.size > 1) {
+            return Reading(
+                operation = first.operation,
+                amount = DecodedAmount.Unstated,
+                counterparty = null,
+            )
+        }
+        return first
+    }
+
+    /** One `Any` in `TxBody.messages`. */
+    private data class AnyMessage(val url: String, val value: ByteArray)
+
+    /** Reads every `Any` in `TxBody.messages`; a partial result is refused. */
+    private fun messageBodies(body: ByteArray): List<AnyMessage>? {
+        val reader = ByteReader(body)
+        val messages = mutableListOf<AnyMessage>()
+        var fields = 0
+
+        while (!reader.isAtEnd) {
+            if (++fields > MAX_FIELDS) return null
+            val tag = reader.readTag() ?: return null
+
+            if (tag.field == 1L && tag.wire == WireType.LengthDelimited) {
+                if (messages.size >= MAX_MESSAGES) return null
+                val any = reader.readLengthDelimited() ?: return null
+                messages.add(anyContents(any) ?: return null)
+            } else {
+                if (!reader.skip(tag.wire)) return null
+            }
+        }
+
+        return messages
+    }
+
+    /** Reads to the end, which preserves protobuf's last-one-wins semantics. */
+    private fun anyContents(any: ByteArray): AnyMessage? {
+        val reader = ByteReader(any)
+        var url: String? = null
+        var value: ByteArray? = null
+        var fields = 0
+
+        while (!reader.isAtEnd) {
+            if (++fields > MAX_FIELDS) return null
+            val tag = reader.readTag() ?: return null
+
+            when {
+                tag.field == 1L && tag.wire == WireType.LengthDelimited ->
+                    url = reader.readUtf8() ?: return null
+
+                tag.field == 2L && tag.wire == WireType.LengthDelimited ->
+                    value = reader.readLengthDelimited() ?: return null
+
+                else -> if (!reader.skip(tag.wire)) return null
+            }
+        }
+
+        // A missing value is legal protobuf and decodes as an empty message; a missing type URL
+        // names nothing at all.
+        return AnyMessage(url ?: return null, value ?: ByteArray(0))
+    }
+
+    // MARK: - The messages this can corroborate
+
+    /** Names only the message types whose values are decoded here. */
+    private fun read(message: AnyMessage): Reading? =
+        when (message.url) {
+            // delegator 1, validator 2, amount 3 (Coin)
+            CosmosStakingHelper.MSG_DELEGATE_TYPE_URL ->
+                readAddressed(
+                    message.value,
+                    DecodedOperation.Delegate,
+                    validatorField = 2L,
+                    amountField = 3L,
+                )
+
+            CosmosStakingHelper.MSG_UNDELEGATE_TYPE_URL ->
+                readAddressed(
+                    message.value,
+                    DecodedOperation.Undelegate,
+                    validatorField = 2L,
+                    amountField = 3L,
+                )
+
+            // Source is field 2, destination field 3 — the destination is the relevant
+            // counterparty, and reading the wrong one names the validator being left.
+            CosmosStakingHelper.MSG_BEGIN_REDELEGATE_TYPE_URL ->
+                readAddressed(
+                    message.value,
+                    DecodedOperation.Redelegate,
+                    validatorField = 3L,
+                    amountField = 4L,
+                )
+
+            // A reward withdrawal carries no Coin: the chain settles what has accrued.
+            CosmosStakingHelper.MSG_WITHDRAW_DELEGATOR_REWARD_TYPE_URL ->
+                readAddressed(
+                    message.value,
+                    DecodedOperation.ClaimRewards,
+                    validatorField = 2L,
+                    amountField = null,
+                )
+
+            // from 1, to 2, amount 3 (repeated Coin)
+            MSG_SEND_TYPE_URL ->
+                readAddressed(
+                    message.value,
+                    DecodedOperation.Transfer,
+                    validatorField = 2L,
+                    amountField = 3L,
+                )
+
+            else -> null
+        }
+
+    /** Pulls the named address and an optional `Coin` out of one message body. */
+    private fun readAddressed(
+        body: ByteArray,
+        operation: DecodedOperation,
+        validatorField: Long,
+        amountField: Long?,
+    ): Reading? {
+        val reader = ByteReader(body)
+        var address: String? = null
+        val coins = mutableListOf<Pair<String, BigInteger>>()
+        var fields = 0
+
+        while (!reader.isAtEnd) {
+            if (++fields > MAX_FIELDS) return null
+            val tag = reader.readTag() ?: return null
+
+            when {
+                tag.field == validatorField && tag.wire == WireType.LengthDelimited ->
+                    address = reader.readUtf8() ?: return null
+
+                amountField != null &&
+                    tag.field == amountField &&
+                    tag.wire == WireType.LengthDelimited -> {
+                    val raw = reader.readLengthDelimited() ?: return null
+                    coins.add(coin(raw) ?: return null)
+                }
+
+                else -> if (!reader.skip(tag.wire)) return null
+            }
+        }
+
+        // An absent address proves nothing about who the operation is directed at.
+        if (address.isNullOrEmpty()) return null
+
+        // A multi-denom send has no single amount to name.
+        val amount =
+            if (coins.size == 1)
+                DecodedAmount.Units(coins[0].second, DecodedAsset.Denom(coins[0].first))
+            else DecodedAmount.Unstated
+
+        return Reading(
+            operation = operation,
+            amount = amount,
+            counterparty =
+                if (operation == DecodedOperation.Transfer) DecodedCounterparty.Contract(address)
+                else DecodedCounterparty.Validator(address),
+        )
+    }
+
+    /** `cosmos.base.v1beta1.Coin` — denom 1, amount 2, both strings. */
+    private fun coin(body: ByteArray): Pair<String, BigInteger>? {
+        val reader = ByteReader(body)
+        var denom: String? = null
+        var amount: BigInteger? = null
+        var fields = 0
+
+        while (!reader.isAtEnd) {
+            if (++fields > MAX_FIELDS) return null
+            val tag = reader.readTag() ?: return null
+
+            when {
+                tag.field == 1L && tag.wire == WireType.LengthDelimited ->
+                    denom = reader.readUtf8() ?: return null
+
+                tag.field == 2L && tag.wire == WireType.LengthDelimited -> {
+                    val text = reader.readUtf8() ?: return null
+                    val value = text.toBigIntegerOrNull() ?: return null
+                    if (value.signum() < 0) return null
+                    amount = value
+                }
+
+                else -> if (!reader.skip(tag.wire)) return null
+            }
+        }
+
+        val resolvedDenom = denom?.takeIf { it.isNotEmpty() } ?: return null
+        return resolvedDenom to (amount ?: return null)
+    }
+
+    private fun String.toBigIntegerOrNull(): BigInteger? =
+        runCatching { BigInteger(this) }.getOrNull()
+
+    // MARK: - Bounds-checked protobuf reader
+
+    /** Protobuf wire types, from the low three bits of a tag. */
+    private enum class WireType(val value: Long) {
+        Varint(0),
+        Fixed64(1),
+        LengthDelimited(2),
+        StartGroup(3),
+        EndGroup(4),
+        Fixed32(5);
+
+        companion object {
+            fun from(value: Long): WireType? = entries.firstOrNull { it.value == value }
+        }
+    }
+
+    private data class Tag(val field: Long, val wire: WireType)
+
+    /**
+     * Reads peer-supplied bytes without ever indexing past the end. Every accessor answers null on
+     * malformed input instead of throwing, so a truncated body is a refusal rather than a crash on
+     * a screen the user is mid-ceremony on.
+     */
+    private class ByteReader(private val bytes: ByteArray) {
+        private var index = 0
+
+        val isAtEnd: Boolean
+            get() = index >= bytes.size
+
+        /** Base-128 varint that refuses `Long` overflow. */
+        fun readVarint(): Long? {
+            var value = 0L
+            var shift = 0
+
+            while (shift < 64) {
+                if (index >= bytes.size) return null
+                val byte = bytes[index].toInt() and 0xFF
+                index++
+
+                val payload = (byte and 0x7F).toLong()
+                // Only one payload bit fits at shift 63.
+                if (shift == 63 && payload > 1) return null
+
+                value = value or (payload shl shift)
+                if (byte and 0x80 == 0) return value
+                shift += 7
+            }
+
+            return null
+        }
+
+        fun readTag(): Tag? {
+            val tag = readVarint() ?: return null
+            val wire = WireType.from(tag and 0x07) ?: return null
+            return Tag(field = tag ushr 3, wire = wire)
+        }
+
+        fun readLengthDelimited(): ByteArray? {
+            val length = readVarint() ?: return null
+            if (length < 0 || length > Int.MAX_VALUE.toLong()) return null
+            val count = length.toInt()
+            if (bytes.size - index < count) return null
+
+            val end = index + count
+            val slice = bytes.copyOfRange(index, end)
+            index = end
+            return slice
+        }
+
+        /** A length-delimited field read as UTF-8, refusing anything that is not valid UTF-8. */
+        fun readUtf8(): String? {
+            val raw = readLengthDelimited() ?: return null
+            val text = raw.toString(Charsets.UTF_8)
+            // `toString` substitutes U+FFFD rather than failing, so round-trip to catch it.
+            return text.takeIf { it.toByteArray(Charsets.UTF_8).contentEquals(raw) }
+        }
+
+        fun skip(wire: WireType): Boolean =
+            when (wire) {
+                WireType.Varint -> readVarint() != null
+                WireType.Fixed64 -> advance(8)
+                WireType.LengthDelimited -> readLengthDelimited() != null
+                WireType.Fixed32 -> advance(4)
+                // Deprecated groups are not valid in the SignDocs this supports.
+                WireType.StartGroup,
+                WireType.EndGroup -> false
+            }
+
+        private fun advance(count: Int): Boolean {
+            if (bytes.size - index < count) return false
+            index += count
+            return true
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocReader.kt
@@ -28,14 +28,13 @@ internal object CosmosSignDocReader {
     )
 
     /**
-     * A body that walked cleanly: what its messages say, when they are of a type this names, and
-     * the memo the body itself commits to.
+     * A body that read completely: what its messages say, and the memo the body itself commits to.
      *
-     * Both are read in one pass because both are signed. A body whose messages this cannot name
-     * still has a memo that the chain acts on — a switch and a governance vote are exactly that —
-     * and dropping it would leave a co-signer reading an unnamed transaction.
+     * Both are read in one pass because both are signed. The memo is carried alongside rather than
+     * instead of the reading: a memo can say what a transfer is for, but only the message says what
+     * the chain will do, so a caller that wants to use one has to check it against the other.
      */
-    data class Body(val reading: Reading?, val memo: String?)
+    data class Body(val reading: Reading, val memo: String?)
 
     // MARK: - Refusal limits
 
@@ -48,8 +47,17 @@ internal object CosmosSignDocReader {
     /** Bounds unknown-field scans. */
     private const val MAX_FIELDS = 512
 
-    /** `cosmos.bank.v1beta1.MsgSend`, the one non-staking message this names. */
+    /** `cosmos.bank.v1beta1.MsgSend`, the transfer every memo-carried operation rides on. */
     private const val MSG_SEND_TYPE_URL = "/cosmos.bank.v1beta1.MsgSend"
+
+    /**
+     * A governance vote states itself in its own message — `QBTCTransactionHelper` writes the
+     * v1beta1 form and iOS's dYdX helper has wallet-core write it, so reading the message rather
+     * than the memo beside it is both stronger evidence and the same verb on either initiator. The
+     * v1 module is accepted too, since a dApp may build against it and the field offsets match.
+     */
+    private const val MSG_VOTE_TYPE_URL = "/cosmos.gov.v1beta1.MsgVote"
+    private const val MSG_VOTE_V1_TYPE_URL = "/cosmos.gov.v1.MsgVote"
 
     /** `TxBody.memo`. */
     private const val MEMO_FIELD = 2L
@@ -66,16 +74,15 @@ internal object CosmosSignDocReader {
         val walked = walk(body) ?: return null
         val messages = walked.messages.takeIf { it.isNotEmpty() } ?: return null
 
-        // Messages of no type this names leave the memo as the only thing the body states.
-        val shapes = messages.map { shape(it.url) }
-        if (shapes.all { it == null }) return Body(reading = null, memo = walked.memo)
-
-        // Every message must decode, and they must agree on one operation. A body that mixes verbs
-        // has no single one to name, and naming either would describe only part of what is signed.
+        // Every message must be of a type this names and must decode, and they must agree on one
+        // operation. A message this cannot name is refused rather than described by the memo beside
+        // it: the memo is peer-supplied text, and letting it speak for an unreadable message is how
+        // a `MsgExec` gets presented as a switch. A body that mixes verbs has no single one to
+        // name, and naming either would describe only part of what is signed.
         val readings = ArrayList<Reading>(messages.size)
-        for ((message, shape) in messages.zip(shapes)) {
-            // A recognised message riding beside an unrecognised one is the same partial reading.
-            readings.add(read(message.value, shape ?: return null) ?: return null)
+        for (message in messages) {
+            val shape = shape(message.url) ?: return null
+            readings.add(read(message.value, shape) ?: return null)
         }
 
         val first = readings.first()
@@ -160,38 +167,58 @@ internal object CosmosSignDocReader {
 
     // MARK: - The messages this can corroborate
 
+    /** What the address a message names is, to the reading. */
+    private enum class Named {
+        /** The validator the operation is directed at. */
+        Validator,
+
+        /** The account a transfer settles with. */
+        Recipient,
+
+        /** The signer's own account: proof the message is well-formed, not a counterparty. */
+        Signer,
+    }
+
     /** Where one message type keeps the address and the `Coin` this reads. */
     private data class Shape(
         val operation: DecodedOperation,
         val addressField: Long,
         val amountField: Long?,
+        val named: Named,
     )
 
-    /**
-     * Names only the message types whose values are decoded here. A null shape is a type this
-     * cannot name — distinct from a named type whose body would not read, which is a refusal.
-     */
+    /** Names only the message types whose values are decoded here; anything else is refused. */
     private fun shape(url: String): Shape? =
         when (url) {
             // delegator 1, validator 2, amount 3 (Coin)
             CosmosStakingHelper.MSG_DELEGATE_TYPE_URL ->
-                Shape(DecodedOperation.Delegate, addressField = 2L, amountField = 3L)
+                Shape(DecodedOperation.Delegate, 2L, amountField = 3L, named = Named.Validator)
 
             CosmosStakingHelper.MSG_UNDELEGATE_TYPE_URL ->
-                Shape(DecodedOperation.Undelegate, addressField = 2L, amountField = 3L)
+                Shape(DecodedOperation.Undelegate, 2L, amountField = 3L, named = Named.Validator)
 
             // Source is field 2, destination field 3 — the destination is the relevant
             // counterparty, and reading the wrong one names the validator being left.
             CosmosStakingHelper.MSG_BEGIN_REDELEGATE_TYPE_URL ->
-                Shape(DecodedOperation.Redelegate, addressField = 3L, amountField = 4L)
+                Shape(DecodedOperation.Redelegate, 3L, amountField = 4L, named = Named.Validator)
 
             // A reward withdrawal carries no Coin: the chain settles what has accrued.
             CosmosStakingHelper.MSG_WITHDRAW_DELEGATOR_REWARD_TYPE_URL ->
-                Shape(DecodedOperation.ClaimRewards, addressField = 2L, amountField = null)
+                Shape(
+                    DecodedOperation.ClaimRewards,
+                    2L,
+                    amountField = null,
+                    named = Named.Validator,
+                )
 
             // from 1, to 2, amount 3 (repeated Coin)
             MSG_SEND_TYPE_URL ->
-                Shape(DecodedOperation.Transfer, addressField = 2L, amountField = 3L)
+                Shape(DecodedOperation.Transfer, 2L, amountField = 3L, named = Named.Recipient)
+
+            // proposal 1, voter 2, option 3. The voter is the signer, and a ballot moves nothing.
+            MSG_VOTE_TYPE_URL,
+            MSG_VOTE_V1_TYPE_URL ->
+                Shape(DecodedOperation.Vote, 2L, amountField = null, named = Named.Signer)
 
             else -> null
         }
@@ -235,9 +262,11 @@ internal object CosmosSignDocReader {
             operation = shape.operation,
             amount = amount,
             counterparty =
-                if (shape.operation == DecodedOperation.Transfer)
-                    DecodedCounterparty.Contract(address)
-                else DecodedCounterparty.Validator(address),
+                when (shape.named) {
+                    Named.Validator -> DecodedCounterparty.Validator(address)
+                    Named.Recipient -> DecodedCounterparty.Contract(address)
+                    Named.Signer -> null
+                },
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosSignDocReader.kt
@@ -20,12 +20,22 @@ import java.math.BigInteger
  */
 internal object CosmosSignDocReader {
 
-    /** What a SignDoc body turned out to be. */
+    /** What a SignDoc body's messages turned out to be. */
     data class Reading(
         val operation: DecodedOperation,
         val amount: DecodedAmount,
         val counterparty: DecodedCounterparty?,
     )
+
+    /**
+     * A body that walked cleanly: what its messages say, when they are of a type this names, and
+     * the memo the body itself commits to.
+     *
+     * Both are read in one pass because both are signed. A body whose messages this cannot name
+     * still has a memo that the chain acts on — a switch and a governance vote are exactly that —
+     * and dropping it would leave a co-signer reading an unnamed transaction.
+     */
+    data class Body(val reading: Reading?, val memo: String?)
 
     // MARK: - Refusal limits
 
@@ -33,7 +43,7 @@ internal object CosmosSignDocReader {
     private const val MAX_BODY_BYTES = 64 * 1024
 
     /** Messages in one body. A batched rewards claim sends one per validator. */
-    private const val MAX_MESSAGES = 64
+    internal const val MAX_MESSAGES = 64
 
     /** Bounds unknown-field scans. */
     private const val MAX_FIELDS = 512
@@ -41,22 +51,31 @@ internal object CosmosSignDocReader {
     /** `cosmos.bank.v1beta1.MsgSend`, the one non-staking message this names. */
     private const val MSG_SEND_TYPE_URL = "/cosmos.bank.v1beta1.MsgSend"
 
+    /** `TxBody.memo`. */
+    private const val MEMO_FIELD = 2L
+
     /**
      * Reads one complete SignDoc body, or refuses it.
      *
      * @param body the decoded `SignDirect.bodyBytes` — already base64-decoded by
      *   [com.vultisig.wallet.data.models.transaction_decoding.OpaqueSignedContent.CosmosSignDirect].
      */
-    fun read(body: ByteArray): Reading? {
+    fun read(body: ByteArray): Body? {
         if (body.isEmpty() || body.size > MAX_BODY_BYTES) return null
 
-        val messages = messageBodies(body)?.takeIf { it.isNotEmpty() } ?: return null
+        val walked = walk(body) ?: return null
+        val messages = walked.messages.takeIf { it.isNotEmpty() } ?: return null
+
+        // Messages of no type this names leave the memo as the only thing the body states.
+        val shapes = messages.map { shape(it.url) }
+        if (shapes.all { it == null }) return Body(reading = null, memo = walked.memo)
 
         // Every message must decode, and they must agree on one operation. A body that mixes verbs
         // has no single one to name, and naming either would describe only part of what is signed.
         val readings = ArrayList<Reading>(messages.size)
-        for (message in messages) {
-            readings.add(read(message) ?: return null)
+        for ((message, shape) in messages.zip(shapes)) {
+            // A recognised message riding beside an unrecognised one is the same partial reading.
+            readings.add(read(message.value, shape ?: return null) ?: return null)
         }
 
         val first = readings.first()
@@ -64,38 +83,52 @@ internal object CosmosSignDocReader {
 
         // A homogeneous batch has one verb but no single amount or counterparty.
         if (readings.size > 1) {
-            return Reading(
-                operation = first.operation,
-                amount = DecodedAmount.Unstated,
-                counterparty = null,
+            return Body(
+                reading =
+                    Reading(
+                        operation = first.operation,
+                        amount = DecodedAmount.Unstated,
+                        counterparty = null,
+                    ),
+                memo = walked.memo,
             )
         }
-        return first
+        return Body(reading = first, memo = walked.memo)
     }
 
     /** One `Any` in `TxBody.messages`. */
     private data class AnyMessage(val url: String, val value: ByteArray)
 
-    /** Reads every `Any` in `TxBody.messages`; a partial result is refused. */
-    private fun messageBodies(body: ByteArray): List<AnyMessage>? {
+    /** A `TxBody` walked to its end. */
+    private data class Walked(val messages: List<AnyMessage>, val memo: String?)
+
+    /** Reads every `Any` in `TxBody.messages` and the body's memo; a partial result is refused. */
+    private fun walk(body: ByteArray): Walked? {
         val reader = ByteReader(body)
         val messages = mutableListOf<AnyMessage>()
+        var memo: String? = null
         var fields = 0
 
         while (!reader.isAtEnd) {
             if (++fields > MAX_FIELDS) return null
             val tag = reader.readTag() ?: return null
 
-            if (tag.field == 1L && tag.wire == WireType.LengthDelimited) {
-                if (messages.size >= MAX_MESSAGES) return null
-                val any = reader.readLengthDelimited() ?: return null
-                messages.add(anyContents(any) ?: return null)
-            } else {
-                if (!reader.skip(tag.wire)) return null
+            when {
+                tag.field == 1L && tag.wire == WireType.LengthDelimited -> {
+                    if (messages.size >= MAX_MESSAGES) return null
+                    val any = reader.readLengthDelimited() ?: return null
+                    messages.add(anyContents(any) ?: return null)
+                }
+
+                // Reading to the end preserves protobuf's last-one-wins semantics here too.
+                tag.field == MEMO_FIELD && tag.wire == WireType.LengthDelimited ->
+                    memo = reader.readUtf8() ?: return null
+
+                else -> if (!reader.skip(tag.wire)) return null
             }
         }
 
-        return messages
+        return Walked(messages, memo?.takeIf { it.isNotEmpty() })
     }
 
     /** Reads to the end, which preserves protobuf's last-one-wins semantics. */
@@ -127,64 +160,44 @@ internal object CosmosSignDocReader {
 
     // MARK: - The messages this can corroborate
 
-    /** Names only the message types whose values are decoded here. */
-    private fun read(message: AnyMessage): Reading? =
-        when (message.url) {
+    /** Where one message type keeps the address and the `Coin` this reads. */
+    private data class Shape(
+        val operation: DecodedOperation,
+        val addressField: Long,
+        val amountField: Long?,
+    )
+
+    /**
+     * Names only the message types whose values are decoded here. A null shape is a type this
+     * cannot name — distinct from a named type whose body would not read, which is a refusal.
+     */
+    private fun shape(url: String): Shape? =
+        when (url) {
             // delegator 1, validator 2, amount 3 (Coin)
             CosmosStakingHelper.MSG_DELEGATE_TYPE_URL ->
-                readAddressed(
-                    message.value,
-                    DecodedOperation.Delegate,
-                    validatorField = 2L,
-                    amountField = 3L,
-                )
+                Shape(DecodedOperation.Delegate, addressField = 2L, amountField = 3L)
 
             CosmosStakingHelper.MSG_UNDELEGATE_TYPE_URL ->
-                readAddressed(
-                    message.value,
-                    DecodedOperation.Undelegate,
-                    validatorField = 2L,
-                    amountField = 3L,
-                )
+                Shape(DecodedOperation.Undelegate, addressField = 2L, amountField = 3L)
 
             // Source is field 2, destination field 3 — the destination is the relevant
             // counterparty, and reading the wrong one names the validator being left.
             CosmosStakingHelper.MSG_BEGIN_REDELEGATE_TYPE_URL ->
-                readAddressed(
-                    message.value,
-                    DecodedOperation.Redelegate,
-                    validatorField = 3L,
-                    amountField = 4L,
-                )
+                Shape(DecodedOperation.Redelegate, addressField = 3L, amountField = 4L)
 
             // A reward withdrawal carries no Coin: the chain settles what has accrued.
             CosmosStakingHelper.MSG_WITHDRAW_DELEGATOR_REWARD_TYPE_URL ->
-                readAddressed(
-                    message.value,
-                    DecodedOperation.ClaimRewards,
-                    validatorField = 2L,
-                    amountField = null,
-                )
+                Shape(DecodedOperation.ClaimRewards, addressField = 2L, amountField = null)
 
             // from 1, to 2, amount 3 (repeated Coin)
             MSG_SEND_TYPE_URL ->
-                readAddressed(
-                    message.value,
-                    DecodedOperation.Transfer,
-                    validatorField = 2L,
-                    amountField = 3L,
-                )
+                Shape(DecodedOperation.Transfer, addressField = 2L, amountField = 3L)
 
             else -> null
         }
 
     /** Pulls the named address and an optional `Coin` out of one message body. */
-    private fun readAddressed(
-        body: ByteArray,
-        operation: DecodedOperation,
-        validatorField: Long,
-        amountField: Long?,
-    ): Reading? {
+    private fun read(body: ByteArray, shape: Shape): Reading? {
         val reader = ByteReader(body)
         var address: String? = null
         val coins = mutableListOf<Pair<String, BigInteger>>()
@@ -195,11 +208,11 @@ internal object CosmosSignDocReader {
             val tag = reader.readTag() ?: return null
 
             when {
-                tag.field == validatorField && tag.wire == WireType.LengthDelimited ->
+                tag.field == shape.addressField && tag.wire == WireType.LengthDelimited ->
                     address = reader.readUtf8() ?: return null
 
-                amountField != null &&
-                    tag.field == amountField &&
+                shape.amountField != null &&
+                    tag.field == shape.amountField &&
                     tag.wire == WireType.LengthDelimited -> {
                     val raw = reader.readLengthDelimited() ?: return null
                     coins.add(coin(raw) ?: return null)
@@ -219,10 +232,11 @@ internal object CosmosSignDocReader {
             else DecodedAmount.Unstated
 
         return Reading(
-            operation = operation,
+            operation = shape.operation,
             amount = amount,
             counterparty =
-                if (operation == DecodedOperation.Transfer) DecodedCounterparty.Contract(address)
+                if (shape.operation == DecodedOperation.Transfer)
+                    DecodedCounterparty.Contract(address)
                 else DecodedCounterparty.Validator(address),
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosTransactionDecoder.kt
@@ -49,11 +49,14 @@ class CosmosTransactionDecoder @Inject constructor() : TransactionContentDecoder
         val fields = memo.split(":")
         val head = fields.firstOrNull() ?: return null
 
-        // The chain matches these heads case-insensitively.
+        // The chain matches these heads case-insensitively. Each is matched against its whole
+        // layout: a memo with fields this grammar cannot account for is one the reader does not
+        // recognise, and naming it anyway would present an ambiguous string as a verified action.
         return when (head.uppercase()) {
-            // `SWITCH` moves the asset to the sender's THORChain address.
+            // `SWITCH:<address>` moves the asset to the sender's THORChain address.
             "SWITCH" -> {
-                if (fields.getOrNull(1).isNullOrEmpty()) return null
+                if (fields.size != SWITCH_FIELDS) return null
+                if (fields[SWITCH_ADDRESS_FIELD].isEmpty()) return null
                 DecodedTransaction(
                     operation = DecodedOperation.SwitchChain,
                     amount = carried(content.amount),
@@ -61,11 +64,13 @@ class CosmosTransactionDecoder @Inject constructor() : TransactionContentDecoder
                 )
             }
 
-            // Governance votes move no quantity. `QBTC_VOTE` is what this app builds; `DYDX_VOTE`
-            // is the same grammar from an iOS initiator, and a co-signer has to read both.
+            // `<CHAIN>_VOTE:<option>:<proposal>` moves no quantity. `QBTC_VOTE` is what this app
+            // builds; `DYDX_VOTE` is the same grammar from an iOS initiator, and a co-signer has
+            // to read both.
             "QBTC_VOTE",
             "DYDX_VOTE" -> {
-                if (fields.getOrNull(2).isNullOrEmpty()) return null
+                if (fields.size != VOTE_FIELDS) return null
+                if (fields.drop(1).any { it.isEmpty() }) return null
                 DecodedTransaction(
                     operation = DecodedOperation.Vote,
                     amount = DecodedAmount.Unstated,
@@ -99,6 +104,14 @@ class CosmosTransactionDecoder @Inject constructor() : TransactionContentDecoder
     private companion object {
         /** An earlier approve or swap route makes the sidecar memo inert. */
         val MEMO_PRECEDENCE = MemoPrecedence.MemoIsInertWhenRoutedEarlier
+
+        const val SWITCH_FIELDS = 2
+        const val SWITCH_ADDRESS_FIELD = 1
+
+        /**
+         * The head, the option, and the proposal id — `GovernanceViewModel` writes exactly three.
+         */
+        const val VOTE_FIELDS = 3
 
         /** What the transaction carries, when it carries a figure at all. */
         fun carried(signed: SignedAmount): DecodedAmount =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosTransactionDecoder.kt
@@ -1,0 +1,114 @@
+package com.vultisig.wallet.data.blockchain.cosmos
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.models.transaction_decoding.CorroboratedContent
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedEvidence
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.data.models.transaction_decoding.MemoPrecedence
+import com.vultisig.wallet.data.models.transaction_decoding.SignedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
+import com.vultisig.wallet.data.models.transaction_decoding.TransactionContentDecoder
+import javax.inject.Inject
+import vultisig.keysign.v1.TransactionType
+
+/**
+ * Reads Cosmos operations carried by an active memo or by the wire discriminator that selects the
+ * signing shape. SignDoc-contained operations belong to [CosmosSignDocDecoder], which is registered
+ * ahead of this one and consumes the body before it can be reached here.
+ *
+ * Mirrors the iOS `CosmosTransactionDecoder`.
+ */
+class CosmosTransactionDecoder @Inject constructor() : TransactionContentDecoder {
+
+    /**
+     * The whole Cosmos family rather than iOS's hand-listed subset. The grammar below is
+     * chain-agnostic within the family, and Android's producers do not line up with that list:
+     * there is no Kujira here, governance votes are built for QBTC, and IBC transfers are offered
+     * from several of these chains. Narrowing further would silently drop readings the app itself
+     * emits. THORChain and MAYAChain are a different standard and keep their own decoders.
+     */
+    override val handles: Set<Chain> =
+        Chain.entries.filter { it.standard == TokenStandard.COSMOS }.toSet()
+
+    override fun decode(tx: SignedTransactionContent): DecodedTransaction? {
+        val content = tx.corroborated ?: return null
+
+        content.memo(MEMO_PRECEDENCE)?.let { memo ->
+            decodeMemo(memo, content)?.let {
+                return it
+            }
+        }
+        return decodeWireType(content)
+    }
+
+    private fun decodeMemo(memo: String, content: CorroboratedContent): DecodedTransaction? {
+        val fields = memo.split(":")
+        val head = fields.firstOrNull() ?: return null
+
+        // The chain matches these heads case-insensitively.
+        return when (head.uppercase()) {
+            // `SWITCH` moves the asset to the sender's THORChain address.
+            "SWITCH" -> {
+                if (fields.getOrNull(1).isNullOrEmpty()) return null
+                DecodedTransaction(
+                    operation = DecodedOperation.SwitchChain,
+                    amount = carried(content.amount),
+                    evidence = DecodedEvidence.Memo,
+                )
+            }
+
+            // Governance votes move no quantity. `QBTC_VOTE` is what this app builds; `DYDX_VOTE`
+            // is the same grammar from an iOS initiator, and a co-signer has to read both.
+            "QBTC_VOTE",
+            "DYDX_VOTE" -> {
+                if (fields.getOrNull(2).isNullOrEmpty()) return null
+                DecodedTransaction(
+                    operation = DecodedOperation.Vote,
+                    amount = DecodedAmount.Unstated,
+                    evidence = DecodedEvidence.Memo,
+                )
+            }
+
+            else -> null
+        }
+    }
+
+    private fun decodeWireType(content: CorroboratedContent): DecodedTransaction? =
+        when (content.transactionType) {
+            TransactionType.TRANSACTION_TYPE_IBC_TRANSFER ->
+                DecodedTransaction(
+                    operation = DecodedOperation.IbcTransfer,
+                    amount = carried(content.amount),
+                    evidence = DecodedEvidence.WireTransactionType,
+                )
+
+            TransactionType.TRANSACTION_TYPE_VOTE ->
+                DecodedTransaction(
+                    operation = DecodedOperation.Vote,
+                    amount = DecodedAmount.Unstated,
+                    evidence = DecodedEvidence.WireTransactionType,
+                )
+
+            else -> null
+        }
+
+    private companion object {
+        /** An earlier approve or swap route makes the sidecar memo inert. */
+        val MEMO_PRECEDENCE = MemoPrecedence.MemoIsInertWhenRoutedEarlier
+
+        /** What the transaction carries, when it carries a figure at all. */
+        fun carried(signed: SignedAmount): DecodedAmount =
+            when (signed) {
+                is SignedAmount.Committed ->
+                    if (signed.value.signum() > 0)
+                        DecodedAmount.Units(signed.value, DecodedAsset.TransactionCoin)
+                    else DecodedAmount.Unstated
+
+                SignedAmount.ComputedAtSigning -> DecodedAmount.Unstated
+            }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosTransactionDecoder.kt
@@ -46,40 +46,14 @@ class CosmosTransactionDecoder @Inject constructor() : TransactionContentDecoder
     }
 
     private fun decodeMemo(memo: String, content: CorroboratedContent): DecodedTransaction? {
-        val fields = memo.split(":")
-        val head = fields.firstOrNull() ?: return null
-
-        // The chain matches these heads case-insensitively. Each is matched against its whole
-        // layout: a memo with fields this grammar cannot account for is one the reader does not
-        // recognise, and naming it anyway would present an ambiguous string as a verified action.
-        return when (head.uppercase()) {
-            // `SWITCH:<address>` moves the asset to the sender's THORChain address.
-            "SWITCH" -> {
-                if (fields.size != SWITCH_FIELDS) return null
-                if (fields[SWITCH_ADDRESS_FIELD].isEmpty()) return null
-                DecodedTransaction(
-                    operation = DecodedOperation.SwitchChain,
-                    amount = carried(content.amount),
-                    evidence = DecodedEvidence.Memo,
-                )
-            }
-
-            // `<CHAIN>_VOTE:<option>:<proposal>` moves no quantity. `QBTC_VOTE` is what this app
-            // builds; `DYDX_VOTE` is the same grammar from an iOS initiator, and a co-signer has
-            // to read both.
-            "QBTC_VOTE",
-            "DYDX_VOTE" -> {
-                if (fields.size != VOTE_FIELDS) return null
-                if (fields.drop(1).any { it.isEmpty() }) return null
-                DecodedTransaction(
-                    operation = DecodedOperation.Vote,
-                    amount = DecodedAmount.Unstated,
-                    evidence = DecodedEvidence.Memo,
-                )
-            }
-
-            else -> null
-        }
+        val reading = CosmosMemoReader.read(memo) ?: return null
+        return DecodedTransaction(
+            operation = reading.operation,
+            amount =
+                if (reading.movesTheCarriedAmount) carried(content.amount)
+                else DecodedAmount.Unstated,
+            evidence = DecodedEvidence.Memo,
+        )
     }
 
     private fun decodeWireType(content: CorroboratedContent): DecodedTransaction? =
@@ -104,14 +78,6 @@ class CosmosTransactionDecoder @Inject constructor() : TransactionContentDecoder
     private companion object {
         /** An earlier approve or swap route makes the sidecar memo inert. */
         val MEMO_PRECEDENCE = MemoPrecedence.MemoIsInertWhenRoutedEarlier
-
-        const val SWITCH_FIELDS = 2
-        const val SWITCH_ADDRESS_FIELD = 1
-
-        /**
-         * The head, the option, and the proposal id — `GovernanceViewModel` writes exactly three.
-         */
-        const val VOTE_FIELDS = 3
 
         /** What the transaction carries, when it carries a figure at all. */
         fun carried(signed: SignedAmount): DecodedAmount =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/cosmos/CosmosTransactionDecoder.kt
@@ -49,9 +49,13 @@ class CosmosTransactionDecoder @Inject constructor() : TransactionContentDecoder
         val reading = CosmosMemoReader.read(memo) ?: return null
         return DecodedTransaction(
             operation = reading.operation,
+            // Only a verb a transfer carries moves the transaction's figure; a vote rides beside
+            // its own message and states no quantity.
             amount =
-                if (reading.movesTheCarriedAmount) carried(content.amount)
-                else DecodedAmount.Unstated,
+                when (reading.carrier) {
+                    CosmosMemoReader.Carrier.Transfer -> carried(content.amount)
+                    CosmosMemoReader.Carrier.OwnMessage -> DecodedAmount.Unstated
+                },
             evidence = DecodedEvidence.Memo,
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/maya/MayaChainTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/maya/MayaChainTransactionDecoder.kt
@@ -1,0 +1,108 @@
+package com.vultisig.wallet.data.blockchain.maya
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedCounterparty
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedEvidence
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.data.models.transaction_decoding.MemoPrecedence
+import com.vultisig.wallet.data.models.transaction_decoding.SignedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
+import com.vultisig.wallet.data.models.transaction_decoding.TransactionContentDecoder
+import javax.inject.Inject
+
+/**
+ * Decodes MAYAChain pool and node memos.
+ *
+ * Mirrors the iOS `MayaChainTransactionDecoder`. It is scoped to MAYAChain alone rather than shared
+ * with THORChain because the two use the same memo heads with different field layouts — a Maya
+ * `BOND` names its node in field 3 behind an asset and a unit count, where a THORChain `BOND` names
+ * it in field 1. Reading one grammar with the other's offsets names the wrong node.
+ */
+class MayaChainTransactionDecoder @Inject constructor() : TransactionContentDecoder {
+
+    override val handles: Set<Chain> = setOf(Chain.MayaChain)
+
+    override fun decode(tx: SignedTransactionContent): DecodedTransaction? {
+        val content = tx.corroborated ?: return null
+        val memo = content.memo(MEMO_PRECEDENCE) ?: return null
+
+        val fields = memo.split(":")
+        val head = fields.firstOrNull() ?: return null
+
+        return when (head.uppercase()) {
+            "POOL+" ->
+                DecodedTransaction(
+                    operation = DecodedOperation.Stake,
+                    amount = carried(content.amount),
+                    evidence = DecodedEvidence.Memo,
+                )
+
+            // `POOL-:<basisPoints>[:affiliate:rate]` — later fields may name a single-sided asset.
+            "POOL-" -> {
+                val bps = fields.getOrNull(1)?.toIntOrNull() ?: return null
+                if (bps !in 1..MAX_BASIS_POINTS) return null
+                DecodedTransaction(
+                    operation = DecodedOperation.Unstake,
+                    amount = DecodedAmount.Fraction(bps, DecodedAsset.TransactionCoin),
+                    evidence = DecodedEvidence.Memo,
+                )
+            }
+
+            // `BOND:<asset>:<units>:<node>[:provider]`
+            "BOND" -> node(fields)?.let { bonded(DecodedOperation.Bond, it) }
+
+            "UNBOND" -> node(fields)?.let { bonded(DecodedOperation.Unbond, it) }
+
+            "LEAVE" -> {
+                val node = fields.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
+                DecodedTransaction(
+                    operation = DecodedOperation.Leave,
+                    amount = DecodedAmount.Unstated,
+                    counterparty = DecodedCounterparty.Node(node),
+                    evidence = DecodedEvidence.Memo,
+                )
+            }
+
+            else -> null
+        }
+    }
+
+    private fun node(fields: List<String>): String? =
+        fields.getOrNull(NODE_FIELD)?.takeIf { it.isNotEmpty() }
+
+    /**
+     * Bond and unbond name their size in LP units, which are not base units of any asset and cannot
+     * be rendered as a currency amount. Until there is a presentation that says "N units of pool",
+     * the verb and the node are the whole truthful reading.
+     */
+    private fun bonded(operation: DecodedOperation, node: String) =
+        DecodedTransaction(
+            operation = operation,
+            amount = DecodedAmount.Unstated,
+            counterparty = DecodedCounterparty.Node(node),
+            evidence = DecodedEvidence.Memo,
+        )
+
+    private companion object {
+        /** An earlier approve or swap route makes the sidecar memo inert. */
+        val MEMO_PRECEDENCE = MemoPrecedence.MemoIsInertWhenRoutedEarlier
+
+        /** `BOND` and `UNBOND` carry the node behind the asset and the unit count. */
+        const val NODE_FIELD = 3
+
+        const val MAX_BASIS_POINTS = 10_000
+
+        fun carried(signed: SignedAmount): DecodedAmount =
+            when (signed) {
+                is SignedAmount.Committed ->
+                    if (signed.value.signum() > 0)
+                        DecodedAmount.Units(signed.value, DecodedAsset.TransactionCoin)
+                    else DecodedAmount.Unstated
+
+                SignedAmount.ComputedAtSigning -> DecodedAmount.Unstated
+            }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/maya/MayaChainTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/maya/MayaChainTransactionDecoder.kt
@@ -32,17 +32,26 @@ class MayaChainTransactionDecoder @Inject constructor() : TransactionContentDeco
         val fields = memo.split(":")
         val head = fields.firstOrNull() ?: return null
 
+        // Each head is matched against its whole documented layout, not just the slots this
+        // renders. A memo carrying too few fields to be that operation, or surplus fields this
+        // grammar cannot account for, is a memo the reader does not recognise — and naming it
+        // anyway would present an ambiguous string as a verified action.
         return when (head.uppercase()) {
-            "POOL+" ->
+            // `POOL+` alone; a Cacao pool deposit parameterises nothing.
+            "POOL+" -> {
+                if (fields.size != POOL_DEPOSIT_FIELDS) return null
                 DecodedTransaction(
                     operation = DecodedOperation.Stake,
                     amount = carried(content.amount),
                     evidence = DecodedEvidence.Memo,
                 )
+            }
 
-            // `POOL-:<basisPoints>[:affiliate:rate]` — later fields may name a single-sided asset.
+            // `POOL-:<basisPoints>[:affiliate:rate]`. iOS builds the bare two-field form and this
+            // app appends an affiliate and a rate, so a co-signer has to accept both.
             "POOL-" -> {
-                val bps = fields.getOrNull(1)?.toIntOrNull() ?: return null
+                if (fields.size !in POOL_WITHDRAW_FIELDS) return null
+                val bps = fields[BASIS_POINTS_FIELD].toIntOrNull() ?: return null
                 if (bps !in 1..MAX_BASIS_POINTS) return null
                 DecodedTransaction(
                     operation = DecodedOperation.Unstake,
@@ -51,13 +60,14 @@ class MayaChainTransactionDecoder @Inject constructor() : TransactionContentDeco
                 )
             }
 
-            // `BOND:<asset>:<units>:<node>[:provider]`
-            "BOND" -> node(fields)?.let { bonded(DecodedOperation.Bond, it) }
+            "BOND" -> bonded(DecodedOperation.Bond, fields)
 
-            "UNBOND" -> node(fields)?.let { bonded(DecodedOperation.Unbond, it) }
+            "UNBOND" -> bonded(DecodedOperation.Unbond, fields)
 
+            // `LEAVE:<node>`, and nothing behind it.
             "LEAVE" -> {
-                val node = fields.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
+                if (fields.size != LEAVE_FIELDS) return null
+                val node = fields[LEAVE_NODE_FIELD].takeIf { it.isNotEmpty() } ?: return null
                 DecodedTransaction(
                     operation = DecodedOperation.Leave,
                     amount = DecodedAmount.Unstated,
@@ -70,28 +80,48 @@ class MayaChainTransactionDecoder @Inject constructor() : TransactionContentDeco
         }
     }
 
-    private fun node(fields: List<String>): String? =
-        fields.getOrNull(NODE_FIELD)?.takeIf { it.isNotEmpty() }
-
     /**
-     * Bond and unbond name their size in LP units, which are not base units of any asset and cannot
-     * be rendered as a currency amount. Until there is a presentation that says "N units of pool",
-     * the verb and the node are the whole truthful reading.
+     * `BOND:<asset>:<units>:<node>[:provider]`.
+     *
+     * The unit count is the one slot allowed to be empty — this app writes it empty whenever the
+     * bond names no LP units — so what is required here is the layout, and a value in every slot
+     * that carries meaning. A provider is optional, but an empty one is a field that says nothing.
+     *
+     * The size itself is never read: LP units are not base units of any asset and cannot be
+     * rendered as a currency amount, and the value the transaction carries is a dust floor rather
+     * than the bond. Until there is a presentation that says "N units of pool", the verb and the
+     * node are the whole truthful reading.
      */
-    private fun bonded(operation: DecodedOperation, node: String) =
-        DecodedTransaction(
+    private fun bonded(operation: DecodedOperation, fields: List<String>): DecodedTransaction? {
+        if (fields.size !in BOND_FIELDS) return null
+        if (fields[ASSET_FIELD].isEmpty()) return null
+        if (fields.size > PROVIDER_FIELD && fields[PROVIDER_FIELD].isEmpty()) return null
+        val node = fields[NODE_FIELD].takeIf { it.isNotEmpty() } ?: return null
+
+        return DecodedTransaction(
             operation = operation,
             amount = DecodedAmount.Unstated,
             counterparty = DecodedCounterparty.Node(node),
             evidence = DecodedEvidence.Memo,
         )
+    }
 
     private companion object {
         /** An earlier approve or swap route makes the sidecar memo inert. */
         val MEMO_PRECEDENCE = MemoPrecedence.MemoIsInertWhenRoutedEarlier
 
         /** `BOND` and `UNBOND` carry the node behind the asset and the unit count. */
+        const val ASSET_FIELD = 1
         const val NODE_FIELD = 3
+        const val PROVIDER_FIELD = 4
+        val BOND_FIELDS = 4..5
+
+        const val POOL_DEPOSIT_FIELDS = 1
+        const val BASIS_POINTS_FIELD = 1
+        val POOL_WITHDRAW_FIELDS = 2..4
+
+        const val LEAVE_FIELDS = 2
+        const val LEAVE_NODE_FIELD = 1
 
         const val MAX_BASIS_POINTS = 10_000
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/maya/MayaChainTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/maya/MayaChainTransactionDecoder.kt
@@ -47,10 +47,13 @@ class MayaChainTransactionDecoder @Inject constructor() : TransactionContentDeco
                 )
             }
 
-            // `POOL-:<basisPoints>[:affiliate:rate]`. iOS builds the bare two-field form and this
-            // app appends an affiliate and a rate, so a co-signer has to accept both.
+            // `POOL-:<basisPoints>` or `POOL-:<basisPoints>:<affiliate>:<rate>`. iOS builds the
+            // bare form and this app appends an affiliate and a rate, so a co-signer has to accept
+            // both — but only those two: a memo stopping between them names an affiliate whose fee
+            // it does not state.
             "POOL-" -> {
                 if (fields.size !in POOL_WITHDRAW_FIELDS) return null
+                if (fields.drop(BASIS_POINTS_FIELD).any { it.isEmpty() }) return null
                 val bps = fields[BASIS_POINTS_FIELD].toIntOrNull() ?: return null
                 if (bps !in 1..MAX_BASIS_POINTS) return null
                 DecodedTransaction(
@@ -118,7 +121,9 @@ class MayaChainTransactionDecoder @Inject constructor() : TransactionContentDeco
 
         const val POOL_DEPOSIT_FIELDS = 1
         const val BASIS_POINTS_FIELD = 1
-        val POOL_WITHDRAW_FIELDS = 2..4
+
+        /** The bare basis-point form, or the one carrying both an affiliate and its rate. */
+        val POOL_WITHDRAW_FIELDS = setOf(2, 4)
 
         const val LEAVE_FIELDS = 2
         const val LEAVE_NODE_FIELD = 1

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
@@ -1,5 +1,8 @@
 package com.vultisig.wallet.data.models.transaction_decoding
 
+import com.vultisig.wallet.data.blockchain.cosmos.CosmosSignDocDecoder
+import com.vultisig.wallet.data.blockchain.cosmos.CosmosTransactionDecoder
+import com.vultisig.wallet.data.blockchain.maya.MayaChainTransactionDecoder
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaTransactionDecoder
 import dagger.Module
 import dagger.Provides
@@ -22,6 +25,17 @@ internal object TransactionDecodingModule {
     @Provides
     @Singleton
     fun provideSignedTransactionDecoder(
-        solana: SolanaTransactionDecoder
-    ): SignedTransactionDecoder = SignedTransactionDecoder().apply { register(solana) }
+        solana: SolanaTransactionDecoder,
+        cosmosSignDoc: CosmosSignDocDecoder,
+        cosmos: CosmosTransactionDecoder,
+        maya: MayaChainTransactionDecoder,
+    ): SignedTransactionDecoder =
+        SignedTransactionDecoder().apply {
+            register(solana)
+            // The signed body outranks the sidecars that travel beside it, so the SignDoc reader
+            // is asked before the memo and wire-type grammar on the same chains.
+            register(cosmosSignDoc)
+            register(cosmos)
+            register(maya)
+        }
 }


### PR DESCRIPTION
## Summary

The first reader on the decoder registry that works from a peer's own bytes rather than a structure the initiator handed over. A co-signer receiving a Cosmos SignDoc had nothing to read it with, so a delegate that states its amount perfectly well arrived as an unnamed transaction. Android mirror of [vultisig-ios#5222](https://github.com/vultisig/vultisig-ios/pull/5222).

Reads delegate, undelegate, redelegate and rewards claims from either the initiator's staking intent or the active SignDoc body; reads the switch and governance memos — from the sidecar an initiator holds and from the `TxBody.memo` a co-signer's own bytes commit to — and the IBC and vote wire discriminators; and gives MAYAChain pool and node memos their own reader.

## Reviewer contract

1. **What proves the operation?** Recognised protobuf messages in the active signed SignDoc body, or the memo that same body commits to, or the initiator pre-image that produces those bytes. Where no SignDoc owns the payload, an active sidecar memo or the wire discriminator that selects the signing shape. Never the payload's flat sidecars while a SignDoc is active, since those are peer-supplied.
2. **When does a memo speak?** Only over the message that carries it. Inside a SignDoc a memo is peer-supplied text beside the bytes the chain acts on, so it names the operation only for a readable `MsgSend` and only for a verb a send can carry — which is the switch, and nothing else. A vote states itself in its own `MsgVote` and is read from there. `CosmosMemoReader` names the carrier for each verb, and one grammar serves both the sidecar route and the body route so the two devices cannot drift.
3. **Which surfaces can reach it?** Initiator Verify — including the Cosmos staking summary, which now renders the shared hero — and co-signer Keysign confirmation, plus Done.
4. **What is deliberately refused?** Malformed, mixed, partial and oversized bodies; unknown message types, whatever memo rides beside them; multi-denom sends; a memo outranked by an earlier approve or swap route, or by the message it does not belong to; and any message whose address the reader could not name.
5. **What hero appears?** The Cosmos verb with its signed amount and validator, or — for a rewards claim, which names no quantity — the verb with the scope it commits to.

## The parser is hand-written on purpose

The Cosmos message set is not in `commondata`, so there is no generated decoder to reach for. More to the point, the refusals are what this exists for: every length and varint in a SignDoc body is peer-supplied, and the reader is asked to run on a screen the user is already mid-ceremony on. So `ByteReader` answers null on malformed input rather than throwing, groups are rejected outright, varints refuse `Long` overflow, and a body that mixes verbs is refused whole rather than described by whichever message happened to come first.

A homogeneous batch — a rewards claim sends one message per validator — keeps its verb but drops the amount and counterparty, because a batch has neither a single figure nor a single validator to name.

## Four departures from iOS

**The denom comes from `CosmosStakingConfig`, not the payload.** Android's `CosmosStakingPayload` does not carry one, and `entryFor(chain).bondDenom` is the same source `CosmosStakingSignDataResolver` encodes the `Coin` from — so the initiator reads the denom its own signer is about to write, and both devices agree. A chain with no staking entry has no denom to name and is refused rather than guessed at.

**`CosmosTransactionDecoder` handles the whole Cosmos family** rather than iOS's hand-listed six. That list does not describe this app: there is no Kujira here, governance votes are built for QBTC, and IBC transfers are offered from several of these chains. Narrowing to iOS's set would silently drop readings the app itself emits. The grammar is chain-agnostic within the family, and THORChain and MAYAChain are a different standard with their own decoders.

**`QBTC_VOTE` is recognised alongside `DYDX_VOTE`.** The first is the memo this app builds; the second is the same grammar from an iOS initiator, and a co-signer has to read both.

**Bond and unbond state no amount.** A Maya `BOND` names its size in LP units, which are not base units of any asset, and the transaction's own carried value defaults to a single base unit of dust — presenting that as the bond is the "you're sending 0.0002 of dust" hazard in different clothes. Verb and node are the whole truthful reading until there is a presentation for pool units.

## Also

iOS's presentation change in this PR — resolving a denom that matches the chain's fee unit — already shipped here, so there was nothing to port. The Tron and TON readers iOS registers alongside these have not been mirrored yet, so the registry order is Solana, CosmosSignDoc, Cosmos, MAYAChain.

## Test plan

- `:app` and `:data` unit suites green; ktfmt and `lintDebug` clean.
- The SignDoc reader was exercised against the encoder that produces its input — `CosmosStakingHelper` — rather than against assumptions: delegate, undelegate, redelegate (which is where the field offsets matter, since source is field 2 and destination field 3), single and batched rewards claims, mixed verbs, a truncated body, random bytes, and an unrecognised message riding beside a recognised one. The memo path was exercised the same way: a switch memo on a send, a memo riding on a delegate (which stays a delegate), a vote memo on a send (which stays a transfer), a switch memo beside a `MsgVote` (which stays a vote), a memo on a truncated body, and `SWITCH:` / `QBTC_VOTE:` / `DYDX_VOTE:` beside a `MsgExec` — all four of the last refused. All read or refused as intended.
- Instruction shapes were checked against `CosmosStakingSignDataResolver`, which is what writes the `signDirect` bytes a co-signer receives.

**Not yet verified against a live cross-device ceremony.** The initiator path is exercised by the staking screens; the byte path deserves a co-signed delegate, undelegate, redelegate and claim on two devices before merge, and a Maya bond and pool memo on the deposit verify screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EkE5A8K1LQZ7FYfxCyC2D


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer transaction summaries during Cosmos staking verification, showing decoded transaction details when available.
  * Added support for recognizing Cosmos staking, reward-claim, transfer, redelegation, and voting transactions.
  * Added support for decoding MAYAChain pool, bond, unbond, and leave transactions.

* **Bug Fixes**
  * Improved validation of transaction data by rejecting incomplete, malformed, unsupported, or ambiguous messages.
  * Improved handling of Cosmos transaction memos and multi-validator reward claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

