### PR TITLE
fix(navigation): URL-encode custom NavType route args

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/navigation/Navigation.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.ui.navigation
 
+import android.net.Uri
 import android.os.Bundle
 import androidx.annotation.Keep
 import androidx.navigation.NavType
@@ -716,21 +717,40 @@ internal val BackupPasswordTypeNavType = createNavType<BackupVault.BackupPasswor
 
 internal val ChainDashboardRouteNavType = createNavType<ChainDashboardRoute>()
 
+/**
+ * Tolerates unknown keys so a back stack serialized by an older process still restores after a
+ * route argument gains a field.
+ */
+private val navTypeJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * [NavType.serializeAsValue] output is spliced straight into the route string by
+ * `RouteBuilder.addPath`, so it must be percent-encoded — otherwise a `/`, `?`, `#` or space
+ * anywhere in the JSON (a THORChain memo carried by a send deeplink, for instance) changes the
+ * shape of the route and it stops matching its destination.
+ *
+ * [NavType.parseValue] does NOT decode, matching the built-in `NavType.StringType`: the framework
+ * has already run `Uri.decode` on the matched value by then (`NavDeepLink.getMatchingPathArguments`
+ * for path args, `Uri.getQueryParameters` for query args). Decoding again would corrupt any payload
+ * holding a literal percent sequence.
+ *
+ * [put] and [get] stay unencoded — they cross a [Bundle], not a route string.
+ */
 private inline fun <reified T> createNavType(isNullableAllowed: Boolean = false): NavType<T> =
     object : NavType<T>(isNullableAllowed = isNullableAllowed) {
         override fun put(bundle: Bundle, key: String, value: T) {
-            bundle.putString(key, Json.encodeToString(value))
+            bundle.putString(key, navTypeJson.encodeToString(value))
         }
 
-        override fun get(bundle: Bundle, key: String): T {
-            return Json.decodeFromString(bundle.getString(key)!!)
+        override fun get(bundle: Bundle, key: String): T? {
+            return bundle.getString(key)?.let { navTypeJson.decodeFromString(it) }
         }
 
         override fun parseValue(value: String): T {
-            return Json.decodeFromString(value)
+            return navTypeJson.decodeFromString(value)
         }
 
         override fun serializeAsValue(value: T): String {
-            return Json.encodeToString(value)
+            return Uri.encode(navTypeJson.encodeToString(value))
         }
     }

--- a/app/src/test/java/com/vultisig/wallet/ui/navigation/RouteNavTypeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/navigation/RouteNavTypeTest.kt
@@ -1,0 +1,117 @@
+package com.vultisig.wallet.ui.navigation
+
+import android.net.Uri
+import android.os.Bundle
+import com.vultisig.wallet.data.models.SendDeeplinkData
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import java.net.URLDecoder
+import java.net.URLEncoder
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+/**
+ * `Uri` is unavailable in plain JVM unit tests, so the percent-encoding pair is stood in with the
+ * JDK's own encoder — an implementation independent of the one under test, which is what makes the
+ * round-trip assertions meaningful.
+ */
+internal class RouteNavTypeTest {
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(Uri::class)
+        every { Uri.encode(any<String>()) } answers
+            {
+                URLEncoder.encode(firstArg<String>(), Charsets.UTF_8).replace("+", "%20")
+            }
+        every { Uri.decode(any<String>()) } answers
+            {
+                URLDecoder.decode(firstArg<String>(), Charsets.UTF_8)
+            }
+    }
+
+    @AfterEach fun tearDown() = unmockkStatic(Uri::class)
+
+    @Test
+    fun `serializeAsValue leaves no character that would reshape the route`() {
+        val openType = deepLink(memo = "=:ETH.ETH:0xAbC123:0/1/0 #stream?x=1")
+
+        val serialized = VaultListOpenTypeNavType.serializeAsValue(openType)
+
+        // RouteBuilder splices this straight into the path as "/$value", and the path pattern
+        // matches a single segment, so any of these would leave the route unmatchable.
+        serialized shouldNotContain "/"
+        serialized shouldNotContain "?"
+        serialized shouldNotContain "#"
+        serialized shouldNotContain " "
+    }
+
+    @Test
+    fun `a memo carrying path separators survives the route round trip`() {
+        val openType = deepLink(memo = "=:ETH.ETH:0xAbC123:0/1/0")
+
+        val restored = roundTrip(openType)
+
+        restored shouldBe openType
+    }
+
+    @Test
+    fun `a payload with no reserved characters round trips unchanged`() {
+        val openType = Route.VaultList.OpenType.Home(vaultId = "vault-1")
+
+        roundTrip(openType) shouldBe openType
+    }
+
+    @Test
+    fun `parseValue does not decode a second time`() {
+        // The framework has already decoded by the time parseValue runs, so a percent sequence
+        // reaching it is literal payload — decoding again would turn this memo into "0/1/0".
+        val openType = deepLink(memo = "0%2F1%2F0")
+
+        val restored = roundTrip(openType)
+
+        (restored as Route.VaultList.OpenType.DeepLink).sendDeepLinkData.memo shouldBe "0%2F1%2F0"
+    }
+
+    @Test
+    fun `get returns null for an absent key instead of throwing`() {
+        val bundle = mockk<Bundle>()
+        every { bundle.getString("openType") } returns null
+
+        VaultListOpenTypeNavType[bundle, "openType"].shouldBeNull()
+    }
+
+    @Test
+    fun `parseValue tolerates a key written by a newer version of the route`() {
+        val openType = deepLink(memo = "swap")
+        val withUnknownKey =
+            Uri.decode(VaultListOpenTypeNavType.serializeAsValue(openType))
+                .replace("\"memo\":", "\"unknownKey\":true,\"memo\":")
+
+        VaultListOpenTypeNavType.parseValue(withUnknownKey) shouldBe openType
+    }
+
+    /** Mirrors the framework: the matched route segment is `Uri.decode`d before `parseValue`. */
+    private fun roundTrip(openType: Route.VaultList.OpenType): Route.VaultList.OpenType {
+        val routeSegment = VaultListOpenTypeNavType.serializeAsValue(openType)
+        return VaultListOpenTypeNavType.parseValue(Uri.decode(routeSegment))
+    }
+
+    private fun deepLink(memo: String) =
+        Route.VaultList.OpenType.DeepLink(
+            sendDeepLinkData =
+                SendDeeplinkData(
+                    assetChain = "THORChain",
+                    assetTicker = "RUNE",
+                    toAddress = "thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t",
+                    amount = "0.01",
+                    memo = memo,
+                )
+        )
+}


### PR DESCRIPTION
Closes #5828

## Summary

`createNavType` returned raw JSON from `serializeAsValue`, and `RouteBuilder.addPath` splices that straight into the route string. Any route argument whose JSON contains `/`, `?`, `#` or a space produced a route that no longer matched its destination, and `NavController` swallows the resulting exception — the user taps and nothing happens, with no error shown.

The live path is a send deeplink: `SendDeeplinkData.memo` is free-form and THORChain memos routinely carry `/`.

- `serializeAsValue` now percent-encodes its output, as `NavType`'s own KDoc requires.
- `parseValue` deliberately does **not** decode. androidx has already run `Uri.decode` on the matched value by then — `NavDeepLink.getMatchingPathArguments` for path args, `Uri.getQueryParameters` for query args — so decoding again would turn a payload holding a literal `%2F` into a `/`. This is the same asymmetry the built-in `NavType.StringType` has, and it is the one place this PR diverges from the fix sketched in the issue.
- `put` / `get` stay unencoded: they cross a `Bundle`, not a route string. Persisted back stack state is therefore unaffected by this change.
- The shared `Json` now sets `ignoreUnknownKeys = true`, so a back stack serialized by an older process still restores after a route argument gains a field.
- `get` returns `null` for an absent key instead of `bundle.getString(key)!!`. `NavType.get` is already declared to return `T?`, so no signature gymnastics were needed.

All four instances are covered, since they share the factory: `BackupTypeNavType`, `VaultListOpenTypeNavType`, `BackupPasswordTypeNavType`, `ChainDashboardRouteNavType`.

## Test plan

**Unit tests** — `RouteNavTypeTest`, 6 cases:

- `serializeAsValue` output contains no `/`, `?`, `#` or space for a payload full of them
- a memo carrying `/` survives serialize → framework decode → parse
- a payload with no reserved characters round-trips unchanged
- `parseValue` does not decode a second time (a literal `%2F` stays `%2F`)
- `get` returns null for an absent key instead of throwing
- an unknown key written by a newer version of the route still parses

`Uri` is unavailable in JVM unit tests, so the encode/decode pair is stubbed with the JDK's `URLEncoder`/`URLDecoder` — an independent implementation, which is what makes the round-trip assertions meaningful. Reverting `serializeAsValue` to unencoded fails the first test; adding `Uri.decode` back into `parseValue` fails the fourth.

```
./gradlew :app:testDebugUnitTest   # full suite green
./gradlew assembleDebug            # succeeds
```

**Manual — on device, with at least one vault.** Paste each link into the Chrome address bar and open it with Vultisig (the in-app QR scanner does not reach this path; a send deeplink scanned in-app routes to the scan-error screen).

Fails before this change, works after:

```
vultisig://send?assetChain=THORChain&assetTicker=RUNE&toAddress=thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t&amount=0.01&memo=%3D%3AETH.ETH%3A0xAbC123%3A0%2F1%2F0
```

Expected after the fix: the vault-list sheet opens, and picking a vault lands on Send prefilled with RUNE on THORChain, that address, `0.01`, and the memo `=:ETH.ETH:0xAbC123:0/1/0` intact. Before the fix the app simply foregrounds and nothing happens.

Control, unaffected either way — same link with a memo that has no path separators:

```
vultisig://send?assetChain=THORChain&assetTicker=RUNE&toAddress=thor12a9rpf9u2ulwuezxkh6uas4au7xnde8umdua5t&amount=0.01&memo=%3D%3AETH.ETH%3A0xAbC123
```

Also worth a pass, since they share the factory: vault backup (password + backup-type routes) and the chain dashboard / DeFi position screens.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation argument handling for special characters and percent-encoded values.
  * Added support for safely reading missing or nullable navigation arguments.
  * Improved compatibility when navigation data includes unrecognized fields.

* **Tests**
  * Added coverage for deep links, reserved characters, percent sequences, null values, and forward-compatible navigation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->