### PR TITLE
fix(keygen): await relay sends with a bounded retry budget

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/keygen/CeremonyStallClock.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/CeremonyStallClock.kt
@@ -1,0 +1,51 @@
+package com.vultisig.wallet.data.keygen
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Bounds how long a keygen ceremony may go without making progress.
+ *
+ * The clock this replaces ran from the start of the attempt, so three signers in far apart regions
+ * failed at 60 s even while their messages were still arriving and being applied — the `timeout:
+ * failed to create vault within 60 seconds` of issue #5813. This one measures the gap since the
+ * last *applied* inbound message, so a slow but healthy ceremony survives and a genuinely stalled
+ * one still fails in 60 s.
+ *
+ * "Applied" rather than "arrived" is the load-bearing word. A message this device cannot clear —
+ * one whose relay delete failed — is re-served by every poll, so a clock reset on arrival would
+ * keep a doomed attempt alive until the relay expires the message. That is exactly why
+ * [KeysignMessagePoller] keeps an absolute deadline instead (issue #5488), and why this class is
+ * not used there. The keygen loops dedupe on the message hash before applying, so a re-served
+ * message reaches [markProgress] only the first time.
+ */
+internal class CeremonyStallClock(
+    private val limit: Duration = DEFAULT_LIMIT,
+    private val nanoTime: () -> Long = System::nanoTime,
+) {
+    @Volatile private var lastProgressAt: Long = nanoTime()
+
+    /** Seconds of silence this clock tolerates, for the caller's failure message. */
+    val limitSeconds: Long
+        get() = limit.inWholeSeconds
+
+    /** Restarts the clock. Call when an attempt begins waiting on its peers. */
+    fun reset() {
+        lastProgressAt = nanoTime()
+    }
+
+    /** Records that this device applied inbound protocol input from a peer. */
+    fun markProgress() {
+        lastProgressAt = nanoTime()
+    }
+
+    /** Time since the last applied message, or since [reset] if none has been applied. */
+    fun sinceProgress(): Duration = (nanoTime() - lastProgressAt).nanoseconds
+
+    fun isStalled(): Boolean = sinceProgress() > limit
+
+    companion object {
+        val DEFAULT_LIMIT = 60.seconds
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
@@ -28,6 +28,7 @@ import com.silencelaboratories.godkls.godkls.tss_buffer_free
 import com.silencelaboratories.godkls.lib_error
 import com.silencelaboratories.godkls.lib_error.LIB_OK
 import com.silencelaboratories.godkls.tss_buffer
+import com.vultisig.wallet.data.api.RelaySendFailedException
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.mediator.Message
 import com.vultisig.wallet.data.models.TssAction
@@ -238,6 +239,12 @@ class DKLSKeygen(
                     delay(100)
                 }
             } catch (e: CancellationException) {
+                throw e
+            } catch (e: RelaySendFailedException) {
+                // The outbound round an applied message triggered never landed, so no peer will
+                // answer it — and applying that message has already reset the stall clock, so
+                // logging this as a failed read leaves the loop waiting well past the limit for a
+                // reply nobody will send (#5813). The retry wrapper restarts the attempt instead.
                 throw e
             } catch (e: Exception) {
                 Timber.e(e, "Failed to get messages")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeygen.kt
@@ -71,6 +71,7 @@ class DKLSKeygen(
             isEncryptionGCM = true,
         )
     val cache = mutableMapOf<String, Any>()
+    private val stall = CeremonyStallClock()
     var setupMessage: ByteArray = byteArrayOf()
     var keyshare: DKLSKeyshare? = null
     private var activeMessageId: String? = null
@@ -180,7 +181,7 @@ class DKLSKeygen(
     }
 
     @Throws(Exception::class)
-    private fun processDKLSOutboundMessage(handle: Handle) {
+    private suspend fun processDKLSOutboundMessage(handle: Handle) {
         while (true) {
             val (result, outboundMessage) = getDKLSOutboundMessage(handle)
             if (result != LIB_OK) {
@@ -190,22 +191,27 @@ class DKLSKeygen(
                 return
             }
 
+            val encodedOutboundMessage = Base64.encode(outboundMessage)
             val message = outboundMessage.toDklsGoSlice()
-            try {
-                val encodedOutboundMessage = Base64.encode(outboundMessage)
-                for (i in keygenCommittee.indices) {
-                    val receiverArray = getOutboundMessageReceiver(handle, message, i.toLong())
-                    if (receiverArray.isEmpty()) {
-                        break
+            // Collect the receivers and release the native slice before sending: the fan-out
+            // suspends for as long as the relay makes it, and nothing reads the slice by then.
+            val receivers =
+                try {
+                    buildList {
+                        for (i in keygenCommittee.indices) {
+                            val receiverArray =
+                                getOutboundMessageReceiver(handle, message, i.toLong())
+                            if (receiverArray.isEmpty()) {
+                                break
+                            }
+                            add(receiverArray.toString(Charsets.UTF_8))
+                        }
                     }
-                    val receiverString = receiverArray.toString(Charsets.UTF_8)
-                    Timber.d("sending message from ${this.localPartyId} to: $receiverString")
-
-                    messenger.send(this.localPartyId, receiverString, encodedOutboundMessage)
+                } finally {
+                    message.free()
                 }
-            } finally {
-                message.free()
-            }
+
+            messenger.fanOut(this.localPartyId, receivers, encodedOutboundMessage)
         }
     }
 
@@ -213,7 +219,7 @@ class DKLSKeygen(
     private suspend fun pullInboundMessages(handle: Handle): Boolean {
         Timber.d("start pulling inbound messages")
 
-        val start = System.nanoTime()
+        stall.reset()
         while (true) {
             try {
                 val msgs =
@@ -238,9 +244,11 @@ class DKLSKeygen(
                 delay(1000) // backoff delay
             }
 
-            val elapsedTime = (System.nanoTime() - start) / 1_000_000_000.0
-            if (elapsedTime > 60) {
-                error("timeout: failed to create vault within 60 seconds")
+            if (stall.isStalled()) {
+                error(
+                    "timeout: failed to create vault, no keygen progress for " +
+                        "${stall.limitSeconds} seconds"
+                )
             }
         }
     }
@@ -293,6 +301,7 @@ class DKLSKeygen(
                 error("fail to apply message to dkls, $result")
             }
             cache[key] = Any()
+            stall.markProgress()
             deleteMessageFromServer(msg.hash)
             processDKLSOutboundMessage(handle)
 

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/DklsKeysign.kt
@@ -243,7 +243,7 @@ class DKLSKeysign(
         }
     }
 
-    private fun processDKLSOutboundMessage(handle: Handle) {
+    private suspend fun processDKLSOutboundMessage(handle: Handle, deadlineNanos: Long? = null) {
         while (true) {
             val (result, outboundMessage) = getDKLSOutboundMessage(handle)
             if (result != LIB_OK) {
@@ -252,23 +252,27 @@ class DKLSKeysign(
             if (outboundMessage.isEmpty()) {
                 return
             }
+            val encodedOutboundMessage = Base64.encode(outboundMessage)
             val message = outboundMessage.toDklsGoSlice()
-            try {
-                val encodedOutboundMessage = Base64.encode(outboundMessage)
-                for (i in keysignCommittee.indices) {
-                    val receiverArray = getOutboundMessageReceiver(handle, message, i.toLong())
-                    if (receiverArray.isEmpty()) {
-                        break
+            // Collect the receivers and release the native slice before sending: the fan-out
+            // suspends for as long as the relay makes it, and nothing reads the slice by then.
+            val receivers =
+                try {
+                    buildList {
+                        for (i in keysignCommittee.indices) {
+                            val receiverArray =
+                                getOutboundMessageReceiver(handle, message, i.toLong())
+                            if (receiverArray.isEmpty()) {
+                                break
+                            }
+                            add(String(receiverArray, Charsets.UTF_8))
+                        }
                     }
-                    val receiverString = String(receiverArray, Charsets.UTF_8)
-                    println(
-                        "sending message from $localPartyID to: $receiverString, content length: ${encodedOutboundMessage.length}"
-                    )
-                    messenger.send(localPartyID, receiverString, encodedOutboundMessage)
+                } finally {
+                    message.free()
                 }
-            } finally {
-                message.free()
-            }
+
+            messenger.fanOut(localPartyID, receivers, encodedOutboundMessage, deadlineNanos)
         }
     }
 
@@ -309,7 +313,7 @@ class DKLSKeysign(
             }
             cache[key] = Any()
             deleteMessageFromServer(msg.hash, messageID)
-            processDKLSOutboundMessage(handle)
+            processDKLSOutboundMessage(handle, poller.attemptDeadlineNanos)
             if (isFinished[0] != 0) {
                 return true
             }

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/KeysignMessagePoller.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/KeysignMessagePoller.kt
@@ -34,6 +34,17 @@ internal class KeysignMessagePoller(
     private val heardFromEver = mutableSetOf<String>()
     private var waitingNotified = false
 
+    /**
+     * [System.nanoTime] instant the current attempt's deadline expires, or `null` before the first
+     * [poll]. Relay work started from inside `applyMessages` — the outbound fan-out an applied
+     * message triggers — reads it so a send's own retry budget is clipped to what is left of the
+     * attempt. Without that clip an awaited send could spend its full budget inside a deadline that
+     * had already passed, turning a recoverable relay failure into a signing timeout.
+     */
+    @Volatile
+    var attemptDeadlineNanos: Long? = null
+        private set
+
     /** Whether any peer has answered since [resetForNewMessage]; the retry budget depends on it. */
     val hasHeardFromAnyPeer: Boolean
         get() = heardFromEver.isNotEmpty()
@@ -78,6 +89,7 @@ internal class KeysignMessagePoller(
 
         heardFromThisWindow.clear()
         val startedAt = nanoTime()
+        attemptDeadlineNanos = startedAt + ATTEMPT_TIMEOUT.inWholeNanoseconds
         var lastBatchAt = startedAt
         while (true) {
             try {

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/KeysignMessagePoller.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/KeysignMessagePoller.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.keygen
 
+import com.vultisig.wallet.data.api.RelaySendFailedException
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.mediator.Message
 import kotlin.time.Duration
@@ -80,6 +81,12 @@ internal class KeysignMessagePoller(
      * deadline whenever a batch arrives would keep a doomed attempt alive until the relay expires
      * the message, stranding the user on the signing screen (#5488). Only the silent-peer hint
      * reads the resettable clock.
+     *
+     * Tolerating such a message is why a failure inside [applyMessages] is logged and re-polled
+     * rather than thrown. Two are not tolerable and leave at once: a [RelaySendFailedException]
+     * from the outbound round an applied message triggers, and a [MaliciousPartyException]. Neither
+     * can improve by polling again, and both have a caller that handles them better than a timeout
+     * 60 s later.
      */
     suspend fun poll(
         messageID: String,
@@ -104,6 +111,15 @@ internal class KeysignMessagePoller(
                     delay(POLL_INTERVAL)
                 }
             } catch (e: CancellationException) {
+                throw e
+            } catch (e: RelaySendFailedException) {
+                // This device's own outbound round never landed, so the reply being polled for
+                // cannot arrive. Logging it as a failed read would park the attempt here until the
+                // deadline; the keysign wrapper can recover or restart it now instead.
+                throw e
+            } catch (e: MaliciousPartyException) {
+                // A protocol verdict from the library, not a transient failure. The wrapper's
+                // no-retry branch has to see it rather than the timeout it would otherwise become.
                 throw e
             } catch (e: Exception) {
                 Timber.e(e, "Failed to get messages")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeygen.kt
@@ -20,6 +20,7 @@ import com.silencelaboratories.godilithium.godilithium.tss_buffer_free
 import com.silencelaboratories.godilithium.mldsa_error
 import com.silencelaboratories.godilithium.mldsa_error.LIB_OK
 import com.silencelaboratories.godilithium.tss_buffer
+import com.vultisig.wallet.data.api.RelaySendFailedException
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.mediator.Message
 import com.vultisig.wallet.data.tss.TssMessenger
@@ -167,6 +168,12 @@ class MldsaKeygen(
                     delay(100)
                 }
             } catch (e: CancellationException) {
+                throw e
+            } catch (e: RelaySendFailedException) {
+                // The outbound round an applied message triggered never landed, so no peer will
+                // answer it — and applying that message has already reset the stall clock, so
+                // logging this as a failed read leaves the loop waiting well past the limit for a
+                // reply nobody will send (#5813). The retry wrapper restarts the attempt instead.
                 throw e
             } catch (e: Exception) {
                 Timber.e(e, "Failed to get messages")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeygen.kt
@@ -57,6 +57,7 @@ class MldsaKeygen(
         )
 
     private val cache = mutableMapOf<String, Any>()
+    private val stall = CeremonyStallClock()
     var setupMessage: ByteArray = byteArrayOf()
     var keyshare: MldsaKeyshare? = null
     private var activeMessageId: String? = null
@@ -114,7 +115,7 @@ class MldsaKeygen(
     }
 
     @Throws(Exception::class)
-    private fun processMldsaOutboundMessage(handle: Handle) {
+    private suspend fun processMldsaOutboundMessage(handle: Handle) {
         while (true) {
             val (result, outboundMessage) = getMldsaOutboundMessage(handle)
             if (result != LIB_OK) {
@@ -124,21 +125,27 @@ class MldsaKeygen(
                 return
             }
 
+            val encodedOutboundMessage = Base64.encode(outboundMessage)
             val message = outboundMessage.toMldsaGoSlice()
-            try {
-                val encodedOutboundMessage = Base64.encode(outboundMessage)
-                for (i in keygenCommittee.indices) {
-                    val receiverArray = getOutboundMessageReceiver(handle, message, i.toLong())
-                    if (receiverArray.isEmpty()) {
-                        break
+            // Collect the receivers and release the native slice before sending: the fan-out
+            // suspends for as long as the relay makes it, and nothing reads the slice by then.
+            val receivers =
+                try {
+                    buildList {
+                        for (i in keygenCommittee.indices) {
+                            val receiverArray =
+                                getOutboundMessageReceiver(handle, message, i.toLong())
+                            if (receiverArray.isEmpty()) {
+                                break
+                            }
+                            add(receiverArray.toString(Charsets.UTF_8))
+                        }
                     }
-                    val receiverString = receiverArray.toString(Charsets.UTF_8)
-                    Timber.d("sending message from $localPartyId to: $receiverString")
-                    messenger.send(localPartyId, receiverString, encodedOutboundMessage)
+                } finally {
+                    message.free()
                 }
-            } finally {
-                message.free()
-            }
+
+            messenger.fanOut(localPartyId, receivers, encodedOutboundMessage)
         }
     }
 
@@ -146,7 +153,7 @@ class MldsaKeygen(
     private suspend fun pullInboundMessages(handle: Handle): Boolean {
         Timber.d("start pulling inbound messages for MLDSA keygen")
 
-        val start = System.nanoTime()
+        stall.reset()
         while (true) {
             try {
                 val msgs =
@@ -166,9 +173,10 @@ class MldsaKeygen(
                 delay(1000) // backoff delay
             }
 
-            val elapsedTime = (System.nanoTime() - start) / 1_000_000_000.0
-            if (elapsedTime > 60) {
-                error("timeout: MLDSA keygen did not finish within 60 seconds")
+            if (stall.isStalled()) {
+                error(
+                    "timeout: MLDSA keygen made no progress for " + "${stall.limitSeconds} seconds"
+                )
             }
         }
     }
@@ -207,6 +215,7 @@ class MldsaKeygen(
                 error("fail to apply message to mldsa, $result")
             }
             cache[key] = Any()
+            stall.markProgress()
             deleteMessageFromServer(msg.hash)
             processMldsaOutboundMessage(handle)
 

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/MldsaKeysign.kt
@@ -278,7 +278,7 @@ class MldsaKeysign(
         }
 
     /** Drains all pending outbound messages and routes them to committee peers. */
-    private fun drainOutbound(handle: Handle) {
+    private suspend fun drainOutbound(handle: Handle, deadlineNanos: Long? = null) {
         while (true) {
             val (result, payload) = readOutboundMessage(handle)
             if (result != LIB_OK) Timber.d("outbound message error: %s", result)
@@ -286,22 +286,22 @@ class MldsaKeysign(
 
             val encoded = Base64.encode(payload)
             val slice = payload.toMldsaGoSlice()
-            try {
-                for (i in keysignCommittee.indices) {
-                    val receiver = getOutboundReceiver(handle, slice, i.toLong())
-                    if (receiver.isEmpty()) break
-                    val receiverId = String(receiver, Charsets.UTF_8)
-                    Timber.d(
-                        "sending from %s to %s, length=%d",
-                        localPartyID,
-                        receiverId,
-                        encoded.length,
-                    )
-                    messenger?.send(localPartyID, receiverId, encoded)
+            // Collect the receivers and release the native slice before sending: the fan-out
+            // suspends for as long as the relay makes it, and nothing reads the slice by then.
+            val receivers =
+                try {
+                    buildList {
+                        for (i in keysignCommittee.indices) {
+                            val receiver = getOutboundReceiver(handle, slice, i.toLong())
+                            if (receiver.isEmpty()) break
+                            add(String(receiver, Charsets.UTF_8))
+                        }
+                    }
+                } finally {
+                    slice.free()
                 }
-            } finally {
-                slice.free()
-            }
+
+            messenger?.fanOut(localPartyID, receivers, encoded, deadlineNanos)
         }
     }
 
@@ -343,7 +343,7 @@ class MldsaKeysign(
 
             appliedMessages += cacheKey
             deleteMessageFromServer(msg.hash, messageID)
-            drainOutbound(handle)
+            drainOutbound(handle, poller.attemptDeadlineNanos)
 
             if (isFinished[0] != 0) return true
         }

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/RelayFanOut.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/RelayFanOut.kt
@@ -1,0 +1,39 @@
+package com.vultisig.wallet.data.keygen
+
+import com.vultisig.wallet.data.tss.TssMessenger
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import timber.log.Timber
+
+/**
+ * Sends one outbound protocol message to every receiver of the round and waits for the relay to
+ * accept all of them, throwing if any send exhausts its retry budget.
+ *
+ * Concurrently, deliberately. [TssMessenger.sendAwait] now spends up to a full
+ * [com.vultisig.wallet.data.api.RelaySendBudget] — 39 s — before it gives up, and a serial loop
+ * would multiply that by the committee size, so a three-signer round could burn past the 60 s
+ * ceremony stall on retries alone. Fanning out in parallel keeps one round's worst case at a single
+ * budget however many peers there are, which is what makes the awaited send affordable at all.
+ *
+ * A failure cancels the sibling sends and propagates: the round did not happen, and the attempt
+ * wrapper retries the ceremony rather than waiting out a reply that can never arrive.
+ */
+internal suspend fun TssMessenger.fanOut(
+    from: String,
+    receivers: List<String>,
+    encodedMessage: String,
+    deadlineNanos: Long? = null,
+) {
+    if (receivers.isEmpty()) return
+    coroutineScope {
+        receivers
+            .map { receiver ->
+                async {
+                    Timber.d("sending message from %s to: %s", from, receiver)
+                    sendAwait(from, receiver, encodedMessage, deadlineNanos)
+                }
+            }
+            .awaitAll()
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
@@ -71,6 +71,7 @@ class SchnorrKeygen(
         )
 
     val cache = mutableMapOf<String, Any>()
+    private val stall = CeremonyStallClock()
     var keyshare: DKLSKeyshare? = null
     private var activeMessageId: String? = null
 
@@ -125,7 +126,7 @@ class SchnorrKeygen(
         }
     }
 
-    private fun processSchnorrOutboundMessage(handle: Handle) {
+    private suspend fun processSchnorrOutboundMessage(handle: Handle) {
         while (true) {
             val (result, outboundMessage) = getSchnorrOutboundMessage(handle)
             if (result != LIB_OK) {
@@ -135,28 +136,34 @@ class SchnorrKeygen(
                 return
             }
 
+            val encodedOutboundMessage = Base64.encode(outboundMessage)
             val message = outboundMessage.toSchnorrGoSlice()
-            try {
-                val encodedOutboundMessage = Base64.encode(outboundMessage)
-                for (i in keygenCommittee.indices) {
-                    val receiverArray = getOutboundMessageReceiver(handle, message, i.toLong())
-                    if (receiverArray.isEmpty()) {
-                        break
+            // Collect the receivers and release the native slice before sending: the fan-out
+            // suspends for as long as the relay makes it, and nothing reads the slice by then.
+            val receivers =
+                try {
+                    buildList {
+                        for (i in keygenCommittee.indices) {
+                            val receiverArray =
+                                getOutboundMessageReceiver(handle, message, i.toLong())
+                            if (receiverArray.isEmpty()) {
+                                break
+                            }
+                            add(String(receiverArray, Charsets.UTF_8))
+                        }
                     }
-                    val receiverString = String(receiverArray, Charsets.UTF_8)
-                    Timber.d("sending message from $localPartyId to: $receiverString")
-                    messenger.send(localPartyId, receiverString, encodedOutboundMessage)
+                } finally {
+                    message.free()
                 }
-            } finally {
-                message.free()
-            }
+
+            messenger.fanOut(localPartyId, receivers, encodedOutboundMessage)
         }
     }
 
     private suspend fun pullInboundMessages(handle: Handle): Boolean {
         Timber.d("start pulling inbound messages")
 
-        val start = System.nanoTime()
+        stall.reset()
         while (true) {
             try {
                 val msgs =
@@ -176,9 +183,11 @@ class SchnorrKeygen(
                 delay(1000)
             }
 
-            val elapsedTime = (System.nanoTime() - start) / 1_000_000_000.0
-            if (elapsedTime > 60) {
-                error("timeout: Schnorr keygen did not finish within 60 seconds")
+            if (stall.isStalled()) {
+                error(
+                    "timeout: Schnorr keygen made no progress for " +
+                        "${stall.limitSeconds} seconds"
+                )
             }
         }
     }
@@ -229,6 +238,7 @@ class SchnorrKeygen(
                 error("fail to apply message to schnorr, $result")
             }
             cache[key] = Any()
+            stall.markProgress()
             deleteMessageFromServer(msg.hash)
             processSchnorrOutboundMessage(handle)
             if (isFinished[0] != 0) {

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeygen.kt
@@ -28,6 +28,7 @@ import com.silencelaboratories.goschnorr.goschnorr.tss_buffer_free
 import com.silencelaboratories.goschnorr.schnorr_lib_error
 import com.silencelaboratories.goschnorr.schnorr_lib_error.LIB_OK
 import com.silencelaboratories.goschnorr.tss_buffer
+import com.vultisig.wallet.data.api.RelaySendFailedException
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.mediator.Message
 import com.vultisig.wallet.data.models.TssAction
@@ -177,6 +178,12 @@ class SchnorrKeygen(
                     delay(1000)
                 }
             } catch (e: CancellationException) {
+                throw e
+            } catch (e: RelaySendFailedException) {
+                // The outbound round an applied message triggered never landed, so no peer will
+                // answer it — and applying that message has already reset the stall clock, so
+                // logging this as a failed read leaves the loop waiting well past the limit for a
+                // reply nobody will send (#5813). The retry wrapper restarts the attempt instead.
                 throw e
             } catch (e: Exception) {
                 Timber.e(e, "Failed to get messages")

--- a/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/keygen/SchnorrKeysign.kt
@@ -199,7 +199,7 @@ class SchnorrKeysign(
     /**
      * Drains all pending outbound messages from [handle] and routes each to the appropriate peers.
      */
-    fun processSchnorrOutboundMessage(handle: Handle) {
+    suspend fun processSchnorrOutboundMessage(handle: Handle, deadlineNanos: Long? = null) {
         while (true) {
             val (result, outboundMessage) = getSchnorrOutboundMessage(handle)
             if (result != LIB_OK) {
@@ -208,23 +208,27 @@ class SchnorrKeysign(
             if (outboundMessage.isEmpty()) {
                 return
             }
+            val encodedOutboundMessage = Base64.encode(outboundMessage)
             val message = outboundMessage.toSchnorrGoSlice()
-            try {
-                val encodedOutboundMessage = Base64.encode(outboundMessage)
-                for (i in keysignCommittee.indices) {
-                    val receiverArray = getOutboundMessageReceiver(handle, message, i.toLong())
-                    if (receiverArray.isEmpty()) {
-                        break
+            // Collect the receivers and release the native slice before sending: the fan-out
+            // suspends for as long as the relay makes it, and nothing reads the slice by then.
+            val receivers =
+                try {
+                    buildList {
+                        for (i in keysignCommittee.indices) {
+                            val receiverArray =
+                                getOutboundMessageReceiver(handle, message, i.toLong())
+                            if (receiverArray.isEmpty()) {
+                                break
+                            }
+                            add(String(receiverArray, Charsets.UTF_8))
+                        }
                     }
-                    val receiverString = String(receiverArray, Charsets.UTF_8)
-                    Timber.d(
-                        "sending message from $localPartyID to: $receiverString, content length: ${encodedOutboundMessage.length}"
-                    )
-                    messenger?.send(localPartyID, receiverString, encodedOutboundMessage)
+                } finally {
+                    message.free()
                 }
-            } finally {
-                message.free()
-            }
+
+            messenger?.fanOut(localPartyID, receivers, encodedOutboundMessage, deadlineNanos)
         }
     }
 
@@ -269,7 +273,7 @@ class SchnorrKeysign(
             }
             cache[key] = Any()
             deleteMessageFromServer(msg.hash, messageID)
-            processSchnorrOutboundMessage(handle)
+            processSchnorrOutboundMessage(handle, poller.attemptDeadlineNanos)
             if (isFinished[0] != 0) {
                 return true
             }

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/CeremonyStallClockTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/CeremonyStallClockTest.kt
@@ -1,8 +1,7 @@
 package com.vultisig.wallet.data.keygen
 
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
 import kotlin.time.Duration.Companion.seconds
 import org.junit.jupiter.api.Test
 
@@ -32,7 +31,7 @@ class CeremonyStallClockTest {
     fun `a fresh clock is not stalled`() {
         val fake = FakeClock()
 
-        assertFalse(clockOf(fake).isStalled())
+        clockOf(fake).isStalled() shouldBe false
     }
 
     @Test
@@ -42,7 +41,7 @@ class CeremonyStallClockTest {
 
         fake.advance(59)
 
-        assertFalse(stall.isStalled())
+        stall.isStalled() shouldBe false
     }
 
     @Test
@@ -52,7 +51,7 @@ class CeremonyStallClockTest {
 
         fake.advance(61)
 
-        assertTrue(stall.isStalled())
+        stall.isStalled() shouldBe true
     }
 
     /**
@@ -66,12 +65,14 @@ class CeremonyStallClockTest {
 
         repeat(10) {
             fake.advance(30)
-            assertFalse(stall.isStalled(), "30 s between messages must not trip the stall")
+            withClue("30 s between messages must not trip the stall") {
+                stall.isStalled() shouldBe false
+            }
             stall.markProgress()
         }
 
         // Five minutes of ceremony, none of it silent for 60 s.
-        assertFalse(stall.isStalled())
+        stall.isStalled() shouldBe false
     }
 
     @Test
@@ -83,7 +84,9 @@ class CeremonyStallClockTest {
         stall.markProgress()
         fake.advance(61)
 
-        assertTrue(stall.isStalled(), "a real stall must still fail inside the limit")
+        withClue("a real stall must still fail inside the limit") {
+            stall.isStalled() shouldBe true
+        }
     }
 
     @Test
@@ -92,11 +95,11 @@ class CeremonyStallClockTest {
         val stall = clockOf(fake)
 
         fake.advance(61)
-        assertTrue(stall.isStalled())
+        stall.isStalled() shouldBe true
 
         stall.reset()
 
-        assertFalse(stall.isStalled(), "a retry gets a fresh peer-wait window")
+        withClue("a retry gets a fresh peer-wait window") { stall.isStalled() shouldBe false }
     }
 
     @Test
@@ -106,12 +109,12 @@ class CeremonyStallClockTest {
 
         fake.advance(45)
 
-        assertEquals(45.seconds, stall.sinceProgress())
+        stall.sinceProgress() shouldBe 45.seconds
     }
 
     @Test
     fun `limitSeconds exposes the configured limit`() {
-        assertEquals(60L, clockOf(FakeClock()).limitSeconds)
-        assertEquals(90L, clockOf(FakeClock(), limit = 90.seconds).limitSeconds)
+        clockOf(FakeClock()).limitSeconds shouldBe 60L
+        clockOf(FakeClock(), limit = 90.seconds).limitSeconds shouldBe 90L
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/CeremonyStallClockTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/CeremonyStallClockTest.kt
@@ -1,0 +1,117 @@
+package com.vultisig.wallet.data.keygen
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the progress-based ceremony stall clock from issue #5813.
+ *
+ * Three signers in far apart regions hit `timeout: failed to create vault within 60 seconds` nine
+ * times in a row. The clock they tripped ran from the start of the attempt, so a ceremony that was
+ * still exchanging messages — just slowly — failed anyway. These tests fix the difference: silence
+ * still fails at 60 s, but applied messages keep pushing the deadline out.
+ */
+class CeremonyStallClockTest {
+
+    /** Test clock in nanoseconds, advanced explicitly so no test waits on wall time. */
+    private class FakeClock {
+        var nanos: Long = 1_000_000_000L
+
+        fun advance(seconds: Long) {
+            nanos += seconds * 1_000_000_000L
+        }
+    }
+
+    private fun clockOf(fake: FakeClock, limit: kotlin.time.Duration = 60.seconds) =
+        CeremonyStallClock(limit = limit) { fake.nanos }
+
+    @Test
+    fun `a fresh clock is not stalled`() {
+        val fake = FakeClock()
+
+        assertFalse(clockOf(fake).isStalled())
+    }
+
+    @Test
+    fun `silence short of the limit is not a stall`() {
+        val fake = FakeClock()
+        val stall = clockOf(fake)
+
+        fake.advance(59)
+
+        assertFalse(stall.isStalled())
+    }
+
+    @Test
+    fun `silence past the limit is a stall`() {
+        val fake = FakeClock()
+        val stall = clockOf(fake)
+
+        fake.advance(61)
+
+        assertTrue(stall.isStalled())
+    }
+
+    /**
+     * The fix itself. Under the old attempt-start clock this ceremony failed at 60 s despite a
+     * message landing every 30 s; the deadline now moves with the last applied message.
+     */
+    @Test
+    fun `applied messages keep a slow but healthy ceremony alive`() {
+        val fake = FakeClock()
+        val stall = clockOf(fake)
+
+        repeat(10) {
+            fake.advance(30)
+            assertFalse(stall.isStalled(), "30 s between messages must not trip the stall")
+            stall.markProgress()
+        }
+
+        // Five minutes of ceremony, none of it silent for 60 s.
+        assertFalse(stall.isStalled())
+    }
+
+    @Test
+    fun `the clock still fires once progress actually stops`() {
+        val fake = FakeClock()
+        val stall = clockOf(fake)
+
+        fake.advance(30)
+        stall.markProgress()
+        fake.advance(61)
+
+        assertTrue(stall.isStalled(), "a real stall must still fail inside the limit")
+    }
+
+    @Test
+    fun `reset restarts the window for a new attempt`() {
+        val fake = FakeClock()
+        val stall = clockOf(fake)
+
+        fake.advance(61)
+        assertTrue(stall.isStalled())
+
+        stall.reset()
+
+        assertFalse(stall.isStalled(), "a retry gets a fresh peer-wait window")
+    }
+
+    @Test
+    fun `sinceProgress reports the gap the failure message quotes`() {
+        val fake = FakeClock()
+        val stall = clockOf(fake)
+
+        fake.advance(45)
+
+        assertEquals(45.seconds, stall.sinceProgress())
+    }
+
+    @Test
+    fun `limitSeconds exposes the configured limit`() {
+        assertEquals(60L, clockOf(FakeClock()).limitSeconds)
+        assertEquals(90L, clockOf(FakeClock(), limit = 90.seconds).limitSeconds)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/DklsFamilyRelayRecoveryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/DklsFamilyRelayRecoveryTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.keygen
 
+import com.vultisig.wallet.data.api.RelaySendBudget
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.common.md5
 import com.vultisig.wallet.data.mediator.Message
@@ -100,6 +101,7 @@ class DklsFamilyRelayRecoveryTest {
             serverUrl: String,
             messageId: String?,
             message: Message,
+            budget: RelaySendBudget?,
         ) = unexpected("sendTssMessage")
 
         override suspend fun getTssMessages(

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/FakeRelaySessionApi.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/FakeRelaySessionApi.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.keygen
 
+import com.vultisig.wallet.data.api.RelaySendBudget
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.mediator.Message
 
@@ -12,15 +13,21 @@ import com.vultisig.wallet.data.mediator.Message
  *
  * @param onPoll Serves one `getTssMessages` response, given the 1-based poll number.
  * @param onDelete Handles one `deleteTssMessage` call, given the message hash.
+ * @param onSend Handles one `sendTssMessage` call; suspending, so a test can hold a send open and
+ *   observe whether the ceremony's outbound round waits for it.
  */
 internal class FakeRelaySessionApi(
     private val onPoll: (Int) -> List<Message> = { unexpected("getTssMessages") },
     private val onDelete: (String) -> Unit = {},
+    private val onSend: (suspend (Message) -> Unit)? = null,
 ) : SessionApi {
     var polls = 0
         private set
 
     val deletedHashes = mutableListOf<String>()
+
+    /** Every message handed to [sendTssMessage], in completion order. */
+    val sentMessages = java.util.concurrent.CopyOnWriteArrayList<Message>()
 
     override suspend fun getTssMessages(
         serverUrl: String,
@@ -70,8 +77,16 @@ internal class FakeRelaySessionApi(
     override suspend fun getParticipants(serverUrl: String, sessionId: String): List<String> =
         unexpected("getParticipants")
 
-    override suspend fun sendTssMessage(serverUrl: String, messageId: String?, message: Message) =
-        unexpected("sendTssMessage")
+    override suspend fun sendTssMessage(
+        serverUrl: String,
+        messageId: String?,
+        message: Message,
+        budget: RelaySendBudget?,
+    ) {
+        val handler = onSend ?: unexpected("sendTssMessage")
+        handler(message)
+        sentMessages += message
+    }
 
     override suspend fun markLocalPartyKeysignComplete(
         serverUrl: String,

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/KeysignMessagePollerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/KeysignMessagePollerTest.kt
@@ -1,7 +1,9 @@
 package com.vultisig.wallet.data.keygen
 
+import com.vultisig.wallet.data.api.RelaySendFailedException
 import com.vultisig.wallet.data.mediator.Message
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
@@ -95,6 +97,49 @@ class KeysignMessagePollerTest {
 
         failure.message shouldContain "keysign timed out after 60s"
         clock.elapsed shouldBe ATTEMPT_TIMEOUT + POLL_INTERVAL
+    }
+
+    /**
+     * The other half of the test above, from issue #5813. A message that will not apply is
+     * tolerated; an outbound round that never reached the relay is not. Swallowing this one leaves
+     * the attempt polling out the full deadline for a reply no peer can send, when the keysign
+     * wrapper could consult the relay for a finished signature and restart the attempt at once.
+     */
+    @Test
+    fun `a failed outbound send ends the attempt instead of polling out the deadline`() = runTest {
+        val clock = TestClock()
+        val sessionApi = relay(clock) { listOf(peerMessage()) }
+
+        val failure =
+            shouldThrow<RelaySendFailedException> {
+                poller(sessionApi, clock).poll(MESSAGE_ID) {
+                    throw RelaySendFailedException("failed to send the message to $PEER")
+                }
+            }
+
+        failure.message shouldContain PEER
+        withClue("the attempt must end on the failing poll, not 60 s later") {
+            clock.elapsed shouldBe POLL_INTERVAL
+        }
+    }
+
+    /**
+     * A ban is the library's verdict on a peer, not a transient failure. Polling on would report it
+     * as a timeout, which the keysign wrapper retries — signing again against a party DKLS has
+     * already banned.
+     */
+    @Test
+    fun `a banned party ends the attempt instead of polling out the deadline`() = runTest {
+        val clock = TestClock()
+        val sessionApi = relay(clock) { listOf(peerMessage()) }
+
+        val failure =
+            shouldThrow<MaliciousPartyException> {
+                poller(sessionApi, clock).poll(MESSAGE_ID) { throw MaliciousPartyException(PEER) }
+            }
+
+        failure.partyID shouldBe PEER
+        clock.elapsed shouldBe POLL_INTERVAL
     }
 
     @Test

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/RelayFanOutTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/RelayFanOutTest.kt
@@ -1,0 +1,133 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.keygen
+
+import com.vultisig.wallet.data.tss.TssMessenger
+import com.vultisig.wallet.data.usecases.Encryption
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins [fanOut], the concurrent outbound round the DKLS-family ceremonies use since issue #5813.
+ *
+ * Awaiting each send is the point of that issue, but awaiting them one after another would have
+ * traded one bug for another: a single send can now spend a full 39 s retry budget, so a serial
+ * loop over a three-peer committee could burn past the 60 s ceremony stall on retries alone. These
+ * tests hold the two properties that make the awaited send affordable — the peers are contacted in
+ * parallel, and a failure still reaches the caller instead of being swallowed as before.
+ */
+class RelayFanOutTest {
+
+    private object PlaintextEncryption : Encryption {
+        override fun encrypt(data: ByteArray, password: ByteArray): ByteArray = data
+
+        override fun decrypt(data: ByteArray, password: ByteArray): ByteArray = data
+    }
+
+    private fun messenger(api: FakeRelaySessionApi, scope: CoroutineScope): TssMessenger =
+        TssMessenger(
+            serverAddress = "http://relay.local",
+            sessionID = "session-1",
+            encryptionHex = "00112233445566778899aabbccddeeff",
+            sessionApi = api,
+            coroutineScope = scope,
+            encryption = PlaintextEncryption,
+            isEncryptionGCM = true,
+        )
+
+    @Test
+    fun `every receiver in the round gets the message`() = runTest {
+        val api = FakeRelaySessionApi(onSend = {})
+
+        messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC"), "payload")
+
+        assertEquals(2, api.sentMessages.size)
+        assertContentEquals(
+            listOf(listOf("deviceB"), listOf("deviceC")),
+            api.sentMessages.map { it.to }.sortedBy { it.first() },
+        )
+    }
+
+    /**
+     * The load-bearing property. Three slow sends must cost one send's time, not three: serialising
+     * them is what would push a round past the ceremony stall.
+     */
+    @Test
+    fun `the peers are contacted in parallel, not one after another`() = runTest {
+        val sendDuration = 5_000L
+        val api = FakeRelaySessionApi(onSend = { delay(sendDuration) })
+
+        messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC", "deviceD"), "payload")
+
+        assertEquals(3, api.sentMessages.size)
+        assertEquals(
+            sendDuration,
+            currentTime,
+            "three 5 s sends must cost 5 s in parallel, not 15 s in sequence",
+        )
+    }
+
+    /**
+     * The whole point of #5813: a send that cannot be delivered has to surface. Before the fix it
+     * was logged and dropped, and the ceremony waited out the stall for a reply nobody would send.
+     */
+    @Test
+    fun `a failing send propagates to the caller`() = runTest {
+        val api = FakeRelaySessionApi(onSend = { error("relay rejected the message") })
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC"), "payload")
+            }
+        assertEquals("relay rejected the message", failure.message)
+    }
+
+    /** A round that has already failed should not keep paying for the peers still in flight. */
+    @Test
+    fun `a failing send cancels its siblings`() = runTest {
+        val completed = AtomicInteger(0)
+        val api =
+            FakeRelaySessionApi(
+                onSend = { message ->
+                    if (message.to.single() == "deviceB") error("relay rejected the message")
+                    delay(30_000)
+                    completed.incrementAndGet()
+                }
+            )
+
+        assertFailsWith<IllegalStateException> {
+            messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC"), "payload")
+        }
+
+        assertEquals(0, completed.get(), "the sibling send should have been cancelled")
+        assertTrue(currentTime < 30_000, "the caller must not wait out the cancelled send")
+    }
+
+    @Test
+    fun `a round with no receivers sends nothing`() = runTest {
+        val api = FakeRelaySessionApi(onSend = { error("should not send") })
+
+        messenger(api, this).fanOut("deviceA", emptyList(), "payload")
+
+        assertEquals(0, api.sentMessages.size)
+    }
+
+    @Test
+    fun `the fan-out survives a scope whose dispatcher is not the test one`() = runTest {
+        val api = FakeRelaySessionApi(onSend = {})
+
+        messenger(api, CoroutineScope(Dispatchers.Default))
+            .fanOut("deviceA", listOf("deviceB"), "payload")
+
+        assertEquals(1, api.sentMessages.size)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/RelayFanOutTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/RelayFanOutTest.kt
@@ -4,11 +4,12 @@ package com.vultisig.wallet.data.keygen
 
 import com.vultisig.wallet.data.tss.TssMessenger
 import com.vultisig.wallet.data.usecases.Encryption
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
 import java.util.concurrent.atomic.AtomicInteger
-import kotlin.test.assertContentEquals
-import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
-import kotlin.test.assertTrue
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -50,11 +51,9 @@ class RelayFanOutTest {
 
         messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC"), "payload")
 
-        assertEquals(2, api.sentMessages.size)
-        assertContentEquals(
-            listOf(listOf("deviceB"), listOf("deviceC")),
-            api.sentMessages.map { it.to }.sortedBy { it.first() },
-        )
+        api.sentMessages.size shouldBe 2
+        api.sentMessages.map { it.to }.sortedBy { it.first() } shouldContainExactly
+            listOf(listOf("deviceB"), listOf("deviceC"))
     }
 
     /**
@@ -68,12 +67,10 @@ class RelayFanOutTest {
 
         messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC", "deviceD"), "payload")
 
-        assertEquals(3, api.sentMessages.size)
-        assertEquals(
-            sendDuration,
-            currentTime,
-            "three 5 s sends must cost 5 s in parallel, not 15 s in sequence",
-        )
+        api.sentMessages.size shouldBe 3
+        withClue("three 5 s sends must cost 5 s in parallel, not 15 s in sequence") {
+            currentTime shouldBe sendDuration
+        }
     }
 
     /**
@@ -85,10 +82,10 @@ class RelayFanOutTest {
         val api = FakeRelaySessionApi(onSend = { error("relay rejected the message") })
 
         val failure =
-            assertFailsWith<IllegalStateException> {
+            shouldThrow<IllegalStateException> {
                 messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC"), "payload")
             }
-        assertEquals("relay rejected the message", failure.message)
+        failure.message shouldBe "relay rejected the message"
     }
 
     /** A round that has already failed should not keep paying for the peers still in flight. */
@@ -104,12 +101,14 @@ class RelayFanOutTest {
                 }
             )
 
-        assertFailsWith<IllegalStateException> {
+        shouldThrow<IllegalStateException> {
             messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC"), "payload")
         }
 
-        assertEquals(0, completed.get(), "the sibling send should have been cancelled")
-        assertTrue(currentTime < 30_000, "the caller must not wait out the cancelled send")
+        withClue("the sibling send should have been cancelled") { completed.get() shouldBe 0 }
+        withClue("the caller must not wait out the cancelled send") {
+            currentTime shouldBeLessThan 30_000L
+        }
     }
 
     @Test
@@ -118,7 +117,7 @@ class RelayFanOutTest {
 
         messenger(api, this).fanOut("deviceA", emptyList(), "payload")
 
-        assertEquals(0, api.sentMessages.size)
+        api.sentMessages.size shouldBe 0
     }
 
     @Test
@@ -128,6 +127,6 @@ class RelayFanOutTest {
         messenger(api, CoroutineScope(Dispatchers.Default))
             .fanOut("deviceA", listOf("deviceB"), "payload")
 
-        assertEquals(1, api.sentMessages.size)
+        api.sentMessages.size shouldBe 1
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/RelayFanOutTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/RelayFanOutTest.kt
@@ -2,6 +2,7 @@
 
 package com.vultisig.wallet.data.keygen
 
+import com.vultisig.wallet.data.api.RelaySendFailedException
 import com.vultisig.wallet.data.tss.TssMessenger
 import com.vultisig.wallet.data.usecases.Encryption
 import io.kotest.assertions.throwables.shouldThrow
@@ -76,16 +77,22 @@ class RelayFanOutTest {
     /**
      * The whole point of #5813: a send that cannot be delivered has to surface. Before the fix it
      * was logged and dropped, and the ceremony waited out the stall for a reply nobody would send.
+     *
+     * It surfaces as a [RelaySendFailedException] whatever the underlying fault was, because the
+     * poll loop that receives it tells a lost send from a failed relay read by type alone.
      */
     @Test
     fun `a failing send propagates to the caller`() = runTest {
         val api = FakeRelaySessionApi(onSend = { error("relay rejected the message") })
 
         val failure =
-            shouldThrow<IllegalStateException> {
+            shouldThrow<RelaySendFailedException> {
                 messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC"), "payload")
             }
-        failure.message shouldBe "relay rejected the message"
+        // Read the chain, not `cause`: kotlinx.coroutines recovers the stack trace across the
+        // `async` boundary by re-wrapping the exception in a copy of itself.
+        val rootCause = generateSequence(failure.cause) { it.cause }.last()
+        rootCause.message shouldBe "relay rejected the message"
     }
 
     /** A round that has already failed should not keep paying for the peers still in flight. */
@@ -101,7 +108,7 @@ class RelayFanOutTest {
                 }
             )
 
-        shouldThrow<IllegalStateException> {
+        shouldThrow<RelaySendFailedException> {
             messenger(api, this).fanOut("deviceA", listOf("deviceB", "deviceC"), "payload")
         }
 

--- a/app/src/test/java/com/vultisig/wallet/data/keygen/SchnorrKeysignSetupMessageRetryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/keygen/SchnorrKeysignSetupMessageRetryTest.kt
@@ -2,6 +2,7 @@
 
 package com.vultisig.wallet.data.keygen
 
+import com.vultisig.wallet.data.api.RelaySendBudget
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.common.md5
 import com.vultisig.wallet.data.mediator.Message
@@ -120,6 +121,7 @@ class SchnorrKeysignSetupMessageRetryTest {
             serverUrl: String,
             messageId: String?,
             message: Message,
+            budget: RelaySendBudget?,
         ) = unexpected("sendTssMessage")
 
         override suspend fun getTssMessages(

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -124,7 +124,11 @@ dependencies {
     implementation(libs.androidx.security)
 
     // test
-    testCompileOnly(files("../app/libs/mobile-tss-lib.aar"))
+    // Not compileOnly: TssMessenger implements the gomobile `tss.Messenger` interface, so JUnit
+    // cannot even resolve a test class that names it unless the AAR's classes are on the test
+    // runtime classpath too. Only the interface is loaded — instantiating a native tss type still
+    // needs the gojni library and stays out of unit tests.
+    testImplementation(files("../app/libs/mobile-tss-lib.aar"))
     testImplementation(libs.ktor.client.mock)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RelaySendBudget.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RelaySendBudget.kt
@@ -1,0 +1,75 @@
+package com.vultisig.wallet.data.api
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Bounded retry budget for one relay `POST /message/{sessionID}`.
+ *
+ * Repeating the send is safe: the relay stores by `session-recipient-hash` and overwrites on
+ * repeat, and receivers dedupe by the same key before applying, so a retry of a send the relay had
+ * in fact accepted is a no-op rather than a duplicate round.
+ *
+ * The whole budget has to fit inside the ceremony stall limit. Peers keep their own clocks running
+ * while this side retries, so a send that outlives the stall restarts this party while the others
+ * are still waiting on it. With the defaults that is `4 x 8s + 1s + 2s + 4s` = 39 s, inside the 60
+ * s stall — [worstCase] pins the arithmetic and `RelaySendBudgetTest` asserts it. Do not raise
+ * [requestTimeout] back to the client default.
+ *
+ * @param deadlineNanos [System.nanoTime] instant this send may not outlive, or `null` for
+ *   unbounded. The keysign path passes one because its poll deadline is absolute and deliberately
+ *   not progress-based (`KeysignMessagePoller`, issue #5488): both the per-request timeout and the
+ *   backoff sleeps are clipped to what is left of it, so a send's own retries cannot outlive the
+ *   signing attempt they belong to.
+ */
+data class RelaySendBudget(
+    val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+    val requestTimeout: Duration = DEFAULT_REQUEST_TIMEOUT,
+    val initialBackoff: Duration = DEFAULT_INITIAL_BACKOFF,
+    val deadlineNanos: Long? = null,
+) {
+    init {
+        require(maxAttempts >= 1) { "maxAttempts must be at least 1, was $maxAttempts" }
+    }
+
+    /** [initialBackoff] doubled per elapsed attempt: 1 s after the first failure, then 2 s, 4 s. */
+    fun backoffAfter(attempt: Int): Duration = initialBackoff * (1 shl attempt)
+
+    /** Every attempt timing out, plus every backoff between attempts. */
+    val worstCase: Duration
+        get() =
+            (0 until maxAttempts - 1).fold(requestTimeout * maxAttempts) { total, attempt ->
+                total + backoffAfter(attempt)
+            }
+
+    /**
+     * Milliseconds this attempt's request may take: [requestTimeout], clipped to what is left of
+     * [deadlineNanos]. Returns `null` when the deadline has already passed, which the caller turns
+     * into a failure rather than a request nobody is still waiting for.
+     */
+    fun requestTimeoutMillisAt(nowNanos: Long): Long? {
+        val remaining = remainingAt(nowNanos) ?: return requestTimeout.inWholeMilliseconds
+        if (remaining <= Duration.ZERO) return null
+        return minOf(requestTimeout, remaining).inWholeMilliseconds.coerceAtLeast(1)
+    }
+
+    /** Whether sleeping [backoff] before the next attempt still leaves time inside the deadline. */
+    fun backoffFitsAt(backoff: Duration, nowNanos: Long): Boolean {
+        val remaining = remainingAt(nowNanos) ?: return true
+        return backoff < remaining
+    }
+
+    private fun remainingAt(nowNanos: Long): Duration? =
+        deadlineNanos?.let { (it - nowNanos).nanoseconds }
+
+    companion object {
+        const val DEFAULT_MAX_ATTEMPTS = 4
+        val DEFAULT_REQUEST_TIMEOUT = 8.seconds
+        val DEFAULT_INITIAL_BACKOFF = 1.seconds
+    }
+}
+
+/** Thrown when a relay send is abandoned because its ceremony deadline expired mid-retry. */
+class RelaySendDeadlineExceededException(cause: Throwable? = null) :
+    Exception("relay send abandoned: the ceremony deadline expired", cause)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/RelaySendBudget.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/RelaySendBudget.kt
@@ -70,6 +70,20 @@ data class RelaySendBudget(
     }
 }
 
+/**
+ * Thrown when an awaited relay send did not reach the relay: the budget above was spent, the relay
+ * rejected the message outright, or the deadline expired mid-retry.
+ *
+ * It has its own type because the ceremony poll loops must not treat it as a failed read. Each of
+ * them wraps both `getTssMessages` and the outbound round an applied inbound message triggers in
+ * one broad `catch`, so an unmarked send failure is logged as "Failed to get messages" and the loop
+ * keeps polling for a reply that can never arrive — the exact issue #5813 stall the awaited send
+ * exists to end. `KeysignMessagePoller.poll` and the keygen `pullInboundMessages` loops rethrow
+ * this ahead of that catch so the attempt restarts at once.
+ */
+open class RelaySendFailedException(message: String, cause: Throwable? = null) :
+    Exception(message, cause)
+
 /** Thrown when a relay send is abandoned because its ceremony deadline expired mid-retry. */
 class RelaySendDeadlineExceededException(cause: Throwable? = null) :
-    Exception("relay send abandoned: the ceremony deadline expired", cause)
+    RelaySendFailedException("relay send abandoned: the ceremony deadline expired", cause)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/SessionApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/SessionApi.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -17,6 +18,7 @@ import io.ktor.http.isSuccess
 import java.io.IOException
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -40,7 +42,20 @@ interface SessionApi {
 
     suspend fun getParticipants(serverUrl: String, sessionId: String): List<String>
 
-    suspend fun sendTssMessage(serverUrl: String, messageId: String?, message: Message)
+    /**
+     * Posts one TSS message to the relay.
+     *
+     * @param budget bounded retry budget with a short per-request timeout, for callers that await
+     *   the send and need it to fail inside the ceremony stall limit. `null` keeps the shared relay
+     *   retry and the client's default timeouts, which is what the legacy GG20
+     *   [com.vultisig.wallet.data.tss.TssMessenger.send] path still wants.
+     */
+    suspend fun sendTssMessage(
+        serverUrl: String,
+        messageId: String?,
+        message: Message,
+        budget: RelaySendBudget? = null,
+    )
 
     suspend fun getTssMessages(
         serverUrl: String,
@@ -149,12 +164,20 @@ constructor(private val json: Json, private val httpClient: HttpClient) : Sessio
             .bodyOrThrow<List<String>>()
     }
 
-    override suspend fun sendTssMessage(serverUrl: String, messageId: String?, message: Message) {
-        withRelayRetry {
+    override suspend fun sendTssMessage(
+        serverUrl: String,
+        messageId: String?,
+        message: Message,
+        budget: RelaySendBudget?,
+    ) {
+        withRelayBudget(budget) { timeoutMillis ->
             httpClient
                 .post(serverUrl) {
                     if (!messageId.isNullOrEmpty()) {
                         header(MESSAGE_ID_HEADER_TITLE, messageId)
+                    }
+                    if (timeoutMillis != null) {
+                        timeout { requestTimeoutMillis = timeoutMillis }
                     }
                     setBody(json.encodeToString(message))
                 }
@@ -271,11 +294,35 @@ constructor(private val json: Json, private val httpClient: HttpClient) : Sessio
         }
     }
 
-    private suspend fun <T> withRelayRetry(block: suspend () -> T): T {
+    private suspend fun <T> withRelayRetry(block: suspend () -> T): T =
+        withRelayBudget(budget = null) { block() }
+
+    /**
+     * Runs [block] under a bounded relay retry, retrying only 5xx and transport faults and throwing
+     * a 4xx or a cancellation at once.
+     *
+     * With no [budget] this is the shared relay policy every endpoint has used since #4667: three
+     * attempts, 1 s then 2 s of backoff, and the client's own timeouts. A [budget] tightens all
+     * three for one call — the awaited TSS send needs its whole retry sequence to finish inside the
+     * ceremony stall, so it caps each request and abandons the send rather than sleeping a backoff
+     * that would overshoot the deadline.
+     *
+     * [block] receives the millisecond cap for its request, or `null` when there is none.
+     */
+    private suspend fun <T> withRelayBudget(
+        budget: RelaySendBudget?,
+        block: suspend (requestTimeoutMillis: Long?) -> T,
+    ): T {
+        val maxAttempts = budget?.maxAttempts ?: RELAY_MAX_RETRIES
         var lastException: Exception? = null
-        repeat(RELAY_MAX_RETRIES) { attempt ->
+        repeat(maxAttempts) { attempt ->
+            val requestTimeoutMillis =
+                if (budget == null) null
+                else
+                    budget.requestTimeoutMillisAt(System.nanoTime())
+                        ?: throw RelaySendDeadlineExceededException(lastException)
             try {
-                return block()
+                return block(requestTimeoutMillis)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: HttpException) {
@@ -297,12 +344,20 @@ constructor(private val json: Json, private val httpClient: HttpClient) : Sessio
                     "Relay request transport failure (${e.kind}), retrying (attempt ${attempt + 1})",
                 )
             }
-            if (attempt < RELAY_MAX_RETRIES - 1) {
-                delay(RELAY_BACKOFF_MS * (1L shl attempt))
+            if (attempt < maxAttempts - 1) {
+                val backoff =
+                    budget?.backoffAfter(attempt)?.inWholeMilliseconds
+                        ?: (RELAY_BACKOFF_MS * (1L shl attempt))
+                if (
+                    budget != null && !budget.backoffFitsAt(backoff.milliseconds, System.nanoTime())
+                ) {
+                    throw RelaySendDeadlineExceededException(lastException)
+                }
+                delay(backoff)
             }
         }
         throw lastException
-            ?: IllegalStateException("Relay request failed after $RELAY_MAX_RETRIES retries")
+            ?: IllegalStateException("Relay request failed after $maxAttempts retries")
     }
 
     companion object {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfigurator.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/networkutils/HttpClientConfigurator.kt
@@ -7,6 +7,8 @@ import io.ktor.client.engine.HttpClientEngineConfig
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.HttpCallValidator
 import io.ktor.client.plugins.HttpRequestRetry
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -36,6 +38,10 @@ import kotlinx.serialization.json.Json
  *    exponential backoff: on transport [IOException]s/read-timeouts and on 5xx/429/408 responses.
  *    Non-idempotent requests (e.g. POST broadcasts) are never auto-retried, so a write the server
  *    received but slow-ACKed is not silently resent.
+ * 5. **HttpTimeout** — installed with no defaults, so it is inert unless a request opts in with
+ *    `timeout { requestTimeoutMillis = … }`. Only the awaited TSS relay send does, to keep one hung
+ *    POST from eating the ceremony's stall budget; every other call keeps the engine timeouts
+ *    configured in `NetworkModule`.
  *
  * The retry plugin fires first: if all retries fail, the [IOException] propagates to
  * [HttpCallValidator], which wraps it in a [NetworkException].
@@ -59,6 +65,10 @@ class HttpClientConfigurator @Inject constructor(private val json: Json) {
                     }
                 }
             }
+
+            // No default values: the plugin only engages for a request that sets its own
+            // `timeout { … }`, so installing it here changes nothing for existing callers.
+            install(HttpTimeout)
 
             install(HttpRequestRetry) {
                 exponentialDelay()
@@ -99,7 +109,10 @@ private fun isSafeMethod(method: HttpMethod): Boolean =
  */
 private fun IOException.toNetworkException(): NetworkException =
     when (this) {
-        is SocketTimeoutException ->
+        is SocketTimeoutException,
+        // Ktor's per-request budget expiring is a timeout like any other. Without this branch it
+        // falls through to the generic Transport case and reads as a dead connection in logs.
+        is HttpRequestTimeoutException ->
             NetworkException(0, "Connection timed out", NetworkErrorKind.Timeout, this)
         is UnknownHostException ->
             NetworkException(0, "No internet connection", NetworkErrorKind.NoConnectivity, this)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/tss/TssMessenger.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/tss/TssMessenger.kt
@@ -1,11 +1,13 @@
 package com.vultisig.wallet.data.tss
 
+import com.vultisig.wallet.data.api.RelaySendBudget
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.common.encryptNoEncode
 import com.vultisig.wallet.data.common.md5
 import com.vultisig.wallet.data.mediator.Message
 import com.vultisig.wallet.data.usecases.Encryption
 import com.vultisig.wallet.data.utils.Numeric
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 import kotlinx.coroutines.CancellationException
@@ -24,31 +26,50 @@ class TssMessenger(
     private val isEncryptionGCM: Boolean,
 ) : tss.Messenger {
     private val serverUrl = "$serverAddress/message/$sessionID"
-    private var messageID: String? = null
-    private var counter = 1
+    @Volatile private var messageID: String? = null
+    // Atomic because the DKLS ceremonies fan one outbound round out to every peer concurrently,
+    // and a lost increment would give two messages bound for the same peer the same sequence
+    // number, which the receiver sorts by before applying.
+    private val counter = AtomicInteger(1)
 
     fun setMessageID(messageID: String?) {
         this.messageID = messageID
     }
 
+    /**
+     * Sends one message and does not return until the relay has accepted it or the retry budget is
+     * spent, in which case it throws.
+     *
+     * This is what the DKLS-family ceremonies use. [send] cannot be it: `tss.Messenger` is a
+     * gomobile interface called synchronously from native code on the legacy GG20 path, so its
+     * signature is fixed and it can only fire the send off into [coroutineScope]. That is the bug
+     * behind issue #5813 — a failed relay POST left the ceremony waiting on a reply that could
+     * never arrive until the 60 s stall fired, and then restarting locally while the peers were
+     * still on the old session.
+     *
+     * The retry itself lives in [SessionApi.sendTssMessage]. The message is built once here so
+     * every attempt carries the same hash and sequence number and the relay and receiver dedupe it
+     * instead of applying it twice.
+     *
+     * @param deadlineNanos [System.nanoTime] instant this send may not outlive, or `null` for the
+     *   full [RelaySendBudget]. Callers whose own deadline is absolute pass one so the send cannot
+     *   outlive the round it belongs to.
+     */
+    suspend fun sendAwait(from: String, to: String, body: String, deadlineNanos: Long? = null) {
+        sessionApi.sendTssMessage(
+            serverUrl = serverUrl,
+            messageId = messageID,
+            message = buildMessage(from, to, body),
+            budget = RelaySendBudget(deadlineNanos = deadlineNanos),
+        )
+    }
+
+    /**
+     * Fire-and-forget send required by the gomobile `tss.Messenger` interface, still used by the
+     * legacy GG20 keygen and keysign paths. Prefer [sendAwait] anywhere the call site can suspend.
+     */
     override fun send(from: String, to: String, body: String) {
-        val encryptedBody: ByteArray =
-            if (isEncryptionGCM) {
-                Timber.d("encrypting message with AES+GCM")
-                encryption.encrypt(body.toByteArray(), Numeric.hexStringToByteArray(encryptionHex))
-            } else {
-                Timber.d("encrypting message with AES+CBC")
-                body.encryptNoEncode(encryptionHex)
-            }
-        val message =
-            Message(
-                sessionID,
-                from,
-                listOf(to),
-                Base64.encode(encryptedBody),
-                body.md5(),
-                counter++,
-            )
+        val message = buildMessage(from, to, body)
         coroutineScope.launch {
             for (i in 1..3) {
                 try {
@@ -63,5 +84,24 @@ class TssMessenger(
                 }
             }
         }
+    }
+
+    private fun buildMessage(from: String, to: String, body: String): Message {
+        val encryptedBody: ByteArray =
+            if (isEncryptionGCM) {
+                Timber.d("encrypting message with AES+GCM")
+                encryption.encrypt(body.toByteArray(), Numeric.hexStringToByteArray(encryptionHex))
+            } else {
+                Timber.d("encrypting message with AES+CBC")
+                body.encryptNoEncode(encryptionHex)
+            }
+        return Message(
+            sessionID,
+            from,
+            listOf(to),
+            Base64.encode(encryptedBody),
+            body.md5(),
+            counter.getAndIncrement(),
+        )
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/tss/TssMessenger.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/tss/TssMessenger.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.tss
 
 import com.vultisig.wallet.data.api.RelaySendBudget
+import com.vultisig.wallet.data.api.RelaySendFailedException
 import com.vultisig.wallet.data.api.SessionApi
 import com.vultisig.wallet.data.common.encryptNoEncode
 import com.vultisig.wallet.data.common.md5
@@ -51,17 +52,30 @@ class TssMessenger(
      * every attempt carries the same hash and sequence number and the relay and receiver dedupe it
      * instead of applying it twice.
      *
+     * Every failure leaves as a [RelaySendFailedException]. The ceremony poll loops key on that
+     * type to tell "my own message never landed" — fatal to the attempt — from the failed relay
+     * read they log and retry, so a send failure that arrived as a bare `IOException` would be
+     * swallowed by the very loop waiting on the reply it just lost.
+     *
      * @param deadlineNanos [System.nanoTime] instant this send may not outlive, or `null` for the
      *   full [RelaySendBudget]. Callers whose own deadline is absolute pass one so the send cannot
      *   outlive the round it belongs to.
      */
     suspend fun sendAwait(from: String, to: String, body: String, deadlineNanos: Long? = null) {
-        sessionApi.sendTssMessage(
-            serverUrl = serverUrl,
-            messageId = messageID,
-            message = buildMessage(from, to, body),
-            budget = RelaySendBudget(deadlineNanos = deadlineNanos),
-        )
+        try {
+            sessionApi.sendTssMessage(
+                serverUrl = serverUrl,
+                messageId = messageID,
+                message = buildMessage(from, to, body),
+                budget = RelaySendBudget(deadlineNanos = deadlineNanos),
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: RelaySendFailedException) {
+            throw e
+        } catch (e: Exception) {
+            throw RelaySendFailedException("failed to send the message to $to", e)
+        }
     }
 
     /**

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/RelaySendBudgetTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/RelaySendBudgetTest.kt
@@ -1,0 +1,118 @@
+package com.vultisig.wallet.data.api
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the arithmetic that makes the awaited relay send safe to introduce at all (issue #5813).
+ *
+ * The send used to be fire-and-forget, so how long it took was nobody's problem. Now the ceremony
+ * waits on it, and a send that outlives the 60 s stall restarts this party while its peers are
+ * still waiting on the old session — the exact failure the change is meant to remove.
+ */
+class RelaySendBudgetTest {
+
+    private val stallLimit = 60.seconds
+
+    @Test
+    fun `default worst case stays inside the ceremony stall limit`() {
+        val budget = RelaySendBudget()
+
+        // 4 attempts x 8 s, plus 1 s + 2 s + 4 s of backoff between them.
+        assertEquals(39.seconds, budget.worstCase)
+        assertTrue(
+            budget.worstCase < stallLimit,
+            "send budget ${budget.worstCase} must stay under the $stallLimit stall",
+        )
+    }
+
+    @Test
+    fun `backoff doubles from one second`() {
+        val budget = RelaySendBudget()
+
+        assertEquals(1.seconds, budget.backoffAfter(0))
+        assertEquals(2.seconds, budget.backoffAfter(1))
+        assertEquals(4.seconds, budget.backoffAfter(2))
+    }
+
+    @Test
+    fun `a single attempt has no backoff to add`() {
+        val budget = RelaySendBudget(maxAttempts = 1)
+
+        assertEquals(8.seconds, budget.worstCase)
+    }
+
+    @Test
+    fun `maxAttempts below one is rejected`() {
+        assertFailsWith<IllegalArgumentException> { RelaySendBudget(maxAttempts = 0) }
+    }
+
+    @Test
+    fun `without a deadline every request gets the full timeout`() {
+        val budget = RelaySendBudget()
+
+        assertEquals(8_000L, budget.requestTimeoutMillisAt(nowNanos = 0))
+    }
+
+    @Test
+    fun `a request is clipped to what is left of the deadline`() {
+        val now = 1_000_000_000L
+        val budget = RelaySendBudget(deadlineNanos = now + 3.seconds.inWholeNanoseconds)
+
+        assertEquals(3_000L, budget.requestTimeoutMillisAt(now))
+    }
+
+    @Test
+    fun `a request keeps the full timeout when the deadline is further out`() {
+        val now = 1_000_000_000L
+        val budget = RelaySendBudget(deadlineNanos = now + 30.seconds.inWholeNanoseconds)
+
+        assertEquals(8_000L, budget.requestTimeoutMillisAt(now))
+    }
+
+    /**
+     * Null is the caller's signal to abandon the send rather than start a request nobody awaits.
+     */
+    @Test
+    fun `a passed deadline yields no request timeout at all`() {
+        val now = 1_000_000_000L
+        val budget = RelaySendBudget(deadlineNanos = now - 1)
+
+        assertNull(budget.requestTimeoutMillisAt(now))
+    }
+
+    @Test
+    fun `a sub-millisecond remainder still asks for a real request`() {
+        val now = 1_000_000_000L
+        val budget = RelaySendBudget(deadlineNanos = now + 500)
+
+        assertEquals(1L, budget.requestTimeoutMillisAt(now))
+    }
+
+    @Test
+    fun `a backoff that fits inside the deadline is allowed`() {
+        val now = 1_000_000_000L
+        val budget = RelaySendBudget(deadlineNanos = now + 5.seconds.inWholeNanoseconds)
+
+        assertTrue(budget.backoffFitsAt(1.seconds, now))
+    }
+
+    @Test
+    fun `a backoff that would overshoot the deadline is refused`() {
+        val now = 1_000_000_000L
+        val budget = RelaySendBudget(deadlineNanos = now + 500.milliseconds.inWholeNanoseconds)
+
+        assertFalse(budget.backoffFitsAt(4.seconds, now))
+    }
+
+    @Test
+    fun `without a deadline every backoff fits`() {
+        assertTrue(RelaySendBudget().backoffFitsAt(4.seconds, nowNanos = 0))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/SessionApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/SessionApiTest.kt
@@ -3,12 +3,14 @@
 package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.utils.HttpException
+import com.vultisig.wallet.data.mediator.Message
 import com.vultisig.wallet.data.testutils.MockHttpClient
 import io.ktor.http.HttpStatusCode
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
@@ -122,5 +124,68 @@ class SessionApiTest {
         assertFailsWith<Exception> { api.getSetupMessage(serverUrl, sessionId, null) }
         // 9 delays of 1000 ms between 10 attempts
         assertEquals(9000L, currentTime)
+    }
+
+    private fun message() = Message(sessionId, "deviceA", listOf("deviceB"), "body", "hash", 1)
+
+    /**
+     * The awaited TSS send tightens the shared policy for its own call only (issue #5813): four
+     * attempts with 1 s / 2 s / 4 s of backoff, so the whole sequence lands inside the 60 s
+     * ceremony stall.
+     */
+    @Test
+    fun `sendTssMessage with a budget retries four times with doubling backoff`() = runTest {
+        val api = createApi(HttpStatusCode.InternalServerError)
+
+        assertFailsWith<HttpException> {
+            api.sendTssMessage(serverUrl, null, message(), RelaySendBudget())
+        }
+
+        assertEquals(7000L, currentTime)
+    }
+
+    /**
+     * The legacy GG20 messenger posts through the same endpoint, so the tightened budget must not
+     * leak onto it — without a budget the call keeps the shared three-attempt relay policy.
+     */
+    @Test
+    fun `sendTssMessage without a budget keeps the shared relay policy`() = runTest {
+        val api = createApi(HttpStatusCode.InternalServerError)
+
+        assertFailsWith<HttpException> { api.sendTssMessage(serverUrl, null, message()) }
+
+        assertEquals(3000L, currentTime)
+    }
+
+    /**
+     * A send started inside a keysign attempt must not sleep past that attempt's absolute deadline
+     * — the retry would be posting into a round that has already been abandoned.
+     */
+    @Test
+    fun `sendTssMessage abandons the send when the next backoff would overshoot the deadline`() =
+        runTest {
+            val api = createApi(HttpStatusCode.InternalServerError)
+            // Room for the first request, but not for the 1 s backoff that would follow it.
+            val budget =
+                RelaySendBudget(
+                    deadlineNanos = System.nanoTime() + 200.milliseconds.inWholeNanoseconds
+                )
+
+            assertFailsWith<RelaySendDeadlineExceededException> {
+                api.sendTssMessage(serverUrl, null, message(), budget)
+            }
+
+            assertEquals(0L, currentTime, "no backoff should have been slept")
+        }
+
+    @Test
+    fun `sendTssMessage with a budget still refuses to retry a 4xx`() = runTest {
+        val api = createApi(HttpStatusCode.BadRequest)
+
+        assertFailsWith<HttpException> {
+            api.sendTssMessage(serverUrl, null, message(), RelaySendBudget())
+        }
+
+        assertEquals(0L, currentTime)
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
@@ -20,6 +20,7 @@ import io.ktor.util.appendIfNameAbsent
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.serialization.json.Json
 
@@ -30,6 +31,10 @@ import kotlinx.serialization.json.Json
  * These builders install [ContentNegotiation] and [HttpCallValidator] with the same `IOException →
  * NetworkException(httpStatusCode=0)` mapping used in production, ensuring tests validate real
  * behavior.
+ *
+ * The MockEngine handler runs on the engine's own dispatcher rather than the caller's, so a test
+ * that issues requests concurrently serves them on several pool threads at once. Every builder's
+ * per-call state is therefore atomic; a plain `var` there loses calls under that fan-out.
  */
 object MockHttpClient {
 
@@ -82,39 +87,49 @@ object MockHttpClient {
         }
 
     /**
-     * Mutable holder for the outgoing request bodies captured by [capturingRequest] and
+     * Holder for the outgoing request bodies captured by [capturingRequest] and
      * [capturingRequestSequence]. [lastBody] is the most recent one; [bodies] keeps every request
      * in order, which is what a paginated call needs — asserting only the last body cannot show
      * that page two carried the cursor page one returned.
+     *
+     * Synchronised because the MockEngine handler runs on the engine's own dispatcher, not the
+     * caller's: a test that issues requests concurrently records from several pool threads at once,
+     * and an unguarded list drops entries there.
      */
     class RequestCapture {
-        val bodies = mutableListOf<String>()
+        private val lock = Any()
+        private val recorded = mutableListOf<Record>()
+
+        /** Body of every request in order of completion. */
+        val bodies: List<String>
+            get() = snapshot().map(Record::body)
 
         /**
          * Encoded query string of every request in order, for asserting the paging parameters a
          * walk actually sent (e.g. `offset`/`limit` per page).
          */
-        val queries = mutableListOf<String>()
+        val queries: List<String>
+            get() = snapshot().map(Record::query)
 
-        var lastBody: String = ""
-            private set
+        val lastBody: String
+            get() = snapshot().lastOrNull()?.body ?: ""
 
         /** Encoded path of the most recent request, for asserting which node endpoint was hit. */
-        var lastPath: String = ""
-            private set
+        val lastPath: String
+            get() = snapshot().lastOrNull()?.path ?: ""
 
         internal fun record(body: String, path: String, query: String = "") {
-            lastBody = body
-            lastPath = path
-            bodies += body
-            queries += query
+            synchronized(lock) { recorded += Record(body, path, query) }
         }
+
+        private fun snapshot(): List<Record> = synchronized(lock) { recorded.toList() }
+
+        private data class Record(val body: String, val path: String, val query: String)
     }
 
     /**
      * Like [respondingWith], but records each outgoing request body into [capture] so a test can
-     * assert what was sent (e.g. RPC params). The MockEngine block runs sequentially within a
-     * single coroutine, so a plain field is sufficient.
+     * assert what was sent (e.g. RPC params).
      */
     fun capturingRequest(
         status: HttpStatusCode,
@@ -148,7 +163,7 @@ object MockHttpClient {
         require(responses.isNotEmpty()) {
             "capturingRequestSequence requires at least one response"
         }
-        var index = 0
+        val index = AtomicInteger(0)
         return HttpClient(
             MockEngine { request ->
                 capture.record(
@@ -156,7 +171,7 @@ object MockHttpClient {
                     path = request.url.encodedPath,
                     query = request.url.encodedQuery,
                 )
-                val (status, body) = responses[minOf(index++, responses.size - 1)]
+                val (status, body) = responses[minOf(index.getAndIncrement(), responses.size - 1)]
                 respond(content = body, status = status, headers = JSON_HEADERS)
             }
         ) {
@@ -166,8 +181,7 @@ object MockHttpClient {
 
     /**
      * Builds a client that steps through [responses] in order, pinning the last entry once the
-     * sequence is exhausted. Each entry is a [Pair] of (status, body). The MockEngine block runs
-     * sequentially within a single coroutine, so a plain mutable [Int] is sufficient.
+     * sequence is exhausted. Each entry is a [Pair] of (status, body).
      *
      * Pass a custom [jsonFormat] when a response model contains `@Contextual` fields, same as
      * [respondingWith].
@@ -177,10 +191,10 @@ object MockHttpClient {
         jsonFormat: Json = json,
     ): HttpClient {
         require(responses.isNotEmpty()) { "respondingWithSequence requires at least one response" }
-        var index = 0
+        val index = AtomicInteger(0)
         return HttpClient(
             MockEngine {
-                val i = minOf(index++, responses.size - 1)
+                val i = minOf(index.getAndIncrement(), responses.size - 1)
                 val (status, body) = responses[i]
                 respond(content = body, status = status, headers = JSON_HEADERS)
             }
@@ -199,9 +213,15 @@ object MockHttpClient {
         jsonFormat: Json = json,
         body: (Int) -> String,
     ): HttpClient {
-        var index = 0
+        val index = AtomicInteger(0)
         return HttpClient(
-            MockEngine { respond(content = body(index++), status = status, headers = JSON_HEADERS) }
+            MockEngine {
+                respond(
+                    content = body(index.getAndIncrement()),
+                    status = status,
+                    headers = JSON_HEADERS,
+                )
+            }
         ) {
             installDefaults(jsonFormat)
         }
@@ -221,10 +241,10 @@ object MockHttpClient {
         body: String = "",
         onCall: (Int) -> Unit = {},
     ): HttpClient {
-        var index = 0
+        val index = AtomicInteger(0)
         return HttpClient(
             MockEngine {
-                val call = index++
+                val call = index.getAndIncrement()
                 onCall(call)
                 if (call < failures) throw failWith()
                 respond(content = body, status = status, headers = JSON_HEADERS)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/testutils/MockHttpClient.kt
@@ -8,6 +8,8 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.toByteArray
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.HttpCallValidator
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
@@ -18,6 +20,7 @@ import io.ktor.util.appendIfNameAbsent
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.serialization.json.Json
 
 /**
@@ -205,6 +208,48 @@ object MockHttpClient {
     }
 
     /**
+     * Builds a client that fails its first [failures] calls with the throwable [failWith] produces,
+     * then answers [status] / [body] for every call after that. Mirrors the relay fault the awaited
+     * TSS send has to survive: a peer's first outbound POSTs are rejected and then let through.
+     *
+     * [onCall] receives the zero-based call index before each call is served, for counting.
+     */
+    fun failingThenResponding(
+        failures: Int,
+        failWith: () -> Throwable,
+        status: HttpStatusCode = HttpStatusCode.OK,
+        body: String = "",
+        onCall: (Int) -> Unit = {},
+    ): HttpClient {
+        var index = 0
+        return HttpClient(
+            MockEngine {
+                val call = index++
+                onCall(call)
+                if (call < failures) throw failWith()
+                respond(content = body, status = status, headers = JSON_HEADERS)
+            }
+        ) {
+            installDefaults()
+        }
+    }
+
+    /**
+     * Builds a client whose transport never answers, so only a caller-imposed request timeout ends
+     * the call. Used to prove the awaited relay send caps a hung POST instead of letting it eat the
+     * ceremony's stall budget.
+     */
+    fun hanging(onCall: () -> Unit = {}): HttpClient =
+        HttpClient(
+            MockEngine {
+                onCall()
+                awaitCancellation()
+            }
+        ) {
+            installDefaults()
+        }
+
+    /**
      * Installs the standard plugins matching production
      * [com.vultisig.wallet.data.networkutils.HttpClientConfigurator].
      */
@@ -223,6 +268,8 @@ object MockHttpClient {
                 }
             }
         }
+        // Inert unless a request opts in with `timeout { … }`, exactly as in production.
+        install(HttpTimeout)
     }
 
     /**
@@ -233,7 +280,8 @@ object MockHttpClient {
      */
     private fun IOException.toNetworkException(): NetworkException =
         when (this) {
-            is SocketTimeoutException ->
+            is SocketTimeoutException,
+            is HttpRequestTimeoutException ->
                 NetworkException(0, "Connection timed out", NetworkErrorKind.Timeout, this)
             is UnknownHostException ->
                 NetworkException(0, "No internet connection", NetworkErrorKind.NoConnectivity, this)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/tss/TssMessengerSendAwaitTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/tss/TssMessengerSendAwaitTest.kt
@@ -1,0 +1,294 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.data.tss
+
+import com.vultisig.wallet.data.api.RelaySendBudget
+import com.vultisig.wallet.data.api.RelaySendDeadlineExceededException
+import com.vultisig.wallet.data.api.SessionApiImpl
+import com.vultisig.wallet.data.api.utils.HttpException
+import com.vultisig.wallet.data.mediator.Message
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import com.vultisig.wallet.data.usecases.Encryption
+import com.vultisig.wallet.data.utils.NetworkException
+import io.ktor.client.HttpClient
+import io.ktor.http.HttpStatusCode
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.jupiter.api.Test
+
+/**
+ * Covers [TssMessenger.sendAwait], the awaited relay send added for issue #5813.
+ *
+ * The bug it replaces: `send` fired the POST into a scope nobody joined and only logged the
+ * failure, so a lost relay message left the ceremony waiting 60 s for a reply that could never
+ * arrive, then restarting locally while the other devices were still on the old session.
+ * `sendAwait` waits for the relay to accept the message and throws when the budget is spent, which
+ * is what lets the keygen retry wrapper see the failure at all.
+ *
+ * `sendAwait recovers when the relay rejects the first three posts` is the issue's acceptance case:
+ * fail one device's first outbound POST three times, then let it through.
+ */
+class TssMessengerSendAwaitTest {
+
+    private val serverAddress = "http://relay.local"
+    private val sessionId = "session-1"
+    private val relayUrl = "$serverAddress/message/$sessionId"
+    // 32 hex chars: the AES-CBC path decodes the key as hex, so it has to be well formed.
+    private val encryptionHex = "00112233445566778899aabbccddeeff"
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Passes the body straight through so a test can read the sent payload without decrypting. */
+    private object PlaintextEncryption : Encryption {
+        override fun encrypt(data: ByteArray, password: ByteArray): ByteArray = data
+
+        override fun decrypt(data: ByteArray, password: ByteArray): ByteArray = data
+    }
+
+    private fun messenger(client: HttpClient, scope: CoroutineScope): TssMessenger =
+        TssMessenger(
+            serverAddress = serverAddress,
+            sessionID = sessionId,
+            encryptionHex = encryptionHex,
+            sessionApi = SessionApiImpl(json = json, httpClient = client),
+            coroutineScope = scope,
+            encryption = PlaintextEncryption,
+            isEncryptionGCM = true,
+        )
+
+    private fun alwaysFailing(onCall: (Int) -> Unit = {}): HttpClient =
+        MockHttpClient.failingThenResponding(
+            failures = Int.MAX_VALUE,
+            failWith = { IOException("relay unreachable") },
+            onCall = onCall,
+        )
+
+    private fun sequenceNoOf(requestBody: String): Int =
+        json
+            .parseToJsonElement(requestBody)
+            .jsonObject
+            .getValue("sequence_no")
+            .jsonPrimitive
+            .content
+            .toInt()
+
+    /**
+     * The issue's acceptance case. Three rejected posts then a good one must leave the ceremony
+     * with a delivered message and no error, rather than a swallowed failure and a 60 s stall.
+     */
+    @Test
+    fun `sendAwait recovers when the relay rejects the first three posts`() = runTest {
+        val calls = AtomicInteger(0)
+        val client =
+            MockHttpClient.failingThenResponding(
+                failures = 3,
+                failWith = { IOException("relay unreachable") },
+                onCall = { calls.incrementAndGet() },
+            )
+
+        messenger(client, this).sendAwait("deviceA", "deviceB", "round-one-payload")
+
+        assertEquals(4, calls.get(), "should have used all four attempts")
+        // 1 s + 2 s + 4 s of backoff between the four attempts.
+        assertEquals(7_000L, currentTime)
+    }
+
+    /**
+     * Every retry has to carry the byte-identical message. The relay stores by
+     * `session-recipient-hash` and receivers dedupe by the same key, so a message rebuilt per
+     * attempt — a fresh sequence number, or a fresh AES-GCM nonce — would be applied twice.
+     */
+    @Test
+    fun `sendAwait resends the identical message on every attempt`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val client =
+            MockHttpClient.capturingRequestSequence(
+                capture,
+                HttpStatusCode.InternalServerError to "boom",
+                HttpStatusCode.InternalServerError to "boom",
+                HttpStatusCode.OK to "",
+            )
+
+        messenger(client, this).sendAwait("deviceA", "deviceB", "round-one-payload")
+
+        assertEquals(3, capture.bodies.size)
+        assertEquals(1, capture.bodies.toSet().size, "every attempt must send the same bytes")
+    }
+
+    @Test
+    fun `sendAwait numbers consecutive messages in order`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val messenger =
+            messenger(MockHttpClient.capturingRequest(HttpStatusCode.OK, "", capture), this)
+
+        messenger.sendAwait("deviceA", "deviceB", "first")
+        messenger.sendAwait("deviceA", "deviceB", "second")
+
+        assertContentEquals(listOf(1, 2), capture.bodies.map(::sequenceNoOf))
+    }
+
+    /**
+     * The DKLS ceremonies now fan one round out to every peer at once, so the sequence counter is
+     * written concurrently. A lost increment would give two messages bound for the same peer the
+     * same number, and the receiver sorts by it before applying.
+     */
+    @Test
+    fun `concurrent sends never reuse a sequence number`() = runTest {
+        val capture = MockHttpClient.RequestCapture()
+        val messenger =
+            messenger(MockHttpClient.capturingRequest(HttpStatusCode.OK, "", capture), this)
+
+        (1..16)
+            .map { peer -> async { messenger.sendAwait("deviceA", "device$peer", "payload") } }
+            .awaitAll()
+
+        assertContentEquals((1..16).toList(), capture.bodies.map(::sequenceNoOf).sorted())
+    }
+
+    @Test
+    fun `sendAwait throws once the budget is spent`() = runTest {
+        val calls = AtomicInteger(0)
+        val messenger = messenger(alwaysFailing { calls.incrementAndGet() }, this)
+
+        assertFailsWith<NetworkException> {
+            messenger.sendAwait("deviceA", "deviceB", "round-one-payload")
+        }
+        assertEquals(RelaySendBudget.DEFAULT_MAX_ATTEMPTS, calls.get())
+    }
+
+    @Test
+    fun `sendAwait retries a relay 5xx`() = runTest {
+        val client =
+            MockHttpClient.respondingWithSequence(
+                HttpStatusCode.InternalServerError to "boom",
+                HttpStatusCode.OK to "",
+            )
+
+        messenger(client, this).sendAwait("deviceA", "deviceB", "round-one-payload")
+
+        assertEquals(1_000L, currentTime, "one backoff only")
+    }
+
+    /** A rejected message is deterministic: resending it three more times cannot help. */
+    @Test
+    fun `sendAwait gives up immediately on a 4xx`() = runTest {
+        val calls = AtomicInteger(0)
+        val client =
+            MockHttpClient.failingThenResponding(
+                failures = 0,
+                failWith = { IOException("unused") },
+                status = HttpStatusCode.BadRequest,
+                body = "rejected",
+                onCall = { calls.incrementAndGet() },
+            )
+
+        assertFailsWith<HttpException> {
+            messenger(client, this).sendAwait("deviceA", "deviceB", "round-one-payload")
+        }
+        assertEquals(1, calls.get())
+        assertEquals(0L, currentTime, "a 4xx must not spend any backoff")
+    }
+
+    /**
+     * The keysign poll deadline is absolute (`KeysignMessagePoller`, issue #5488). A send started
+     * from inside an applied message must not outlive it — past the deadline there is nothing left
+     * to send into, and the attempt has already failed.
+     */
+    @Test
+    fun `sendAwait refuses to start once the ceremony deadline has passed`() = runTest {
+        val calls = AtomicInteger(0)
+        val client =
+            MockHttpClient.failingThenResponding(
+                failures = 0,
+                failWith = { IOException("unused") },
+                onCall = { calls.incrementAndGet() },
+            )
+
+        assertFailsWith<RelaySendDeadlineExceededException> {
+            messenger(client, this)
+                .sendAwait(
+                    from = "deviceA",
+                    to = "deviceB",
+                    body = "round-one-payload",
+                    deadlineNanos = System.nanoTime() - 1,
+                )
+        }
+        assertEquals(0, calls.get(), "no request should be started past the deadline")
+    }
+
+    /**
+     * A hung POST used to inherit the client's own timeouts and could sit there while the ceremony
+     * clock ran out. The per-request budget ends it so the attempt is retried instead.
+     *
+     * Real milliseconds, not virtual: Ktor's `HttpTimeout` runs its killer in the client's own
+     * scope rather than the test scheduler's, so the timeout is kept small instead of mocked away.
+     */
+    @Test
+    fun `a hung request is capped instead of waiting out the client default`() = runTest {
+        val calls = AtomicInteger(0)
+        val api =
+            SessionApiImpl(json = json, httpClient = MockHttpClient.hanging(calls::incrementAndGet))
+        val message = Message(sessionId, "deviceA", listOf("deviceB"), "body", "hash", 1)
+
+        assertFailsWith<NetworkException> {
+            api.sendTssMessage(
+                serverUrl = relayUrl,
+                messageId = null,
+                message = message,
+                budget =
+                    RelaySendBudget(
+                        maxAttempts = 2,
+                        requestTimeout = 50.milliseconds,
+                        initialBackoff = 1.milliseconds,
+                    ),
+            )
+        }
+        assertEquals(2, calls.get(), "the hung request must time out and be retried")
+    }
+
+    /**
+     * The legacy GG20 path is a gomobile `tss.Messenger` implementation called synchronously from
+     * native code, so [TssMessenger.send] keeps its signature and its swallow-and-log behaviour.
+     * Changing it is out of scope for #5813 and would break the interface.
+     */
+    @Test
+    fun `the legacy send still swallows a failing relay`() = runTest {
+        val calls = AtomicInteger(0)
+        // A 4xx so the shared relay retry gives up at once and the legacy loop's own three
+        // attempts are the only ones, with no backoff to wait out on a real dispatcher.
+        val client =
+            MockHttpClient.failingThenResponding(
+                failures = 0,
+                failWith = { IOException("unused") },
+                status = HttpStatusCode.BadRequest,
+                body = "rejected",
+                onCall = { calls.incrementAndGet() },
+            )
+        val sendScope = CoroutineScope(Dispatchers.Default)
+
+        try {
+            // Must neither throw nor block the caller.
+            messenger(client, sendScope).send("deviceA", "deviceB", "round-one-payload")
+            sendScope.coroutineContext.job.children.toList().joinAll()
+
+            assertEquals(3, calls.get(), "the legacy loop tries three times and gives up quietly")
+        } finally {
+            sendScope.cancel()
+        }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/tss/TssMessengerSendAwaitTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/tss/TssMessengerSendAwaitTest.kt
@@ -4,6 +4,7 @@ package com.vultisig.wallet.data.tss
 
 import com.vultisig.wallet.data.api.RelaySendBudget
 import com.vultisig.wallet.data.api.RelaySendDeadlineExceededException
+import com.vultisig.wallet.data.api.RelaySendFailedException
 import com.vultisig.wallet.data.api.SessionApiImpl
 import com.vultisig.wallet.data.api.utils.HttpException
 import com.vultisig.wallet.data.mediator.Message
@@ -17,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -160,14 +162,23 @@ class TssMessengerSendAwaitTest {
         assertContentEquals((1..16).toList(), capture.bodies.map(::sequenceNoOf).sorted())
     }
 
+    /**
+     * The type is load-bearing, not decoration: the ceremony poll loops wrap the relay read and the
+     * outbound round in one broad catch, and tell a lost send from a failed read by this class
+     * alone. A bare transport exception here is swallowed by the loop waiting on the reply.
+     */
     @Test
-    fun `sendAwait throws once the budget is spent`() = runTest {
+    fun `sendAwait throws a marked send failure once the budget is spent`() = runTest {
         val calls = AtomicInteger(0)
         val messenger = messenger(alwaysFailing { calls.incrementAndGet() }, this)
 
-        assertFailsWith<NetworkException> {
-            messenger.sendAwait("deviceA", "deviceB", "round-one-payload")
-        }
+        val failure =
+            assertFailsWith<RelaySendFailedException> {
+                messenger.sendAwait("deviceA", "deviceB", "round-one-payload")
+            }
+
+        assertEquals("failed to send the message to deviceB", failure.message)
+        assertIs<NetworkException>(failure.cause, "the transport fault must stay on the cause")
         assertEquals(RelaySendBudget.DEFAULT_MAX_ATTEMPTS, calls.get())
     }
 
@@ -197,9 +208,12 @@ class TssMessengerSendAwaitTest {
                 onCall = { calls.incrementAndGet() },
             )
 
-        assertFailsWith<HttpException> {
-            messenger(client, this).sendAwait("deviceA", "deviceB", "round-one-payload")
-        }
+        val failure =
+            assertFailsWith<RelaySendFailedException> {
+                messenger(client, this).sendAwait("deviceA", "deviceB", "round-one-payload")
+            }
+
+        assertIs<HttpException>(failure.cause, "the rejection status must stay on the cause")
         assertEquals(1, calls.get())
         assertEquals(0L, currentTime, "a 4xx must not spend any backoff")
     }
@@ -219,15 +233,18 @@ class TssMessengerSendAwaitTest {
                 onCall = { calls.incrementAndGet() },
             )
 
-        assertFailsWith<RelaySendDeadlineExceededException> {
-            messenger(client, this)
-                .sendAwait(
-                    from = "deviceA",
-                    to = "deviceB",
-                    body = "round-one-payload",
-                    deadlineNanos = System.nanoTime() - 1,
-                )
-        }
+        val failure =
+            assertFailsWith<RelaySendDeadlineExceededException> {
+                messenger(client, this)
+                    .sendAwait(
+                        from = "deviceA",
+                        to = "deviceB",
+                        body = "round-one-payload",
+                        deadlineNanos = System.nanoTime() - 1,
+                    )
+            }
+
+        assertIs<RelaySendFailedException>(failure, "the poll loops key on the marked type")
         assertEquals(0, calls.get(), "no request should be started past the deadline")
     }
 


### PR DESCRIPTION
Closes #5813

## Why

Three signers in far apart regions hit `timeout: failed to create vault within 60 seconds` nine times in a row.

`TssMessenger.send` fired the relay POST into a `coroutineScope.launch` that nothing joined, retried three times with no backoff, and returned normally after the last failure. A lost message therefore left the ceremony waiting out the full stall for a reply that could never arrive — then restarting locally while the other two devices were still on the old session.

## What changed

- **`TssMessenger.sendAwait`** — awaited send that throws when its budget is spent, so `runKeygenWithRetry` can finally see the failure. The `Message` is built once, so every attempt carries the same hash and sequence number and the relay and receiver dedupe it rather than applying it twice. `send` keeps its gomobile `tss.Messenger` signature for the legacy GG20 path, which native code calls synchronously.

- **`RelaySendBudget`** — 4 attempts, 8 s per request, 1/2/4 s backoff: **39 s worst case, inside the 60 s stall**. Worth noting the retry policy already existed one layer down in `withRelayRetry` (since #4667), so this tightens it for a single call instead of nesting a second loop — a naive re-implementation would have given 3 × 4 = 12 attempts. Without a budget every other endpoint keeps the shared three-attempt policy, the GG20 send included.

- **Per-request timeout is opt-in.** `HttpTimeout` is installed with no defaults and stays inert unless a request asks for it; only the awaited send does. The legacy messenger posts to the same endpoint and is deliberately unaffected.

- **`RelayFanOut`** — an outbound round contacts every peer concurrently. This is what makes the awaited send affordable: a serial loop would multiply 39 s by the committee size and blow the stall on retries alone. The sequence counter is atomic to match.

- **`CeremonyStallClock`** — the three keygen loops now measure the gap since the last *applied* inbound message instead of from attempt start, so a slow but healthy ceremony survives. *Applied* rather than *arrived* is load-bearing: a message this device cannot clear is re-served by every poll, which is exactly why `KeysignMessagePoller` keeps an **absolute** deadline (#5488) and is left alone here. Sends triggered from inside a keysign attempt are clipped to what remains of that deadline, so a send cannot outlive the round it belongs to.

`POST /start` was already awaited on Android (`KeygenPeerDiscoveryViewModel.next()`), so the iOS change for it has no counterpart here.

One build change: `data/build.gradle.kts` moves the tss AAR from `testCompileOnly` to `testImplementation` — JUnit cannot resolve a test class that names `TssMessenger` unless the `tss.Messenger` interface is on the test runtime classpath.

## Parity

iOS shipped the same fix in vultisig/vultisig-ios#5318 (merged). Two deliberate divergences:

- iOS marks its stall clock on **outbound sends** as well as inbound, because `DKLSMessenger.send` fans out serially. Kotlin does not have to — the concurrent fan-out bounds a round at one budget regardless of peer count.
- iOS added a 240 s `CeremonyWatchdog` hard ceiling. Not ported: `runKeygenWithRetry` already bounds the ceremony at 3 attempts, so a second ceiling is a larger refactor than this issue asks for.

vultisig/vultisig-sdk#2311 is still open.

## Test plan

**6,054 unit tests pass across both modules, 0 failures** — 36 of them new. Counts verified in the XML reports rather than trusting a green build, since JUnit 5 silently skips a non-`Unit` `@Test`.

| Suite | Covers |
|---|---|
| `TssMessengerSendAwaitTest` (10) | the issue's acceptance shape — three rejected POSTs then success, against a real `SessionApiImpl` and a mock relay; identical bytes on every retry; distinct sequence numbers under concurrency; 4xx fails fast; hung request is capped; legacy `send` still swallows |
| `RelaySendBudgetTest` (12) | the 39 s < 60 s invariant, backoff doubling, deadline clipping |
| `CeremonyStallClockTest` (8) | a ceremony with a message every 30 s no longer trips at 60 s; a real stall still does |
| `RelayFanOutTest` (6) | three 5 s sends cost 5 s not 15 s; a failure propagates and cancels its siblings |
| `SessionApiTest` (+4) | budget path retries 4× with 1/2/4 s; **no** budget still uses the shared 3-attempt policy |

`:app` and `:data` `compileDebugAndroidTestKotlin` both compile — the `SessionApi` signature change would otherwise have broken androidTest invisibly. Lint passes; no changed file appears in its output. ktfmt applied.

**Not verified:** the issue's 3-device acceptance run (fail one device's first POST three times, then let it through). I could not complete it on emulators — the AVDs available are clones that share an `ANDROID_ID`, so all three derive the same `localPartyId` and the relay collapses them into a single participant. That is a test-rig limitation, not something this branch changes. The multi-device run still needs a pass on real hardware before merge.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved key generation and signing message delivery through concurrent fan-out.
  - Added bounded retries, request timeouts, and deadline-aware relay handling.

- **Bug Fixes**
  - Ceremonies now detect stalls based on actual progress rather than a fixed overall timeout.
  - Improved cancellation and failure handling when relay deliveries fail.

- **Performance**
  - Messages are delivered to multiple recipients concurrently, reducing delays during ceremonies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->