### PR TITLE
fix(keysign): put the Polkadot/Bittensor network fee on the wire

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -124,6 +124,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         specVersion = specific.specVersion,
                         transactionVersion = specific.transactionVersion,
                         genesisHash = specific.genesisHash,
+                        gas = specific.gas,
                     )
                 } else null,
             suicheSpecific =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperPolkadotGasTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperPolkadotGasTest.kt
@@ -1,0 +1,111 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import io.kotest.matchers.shouldBe
+import java.math.BigInteger
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the Substrate network fee (proto `PolkadotSpecific.gas`) across the outbound mapper.
+ *
+ * The initiator computes the fee, holds it in the domain specific and puts it on the wire for the
+ * co-signer. Dropping it at the proto boundary leaves the joining device deserializing the proto3
+ * default, so its Verify screen states a zero cost for a send that pays a real one — and that
+ * screen is the whole safeguard of co-signing. Bittensor rides the same specific, so it shares both
+ * the defect and this cover.
+ */
+class KeysignPayloadProtoMapperPolkadotGasTest {
+
+    private val outbound = PayloadToProtoMapperImpl()
+    private val inbound = KeysignPayloadProtoMapperImpl()
+
+    @Test
+    fun `the network fee survives the domain to proto to domain round-trip`() {
+        val proto = requireNotNull(outbound(polkadotPayload(DOT)))
+
+        proto.polkadotSpecific?.gas shouldBe GAS
+
+        val restored = inbound(proto).blockChainSpecific as BlockChainSpecific.Polkadot
+        restored.gas shouldBe GAS
+    }
+
+    // Bittensor builds the very same specific, so a TAO send loses the fee the same way.
+    @Test
+    fun `a Bittensor send keeps the fee it shares the specific with`() {
+        val proto = requireNotNull(outbound(polkadotPayload(TAO)))
+
+        proto.polkadotSpecific?.gas shouldBe GAS
+
+        val restored = inbound(proto).blockChainSpecific as BlockChainSpecific.Polkadot
+        restored.gas shouldBe GAS
+    }
+
+    // Nothing else pins this specific, and gas was lost precisely because no test noticed a
+    // missing field. Compare the whole thing so the next omission fails here.
+    @Test
+    fun `every field of the specific round-trips unchanged`() {
+        val payload = polkadotPayload(DOT)
+
+        val restored = inbound(requireNotNull(outbound(payload))).blockChainSpecific
+
+        restored shouldBe payload.blockChainSpecific
+    }
+
+    private fun polkadotPayload(coin: Coin) =
+        KeysignPayload(
+            coin = coin,
+            toAddress = "13SykFhb5ZM4jVLGvVdMzmxpEVSVJ8Q4B4TfNw4kdgqfnhaB",
+            toAmount = BigInteger("15000000000"),
+            blockChainSpecific =
+                BlockChainSpecific.Polkadot(
+                    recentBlockHash =
+                        "0x4bd8b3fcd2e5a5f4cbb45b0ec8b1b0da43f38b8b8b0e5f37dfd0f16b0a9e1d55",
+                    nonce = BigInteger("3"),
+                    currentBlockNumber = BigInteger("24186241"),
+                    specVersion = 1_003_004u,
+                    transactionVersion = 26u,
+                    genesisHash =
+                        "0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3",
+                    gas = GAS,
+                ),
+            memo = null,
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "local",
+            libType = null,
+            wasmExecuteContractPayload = null,
+        )
+
+    private companion object {
+        // 0.0165 DOT at 10 decimals — the order of magnitude a real send pays.
+        const val GAS = 165_000_000UL
+
+        val DOT =
+            Coin(
+                chain = Chain.Polkadot,
+                ticker = "DOT",
+                logo = "dot",
+                address = "13SykFhb5ZM4jVLGvVdMzmxpEVSVJ8Q4B4TfNw4kdgqfnhaB",
+                decimal = 10,
+                hexPublicKey = "pub",
+                priceProviderID = "polkadot",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+
+        val TAO =
+            Coin(
+                chain = Chain.Bittensor,
+                ticker = "TAO",
+                logo = "bittensor",
+                address = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+                decimal = 9,
+                hexPublicKey = "pub",
+                priceProviderID = "bittensor",
+                contractAddress = "",
+                isNativeToken = true,
+            )
+    }
+}


### PR DESCRIPTION
Closes #5830

## Problem

`PayloadToProtoMapper` built `PolkadotSpecific` with six of its seven fields and left out `gas`, so the field never reached the wire. Every co-signer deserialized the proto3 default and displayed a **0 DOT network fee** for a send that pays a real one (~0.0165 DOT).

The asymmetry was visible three ways in the same two files:

- the inbound `KeysignPayloadProtoMapper` already reconstructs `BlockChainSpecific.Polkadot(… gas = it.gas)`;
- the `RippleSpecific` branch directly above sets `gas = specific.gas`;
- `BlockChainSpecificRepository` computes `gas = gasFee.value…` from a live estimate at **both** call sites that build this specific — the Polkadot one and the Bittensor one — so the number was held in the domain model and then discarded at the proto boundary.

Bittensor shares the specific, so TAO sends lost the fee identically.

The money is not the point: a co-signer was being asked to approve a transaction whose stated cost was wrong, and on a mixed-platform vault the second device's screen is the safeguard.

## Fix

One line — `gas = specific.gas` in the `PolkadotSpecific(…)` builder, mirroring the `RippleSpecific` branch above it.

## Not touched

- The signed extrinsic. `PolkadotHelper` never reads `gas`, so the transaction and the fee actually charged were correct before this change and are unchanged by it.
- The inbound mapper — it already read the field correctly.
- How a joining device resolves and displays fees. The ask was only to stop dropping the value on the wire.

## Tests

New `KeysignPayloadProtoMapperPolkadotGasTest`, three cases:

| Test | Covers |
|---|---|
| `the network fee survives the domain to proto to domain round-trip` | DOT — asserts both the proto field and the restored domain value |
| `a Bittensor send keeps the fee it shares the specific with` | TAO on the same specific |
| `every field of the specific round-trips unchanged` | full data-class equality — `gas` went missing precisely because nothing pinned this mapper |

Removing only the new line (leaving the Ripple branch intact) fails all three; restoring it passes all three.

## Test plan

- [x] `./gradlew :data:testDebugUnitTest` — 359 classes, 3596 tests, 0 failures, 0 errors. The Ripple, Cosmos, Solana, Sui and TON mapper round-trip tests are green and unchanged.
- [x] `./gradlew assembleDebug`
- [ ] Manual, needs a mixed vault: initiate a DOT send on Android, join from an iOS device — the iOS Verify screen shows the same non-zero network fee as the initiator instead of `0 DOT`. Repeat for TAO. An Android-only vault cannot show the difference, since Android's joining-device fee resolver does not consume the field.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Polkadot transaction payloads now preserve the network gas fee during serialization and deserialization.
  - Polkadot-specific transaction details remain intact when key-signing data is converted between formats.

- **Tests**
  - Added coverage for Polkadot and Bittensor key-signing payload round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->