### PR TITLE
fix(cosmos): send Osmosis ION as uion instead of uosmo

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelper.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.chains.helpers
 
+import androidx.annotation.VisibleForTesting
 import com.google.protobuf.ByteString
 import com.vultisig.wallet.data.crypto.checkError
 import com.vultisig.wallet.data.crypto.cosmosTxBodyMemo
@@ -152,7 +153,8 @@ class CosmosHelper(
         )
     }
 
-    private fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
+    @VisibleForTesting
+    internal fun getPreSignedInputData(keysignPayload: KeysignPayload): ByteArray {
         val atomData =
             keysignPayload.blockChainSpecific as? BlockChainSpecific.Cosmos
                 ?: error("Invalid blockChainSpecific for Cosmos")
@@ -269,15 +271,9 @@ class CosmosHelper(
                                                 listOf(
                                                     Cosmos.Amount.newBuilder()
                                                         .setDenom(
-                                                            if (
-                                                                keysignPayload.coin.contractAddress
-                                                                    .contains("factory/") ||
-                                                                    keysignPayload.coin
-                                                                        .contractAddress
-                                                                        .contains("ibc/")
-                                                            )
-                                                                keysignPayload.coin.contractAddress
-                                                            else denom
+                                                            if (keysignPayload.coin.isNativeToken)
+                                                                denom
+                                                            else keysignPayload.coin.contractAddress
                                                         )
                                                         .setAmount(
                                                             keysignPayload.toAmount.toString()

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/CosmosHelperTest.kt
@@ -1,0 +1,108 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+import wallet.core.jni.CoinType
+import wallet.core.jni.proto.Cosmos
+
+/**
+ * Regression test for issue #5821: the default `MsgSend` arm picked the denom by a
+ * `factory/`/`ibc/` contract-address prefix, so Osmosis ION (`contractAddress = "uion"`, which
+ * matches neither prefix) fell through to the chain's fee denom `uosmo` and signed a transfer of
+ * OSMO instead of ION.
+ */
+@OptIn(ExperimentalStdlibApi::class)
+class CosmosHelperTest {
+
+    private val helper = CosmosHelper(coinType = CoinType.OSMOSIS, denom = "uosmo")
+
+    private fun payload(coin: Coin) =
+        KeysignPayload(
+            coin = coin,
+            toAddress = "osmo1to000000000000000000000000000000abcd",
+            toAmount = BigInteger.valueOf(2_000_000),
+            blockChainSpecific =
+                BlockChainSpecific.Cosmos(
+                    accountNumber = BigInteger.valueOf(7),
+                    sequence = BigInteger.valueOf(3),
+                    gas = BigInteger.valueOf(7_500),
+                    ibcDenomTraces = null,
+                    transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            memo = null,
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "local",
+            libType = null,
+            wasmExecuteContractPayload = null,
+        )
+
+    private fun sentDenom(coin: Coin): String {
+        val input = Cosmos.SigningInput.parseFrom(helper.getPreSignedInputData(payload(coin)))
+        return input.messagesList.single().sendCoinsMessage.amountsList.single().denom
+    }
+
+    // WalletCore's JNI native library targets Android ABIs only, so it cannot load on a
+    // desktop JVM; skip rather than fail when that's the environment we're running in.
+    private fun skipIfJniUnavailable(e: Throwable) {
+        if (
+            e is UnsatisfiedLinkError ||
+                e is ExceptionInInitializerError ||
+                e is NoClassDefFoundError
+        ) {
+            assumeTrue(false, "WalletCore JNI not available: ${e.message}")
+        } else throw e
+    }
+
+    @Test
+    fun `plain send of a non-native token with a bare contract address uses the contract address as denom`() {
+        try {
+            val ion =
+                Coin(
+                    chain = Chain.Osmosis,
+                    ticker = "ION",
+                    logo = "ion",
+                    address = "osmo1from00000000000000000000000000000abcd",
+                    decimal = 6,
+                    hexPublicKey =
+                        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+                    priceProviderID = "",
+                    contractAddress = "uion",
+                    isNativeToken = false,
+                )
+
+            assertEquals("uion", sentDenom(ion))
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+
+    @Test
+    fun `plain send of the native token still uses the chain fee denom`() {
+        try {
+            val osmo =
+                Coin(
+                    chain = Chain.Osmosis,
+                    ticker = "OSMO",
+                    logo = "osmo",
+                    address = "osmo1from00000000000000000000000000000abcd",
+                    decimal = 6,
+                    hexPublicKey =
+                        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+                    priceProviderID = "osmosis",
+                    contractAddress = "",
+                    isNativeToken = true,
+                )
+
+            assertEquals("uosmo", sentDenom(osmo))
+        } catch (e: Throwable) {
+            skipIfJniUnavailable(e)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- The default `MsgSend` branch in `CosmosHelper.getPreSignedInputData` picked the denom by checking whether the coin's contract address contained `factory/` or `ibc/`. Osmosis ION (`contractAddress = "uion"`) matches neither prefix, so a plain ION send fell through to the chain's fee denom (`uosmo`) and silently signed an OSMO transfer instead.
- Replaced the prefix heuristic with the `isNativeToken` test already used a few lines above in the IBC branch, in `TerraHelper`, and on iOS.
- Made `getPreSignedInputData` `internal`/`@VisibleForTesting` so it can be exercised directly from a unit test (it was `private`).

## Issue
Closes #5821

## Test Plan
- [x] Added `CosmosHelperTest`: an Osmosis ION payload builds `denom = "uion"`, and a native OSMO payload still builds `denom = "uosmo"` (skips gracefully if WalletCore's Android-only JNI lib can't load in the local JVM, same pattern as `UtxoHelperTest`)
- [x] `./gradlew :data:testDebugUnitTest` passes
- [x] `./gradlew lint` passes
- [x] `./gradlew assembleDebug` succeeds

https://claude.ai/code/session_01HVr7o3c9i3ceazD2PUxq14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cosmos transaction handling for token transfers.
  * Non-native tokens now use their contract address, while native tokens use the configured chain denomination.
  * Resolved denomination handling for Osmosis plain sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->