### PR TITLE
fix(tokens): stop re-enabling VULT after the user disables it

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/VaultAccountsViewModel.kt
@@ -367,6 +367,12 @@ constructor(
 
     private suspend fun ensureVultEnabled(vault: Vault): Boolean {
         if (vault.coins.any { it.id == Coins.Ethereum.VULT.id }) return true
+        // A token the user turned off is recorded in the disabled list. Without this check the
+        // auto-enable below would put VULT back on every app open — and, worse, enabling also
+        // clears the disabled record, so the choice could never stick.
+        if (vaultRepository.getDisabledCoinIds(vault.id).any { it == Coins.Ethereum.VULT.id }) {
+            return false
+        }
         if (vault.coins.none { it.chain == Chain.Ethereum }) {
             Timber.d("Ethereum chain not enabled, cannot enable VULT token")
             return false


### PR DESCRIPTION
Reported in the bug reports channel: https://discord.com/channels/1203844257220395078/1244701510873387149/1542574098779996220

## Problem

Disabling VULT in the token list does not stick — it is back in the list the next time the app is opened.

## Cause

`VaultAccountsViewModel.loadData()` calls `enableVultTokenIfNeeded()` on every vault load. `ensureVultEnabled()` only asked whether VULT was present in `vault.coins`; it never consulted the `disabledCoin` table that records an explicit opt-out.

Disabling a token goes through `VaultDao.disableTokenFromVault`, which deletes the coin row **and** inserts a `disabledCoin` marker. With the coin row gone, the next load saw VULT as missing and re-added it.

It also could not self-correct: `VaultDao.enableCoins` deletes the `disabledCoin` marker on insert, so the auto-enable erased the record of the user's choice as it went. No amount of toggling it off would make it stick.

## Fix

Check the disabled list before auto-enabling, the same way `TokenRefreshWorker` and `AccountsRepository` already do for their own auto-add paths.

`DiscountTiersViewModel` is deliberately left alone — it enables VULT as part of an explicit "buy VULT" swap action, where the token is needed to receive the swap output.

## Note for existing installs

Any vault where the auto-enable already wiped the disabled marker starts clean, so VULT has to be disabled once more after this build. It sticks from then on.

## Test plan

- `./gradlew :app:compileDebugKotlin` passes
- `./gradlew :app:testDebugUnitTest --tests '*VaultAccountsViewModelTest*'` passes
- Manual: disable VULT in the token list, force-stop and reopen the app, confirm VULT stays off; re-enable it and confirm it stays on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFCtYYi8Kvic1AvryU9Cap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * VULT will no longer be automatically re-enabled when it has been explicitly disabled for a vault.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->