### PR TITLE
fix(swap): show the referral's real saving, and stop charging the top tier for it

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapDiscountChecker.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapDiscountChecker.kt
@@ -1,6 +1,6 @@
 package com.vultisig.wallet.ui.models.swap
 
-import com.vultisig.wallet.data.chains.helpers.THORChainSwaps
+import com.vultisig.wallet.data.chains.helpers.ThorChainAffiliateHelper
 import com.vultisig.wallet.data.usecases.getTierType
 import com.vultisig.wallet.ui.screens.settings.TierType
 import javax.inject.Inject
@@ -28,9 +28,9 @@ internal class SwapDiscountChecker @Inject constructor() {
             tierType = vultBPSDiscount?.getTierType(),
         )
 
-    fun checkReferralBpsDiscount(tierType: TierType?, code: String): ReferralDiscountResult {
+    fun checkReferralBpsDiscount(vultBpsDiscount: Int?, code: String): ReferralDiscountResult {
         val referralBpsDiscount =
-            referralBpsFor(tierType)
+            referralBpsFor(vultBpsDiscount)
                 ?: return ReferralDiscountResult(referralBpsDiscount = null, referralCode = null)
         return ReferralDiscountResult(
             referralBpsDiscount = referralBpsDiscount,
@@ -40,8 +40,13 @@ internal class SwapDiscountChecker @Inject constructor() {
 }
 
 /**
- * Referral discount in bps for a swap at [tierType], or null when none applies: Ultimate already
- * pays no affiliate fee, so there is nothing left for a referral to take off.
+ * What a saved referral code saves the user on a THORChain swap at [vultBpsDiscount], or null when
+ * there is nothing to show.
+ *
+ * Taken from the request builder's own arithmetic so the row states the difference the code makes
+ * to the totals actually sent, rather than the referrer's payout — which is a leg the user pays,
+ * not a reduction, and read as a saving it overstated the row twofold (#5765). Null covers both
+ * ends: no code sent means no row, and a code that saves nothing has no saving to itemize.
  */
-internal fun referralBpsFor(tierType: TierType?): Int? =
-    THORChainSwaps.REFERRED_USER_FEE_RATE_BP.takeUnless { tierType == TierType.ULTIMATE }
+internal fun referralBpsFor(vultBpsDiscount: Int?): Int? =
+    ThorChainAffiliateHelper.referralSavingBps(vultBpsDiscount ?: 0).takeIf { it > 0 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuoteManager.kt
@@ -25,7 +25,6 @@ import com.vultisig.wallet.data.repositories.swap.convertToTokenValue
 import com.vultisig.wallet.data.usecases.ConvertTokenToToken
 import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
 import com.vultisig.wallet.data.usecases.SearchTokenUseCase
-import com.vultisig.wallet.data.usecases.getTierType
 import com.vultisig.wallet.data.utils.plus
 import com.vultisig.wallet.data.utils.thorswapMultiplier
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
@@ -237,7 +236,7 @@ internal fun QuoteCandidate.discountBps(): SwapDiscountBps =
         vult = vultBPSDiscount,
         referral =
             if (provider == SwapProvider.THORCHAIN && this.referral != null) {
-                referralBpsFor(vultBPSDiscount?.getTierType())
+                referralBpsFor(vultBPSDiscount)
             } else null,
     )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapQuotePipeline.kt
@@ -15,7 +15,6 @@ import com.vultisig.wallet.data.repositories.ReferralCodeSettingsRepository
 import com.vultisig.wallet.data.repositories.SwapQuoteRepository
 import com.vultisig.wallet.data.usecases.ConvertTokenAndValueToTokenValueUseCase
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
-import com.vultisig.wallet.data.usecases.getTierType
 import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
 import com.vultisig.wallet.ui.models.send.SendSrc
 import com.vultisig.wallet.ui.utils.UiText
@@ -421,8 +420,7 @@ internal class SwapQuotePipeline(
         var referralCodeToStore: String? = null
         if (provider == SwapProvider.THORCHAIN) {
             referral?.let { code ->
-                val tierType = vultBPSDiscount?.getTierType()
-                val result = swapDiscountChecker.checkReferralBpsDiscount(tierType, code)
+                val result = swapDiscountChecker.checkReferralBpsDiscount(vultBPSDiscount, code)
                 referralCodeToStore = result.referralCode
                 discountInfo = discountInfo.copy(referralBpsDiscount = result.referralBpsDiscount)
             }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapDiscountCheckerTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapDiscountCheckerTest.kt
@@ -1,0 +1,82 @@
+package com.vultisig.wallet.ui.models.swap
+
+import com.vultisig.wallet.data.chains.helpers.ThorChainAffiliateHelper
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.BRONZE_DISCOUNT_BPS
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.DIAMOND_DISCOUNT_BPS
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.GOLD_DISCOUNT_BPS
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.NO_DISCOUNT_BPS
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.PLATINUM_DISCOUNT_BPS
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.SILVER_DISCOUNT_BPS
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.ULTIMATE_DISCOUNT_BPS
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+/**
+ * The referral row states what a saved code does to the user's own fee. Nothing used to pin that
+ * against the bps the request builder sends, which is how the row came to show the referrer's
+ * payout — twice the real saving — and how a top-tier user came to be charged for a code whose row
+ * was hidden (#5765).
+ */
+internal class SwapDiscountCheckerTest {
+
+    private val checker = SwapDiscountChecker()
+
+    /** Every tier discount a swap can carry below Ultimate, which is covered on its own below. */
+    private val tierDiscounts =
+        listOf(
+            NO_DISCOUNT_BPS,
+            BRONZE_DISCOUNT_BPS,
+            SILVER_DISCOUNT_BPS,
+            GOLD_DISCOUNT_BPS,
+            PLATINUM_DISCOUNT_BPS,
+            DIAMOND_DISCOUNT_BPS,
+        )
+
+    /** Total bps thornode charges for a request, which sums the legs of a multi-affiliate list. */
+    private fun sentBps(code: String, discountBps: Int): Int =
+        ThorChainAffiliateHelper.buildAffiliateParams(code, discountBps)["affiliate_bps"]!!.split(
+                "/"
+            )
+            .sumOf { it.toInt() }
+
+    @Test
+    fun `the displayed bps is the delta between the totals sent with and without a code`() {
+        for (discount in tierDiscounts) {
+            val saved = sentBps(code = "vulti", discountBps = discount)
+            val unsaved = sentBps(code = "", discountBps = discount)
+
+            referralBpsFor(discount) shouldBe (unsaved - saved)
+        }
+    }
+
+    @Test
+    fun `that delta is 5 bps at every tier through Diamond, not the referrer's 10`() {
+        for (discount in tierDiscounts) {
+            referralBpsFor(discount) shouldBe 5
+        }
+    }
+
+    @Test
+    fun `a vault with no resolved tier is treated as undiscounted`() {
+        referralBpsFor(null) shouldBe referralBpsFor(NO_DISCOUNT_BPS)
+    }
+
+    @Test
+    fun `the top tier shows no row because the code is not sent, not because it is hidden`() {
+        // The row used to be suppressed at Ultimate while "10/0" still went on the wire, so the
+        // user paid 10 bps invisibly. The code is dropped now, so there is genuinely nothing to
+        // show and the fee is the same 0 an unreferred vault pays.
+        sentBps(code = "vulti", discountBps = ULTIMATE_DISCOUNT_BPS) shouldBe 0
+        sentBps(code = "", discountBps = ULTIMATE_DISCOUNT_BPS) shouldBe 0
+        referralBpsFor(ULTIMATE_DISCOUNT_BPS) shouldBe null
+    }
+
+    @Test
+    fun `a code is cached back only when it actually discounts the swap`() {
+        checker.checkReferralBpsDiscount(GOLD_DISCOUNT_BPS, "vulti") shouldBe
+            ReferralDiscountResult(referralBpsDiscount = 5, referralCode = "vulti")
+
+        checker.checkReferralBpsDiscount(ULTIMATE_DISCOUNT_BPS, "vulti") shouldBe
+            ReferralDiscountResult(referralBpsDiscount = null, referralCode = null)
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFeeRowTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/swap/SwapFeeRowTest.kt
@@ -1,6 +1,6 @@
 package com.vultisig.wallet.ui.models.swap
 
-import com.vultisig.wallet.data.chains.helpers.THORChainSwaps
+import com.vultisig.wallet.data.chains.helpers.ThorChainAffiliateHelper
 import com.vultisig.wallet.data.models.FiatValue
 import com.vultisig.wallet.data.models.SwapProvider
 import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCaseImpl.Companion.GOLD_DISCOUNT_BPS
@@ -20,6 +20,9 @@ internal class SwapFeeRowTest {
 
     /** A $200 source notional, so 20 bps prices at $0.40 and 10 bps at $0.20. */
     private val srcFiat = usd("200.00")
+
+    /** What a referral takes off the user's own fee at every tier through Diamond. */
+    private val referralSaving = ThorChainAffiliateHelper.referralSavingBps(GOLD_DISCOUNT_BPS)
 
     /** BigDecimal equality is scale-sensitive, and the row's arithmetic fixes no scale. */
     private infix fun FiatValue?.shouldBeUsd(amount: String?) {
@@ -161,13 +164,15 @@ internal class SwapFeeRowTest {
         val kyber =
             QuoteCandidate(SwapProvider.KYBER, GOLD_DISCOUNT_BPS, referral = "vulti").discountBps()
 
-        thor shouldBe SwapDiscountBps(GOLD_DISCOUNT_BPS, THORChainSwaps.REFERRED_USER_FEE_RATE_BP)
+        // The user's saving, not the referrer's payout: Vultisig gives up 15 to pay the referrer
+        // 10, so 5 reaches the user (#5765).
+        thor shouldBe SwapDiscountBps(GOLD_DISCOUNT_BPS, referralSaving)
         // Every other provider resolves no referral, so the picker row must not price one.
         kyber shouldBe SwapDiscountBps(GOLD_DISCOUNT_BPS, null)
     }
 
     @Test
-    fun `resolves no referral discount at Ultimate, which already pays nothing`() {
+    fun `resolves no referral discount at Ultimate, where the code is not sent`() {
         QuoteCandidate(SwapProvider.THORCHAIN, ULTIMATE_DISCOUNT_BPS, referral = "vulti")
             .discountBps() shouldBe SwapDiscountBps(ULTIMATE_DISCOUNT_BPS, null)
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/THORChainSwaps.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/THORChainSwaps.kt
@@ -22,9 +22,25 @@ class THORChainSwaps(
 ) {
     companion object {
         const val AFFILIATE_FEE_ADDRESS = "va"
-        const val AFFILIATE_FEE_RATE_BP = 50 // 50 BP
-        const val REFERRED_AFFILIATE_FEE_RATE_BP = 35 // 35 BP when there's a referral
-        const val REFERRED_USER_FEE_RATE_BP = 10 // 10 BP for the referrer
+
+        // The three legs of the affiliate fee, all charged to the user. thornode sums the legs of
+        // a multi-affiliate request, so a referred swap costs REFERRER_PAYOUT_BPS +
+        // REFERRED_AFFILIATE_FEE_RATE_BP, not AFFILIATE_FEE_RATE_BP carved into two.
+        // [ThorChainAffiliateHelper] is where they are combined; derive from it rather than
+        // reading a single leg as if it were a total.
+
+        /** Vultisig's whole take when no referral code is sent. */
+        const val AFFILIATE_FEE_RATE_BP = 50
+
+        /** Vultisig's reduced take when a referral code is sent alongside it. */
+        const val REFERRED_AFFILIATE_FEE_RATE_BP = 35
+
+        /**
+         * What the *referrer* is paid, on top of Vultisig's reduced take — not the referred user's
+         * fee and not their saving. The user saves the difference between the two totals, which is
+         * [ThorChainAffiliateHelper.referralSavingBps].
+         */
+        const val REFERRER_PAYOUT_BPS = 10
 
         // Legacy constants for backward compatibility
         const val AFFILIATE_FEE_RATE = "50"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorChainAffiliateHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/ThorChainAffiliateHelper.kt
@@ -1,16 +1,20 @@
 package com.vultisig.wallet.data.chains.helpers
 
-/** Builds THORChain swap affiliate query parameters, applying referral codes and BPS discounts. */
+/**
+ * Builds THORChain swap affiliate query parameters, and is the single place the referral's cost to
+ * the user is worked out — the wire params and the referral row the UI shows are both derived from
+ * [referralSavingBps], so the number displayed cannot drift from the number sent (#5765).
+ */
 object ThorChainAffiliateHelper {
 
     /**
      * Returns the `affiliate` and `affiliate_bps` query parameters for a swap request.
      *
      * @param referralCode user's referral code; empty string means no referrer
-     * @param discountBps discount in basis points to subtract from the base affiliate fee
+     * @param discountBps VULT tier discount in basis points, subtracted from Vultisig's own leg
      */
     fun buildAffiliateParams(referralCode: String, discountBps: Int): Map<String, String> {
-        return if (referralCode.isNotEmpty()) {
+        return if (appliesReferral(referralCode, discountBps)) {
             val affiliateFeeRateBp =
                 calculateBpsAfterDiscount(
                     baseBps = THORChainSwaps.REFERRED_AFFILIATE_FEE_RATE_BP,
@@ -18,7 +22,7 @@ object ThorChainAffiliateHelper {
                 )
             mapOf(
                 "affiliate" to "$referralCode/${THORChainSwaps.AFFILIATE_FEE_ADDRESS}",
-                "affiliate_bps" to "${THORChainSwaps.REFERRED_USER_FEE_RATE_BP}/$affiliateFeeRateBp",
+                "affiliate_bps" to "${THORChainSwaps.REFERRER_PAYOUT_BPS}/$affiliateFeeRateBp",
             )
         } else {
             val affiliateFeeRateBp =
@@ -32,6 +36,43 @@ object ThorChainAffiliateHelper {
             )
         }
     }
+
+    /**
+     * Whether a saved [referralCode] is actually sent at [discountBps].
+     *
+     * It is, unless it would make the user pay *more* than sending no code at all. Both legs are
+     * clamped at zero independently, so the referrer's fixed payout stops being covered by
+     * Vultisig's reduction once the tier discount has eaten Vultisig's leg — at the Ultimate tier
+     * the referred total is 10 bps against an unreferred 0, and the user was being charged that
+     * silently while the row was hidden. Where the code costs nothing extra it is still sent, so
+     * the referrer keeps their payout whenever it is not the user paying for it.
+     */
+    fun appliesReferral(referralCode: String, discountBps: Int): Boolean =
+        referralCode.isNotEmpty() && referralSavingBps(discountBps) >= 0
+
+    /**
+     * What sending the code saves the user, in bps, at [discountBps]. Negative means it costs them.
+     *
+     * This — not [THORChainSwaps.REFERRER_PAYOUT_BPS] — is the referral row's number: the referrer
+     * is paid 10 while Vultisig gives up 15, so the user keeps the 5 bps difference.
+     */
+    fun referralSavingBps(discountBps: Int): Int =
+        unreferredTotalBps(discountBps) - referredTotalBps(discountBps)
+
+    /** Total bps the user pays with a referral code on the request: both affiliate legs summed. */
+    fun referredTotalBps(discountBps: Int): Int =
+        THORChainSwaps.REFERRER_PAYOUT_BPS +
+            calculateBpsAfterDiscount(
+                baseBps = THORChainSwaps.REFERRED_AFFILIATE_FEE_RATE_BP,
+                discountBps = discountBps,
+            )
+
+    /** Total bps the user pays with no referral code on the request. */
+    fun unreferredTotalBps(discountBps: Int): Int =
+        calculateBpsAfterDiscount(
+            baseBps = THORChainSwaps.AFFILIATE_FEE_RATE_BP,
+            discountBps = discountBps,
+        )
 
     private fun calculateBpsAfterDiscount(baseBps: Int, discountBps: Int): Int {
         return maxOf(0, baseBps - discountBps)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ThorChainAffiliateHelperTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/ThorChainAffiliateHelperTest.kt
@@ -1,9 +1,19 @@
 package com.vultisig.wallet.data.chains.helpers
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 class ThorChainAffiliateHelperTest {
+
+    private companion object {
+        /**
+         * VULT tier discounts a swap can carry, up to Diamond. Ultimate (50) is called out apart.
+         */
+        val TIER_DISCOUNTS = listOf(0, 5, 10, 20, 25, 35)
+        const val ULTIMATE_DISCOUNT_BPS = 50
+    }
 
     @Test
     fun `no referral code, zero discount uses default affiliate fee rate`() {
@@ -41,7 +51,7 @@ class ThorChainAffiliateHelperTest {
 
         assertEquals("alice/${THORChainSwaps.AFFILIATE_FEE_ADDRESS}", params["affiliate"])
         assertEquals(
-            "${THORChainSwaps.REFERRED_USER_FEE_RATE_BP}/${THORChainSwaps.REFERRED_AFFILIATE_FEE_RATE_BP}",
+            "${THORChainSwaps.REFERRER_PAYOUT_BPS}/${THORChainSwaps.REFERRED_AFFILIATE_FEE_RATE_BP}",
             params["affiliate_bps"],
         )
     }
@@ -54,7 +64,7 @@ class ThorChainAffiliateHelperTest {
         val expectedAffiliateBps = THORChainSwaps.REFERRED_AFFILIATE_FEE_RATE_BP - 20
         assertEquals("alice/${THORChainSwaps.AFFILIATE_FEE_ADDRESS}", params["affiliate"])
         assertEquals(
-            "${THORChainSwaps.REFERRED_USER_FEE_RATE_BP}/$expectedAffiliateBps",
+            "${THORChainSwaps.REFERRER_PAYOUT_BPS}/$expectedAffiliateBps",
             params["affiliate_bps"],
         )
     }
@@ -64,7 +74,7 @@ class ThorChainAffiliateHelperTest {
         val params =
             ThorChainAffiliateHelper.buildAffiliateParams(referralCode = "alice", discountBps = 40)
 
-        assertEquals("${THORChainSwaps.REFERRED_USER_FEE_RATE_BP}/0", params["affiliate_bps"])
+        assertEquals("${THORChainSwaps.REFERRER_PAYOUT_BPS}/0", params["affiliate_bps"])
     }
 
     @Test
@@ -77,21 +87,92 @@ class ThorChainAffiliateHelperTest {
     }
 
     @Test
-    fun `full discount keeps the referral split and still pays the referrer`() {
+    fun `full discount drops the referral rather than charging a user who owes nothing`() {
+        // Ultimate pays no affiliate fee at all, so the referrer's leg would be the user's whole
+        // bill: "10/0" is charged 10 bps where "0" is charged nothing (#5765).
         val params =
             ThorChainAffiliateHelper.buildAffiliateParams(referralCode = "alice", discountBps = 50)
 
-        assertEquals("alice/${THORChainSwaps.AFFILIATE_FEE_ADDRESS}", params["affiliate"])
-        assertEquals("${THORChainSwaps.REFERRED_USER_FEE_RATE_BP}/0", params["affiliate_bps"])
+        assertEquals(THORChainSwaps.AFFILIATE_FEE_ADDRESS, params["affiliate"])
+        assertEquals("0", params["affiliate_bps"])
     }
 
     @Test
-    fun `discount beyond the referred affiliate base still preserves the referrer share`() {
+    fun `discount beyond the referred affiliate base also drops the referral`() {
         val params =
             ThorChainAffiliateHelper.buildAffiliateParams(referralCode = "alice", discountBps = 100)
 
-        assertEquals("alice/${THORChainSwaps.AFFILIATE_FEE_ADDRESS}", params["affiliate"])
-        assertEquals("${THORChainSwaps.REFERRED_USER_FEE_RATE_BP}/0", params["affiliate_bps"])
+        assertEquals(THORChainSwaps.AFFILIATE_FEE_ADDRESS, params["affiliate"])
+        assertEquals("0", params["affiliate_bps"])
+    }
+
+    @Test
+    fun `the referral is kept while it costs the user nothing extra`() {
+        // At 40 bps both routes bill 10, so the code is not the user's problem and the referrer
+        // keeps their payout — the split the test above pins. Only a code that would *raise* the
+        // bill is dropped.
+        assertEquals(10, ThorChainAffiliateHelper.unreferredTotalBps(40))
+        assertEquals(10, ThorChainAffiliateHelper.referredTotalBps(40))
+        assertTrue(ThorChainAffiliateHelper.appliesReferral("alice", 40))
+    }
+
+    @Test
+    fun `the saving is the delta between the totals actually sent, at every tier`() {
+        // Measured against thornode: an affiliate list of "10/35" is charged exactly as a flat 45,
+        // so the code moves the user from 50 to 45 — 5 bps, never the referrer's 10.
+        for (discount in TIER_DISCOUNTS) {
+            val saving = ThorChainAffiliateHelper.referralSavingBps(discount)
+            assertEquals(
+                ThorChainAffiliateHelper.unreferredTotalBps(discount) -
+                    ThorChainAffiliateHelper.referredTotalBps(discount),
+                saving,
+                "discount=$discount",
+            )
+            assertEquals(5, saving, "discount=$discount")
+        }
+    }
+
+    @Test
+    fun `the totals match the bps the request builder puts on the wire`() {
+        for (discount in TIER_DISCOUNTS + listOf(ULTIMATE_DISCOUNT_BPS)) {
+            val referred =
+                ThorChainAffiliateHelper.buildAffiliateParams("alice", discount)["affiliate_bps"]!!
+            val unreferred =
+                ThorChainAffiliateHelper.buildAffiliateParams("", discount)["affiliate_bps"]!!
+
+            assertEquals(
+                ThorChainAffiliateHelper.unreferredTotalBps(discount),
+                unreferred.toInt(),
+                "unreferred discount=$discount",
+            )
+            // Whichever branch the gate took, the legs sent sum to what the user is billed.
+            val expectedReferred =
+                if (ThorChainAffiliateHelper.appliesReferral("alice", discount)) {
+                    ThorChainAffiliateHelper.referredTotalBps(discount)
+                } else ThorChainAffiliateHelper.unreferredTotalBps(discount)
+            assertEquals(
+                expectedReferred,
+                referred.split("/").sumOf { it.toInt() },
+                "referred discount=$discount",
+            )
+        }
+    }
+
+    @Test
+    fun `the top tier is no longer charged for a saved code`() {
+        assertEquals(0, ThorChainAffiliateHelper.unreferredTotalBps(ULTIMATE_DISCOUNT_BPS))
+        assertEquals(-10, ThorChainAffiliateHelper.referralSavingBps(ULTIMATE_DISCOUNT_BPS))
+        assertFalse(ThorChainAffiliateHelper.appliesReferral("alice", ULTIMATE_DISCOUNT_BPS))
+    }
+
+    @Test
+    fun `an empty code never applies`() {
+        for (discount in TIER_DISCOUNTS + listOf(ULTIMATE_DISCOUNT_BPS)) {
+            assertFalse(
+                ThorChainAffiliateHelper.appliesReferral("", discount),
+                "discount=$discount",
+            )
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #5765

## What was wrong

**The referral row overstated the saving 2x.** `referralBpsFor` returned `THORChainSwaps.REFERRED_USER_FEE_RATE_BP` (10) — the *referrer's* payout, as the constant's own comment said — and rendered it as the user's discount, minus-signed in both bps and money.

thornode sums the legs of a multi-affiliate request, so `10/35` is charged exactly as a flat `45` against an unreferred `50`. Vultisig gives up 15 to pay the referrer 10, and the user keeps the 5 bps difference. Measured live against the gateway the app ships (`/thorchain/quote/swap`, BTC→ETH, 1 BTC, Gold tier):

| request | `fees.affiliate` | bps |
|---|---|---|
| no affiliate | 0 | 0 |
| `va` / `30` — Gold, no code | 9,545,423 | 30.00 |
| `t/va` / `10/15` — Gold, code saved | 7,954,520 | 25.00 |

The delta is 1,590,903 — exactly 5.00 bps.

**At the top VULT tier a saved code silently cost the user 10 bps.** Both affiliate legs clamp at zero independently, so once the tier discount has eaten Vultisig's leg the referrer's fixed payout is no longer covered by it. At Ultimate the request emitted `affiliate_bps=10/0`, charged 10 bps, against an unreferred `0` charged nothing. The row was gated off at exactly that tier (`takeUnless { tierType == TierType.ULTIMATE }`), so the charge was real, on the wire, and invisible — the display gate suppressed the symptom of a live cost.

## What changed

`ThorChainAffiliateHelper` becomes the single source for both halves, so the number displayed cannot drift from the number sent:

- `referralSavingBps(d)` = `unreferredTotalBps(d) − referredTotalBps(d)` — 5 at every tier through Diamond, −10 at Ultimate.
- `appliesReferral()` drops the code only when it would **raise** the user's own fee. At break-even it is still sent, so the referrer keeps their payout whenever the user isn't the one paying for it.
- `referralBpsFor` now reads that saving and takes the raw VULT bps rather than a re-derived `TierType`. The Ultimate gate is gone — the arithmetic reaches the same answer for the right reason, so no row is shown because there genuinely is no referral, not because it was hidden.
- `REFERRED_USER_FEE_RATE_BP` → `REFERRER_PAYOUT_BPS`. The old name read as the referred user's fee while its comment said the opposite, and the repo's own tests were split on it (`ThorChainAffiliateHelperTest` called it both the "user share" and what "pays the referrer"). That ambiguity is the root cause and would have caused this to recur.

`formatAffiliatePercent` is deliberately untouched: #5812 made the Swap Fee title the undiscounted list rate, and correcting the referral number is what makes the panel add up under that model — as that PR's description predicted.

## Screenshots

Gold-tier vault, BTC→ETH, ~$3.99M notional, on device.

| No referral code saved | Friend's code saved (this PR) |
|---|---|
| <img src="https://i.imgur.com/JO2G9ps.png" width="320" /> | <img src="https://i.imgur.com/n26J0TZ.png" width="320" /> |

The right panel reconciles to the cent: `$19,944.85 − $7,993.60 − $1,998.40 = $9,952.85`, and `$9,952.85 + $1.56 network + $0.25 outbound = $9,954.66` = Total Fee. The gross is 0.49902% of notional under its "0.50%" title. On the old code the same swap grossed to $21,943.25 — 0.549% under that same title, so the mismatch inverted rather than closing.

Total Fee also drops from $11,948.31 to $9,954.66 between the two, a $1,993.65 saving on ~$3.99M — the real 5 bps the code buys, which the row now states instead of the referrer's 10.

## Test plan

- `./gradlew assembleDebug` — passes
- `./gradlew :app:testDebugUnitTest` (2441 tests) and `:data:testDebugUnitTest` (3598 tests) — 0 failures
- `./gradlew :app:lintDebug` and `:app:ktfmtCheck` / `:data:ktfmtCheck` — pass

New `SwapDiscountCheckerTest` pins the displayed bps against the bps actually put on the wire — `referralBpsFor(d)` must equal the delta between the totals `buildAffiliateParams` produces with and without a code, across tiers 0/5/10/20/25/35. Nothing on any platform pinned that, which is how it drifted.

`ThorChainAffiliateHelperTest` gains coverage of the gate and the totals; the two cases that pinned the old behaviour by name (`full discount keeps the referral split and still pays the referrer`, `discount beyond the referred affiliate base still preserves the referrer share`) are updated, since that behaviour is the defect.

Verified on device: Gold tier with a friend's code shows `Referral (-5 bps) −$1,998.40` on the swap form, and swaps with no code saved are unchanged.

## Note for the other platforms

**iOS and Windows have the same top-tier overcharge**, so this PR deliberately diverges from them on that half. Both compute the display as a flat `max(0, 50 − 35 − 10)` = 5, which is what Android now matches. But neither request builder is tier-aware — iOS `ThorchainService.affiliateParams` branches on `!referredCode.isEmpty` alone, so an iOS Ultimate vault with a saved code still sends `10/0` and is still charged for it. Worth a sibling issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved referral discount calculations for swap fees based on the user’s actual discount.
  * Referral parameters are now omitted when they would not reduce the user’s total fee.
  * Ultimate-tier referrals now correctly resolve to no discount where applicable.
  * Referral savings and affiliate payouts are calculated more accurately.

* **Tests**
  * Expanded coverage for discount tiers, referral eligibility, fee totals, savings, and referral-code handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->