### PR TITLE
fix(send): hide memo field for Polkadot and Bittensor

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
@@ -101,6 +101,8 @@ val Coin.isLpToken: Boolean
 val Coin.carriesMemo: Boolean
     get() =
         chain != Chain.Sui &&
+            chain != Chain.Polkadot &&
+            chain != Chain.Bittensor &&
             (isNativeToken ||
                 chain.standard == TokenStandard.COSMOS ||
                 chain == Chain.Ton ||

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinTest.kt
@@ -1,0 +1,61 @@
+package com.vultisig.wallet.data.models
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CoinTest {
+
+    private fun coin(chain: Chain, isNativeToken: Boolean) =
+        Coin(
+            chain = chain,
+            ticker = "",
+            logo = "",
+            address = "",
+            decimal = 0,
+            hexPublicKey = "",
+            priceProviderID = "",
+            contractAddress = "",
+            isNativeToken = isNativeToken,
+        )
+
+    @Test
+    fun `native Polkadot does not carry memo`() {
+        assertFalse(coin(Chain.Polkadot, isNativeToken = true).carriesMemo)
+    }
+
+    @Test
+    fun `native Bittensor does not carry memo`() {
+        assertFalse(coin(Chain.Bittensor, isNativeToken = true).carriesMemo)
+    }
+
+    @Test
+    fun `native Sui does not carry memo`() {
+        assertFalse(coin(Chain.Sui, isNativeToken = true).carriesMemo)
+    }
+
+    @Test
+    fun `native Cosmos family carries memo`() {
+        assertTrue(coin(Chain.GaiaChain, isNativeToken = true).carriesMemo)
+    }
+
+    @Test
+    fun `native Ton carries memo`() {
+        assertTrue(coin(Chain.Ton, isNativeToken = true).carriesMemo)
+    }
+
+    @Test
+    fun `native Solana carries memo`() {
+        assertTrue(coin(Chain.Solana, isNativeToken = true).carriesMemo)
+    }
+
+    @Test
+    fun `native Tron carries memo`() {
+        assertTrue(coin(Chain.Tron, isNativeToken = true).carriesMemo)
+    }
+
+    @Test
+    fun `other native chain carries memo`() {
+        assertTrue(coin(Chain.Ethereum, isNativeToken = true).carriesMemo)
+    }
+}


### PR DESCRIPTION
## Summary
- `Coin.carriesMemo` excludes `Chain.Polkadot` and `Chain.Bittensor` alongside the existing `Chain.Sui` exclusion, since neither signer carries the memo into the signed transaction (`PolkadotHelper` and `BittensorHelper` have no memo handling at all).
- This removes the memo field from the Send form and the memo row from Verify for native DOT and TAO, matching Sui's existing behavior.

Fixes #5825

## Test plan
- [x] `./gradlew :data:testDebugUnitTest --tests com.vultisig.wallet.data.models.CoinTest` passes (new tests cover Polkadot, Bittensor, Sui excluded; Cosmos, Ton, Solana, Tron, and other native chains still true)
- [x] `./gradlew assembleDebug` succeeds

https://claude.ai/code/session_01PR2RvS9CD9L6JrGYeLFa6w

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected memo handling for Polkadot and Bittensor coins, ensuring they are treated consistently with other networks that do not support memo fields.

- **Tests**
  - Added coverage for memo behavior across Polkadot, Bittensor, Sui, Cosmos, Ton, Solana, Tron, and Ethereum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->