### PR TITLE
Fix: stop persisting a failed Polkadot balance read as zero

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/PolkadotApi.kt
@@ -22,10 +22,18 @@ import java.math.BigInteger
 import javax.inject.Inject
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
-import timber.log.Timber
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
 import wallet.core.jni.Hash
+
+// A genuinely absent storage entry (result == null with no error) means the account has never
+// held a balance, which is a real zero rather than a failed read. An error envelope, or a
+// transport failure surfaced by postRpc, must propagate instead of masquerading as that zero.
+internal fun parseBalanceStorageResponse(response: PolkadotGetStorageJson): BigInteger {
+    response.error?.let { error("Polkadot RPC error fetching balance: ${it.message}") }
+    val hex = response.result?.removePrefix("0x") ?: return BigInteger.ZERO
+    return parsePolkadotFreeBalance(hex)
+}
 
 internal fun parsePolkadotFreeBalance(hex: String): BigInteger {
     // minimum 64 hex chars = 32 bytes: 16-byte header (4×u32) + 16-byte free balance (u128)
@@ -86,29 +94,20 @@ interface PolkadotApi {
 internal class PolkadotApiImp @Inject constructor(private val httpClient: HttpClient) :
     PolkadotApi {
     override suspend fun getBalance(address: String): BigInteger {
-        try {
-            val pubKey = AnyAddress(address, CoinType.POLKADOT).data()
-            val blake2b128 = Hash.blake2b(pubKey, 16)
-            val storageKey =
-                "0x" +
-                    SYSTEM_ACCOUNT_PREFIX +
-                    blake2b128.joinToString("") { "%02x".format(it) } +
-                    pubKey.joinToString("") { "%02x".format(it) }
-            val result =
-                httpClient
-                    .postRpc<PolkadotGetStorageJson>(
-                        url = POLKADOT_API_URL,
-                        method = "state_getStorage",
-                        params = buildJsonArray { add(storageKey) },
-                    )
-                    .result ?: return BigInteger.ZERO
-            val hex = result.removePrefix("0x")
-            return parsePolkadotFreeBalance(hex)
-        } catch (e: Exception) {
-            if (e is kotlinx.coroutines.CancellationException) throw e
-            Timber.e(e, "Error fetching Polkadot balance")
-            return BigInteger.ZERO
-        }
+        val pubKey = AnyAddress(address, CoinType.POLKADOT).data()
+        val blake2b128 = Hash.blake2b(pubKey, 16)
+        val storageKey =
+            "0x" +
+                SYSTEM_ACCOUNT_PREFIX +
+                blake2b128.joinToString("") { "%02x".format(it) } +
+                pubKey.joinToString("") { "%02x".format(it) }
+        val response =
+            httpClient.postRpc<PolkadotGetStorageJson>(
+                url = POLKADOT_API_URL,
+                method = "state_getStorage",
+                params = buildJsonArray { add(storageKey) },
+            )
+        return parseBalanceStorageResponse(response)
     }
 
     override suspend fun getNonce(address: String): BigInteger {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/PolkadotJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/PolkadotJson.kt
@@ -3,4 +3,8 @@ package com.vultisig.wallet.data.api.models
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@Serializable data class PolkadotGetStorageJson(@SerialName("result") val result: String?)
+@Serializable
+data class PolkadotGetStorageJson(
+    @SerialName("result") val result: String?,
+    @SerialName("error") val error: RpcError? = null,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -631,9 +631,10 @@ constructor(
             }
 
     override suspend fun getBalanceOrNull(address: String, coin: Coin): BigInteger? =
-        // Solana native is the one read that reports failure as a value rather than as a throw, so
-        // it is asked through the nullable overload; every other chain surfaces a failed read as an
-        // exception out of the flow, which [runCatchingCancellable] turns into the same null.
+        // Solana native is the only read that reports failure as a value rather than as a throw
+        // (see [SolanaApi.getBalance]), so it is asked through the nullable overload; every other
+        // chain surfaces a failed read as an exception out of the flow, which
+        // [runCatchingCancellable] turns into the same null.
         if (coin.chain == Solana && coin.isNativeToken) {
             solanaApi.getBalanceOrNull(address)
         } else {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/PolkadotApiTest.kt
@@ -1,5 +1,7 @@
 package com.vultisig.wallet.data.api
 
+import com.vultisig.wallet.data.api.models.PolkadotGetStorageJson
+import com.vultisig.wallet.data.api.models.RpcError
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -11,6 +13,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
@@ -150,6 +153,26 @@ class PolkadotApiTest {
                 api.isExtrinsicInBlockRange(EXT_HASH, fromBlock = 98, toBlock = 100)
             }
         }
+
+    @Test
+    fun `parseBalanceStorageResponse throws on a JSON-RPC error envelope instead of returning zero`() {
+        assertFailsWith<IllegalStateException> {
+            parseBalanceStorageResponse(
+                PolkadotGetStorageJson(
+                    result = null,
+                    error = RpcError(code = -32000, message = "boom"),
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `parseBalanceStorageResponse returns zero for a genuinely absent storage entry`() {
+        assertEquals(
+            BigInteger.ZERO,
+            parseBalanceStorageResponse(PolkadotGetStorageJson(result = null, error = null)),
+        )
+    }
 
     private fun nullResultResponse(): String = """{"jsonrpc":"2.0","id":1,"result":null}"""
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryBalanceOrNullTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryBalanceOrNullTest.kt
@@ -49,6 +49,7 @@ class BalanceRepositoryBalanceOrNullTest {
     private val thorChainApi = mockk<ThorChainApi>(relaxed = true)
     private val blockchairApi = mockk<BlockChairApi>(relaxed = true)
     private val cardanoApi = mockk<CardanoApi>(relaxed = true)
+    private val polkadotApi = mockk<PolkadotApi>(relaxed = true)
     private val tokenValueDao = mockk<TokenValueDao>(relaxed = true)
 
     private val repository =
@@ -63,7 +64,7 @@ class BalanceRepositoryBalanceOrNullTest {
             tokenPriceRepository = mockk<TokenPriceRepository>(relaxed = true),
             appCurrencyRepository = mockk<AppCurrencyRepository>(relaxed = true),
             tronResourceDataSource = mockk<TronResourceDataSource>(relaxed = true),
-            polkadotApi = mockk<PolkadotApi>(relaxed = true),
+            polkadotApi = polkadotApi,
             bittensorApi = mockk<BittensorApi>(relaxed = true),
             suiApi = mockk<SuiApi>(relaxed = true),
             tonApi = mockk<TonApi>(relaxed = true),
@@ -162,6 +163,17 @@ class BalanceRepositoryBalanceOrNullTest {
         }
 
         coVerify(exactly = 0) { solanaApi.getBalance(any()) }
+        coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
+    }
+
+    @Test
+    fun `a Polkadot balance failure propagates and is not persisted as zero`() = runTest {
+        coEvery { polkadotApi.getBalance(ADDRESS) } throws IllegalStateException("node down")
+
+        assertThrows<IllegalStateException> {
+            repository.getTokenValue(ADDRESS, Coins.Polkadot.DOT).first()
+        }
+
         coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
     }
 


### PR DESCRIPTION
## Summary
- `PolkadotApi.getBalance` converted every RPC/transport failure into `BigInteger.ZERO`, and a JSON-RPC error envelope deserialized to the same `result = null` as a genuinely unfunded account, so `BalanceRepository` cached the fake zero and overwrote the last known balance.
- `PolkadotGetStorageJson` now carries an `error` field, and `getBalance` propagates a transport exception or an RPC error envelope instead of swallowing it — mirroring the fix already shipped for EVM (#5308/#5312) and Blockchair/Cardano/Solana (#5788), so `AccountsRepository`'s existing per-chain catch preserves the cached value.
- A genuinely absent storage entry (no error, `result = null`) still maps to zero, since that's a real answer for an unfunded address.
- Updated the now-inaccurate `getBalanceOrNull` comment that claimed Solana was the only value-reporting read.

## Test plan
- [x] `./gradlew :data:testDebugUnitTest` — new tests cover the RPC-error-throws and absent-storage-is-zero cases, plus a `BalanceRepository` test asserting a Polkadot failure propagates and `insertTokenValue` is not called.
- [x] `./gradlew assembleDebug` succeeds

Fixes #5823

https://claude.ai/code/session_01PR2RvS9CD9L6JrGYeLFa6w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Polkadot balance requests now distinguish missing balances from RPC errors.
  * Missing storage entries return a zero balance, while RPC, transport, parsing, and address errors are surfaced instead of being converted to zero.
  * Failed Polkadot balance lookups are no longer saved as zero values.

* **Tests**
  * Added coverage for error propagation, missing entries, and prevention of incorrect zero-balance persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->