### PR TITLE
feat(keysign): decode THORChain and Rujira operations

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
@@ -214,6 +214,7 @@ constructor(
                 DecodedOperation.Undelegate -> R.string.done_verb_undelegated
                 DecodedOperation.Redelegate -> R.string.done_verb_redelegated
                 DecodedOperation.ClaimRewards -> R.string.done_verb_claimed_rewards
+                DecodedOperation.Claim -> R.string.done_verb_claimed
                 DecodedOperation.Mint -> R.string.done_verb_minted
                 DecodedOperation.Redeem -> R.string.done_verb_redeemed
                 DecodedOperation.SecuredAssetWithdraw,
@@ -255,7 +256,8 @@ constructor(
                 // user reaches the same operation through.
                 DecodedOperation.Stake -> R.string.cosmos_staking_youre_staking
                 DecodedOperation.Unstake -> R.string.cosmos_staking_youre_unstaking
-                DecodedOperation.ClaimRewards -> R.string.cosmos_staking_youre_claiming
+                DecodedOperation.ClaimRewards,
+                DecodedOperation.Claim -> R.string.cosmos_staking_youre_claiming
 
                 DecodedOperation.Bond -> R.string.verify_verb_bonding
                 DecodedOperation.Unbond -> R.string.verify_verb_unbonding

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/DecodedTransactionPresentation.kt
@@ -239,8 +239,7 @@ constructor(
          * A transfer is what the send screens are; a swap is rendered two-sided by its own verify
          * screen; an approval names its spender and allowance; a vote moves nothing, so the verb
          * would be the whole hero; a contract call of unknown shape and an unreadable transaction
-         * have nothing to add. `RemoveLiquidity` is silent for a different reason: naming it would
-         * displace the carrier amount the transaction actually charges.
+         * have nothing to add.
          */
         fun verifyTitleRes(operation: DecodedOperation): Int? =
             when (operation) {
@@ -249,7 +248,6 @@ constructor(
                 DecodedOperation.Approve,
                 DecodedOperation.Vote,
                 DecodedOperation.ContractCall,
-                DecodedOperation.RemoveLiquidity,
                 DecodedOperation.Unknown -> null
 
                 // The Cosmos staking verify screen already ships this exact wording in all ten
@@ -271,6 +269,12 @@ constructor(
                 DecodedOperation.Undelegate -> R.string.verify_verb_undelegating
                 DecodedOperation.Redelegate -> R.string.verify_verb_redelegating
                 DecodedOperation.AddLiquidity -> R.string.verify_verb_adding_liquidity
+
+                // Safe to name only because a withdrawal states a SHARE, and a fractional reading
+                // replaces the surface's own figure rather than retitling it — see [VerifyHero].
+                // Titling it while the carrier charge stood would put donated dust where the payout
+                // belongs.
+                DecodedOperation.RemoveLiquidity -> R.string.verify_verb_removing_liquidity
                 DecodedOperation.Redeem -> R.string.verify_verb_redeeming
                 DecodedOperation.Mint -> R.string.verify_verb_minting
                 DecodedOperation.Merge -> R.string.verify_verb_merging

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ProjectionCoordinator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ProjectionCoordinator.kt
@@ -31,9 +31,16 @@ constructor(@ApplicationContext private val context: Context) {
     fun scope(decoded: DecodedTransaction): String? =
         when (val amount = decoded.amount) {
             is DecodedAmount.Fraction ->
-                // The signed share remains exact even when the projected amount is not.
+                // The signed share remains exact even when the projected amount is not. Which
+                // position it is a share OF follows the operation: a pool withdrawal spends
+                // liquidity, and calling that a staked position would name the wrong holding.
                 context.getString(
-                    R.string.withdrawing_share_of_staked_position,
+                    when (decoded.operation) {
+                        DecodedOperation.AddLiquidity,
+                        DecodedOperation.RemoveLiquidity ->
+                            R.string.withdrawing_share_of_liquidity_position
+                        else -> R.string.withdrawing_share_of_staked_position
+                    },
                     DecodedTransactionPresentation.percentage(amount.basisPoints),
                 )
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ResolvedTransactionHero.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ResolvedTransactionHero.kt
@@ -34,6 +34,7 @@ constructor(
     private val projectionCoordinator: ProjectionCoordinator,
     solanaDelegatedAmount: SolanaDelegatedAmountReader,
     solanaStakeAccountAmount: SolanaStakeAccountAmountReader,
+    tcyStakedPosition: TcyStakedPositionReader,
 ) {
 
     /**
@@ -41,7 +42,7 @@ constructor(
      * the first match wins and no reader sees a transaction it did not claim.
      */
     private val readers: List<PositionReading> =
-        listOf(solanaDelegatedAmount, solanaStakeAccountAmount)
+        listOf(solanaDelegatedAmount, solanaStakeAccountAmount, tcyStakedPosition)
 
     /**
      * Resolves through the first reader that answers for [coin] — the vault's own coin for this

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ThorChainPositionReaders.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ThorChainPositionReaders.kt
@@ -38,7 +38,8 @@ constructor(
         coin.chain == Chain.ThorChain &&
             coin.ticker.equals(TCY_TICKER, ignoreCase = true) &&
             decoded.operation == DecodedOperation.Unstake &&
-            decoded.evidence == DecodedEvidence.Memo &&
+            // The sidecar memo or the same memo signed inside a THORChain body.
+            decoded.evidence.isNoWeaker(than = DecodedEvidence.Memo) &&
             (decoded.amount as? DecodedAmount.Fraction)?.asset == DecodedAsset.TransactionCoin
 
     override suspend fun amount(decoded: DecodedTransaction, coin: Coin): HeroCoinAmount? {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ThorChainPositionReaders.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/ThorChainPositionReaders.kt
@@ -1,0 +1,66 @@
+package com.vultisig.wallet.ui.models.transactiondecoding
+
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedEvidence
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
+import java.math.BigInteger
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Resolves a `TCY-:<bps>` withdrawal against the signer's own staked TCY position.
+ *
+ * ⚠️ **A projection, not a commitment.** The memo commits to a FRACTION of whatever is staked when
+ * THORChain executes it; this applies that fraction to the position the chain reports now, which is
+ * the closest an absolute figure can get. The scope sentence beside it states the share, and stays
+ * true whether or not this read lands — which is why a failed read leaves the hero figure-less
+ * rather than falling back to the literal `0` the transaction carries.
+ *
+ * Mirrors the iOS `TcyStakedPositionReader`. Unlike iOS, this serves the initiator too: Android's
+ * verify surfaces resolve the same reading on both devices, so there is no separate builder-quoted
+ * path (iOS's `QuotedWithdrawalPresentation`) to keep in step with it.
+ */
+@Singleton
+internal class TcyStakedPositionReader
+@Inject
+constructor(
+    private val thorChainApi: ThorChainApi,
+    private val presentation: DecodedTransactionPresentation,
+) : PositionReading {
+
+    override fun handles(decoded: DecodedTransaction, coin: Coin): Boolean =
+        coin.chain == Chain.ThorChain &&
+            coin.ticker.equals(TCY_TICKER, ignoreCase = true) &&
+            decoded.operation == DecodedOperation.Unstake &&
+            decoded.evidence == DecodedEvidence.Memo &&
+            (decoded.amount as? DecodedAmount.Fraction)?.asset == DecodedAsset.TransactionCoin
+
+    override suspend fun amount(decoded: DecodedTransaction, coin: Coin): HeroCoinAmount? {
+        val basisPoints = (decoded.amount as? DecodedAmount.Fraction)?.basisPoints ?: return null
+        if (basisPoints !in 1..MAX_BASIS_POINTS) return null
+
+        // Read against the vault's own address; a joining co-signer's payload never chooses it.
+        val staked = thorChainApi.getUnstakableTcyAmount(coin.address)?.toBigIntegerOrNull()
+        if (staked == null || staked.signum() <= 0) return null
+
+        // Base units throughout, truncating exactly as the unstake form's basis points were
+        // derived, so the figure can never claim more than the share the memo commits to.
+        val amount =
+            staked.multiply(BigInteger.valueOf(basisPoints.toLong())).divide(MAX_BASIS_POINTS_UNITS)
+        if (amount.signum() <= 0) return null
+
+        return presentation.heroAmount(coin, amount)
+    }
+
+    private companion object {
+        const val TCY_TICKER = "TCY"
+        const val MAX_BASIS_POINTS = 10_000
+        val MAX_BASIS_POINTS_UNITS: BigInteger = BigInteger.valueOf(MAX_BASIS_POINTS.toLong())
+    }
+}

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/VerifyTransactionPresentation.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transactiondecoding/VerifyTransactionPresentation.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.ui.models.transactiondecoding
 import android.content.Context
 import androidx.compose.runtime.Immutable
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
 import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
 import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionDecoder
 import com.vultisig.wallet.ui.components.hero.HeroContent
@@ -16,22 +17,37 @@ import javax.inject.Singleton
  * against whatever hero it already resolved.
  *
  * Mirrors the ordering the iOS `TransactionHeroResolver` registers: a chain-state projection
- * outranks a simulation because it states a scope no figure can ("your whole stake"); a simulation
- * outranks the plain decoder because it prices a balance change the signed bytes never state, and
- * only borrows the decoded verb; the signed-amount reading is the last claimant.
+ * outranks a simulation because it states a scope no figure can ("your whole stake"); a reading
+ * whose signed share disowns the carried figure outranks it next, for the same reason iOS registers
+ * its quoted-withdrawal provider ahead of the simulated one; a simulation outranks the plain
+ * decoder because it prices a balance change the signed bytes never state, and only borrows the
+ * decoded verb; the signed-amount reading is the last claimant.
  */
 @Immutable
 internal data class VerifyHero(
     /** The verb alone, for a surface that already holds richer figures. */
     val verb: String,
-    /** A chain-state projection, when a reader resolved one. Null until chain readers land. */
+    /** A chain-state projection, when a reader resolved one. */
     val projected: HeroContent?,
     /** The hero built from the signed amount alone. */
     val decoded: HeroContent,
+    /**
+     * Whether the signed reading contradicts whatever figure the surface resolved on its own.
+     *
+     * True for a signed share: `TCY-:5000` and `-:BTC.BTC:5000` commit to a FRACTION of a position,
+     * so what the transaction carries is a carrier charge — a literal zero, or dust donated to the
+     * pool — and never the payout. Letting that figure stand under a "You're removing liquidity"
+     * title would put the charge exactly where the payout belongs, which is why the reading
+     * replaces the surface's hero here instead of only retitling it.
+     */
+    val carriedAmountIsNotTheOperations: Boolean,
 ) {
     /** Places this reading over the hero [existing] the surface resolved on its own. */
     fun applyTo(existing: HeroContent?): HeroContent =
-        projected ?: existing?.retitled(verb) ?: decoded
+        projected
+            ?: decoded.takeIf { carriedAmountIsNotTheOperations }
+            ?: existing?.retitled(verb)
+            ?: decoded
 }
 
 /**
@@ -82,6 +98,7 @@ constructor(
             verb = title,
             projected = trusted?.let { resolvedTransactionHero.resolve(content, it, title) },
             decoded = presentation.hero(decoded, trusted ?: coin, title),
+            carriedAmountIsNotTheOperations = decoded.amount is DecodedAmount.Fraction,
         )
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiExtensions.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/DeFiExtensions.kt
@@ -130,21 +130,18 @@ internal fun BondedNodePosition.toUiModel(): BondedNodeUiModel {
     )
 }
 
-internal const val STAKING_RUJI_CONTRACT =
-    "thor13g83nn5ef4qzqeafp0508dnvkvm0zqr3sj7eefcn5umu65gqluusrml5cr"
+// The Rujira contract addresses are aliased rather than spelled out here: the signed-transaction
+// reader has to recognise the same set the builders spend, so they live in one place — see
+// [ThorchainStakingContracts].
+internal const val STAKING_RUJI_CONTRACT = ThorchainStakingContracts.STAKING_RUJI
 
-internal const val STAKING_TCY_COMPOUND_CONTRACT =
-    "thor1z7ejlk5wk2pxh9nfwjzkkdnrq4p2f5rjcpudltv0gh282dwfz6nq9g2cr0"
+internal const val STAKING_TCY_COMPOUND_CONTRACT = ThorchainStakingContracts.STAKING_TCY_COMPOUND
 
-// Rujira's liquid-bond contract for bRUNE: `liquid.bond` mints the ybRUNE receipt, `liquid.unbond`
-// redeems it. Aliased rather than spelled out, because the pricing repository reads the same
-// address for the contract's NAV — see [ThorchainStakingContracts].
+/** `liquid.bond` mints the ybRUNE receipt, `liquid.unbond` redeems it. */
 internal const val STAKING_BRUNE_CONTRACT = ThorchainStakingContracts.BRUNE_LIQUID_BOND
 
-internal const val YRUNE_CONTRACT =
-    "thor1mlphkryw5g54yfkrp6xpqzlpv4f8wh6hyw27yyg4z2els8a9gxpqhfhekt"
+internal const val YRUNE_CONTRACT = ThorchainStakingContracts.YRUNE
 
-internal const val YTCY_CONTRACT = "thor1h0hr0rm3dawkedh44hlrmgvya6plsryehcr46yda2vj0wfwgq5xqrs86px"
+internal const val YTCY_CONTRACT = ThorchainStakingContracts.YTCY
 
-internal const val YRUNE_YTCY_AFFILIATE_CONTRACT =
-    "thor1v3f7h384r8hw6r3dtcgfq6d5fq842u6cjzeuu8nr0cp93j7zfxyquyrfl8"
+internal const val YRUNE_YTCY_AFFILIATE_CONTRACT = ThorchainStakingContracts.YVAULT_AFFILIATE

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1778,6 +1778,7 @@
     <string name="verify_verb_undelegating">Du beendest die Delegation</string>
     <string name="verify_verb_redelegating">Du delegierst neu</string>
     <string name="verify_verb_adding_liquidity">Du fügst Liquidität hinzu</string>
+    <string name="verify_verb_removing_liquidity">Du entfernst Liquidität</string>
     <string name="verify_verb_redeeming">Du löst ein</string>
     <string name="verify_verb_minting">Du prägst</string>
     <string name="verify_verb_merging">Du führst zusammen</string>
@@ -1787,4 +1788,5 @@
     <string name="scope_rewards_accrued_so_far">bisher angefallene Belohnungen</string>
     <string name="scope_delegated_amount_after_rent">der delegierte Betrag nach Abzug der Mietreserve</string>
     <string name="withdrawing_share_of_staked_position">%1$s deiner Stake-Position</string>
+    <string name="withdrawing_share_of_liquidity_position">%1$s deiner Liquiditätsposition</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1753,6 +1753,7 @@
     <string name="done_verb_undelegated">Delegation beendet</string>
     <string name="done_verb_redelegated">Neu delegiert</string>
     <string name="done_verb_claimed_rewards">Belohnungen beansprucht</string>
+    <string name="done_verb_claimed">Beansprucht</string>
     <string name="done_verb_minted">Geprägt</string>
     <string name="done_verb_redeemed">Eingelöst</string>
     <string name="done_verb_withdrew">Ausgezahlt</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1752,6 +1752,7 @@
     <string name="done_verb_undelegated">Delegación cancelada</string>
     <string name="done_verb_redelegated">Redelegado</string>
     <string name="done_verb_claimed_rewards">Recompensas reclamadas</string>
+    <string name="done_verb_claimed">Reclamado</string>
     <string name="done_verb_minted">Acuñado</string>
     <string name="done_verb_redeemed">Canjeado</string>
     <string name="done_verb_withdrew">Retirado</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1777,6 +1777,7 @@
     <string name="verify_verb_undelegating">Estás cancelando la delegación</string>
     <string name="verify_verb_redelegating">Estás redelegando</string>
     <string name="verify_verb_adding_liquidity">Estás añadiendo liquidez</string>
+    <string name="verify_verb_removing_liquidity">Estás retirando liquidez</string>
     <string name="verify_verb_redeeming">Estás canjeando</string>
     <string name="verify_verb_minting">Estás acuñando</string>
     <string name="verify_verb_merging">Estás fusionando</string>
@@ -1786,4 +1787,5 @@
     <string name="scope_rewards_accrued_so_far">recompensas acumuladas hasta ahora</string>
     <string name="scope_delegated_amount_after_rent">el importe delegado después de la reserva de alquiler</string>
     <string name="withdrawing_share_of_staked_position">%1$s de tu posición en staking</string>
+    <string name="withdrawing_share_of_liquidity_position">%1$s de tu posición de liquidez</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1787,6 +1787,7 @@
     <string name="verify_verb_undelegating">Poništavate delegaciju</string>
     <string name="verify_verb_redelegating">Ponovno delegirate</string>
     <string name="verify_verb_adding_liquidity">Dodajete likvidnost</string>
+    <string name="verify_verb_removing_liquidity">Uklanjate likvidnost</string>
     <string name="verify_verb_redeeming">Otkupljujete</string>
     <string name="verify_verb_minting">Kujete</string>
     <string name="verify_verb_merging">Spajate</string>
@@ -1796,4 +1797,5 @@
     <string name="scope_rewards_accrued_so_far">do sada stečene nagrade</string>
     <string name="scope_delegated_amount_after_rent">delegirani iznos nakon rezerve za najam</string>
     <string name="withdrawing_share_of_staked_position">%1$s vaše uložene pozicije</string>
+    <string name="withdrawing_share_of_liquidity_position">%1$s vaše pozicije likvidnosti</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1762,6 +1762,7 @@
     <string name="done_verb_undelegated">Delegacija poništena</string>
     <string name="done_verb_redelegated">Ponovno delegirano</string>
     <string name="done_verb_claimed_rewards">Nagrade preuzete</string>
+    <string name="done_verb_claimed">Preuzeto</string>
     <string name="done_verb_minted">Iskovano</string>
     <string name="done_verb_redeemed">Otkupljeno</string>
     <string name="done_verb_withdrew">Podignuto</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1780,6 +1780,7 @@
     <string name="verify_verb_undelegating">Stai annullando la delega</string>
     <string name="verify_verb_redelegating">Stai ridelegando</string>
     <string name="verify_verb_adding_liquidity">Stai aggiungendo liquidità</string>
+    <string name="verify_verb_removing_liquidity">Stai rimuovendo liquidità</string>
     <string name="verify_verb_redeeming">Stai riscattando</string>
     <string name="verify_verb_minting">Stai coniando</string>
     <string name="verify_verb_merging">Stai unendo</string>
@@ -1789,4 +1790,5 @@
     <string name="scope_rewards_accrued_so_far">ricompense maturate finora</string>
     <string name="scope_delegated_amount_after_rent">l’importo delegato dopo la riserva di affitto</string>
     <string name="withdrawing_share_of_staked_position">%1$s della tua posizione in stake</string>
+    <string name="withdrawing_share_of_liquidity_position">%1$s della tua posizione di liquidità</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1755,6 +1755,7 @@
     <string name="done_verb_undelegated">Delega annullata</string>
     <string name="done_verb_redelegated">Ridelegato</string>
     <string name="done_verb_claimed_rewards">Ricompense reclamate</string>
+    <string name="done_verb_claimed">Reclamato</string>
     <string name="done_verb_minted">Coniato</string>
     <string name="done_verb_redeemed">Riscattato</string>
     <string name="done_verb_withdrew">Prelevato</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1793,6 +1793,7 @@
     <string name="verify_verb_undelegating">위임 해제 중</string>
     <string name="verify_verb_redelegating">재위임 중</string>
     <string name="verify_verb_adding_liquidity">유동성 추가 중</string>
+    <string name="verify_verb_removing_liquidity">유동성 제거 중</string>
     <string name="verify_verb_redeeming">상환 중</string>
     <string name="verify_verb_minting">발행 중</string>
     <string name="verify_verb_merging">병합 중</string>
@@ -1802,4 +1803,5 @@
     <string name="scope_rewards_accrued_so_far">현재까지 누적된 보상</string>
     <string name="scope_delegated_amount_after_rent">임대 예치금을 제외한 위임 금액</string>
     <string name="withdrawing_share_of_staked_position">스테이킹 포지션의 %1$s</string>
+    <string name="withdrawing_share_of_liquidity_position">유동성 포지션의 %1$s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1768,6 +1768,7 @@
     <string name="done_verb_undelegated">위임 해제됨</string>
     <string name="done_verb_redelegated">재위임됨</string>
     <string name="done_verb_claimed_rewards">보상 수령됨</string>
+    <string name="done_verb_claimed">수령됨</string>
     <string name="done_verb_minted">발행됨</string>
     <string name="done_verb_redeemed">상환됨</string>
     <string name="done_verb_withdrew">출금됨</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1770,6 +1770,7 @@
     <string name="verify_verb_undelegating">Je trekt de delegatie in</string>
     <string name="verify_verb_redelegating">Je delegeert opnieuw</string>
     <string name="verify_verb_adding_liquidity">Je voegt liquiditeit toe</string>
+    <string name="verify_verb_removing_liquidity">Je verwijdert liquiditeit</string>
     <string name="verify_verb_redeeming">Je wisselt in</string>
     <string name="verify_verb_minting">Je munt</string>
     <string name="verify_verb_merging">Je voegt samen</string>
@@ -1779,4 +1780,5 @@
     <string name="scope_rewards_accrued_so_far">tot nu toe opgebouwde beloningen</string>
     <string name="scope_delegated_amount_after_rent">het gedelegeerde bedrag na de huurreserve</string>
     <string name="withdrawing_share_of_staked_position">%1$s van je gestakete positie</string>
+    <string name="withdrawing_share_of_liquidity_position">%1$s van je liquiditeitspositie</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1745,6 +1745,7 @@
     <string name="done_verb_undelegated">Delegatie ingetrokken</string>
     <string name="done_verb_redelegated">Opnieuw gedelegeerd</string>
     <string name="done_verb_claimed_rewards">Beloningen geclaimd</string>
+    <string name="done_verb_claimed">Geclaimd</string>
     <string name="done_verb_minted">Gemunt</string>
     <string name="done_verb_redeemed">Ingewisseld</string>
     <string name="done_verb_withdrew">Opgenomen</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1750,6 +1750,7 @@
     <string name="done_verb_undelegated">Delegação cancelada</string>
     <string name="done_verb_redelegated">Redelegado</string>
     <string name="done_verb_claimed_rewards">Recompensas reivindicadas</string>
+    <string name="done_verb_claimed">Reivindicado</string>
     <string name="done_verb_minted">Cunhado</string>
     <string name="done_verb_redeemed">Resgatado</string>
     <string name="done_verb_withdrew">Sacado</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1775,6 +1775,7 @@
     <string name="verify_verb_undelegating">Você está cancelando a delegação</string>
     <string name="verify_verb_redelegating">Você está redelegando</string>
     <string name="verify_verb_adding_liquidity">Você está adicionando liquidez</string>
+    <string name="verify_verb_removing_liquidity">Você está removendo liquidez</string>
     <string name="verify_verb_redeeming">Você está resgatando</string>
     <string name="verify_verb_minting">Você está cunhando</string>
     <string name="verify_verb_merging">Você está mesclando</string>
@@ -1784,4 +1785,5 @@
     <string name="scope_rewards_accrued_so_far">recompensas acumuladas até agora</string>
     <string name="scope_delegated_amount_after_rent">o valor delegado após a reserva de aluguel</string>
     <string name="withdrawing_share_of_staked_position">%1$s da sua posição em stake</string>
+    <string name="withdrawing_share_of_liquidity_position">%1$s da sua posição de liquidez</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1790,6 +1790,7 @@
     <string name="verify_verb_undelegating">Вы отменяете делегирование</string>
     <string name="verify_verb_redelegating">Вы переделегируете</string>
     <string name="verify_verb_adding_liquidity">Вы добавляете ликвидность</string>
+    <string name="verify_verb_removing_liquidity">Вы удаляете ликвидность</string>
     <string name="verify_verb_redeeming">Вы выкупаете</string>
     <string name="verify_verb_minting">Вы чеканите</string>
     <string name="verify_verb_merging">Вы объединяете</string>
@@ -1799,4 +1800,5 @@
     <string name="scope_rewards_accrued_so_far">накопленные на данный момент награды</string>
     <string name="scope_delegated_amount_after_rent">делегированная сумма за вычетом резерва за аренду</string>
     <string name="withdrawing_share_of_staked_position">%1$s вашей стейкинг-позиции</string>
+    <string name="withdrawing_share_of_liquidity_position">%1$s вашей позиции ликвидности</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1765,6 +1765,7 @@
     <string name="done_verb_undelegated">Делегирование отменено</string>
     <string name="done_verb_redelegated">Переделегировано</string>
     <string name="done_verb_claimed_rewards">Награды получены</string>
+    <string name="done_verb_claimed">Получено</string>
     <string name="done_verb_minted">Отчеканено</string>
     <string name="done_verb_redeemed">Выкуплено</string>
     <string name="done_verb_withdrew">Выведено</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2075,6 +2075,7 @@
     <string name="done_verb_undelegated">已解除委托</string>
     <string name="done_verb_redelegated">已重新委托</string>
     <string name="done_verb_claimed_rewards">已领取奖励</string>
+    <string name="done_verb_claimed">已领取</string>
     <string name="done_verb_minted">已铸造</string>
     <string name="done_verb_redeemed">已赎回</string>
     <string name="done_verb_withdrew">已提取</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -2100,6 +2100,7 @@
     <string name="verify_verb_undelegating">您正在解除委托</string>
     <string name="verify_verb_redelegating">您正在重新委托</string>
     <string name="verify_verb_adding_liquidity">您正在添加流动性</string>
+    <string name="verify_verb_removing_liquidity">您正在移除流动性</string>
     <string name="verify_verb_redeeming">您正在赎回</string>
     <string name="verify_verb_minting">您正在铸造</string>
     <string name="verify_verb_merging">您正在合并</string>
@@ -2109,4 +2110,5 @@
     <string name="scope_rewards_accrued_so_far">至今累积的奖励</string>
     <string name="scope_delegated_amount_after_rent">扣除租金储备后的委托金额</string>
     <string name="withdrawing_share_of_staked_position">您质押仓位的 %1$s</string>
+    <string name="withdrawing_share_of_liquidity_position">您流动性仓位的 %1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1835,6 +1835,7 @@
     <string name="verify_verb_undelegating">You’re undelegating</string>
     <string name="verify_verb_redelegating">You’re redelegating</string>
     <string name="verify_verb_adding_liquidity">You’re adding liquidity</string>
+    <string name="verify_verb_removing_liquidity">You’re removing liquidity</string>
     <string name="verify_verb_redeeming">You’re redeeming</string>
     <string name="verify_verb_minting">You’re minting</string>
     <string name="verify_verb_merging">You’re merging</string>
@@ -1844,4 +1845,5 @@
     <string name="scope_rewards_accrued_so_far">rewards accrued so far</string>
     <string name="scope_delegated_amount_after_rent">the delegated amount after deducting the rent reserve</string>
     <string name="withdrawing_share_of_staked_position">%1$s of your staked position</string>
+    <string name="withdrawing_share_of_liquidity_position">%1$s of your liquidity position</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1810,6 +1810,7 @@
     <string name="done_verb_undelegated">Undelegated</string>
     <string name="done_verb_redelegated">Redelegated</string>
     <string name="done_verb_claimed_rewards">Claimed rewards</string>
+    <string name="done_verb_claimed">Claimed</string>
     <string name="done_verb_minted">Minted</string>
     <string name="done_verb_redeemed">Redeemed</string>
     <string name="done_verb_withdrew">Withdrew</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/ThorChainApi.kt
@@ -43,6 +43,7 @@ import com.vultisig.wallet.data.api.models.thorchain.ThorOwnerData
 import com.vultisig.wallet.data.api.models.thorchain.ThorchainConstantsResponse
 import com.vultisig.wallet.data.api.models.thorchain.ThorchainLimitSwapQueueResponse
 import com.vultisig.wallet.data.api.models.thorchain.VaultRedemptionResponseJson
+import com.vultisig.wallet.data.blockchain.thorchain.ThorChainInboundVaultSnapshot
 import com.vultisig.wallet.data.chains.helpers.ThorChainAffiliateHelper
 import com.vultisig.wallet.data.common.Endpoints
 import com.vultisig.wallet.data.utils.NetworkException
@@ -189,6 +190,7 @@ constructor(
     private val httpClient: HttpClient,
     private val thorChainSwapQuoteResponseJsonSerializer: ThorChainSwapQuoteResponseJsonSerializer,
     private val json: Json,
+    private val inboundVaultSnapshot: ThorChainInboundVaultSnapshot,
 ) : ThorChainApi {
 
     override suspend fun getUnstakableTcyAmount(address: String): String? {
@@ -386,15 +388,22 @@ constructor(
         )
     }
 
-    override suspend fun getTHORChainInboundAddresses(): List<THORChainInboundAddress> =
-        httpClient
-            .get("$THORNODE_BASE/thorchain/inbound_addresses") {
-                header(X_CLIENT_ID_HEADER, X_CLIENT_ID_VALUE)
-                // Inbound status drives a fail-closed halt gate, so it must never be served from
-                // the shared HttpCache if upstream ever starts sending cache headers.
-                header(HttpHeaders.CacheControl, "no-cache, no-store")
-            }
-            .bodyOrThrow()
+    override suspend fun getTHORChainInboundAddresses(): List<THORChainInboundAddress> {
+        val addresses: List<THORChainInboundAddress> =
+            httpClient
+                .get("$THORNODE_BASE/thorchain/inbound_addresses") {
+                    header(X_CLIENT_ID_HEADER, X_CLIENT_ID_VALUE)
+                    // Inbound status drives a fail-closed halt gate, so it must never be served
+                    // from the shared HttpCache if upstream ever starts sending cache headers.
+                    header(HttpHeaders.CacheControl, "no-cache, no-store")
+                }
+                .bodyOrThrow()
+        // Every caller here warms the snapshot a signing screen reads synchronously. The halt gate
+        // above is unaffected: it keeps reading this live response, and the snapshot is only ever
+        // asked which addresses were vaults — see [ThorChainInboundVaultSnapshot].
+        inboundVaultSnapshot.record(addresses)
+        return addresses
+    }
 
     override suspend fun getLimitSwapQueue(sender: String): ThorchainLimitSwapQueueResponse =
         httpClient

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/THORChainInboundAddress.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/thorchain/THORChainInboundAddress.kt
@@ -25,4 +25,10 @@ data class THORChainInboundAddress(
      * rather than guessing.
      */
     @SerialName("dust_threshold") val dustThreshold: String? = null,
+    /**
+     * The router contract inbound tokens are sent to, on the chains that have one (the EVM family).
+     * A native deposit goes to [address] instead, so which of the two a destination has to match is
+     * decided by whether the asset is the chain's native coin.
+     */
+    @SerialName("router") val router: String? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainSignDocReader.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainSignDocReader.kt
@@ -1,0 +1,95 @@
+package com.vultisig.wallet.data.blockchain.thorchain
+
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.usecases.ThorChainAsset
+import com.vultisig.wallet.data.usecases.ThorMsgDepositBody
+import com.vultisig.wallet.data.usecases.TxBody
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
+
+/**
+ * Reads the one THORChain message a dApp-built SignDoc carries a memo in: `/types.MsgDeposit`.
+ *
+ * THORChain's own messages are not Cosmos SDK ones. A deposit keeps its memo *inside* the message
+ * rather than on the `TxBody`, its coin names an `Asset` rather than a denom, and its type URL is
+ * one `CosmosSignDocReader` deliberately refuses — so a THORChain body reached no reader at all,
+ * and a co-signer shown a dApp's `TCY-:5000` saw whatever screen it already had. This is the reader
+ * that gap was missing.
+ *
+ * The body is decoded through the same serializable models the joining device renders the request
+ * from, so the verb read here and the message shown beside it come from one parse of one set of
+ * bytes and cannot disagree. The refusals are this reader's own: a body it cannot name completely
+ * is refused as a whole, for the reason `CosmosSignDocReader` gives — a confident wrong verb serves
+ * a co-signer worse than the screen it already had.
+ */
+internal object THORChainSignDocReader {
+
+    /** A deposit that read completely: the memo THORNode will execute, and what it carries. */
+    data class Deposit(val memo: String, val carried: DecodedAmount)
+
+    /** Refuses a body larger than any real deposit. */
+    private const val MAX_BODY_BYTES = 64 * 1024
+
+    private const val MSG_DEPOSIT_TYPE_URL = "/types.MsgDeposit"
+
+    /** THORChain's native chain, as the `Asset` spells it. */
+    private const val NATIVE_CHAIN = "THOR"
+    private const val NATIVE_TICKER = "RUNE"
+
+    /** THORChain addresses are 20 raw bytes on the wire; anything else is not a signer. */
+    private const val ADDRESS_BYTES = 20
+
+    /**
+     * Reads one complete deposit, or refuses the body.
+     *
+     * Exactly one message is accepted. A batch has no single reading, and THORNode executes one
+     * memo per deposit anyway; any other message type is not this grammar's to name.
+     */
+    fun read(body: ByteArray): Deposit? {
+        if (body.isEmpty() || body.size > MAX_BODY_BYTES) return null
+
+        val txBody = runCatching { ProtoBuf.Default.decodeFromByteArray<TxBody>(body) }.getOrNull()
+        val message = txBody?.messages?.singleOrNull() ?: return null
+        if (message.typeUrl != MSG_DEPOSIT_TYPE_URL) return null
+
+        val deposit =
+            runCatching { ProtoBuf.Default.decodeFromByteArray<ThorMsgDepositBody>(message.value) }
+                .getOrNull() ?: return null
+        if (deposit.signer.size != ADDRESS_BYTES) return null
+
+        // An empty memo is a deposit THORNode would reject; there is nothing to read.
+        val memo = deposit.memo.takeIf { it.isNotEmpty() } ?: return null
+
+        return Deposit(memo = memo, carried = carried(deposit))
+    }
+
+    /**
+     * What the deposit carries, in the units it states them.
+     *
+     * Only a plain THORChain-native asset can be named: RUNE is the chain's own unit, and every
+     * other native asset is keyed by the denom its ticker spells. A synth, trade or secured asset
+     * is a different denom altogether, and several coins have no single figure — both state no
+     * amount rather than a wrong one. A zero is what a share-based memo such as `TCY-` carries, and
+     * is not the amount either.
+     */
+    private fun carried(deposit: ThorMsgDepositBody): DecodedAmount {
+        val coin = deposit.coins.singleOrNull() ?: return DecodedAmount.Unstated
+        val units = coin.amount.toBigIntegerOrNull() ?: return DecodedAmount.Unstated
+        if (units.signum() <= 0) return DecodedAmount.Unstated
+
+        val asset = coin.asset.takeIf { it.isPlainNative() } ?: return DecodedAmount.Unstated
+        return DecodedAmount.Units(
+            units,
+            if (asset.ticker.equals(NATIVE_TICKER, ignoreCase = true)) DecodedAsset.ChainNative
+            else DecodedAsset.Denom(asset.ticker.lowercase()),
+        )
+    }
+
+    private fun ThorChainAsset.isPlainNative(): Boolean =
+        chain.equals(NATIVE_CHAIN, ignoreCase = true) &&
+            ticker.isNotEmpty() &&
+            !synth &&
+            !trade &&
+            !secured
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainTransactionDecoder.kt
@@ -10,6 +10,7 @@ import com.vultisig.wallet.data.models.transaction_decoding.DecodedEvidence
 import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
 import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
 import com.vultisig.wallet.data.models.transaction_decoding.MemoPrecedence
+import com.vultisig.wallet.data.models.transaction_decoding.OpaqueSignedContent
 import com.vultisig.wallet.data.models.transaction_decoding.SignedAmount
 import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
 import com.vultisig.wallet.data.models.transaction_decoding.TransactionContentDecoder
@@ -30,6 +31,12 @@ import vultisig.keysign.v1.WasmExecuteContractPayload
  * Mirrors the iOS `THORChainTransactionDecoder`. It declares no chain scope: an inbound deposit
  * leaves Bitcoin or Ethereum, so nothing about the chain a transaction is on says THORChain, and
  * the reader has to establish provenance from the transaction itself.
+ *
+ * ⚠️ **One departure from iOS: a signed THORChain body is read, not withheld.** A dApp-built
+ * `/types.MsgDeposit` keeps its memo inside the message the co-signer is sent, where the Cosmos
+ * family reader — by design — refuses to name it. iOS leaves such a body unread; here
+ * [THORChainSignDocReader] reads it, and the memo grammar below runs over it at the strongest
+ * evidence there is.
  */
 class THORChainTransactionDecoder
 @Inject
@@ -39,8 +46,9 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
     override val handles: Set<Chain>? = null
 
     override fun decode(tx: SignedTransactionContent): DecodedTransaction? {
-        // Flat fields beside an opaque signed artifact are untrusted sidecars.
-        val content = tx.corroborated ?: return null
+        // Flat fields beside an opaque signed artifact are untrusted sidecars. The artifact itself
+        // is not: for a dApp-built THORChain deposit it is the only place the memo lives at all.
+        val content = tx.corroborated ?: return decodeSignedBody(tx)
 
         return when (provenance(tx, content)) {
             Provenance.Unrelated -> null
@@ -53,7 +61,7 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
                     return decodeWasm(it)
                 }
                 content.memo(MEMO_PRECEDENCE)?.let { memo ->
-                    decodeMemo(memo, content)?.let {
+                    decodeMemo(memo, carried(content.amount))?.let {
                         return it
                     }
                 }
@@ -61,8 +69,28 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
             }
 
             // Foreign-chain wasm payloads cannot be THORChain contract calls.
-            Provenance.Inbound -> content.memo(MEMO_PRECEDENCE)?.let { decodeMemo(it, content) }
+            Provenance.Inbound ->
+                content.memo(MEMO_PRECEDENCE)?.let { decodeMemo(it, carried(content.amount)) }
         }
+    }
+
+    /**
+     * Reads the memo out of a signed THORChain body rather than from beside it.
+     *
+     * A dApp asks the wallet to sign a `/types.MsgDeposit` it built itself; the memo the chain will
+     * execute is inside that message, and the flat fields the payload carries alongside describe
+     * nothing the signer reads. The same grammar applies — it is the same memo — but at the
+     * strongest evidence there is, and with the figure the deposit itself commits to. Only the
+     * native chain has these bodies: an inbound route leaves a chain with no SignDoc to read.
+     */
+    private fun decodeSignedBody(tx: SignedTransactionContent): DecodedTransaction? {
+        if (tx.chain !in NATIVE_CHAINS) return null
+        if (!tx.signedDataBodyIsActive) return null
+        val direct = tx.signedData as? OpaqueSignedContent.CosmosSignDirect ?: return null
+        val deposit = THORChainSignDocReader.read(direct.bodyBytes) ?: return null
+
+        return decodeMemo(deposit.memo, deposit.carried)
+            ?.copy(evidence = DecodedEvidence.SignedData)
     }
 
     private enum class Provenance {
@@ -239,7 +267,7 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
      * Verbs THORChain and Rujira spell the same are told apart by shape: a Rujira memo names a
      * `thor1…` contract and a raw amount where a node memo names a node address.
      */
-    private fun decodeMemo(memo: String, content: CorroboratedContent): DecodedTransaction? {
+    private fun decodeMemo(memo: String, carried: DecodedAmount): DecodedTransaction? {
         val fields = memo.split(":")
         val head = fields.firstOrNull() ?: return null
 
@@ -264,14 +292,14 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
                 if (fields.size > 2)
                     DecodedTransaction(
                         operation = DecodedOperation.LimitOrderPlacement,
-                        amount = carried(content.amount),
+                        amount = carried,
                         evidence = DecodedEvidence.Memo,
                     )
                 else null
 
             "bond" ->
                 if (isRujiraForm) rujira(DecodedOperation.Stake, fields)
-                else node(DecodedOperation.Bond, fields, carried(content.amount))
+                else node(DecodedOperation.Bond, fields, carried)
 
             // Rujira's `withdraw` shares its spelling with the pool-withdrawal alias. A pool is
             // named `CHAIN.ASSET`, never `thor1…`, so the Rujira shape can never be a pool memo.
@@ -302,7 +330,7 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
             "tcy+" ->
                 DecodedTransaction(
                     operation = DecodedOperation.Stake,
-                    amount = carried(content.amount),
+                    amount = carried,
                     evidence = DecodedEvidence.Memo,
                 )
 
@@ -317,11 +345,11 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
                     )
                 }
 
-            "secure+" -> named(DecodedOperation.SecuredAssetDeposit, fields, content)
+            "secure+" -> named(DecodedOperation.SecuredAssetDeposit, fields, carried)
 
-            "secure-" -> named(DecodedOperation.SecuredAssetWithdraw, fields, content)
+            "secure-" -> named(DecodedOperation.SecuredAssetWithdraw, fields, carried)
 
-            "merge" -> named(DecodedOperation.Merge, fields, content)
+            "merge" -> named(DecodedOperation.Merge, fields, carried)
 
             // `unmerge:<token>:<shares>` states its own share count, in the shares' own units.
             "unmerge" -> {
@@ -357,7 +385,7 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
                     ?.let { pool ->
                         DecodedTransaction(
                             operation = DecodedOperation.AddLiquidity,
-                            amount = carried(content.amount),
+                            amount = carried,
                             counterparty = DecodedCounterparty.Pool(pool),
                             evidence = DecodedEvidence.Memo,
                         )
@@ -408,12 +436,12 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
     private fun named(
         operation: DecodedOperation,
         fields: List<String>,
-        content: CorroboratedContent,
+        carried: DecodedAmount,
     ): DecodedTransaction? {
         if (fields.getOrNull(1).isNullOrEmpty()) return null
         return DecodedTransaction(
             operation = operation,
-            amount = carried(content.amount),
+            amount = carried,
             evidence = DecodedEvidence.Memo,
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainTransactionDecoder.kt
@@ -46,10 +46,11 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
             Provenance.Unrelated -> null
 
             Provenance.Native -> {
-                content.wasmPayload?.let { wasm ->
-                    decodeWasm(wasm)?.let {
-                        return it
-                    }
+                // A wasm payload is the whole reading: a memo beside a contract call is decoration
+                // the contract never parses, so an unrecognised execute stops at "contract call"
+                // rather than falling through to the memo grammar behind it.
+                content.wasmPayload?.let {
+                    return decodeWasm(it)
                 }
                 content.memo(MEMO_PRECEDENCE)?.let { memo ->
                     decodeMemo(memo, content)?.let {
@@ -98,16 +99,30 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
 
     // MARK: - Contract calls
 
-    private fun decodeWasm(wasm: WasmExecuteContractPayload): DecodedTransaction? {
+    /**
+     * Reads a wasm execute, but only the ones addressed to a contract that means these verbs.
+     *
+     * `bond`, `withdraw`, `deposit` and `claim` are ordinary CosmWasm message keys, not a namespace
+     * Rujira owns: any contract on THORChain can spell them, and being on THORChain is all the
+     * provenance the transaction itself carries. Without the allowlist an unrelated contract's
+     * `{"withdraw":{"slippage":…}}` would be titled "You're redeeming" over its attached funds. So
+     * the contract has to be one this app transacts with — see
+     * [ThorchainStakingContracts.WASM_CONTRACTS] — before its message is read as anything but a
+     * contract call.
+     */
+    private fun decodeWasm(wasm: WasmExecuteContractPayload): DecodedTransaction {
         val counterparty = DecodedCounterparty.Contract(wasm.contractAddress)
-        val operation =
-            operation(wasm.executeMsg)
-                ?: return DecodedTransaction(
-                    operation = DecodedOperation.ContractCall,
-                    amount = DecodedAmount.Unstated,
-                    counterparty = counterparty,
-                    evidence = DecodedEvidence.WasmExecuteMsg,
-                )
+        val opaque =
+            DecodedTransaction(
+                operation = DecodedOperation.ContractCall,
+                amount = DecodedAmount.Unstated,
+                counterparty = counterparty,
+                evidence = DecodedEvidence.WasmExecuteMsg,
+            )
+
+        if (wasm.contractAddress !in ThorchainStakingContracts.WASM_CONTRACTS) return opaque
+
+        val operation = operation(wasm.executeMsg) ?: return opaque
 
         return DecodedTransaction(
             operation = operation,
@@ -204,9 +219,14 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
     // MARK: - Memo grammar
 
     /**
-     * Memo heads are case-folded the way THORNode folds them. Verbs THORChain and Rujira spell the
-     * same are told apart by shape: a Rujira memo names a `thor1…` contract and a raw amount where
-     * a node memo names a node address.
+     * Memo heads are case-folded the way THORNode folds them, and every documented spelling of a
+     * head this reads is accepted: THORNode treats `ADD`, `+` and `a` as one verb, and `WITHDRAW`,
+     * `-` and `wd` as another, so a memo the network executes as a pool withdrawal has to read as
+     * one here whichever alias built it. Recognising only the symbol forms left the long forms —
+     * the ones the docs lead with, and the ones other wallets and manual memos use — unread.
+     *
+     * Verbs THORChain and Rujira spell the same are told apart by shape: a Rujira memo names a
+     * `thor1…` contract and a raw amount where a node memo names a node address.
      */
     private fun decodeMemo(memo: String, content: CorroboratedContent): DecodedTransaction? {
         val fields = memo.split(":")
@@ -242,7 +262,11 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
                 if (isRujiraForm) rujira(DecodedOperation.Stake, fields)
                 else node(DecodedOperation.Bond, fields, carried(content.amount))
 
-            "withdraw" -> if (isRujiraForm) rujira(DecodedOperation.Unstake, fields) else null
+            // Rujira's `withdraw` shares its spelling with the pool-withdrawal alias. A pool is
+            // named `CHAIN.ASSET`, never `thor1…`, so the Rujira shape can never be a pool memo.
+            "withdraw" ->
+                if (isRujiraForm) rujira(DecodedOperation.Unstake, fields)
+                else removeLiquidity(fields)
 
             "claim" -> if (isRujiraForm) rujira(DecodedOperation.ClaimRewards, fields) else null
 
@@ -301,7 +325,21 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
                 else null
             }
 
-            "+" ->
+            // `TCY[:<l1 address>]` claims a TCY allocation. What it claims is settled from chain
+            // state, and the transaction itself carries only the dust that delivers the memo, so
+            // there is no amount to state.
+            "tcy" ->
+                if (fields.size <= TCY_CLAIM_MAX_FIELDS && fields.drop(1).none { it.isEmpty() })
+                    DecodedTransaction(
+                        operation = DecodedOperation.Claim,
+                        amount = DecodedAmount.Unstated,
+                        evidence = DecodedEvidence.Memo,
+                    )
+                else null
+
+            "+",
+            "add",
+            "a" ->
                 fields
                     .getOrNull(1)
                     ?.takeIf { it.isNotEmpty() }
@@ -314,22 +352,27 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
                         )
                     }
 
-            // `-:<pool>:<bps>`; a single-sided withdrawal appends its asset after the basis points.
-            "-" -> {
-                val pool = fields.getOrNull(1)?.takeIf { it.isNotEmpty() }
-                val fraction = fraction(fields.getOrNull(2))
-                if (pool != null && fraction != null)
-                    DecodedTransaction(
-                        operation = DecodedOperation.RemoveLiquidity,
-                        amount = fraction,
-                        counterparty = DecodedCounterparty.Pool(pool),
-                        evidence = DecodedEvidence.Memo,
-                    )
-                else null
-            }
+            "-",
+            "wd" -> removeLiquidity(fields)
 
             else -> null
         }
+    }
+
+    /**
+     * `-:<pool>:<bps>`, under any of its three heads; a single-sided withdrawal appends the asset
+     * it wants back after the basis points.
+     */
+    private fun removeLiquidity(fields: List<String>): DecodedTransaction? {
+        val pool = fields.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
+        val fraction = fraction(fields.getOrNull(2)) ?: return null
+
+        return DecodedTransaction(
+            operation = DecodedOperation.RemoveLiquidity,
+            amount = fraction,
+            counterparty = DecodedCounterparty.Pool(pool),
+            evidence = DecodedEvidence.Memo,
+        )
     }
 
     /** A node memo: the verb, the node it names, and whatever figure the transaction carries. */
@@ -424,6 +467,9 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
         const val RUJIRA_CONTRACT_FIELD = 1
         const val RUJIRA_AMOUNT_FIELD = 2
         const val MAX_BASIS_POINTS = 10_000
+
+        /** `TCY`, optionally naming the L1 address the allocation is claimed from. */
+        const val TCY_CLAIM_MAX_FIELDS = 2
 
         const val KEY_EXECUTE = "execute"
         const val KEY_MSG = "msg"

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainTransactionDecoder.kt
@@ -104,11 +104,10 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
      *
      * `bond`, `withdraw`, `deposit` and `claim` are ordinary CosmWasm message keys, not a namespace
      * Rujira owns: any contract on THORChain can spell them, and being on THORChain is all the
-     * provenance the transaction itself carries. Without the allowlist an unrelated contract's
+     * provenance the transaction itself carries. Without an allowlist an unrelated contract's
      * `{"withdraw":{"slippage":…}}` would be titled "You're redeeming" over its attached funds. So
-     * the contract has to be one this app transacts with — see
-     * [ThorchainStakingContracts.WASM_CONTRACTS] — before its message is read as anything but a
-     * contract call.
+     * [operation] reads each shape only at the contracts that mean it, and anything else stops here
+     * as a contract call that states no amount.
      */
     private fun decodeWasm(wasm: WasmExecuteContractPayload): DecodedTransaction {
         val counterparty = DecodedCounterparty.Contract(wasm.contractAddress)
@@ -120,9 +119,7 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
                 evidence = DecodedEvidence.WasmExecuteMsg,
             )
 
-        if (wasm.contractAddress !in ThorchainStakingContracts.WASM_CONTRACTS) return opaque
-
-        val operation = operation(wasm.executeMsg) ?: return opaque
+        val operation = operation(wasm) ?: return opaque
 
         return DecodedTransaction(
             operation = operation,
@@ -158,30 +155,44 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
     }
 
     /**
-     * Parses direct Rujira JSON and base64-wrapped yVault JSON. Ambiguous action sets are refused
-     * rather than resolved by whichever key happened to come first.
+     * Parses direct Rujira JSON and base64-wrapped yVault JSON, each only at the contracts where
+     * its keys mean what they say. Ambiguous action sets are refused rather than resolved by
+     * whichever key happened to come first.
+     *
+     * The three shapes do not overlap in practice — a mint is fronted by the affiliate router, a
+     * redemption is addressed at the vault token, staking at a staking contract — so each is asked
+     * for only where this app and iOS actually send it.
      */
-    private fun operation(executeMsg: String): DecodedOperation? {
+    private fun operation(wasm: WasmExecuteContractPayload): DecodedOperation? {
         val root =
-            runCatching { Json.parseToJsonElement(executeMsg).jsonObject }.getOrNull()
+            runCatching { Json.parseToJsonElement(wasm.executeMsg).jsonObject }.getOrNull()
                 ?: return null
 
-        vaultEnvelopeOperation(root)?.let {
-            return it
+        return when (wasm.contractAddress) {
+            in ThorchainStakingContracts.VAULT_MINT_ROUTERS -> vaultEnvelopeOperation(root)
+            in ThorchainStakingContracts.VAULT_TOKEN_CONTRACTS -> yVaultRedeemOperation(root)
+            in ThorchainStakingContracts.STAKING_CONTRACTS -> rujiraOperation(root, depth = 0)
+            else -> null
         }
-        yVaultRedeemOperation(root)?.let {
-            return it
-        }
-        return rujiraOperation(root, depth = 0)
     }
 
     /**
      * The yVault envelope: an outer `execute` naming the target contract, with the real instruction
      * base64-encoded inside it.
+     *
+     * The envelope forwards, so allowlisting the contract it is *addressed* to only proves who
+     * carries the call, not what it lands on. `contract_addr` is where the instruction actually
+     * executes, and `deposit`/`withdraw` mean mint and redeem only at a vault token — so the
+     * forwarding target has to be one too, or a call routed through the same affiliate to somewhere
+     * else would be named a yVault mint. Both platforms write the same envelope: iOS wraps its
+     * redeem in it as well, and its target is the same yRUNE/yTCY pair.
      */
     private fun vaultEnvelopeOperation(root: JsonObject): DecodedOperation? {
-        val encoded =
-            (root[KEY_EXECUTE] as? JsonObject)?.get(KEY_MSG)?.asStringOrNull() ?: return null
+        val envelope = (root[KEY_EXECUTE] as? JsonObject) ?: return null
+        val target = envelope[KEY_CONTRACT_ADDR]?.asStringOrNull() ?: return null
+        if (target !in VAULT_TOKEN_CONTRACTS) return null
+
+        val encoded = envelope[KEY_MSG]?.asStringOrNull() ?: return null
         val decoded =
             runCatching { String(Base64.getDecoder().decode(encoded)) }.getOrNull() ?: return null
         val inner =
@@ -195,8 +206,8 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
      * redemption straight to the token contract as a bare `{"withdraw":{"slippage":"…"}}`, where
      * iOS wraps the same instruction in the `execute` envelope above. Read by [RUJIRA_ACTIONS]
      * alone, that bare `withdraw` would name the redemption an unstake — the wrong verb over the
-     * right figure. The slippage is what tells the two apart: a Rujira `account.withdraw` states an
-     * amount and never a slippage, and it is namespaced rather than bare.
+     * right figure. Two things tell them apart: the contract, because only a vault token redeems,
+     * and the slippage, because a Rujira `account.withdraw` states an amount and never a slippage.
      */
     private fun yVaultRedeemOperation(root: JsonObject): DecodedOperation? {
         val withdraw = (root[KEY_WITHDRAW] as? JsonObject) ?: return null
@@ -472,9 +483,13 @@ constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionC
         const val TCY_CLAIM_MAX_FIELDS = 2
 
         const val KEY_EXECUTE = "execute"
+        const val KEY_CONTRACT_ADDR = "contract_addr"
         const val KEY_MSG = "msg"
         const val KEY_WITHDRAW = "withdraw"
         const val KEY_SLIPPAGE = "slippage"
+
+        /** Where a yVault envelope may forward to — see [ThorchainStakingContracts]. */
+        val VAULT_TOKEN_CONTRACTS = ThorchainStakingContracts.VAULT_TOKEN_CONTRACTS
 
         /** Actions the yVault envelope carries, in the vault's own vocabulary. */
         val VAULT_ACTIONS =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/THORChainTransactionDecoder.kt
@@ -1,0 +1,463 @@
+package com.vultisig.wallet.data.blockchain.thorchain
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.transaction_decoding.CorroboratedContent
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedCounterparty
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedEvidence
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.data.models.transaction_decoding.MemoPrecedence
+import com.vultisig.wallet.data.models.transaction_decoding.SignedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
+import com.vultisig.wallet.data.models.transaction_decoding.TransactionContentDecoder
+import java.util.Base64
+import javax.inject.Inject
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import vultisig.keysign.v1.TransactionType
+import vultisig.keysign.v1.WasmExecuteContractPayload
+
+/**
+ * Reads THORChain memos and Rujira wasm messages, but only where signed content proves the native
+ * or inbound route. A user-typed lookalike memo on an unrelated chain stays unknown.
+ *
+ * Mirrors the iOS `THORChainTransactionDecoder`. It declares no chain scope: an inbound deposit
+ * leaves Bitcoin or Ethereum, so nothing about the chain a transaction is on says THORChain, and
+ * the reader has to establish provenance from the transaction itself.
+ */
+class THORChainTransactionDecoder
+@Inject
+constructor(private val inboundVaults: InboundVaultCorroborating) : TransactionContentDecoder {
+
+    /** Inbound routes may originate on any chain, so provenance gates decoding. */
+    override val handles: Set<Chain>? = null
+
+    override fun decode(tx: SignedTransactionContent): DecodedTransaction? {
+        // Flat fields beside an opaque signed artifact are untrusted sidecars.
+        val content = tx.corroborated ?: return null
+
+        return when (provenance(tx, content)) {
+            Provenance.Unrelated -> null
+
+            Provenance.Native -> {
+                content.wasmPayload?.let { wasm ->
+                    decodeWasm(wasm)?.let {
+                        return it
+                    }
+                }
+                content.memo(MEMO_PRECEDENCE)?.let { memo ->
+                    decodeMemo(memo, content)?.let {
+                        return it
+                    }
+                }
+                decodeWireType(content)
+            }
+
+            // Foreign-chain wasm payloads cannot be THORChain contract calls.
+            Provenance.Inbound -> content.memo(MEMO_PRECEDENCE)?.let { decodeMemo(it, content) }
+        }
+    }
+
+    private enum class Provenance {
+        /** The transaction is on THORChain itself. */
+        Native,
+
+        /** Signed content names a THORChain vault as the destination. */
+        Inbound,
+
+        /** Nothing corroborates THORChain, so its grammar does not apply. */
+        Unrelated,
+    }
+
+    private fun provenance(tx: SignedTransactionContent, content: CorroboratedContent): Provenance {
+        if (tx.chain in NATIVE_CHAINS) return Provenance.Native
+
+        return when {
+            content.swap is SwapPayload.ThorChain -> Provenance.Inbound
+
+            // An active approve or non-THOR swap outranks flat destination data.
+            content.swap != null || content.approve != null -> Provenance.Unrelated
+
+            // A recorded inbound vault can corroborate signed LP and secured-asset destinations.
+            // A cold snapshot refuses rather than blocking a signing screen on a fetch.
+            inboundVaults.corroborates(
+                destination = content.toAddress,
+                chain = tx.chain,
+                isNative = tx.isNativeCoin,
+            ) -> Provenance.Inbound
+
+            else -> Provenance.Unrelated
+        }
+    }
+
+    // MARK: - Contract calls
+
+    private fun decodeWasm(wasm: WasmExecuteContractPayload): DecodedTransaction? {
+        val counterparty = DecodedCounterparty.Contract(wasm.contractAddress)
+        val operation =
+            operation(wasm.executeMsg)
+                ?: return DecodedTransaction(
+                    operation = DecodedOperation.ContractCall,
+                    amount = DecodedAmount.Unstated,
+                    counterparty = counterparty,
+                    evidence = DecodedEvidence.WasmExecuteMsg,
+                )
+
+        return DecodedTransaction(
+            operation = operation,
+            amount = amount(operation, wasm),
+            counterparty = counterparty,
+            evidence = DecodedEvidence.WasmExecuteMsg,
+        )
+    }
+
+    /**
+     * What the operation moves, in the units the signed content states them.
+     *
+     * The attached funds are the only quantity a wasm execute proves. There is deliberately no
+     * fallback to the transaction's memo: a memo beside a wasm payload is already withheld by
+     * [SignedTransactionContent.memoIsOutranked], and a memo beside a contract call is decoration
+     * the contract itself never reads. Where an operation states its own amount inside the execute
+     * message instead — Rujira's `account.withdraw` — the amount names no denom, so nothing here
+     * could say what asset it counts.
+     */
+    private fun amount(
+        operation: DecodedOperation,
+        wasm: WasmExecuteContractPayload,
+    ): DecodedAmount {
+        // Mint output is execution-set; attached funds are the input, not the output.
+        if (operation == DecodedOperation.Mint) return DecodedAmount.Unstated
+
+        // Several attached denoms are ambiguous; never present only the first.
+        val funds = wasm.coins.filterNotNull().singleOrNull() ?: return DecodedAmount.Unstated
+        val units = funds.amount.toBigIntegerOrNull() ?: return DecodedAmount.Unstated
+        if (units.signum() <= 0) return DecodedAmount.Unstated
+
+        return DecodedAmount.Units(units, DecodedAsset.Denom(funds.denom))
+    }
+
+    /**
+     * Parses direct Rujira JSON and base64-wrapped yVault JSON. Ambiguous action sets are refused
+     * rather than resolved by whichever key happened to come first.
+     */
+    private fun operation(executeMsg: String): DecodedOperation? {
+        val root =
+            runCatching { Json.parseToJsonElement(executeMsg).jsonObject }.getOrNull()
+                ?: return null
+
+        vaultEnvelopeOperation(root)?.let {
+            return it
+        }
+        yVaultRedeemOperation(root)?.let {
+            return it
+        }
+        return rujiraOperation(root, depth = 0)
+    }
+
+    /**
+     * The yVault envelope: an outer `execute` naming the target contract, with the real instruction
+     * base64-encoded inside it.
+     */
+    private fun vaultEnvelopeOperation(root: JsonObject): DecodedOperation? {
+        val encoded =
+            (root[KEY_EXECUTE] as? JsonObject)?.get(KEY_MSG)?.asStringOrNull() ?: return null
+        val decoded =
+            runCatching { String(Base64.getDecoder().decode(encoded)) }.getOrNull() ?: return null
+        val inner =
+            runCatching { Json.parseToJsonElement(decoded).jsonObject }.getOrNull() ?: return null
+
+        return inner.keys.mapNotNull(VAULT_ACTIONS::get).singleOrNull()
+    }
+
+    /**
+     * ⚠️ **An Android departure, and the one shape iOS cannot produce.** This app sends a yVault
+     * redemption straight to the token contract as a bare `{"withdraw":{"slippage":"…"}}`, where
+     * iOS wraps the same instruction in the `execute` envelope above. Read by [RUJIRA_ACTIONS]
+     * alone, that bare `withdraw` would name the redemption an unstake — the wrong verb over the
+     * right figure. The slippage is what tells the two apart: a Rujira `account.withdraw` states an
+     * amount and never a slippage, and it is namespaced rather than bare.
+     */
+    private fun yVaultRedeemOperation(root: JsonObject): DecodedOperation? {
+        val withdraw = (root[KEY_WITHDRAW] as? JsonObject) ?: return null
+        return DecodedOperation.Redeem.takeIf { withdraw.containsKey(KEY_SLIPPAGE) }
+    }
+
+    /** Searches one namespace level; deeper keys are the action's own parameters. */
+    private fun rujiraOperation(node: JsonObject, depth: Int): DecodedOperation? {
+        val actions = node.keys.mapNotNull(RUJIRA_ACTIONS::get)
+        if (actions.size == 1) return actions.single()
+        if (actions.size > 1) return null
+
+        if (depth > 0) return null
+
+        // Sorting keeps a malformed multi-namespace message deterministic.
+        val nested = node.keys.sorted().mapNotNull { node[it] as? JsonObject }
+        return nested.mapNotNull { rujiraOperation(it, depth + 1) }.singleOrNull()
+    }
+
+    // MARK: - Memo grammar
+
+    /**
+     * Memo heads are case-folded the way THORNode folds them. Verbs THORChain and Rujira spell the
+     * same are told apart by shape: a Rujira memo names a `thor1…` contract and a raw amount where
+     * a node memo names a node address.
+     */
+    private fun decodeMemo(memo: String, content: CorroboratedContent): DecodedTransaction? {
+        val fields = memo.split(":")
+        val head = fields.firstOrNull() ?: return null
+
+        // The `thor1…` contract plus a numeric third field is what separates a Rujira account
+        // operation from the THORChain node memo sharing its verb.
+        val isRujiraForm =
+            fields.size > RUJIRA_AMOUNT_FIELD &&
+                fields[RUJIRA_CONTRACT_FIELD].startsWith(THOR_ADDRESS_PREFIX) &&
+                fields[RUJIRA_AMOUNT_FIELD].toBigIntegerOrNull() != null
+
+        return when (head.lowercase()) {
+            "m=<" ->
+                if (fields.size > 2)
+                    DecodedTransaction(
+                        operation = DecodedOperation.LimitOrderCancel,
+                        amount = DecodedAmount.Unstated,
+                        evidence = DecodedEvidence.Memo,
+                    )
+                else null
+
+            "=<" ->
+                if (fields.size > 2)
+                    DecodedTransaction(
+                        operation = DecodedOperation.LimitOrderPlacement,
+                        amount = carried(content.amount),
+                        evidence = DecodedEvidence.Memo,
+                    )
+                else null
+
+            "bond" ->
+                if (isRujiraForm) rujira(DecodedOperation.Stake, fields)
+                else node(DecodedOperation.Bond, fields, carried(content.amount))
+
+            "withdraw" -> if (isRujiraForm) rujira(DecodedOperation.Unstake, fields) else null
+
+            "claim" -> if (isRujiraForm) rujira(DecodedOperation.ClaimRewards, fields) else null
+
+            // `UNBOND:<node>:<units>` carries positive base units of the transaction's own coin.
+            "unbond" -> {
+                val units = fields.getOrNull(2)?.toBigIntegerOrNull()
+                if (units != null && units.signum() > 0)
+                    node(
+                        DecodedOperation.Unbond,
+                        fields,
+                        DecodedAmount.Units(units, DecodedAsset.TransactionCoin),
+                    )
+                else null
+            }
+
+            "rebond" ->
+                if (fields.size > 2) node(DecodedOperation.Rebond, fields, DecodedAmount.Unstated)
+                else null
+
+            "leave" -> node(DecodedOperation.Leave, fields, DecodedAmount.Unstated)
+
+            "tcy+" ->
+                DecodedTransaction(
+                    operation = DecodedOperation.Stake,
+                    amount = carried(content.amount),
+                    evidence = DecodedEvidence.Memo,
+                )
+
+            // `TCY-:<bps>` commits to a SHARE of whatever is staked when THORChain executes it, so
+            // what the transaction carries — a literal zero — is not the amount.
+            "tcy-" ->
+                fraction(fields.getOrNull(1))?.let {
+                    DecodedTransaction(
+                        operation = DecodedOperation.Unstake,
+                        amount = it,
+                        evidence = DecodedEvidence.Memo,
+                    )
+                }
+
+            "secure+" -> named(DecodedOperation.SecuredAssetDeposit, fields, content)
+
+            "secure-" -> named(DecodedOperation.SecuredAssetWithdraw, fields, content)
+
+            "merge" -> named(DecodedOperation.Merge, fields, content)
+
+            // `unmerge:<token>:<shares>` states its own share count, in the shares' own units.
+            "unmerge" -> {
+                val token = fields.getOrNull(1)?.takeIf { it.isNotEmpty() }
+                val shares = fields.getOrNull(2)?.toBigIntegerOrNull()
+                if (token != null && shares != null && shares.signum() > 0)
+                    DecodedTransaction(
+                        operation = DecodedOperation.Unmerge,
+                        amount = DecodedAmount.Units(shares, DecodedAsset.Denom(token)),
+                        evidence = DecodedEvidence.Memo,
+                    )
+                else null
+            }
+
+            "+" ->
+                fields
+                    .getOrNull(1)
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.let { pool ->
+                        DecodedTransaction(
+                            operation = DecodedOperation.AddLiquidity,
+                            amount = carried(content.amount),
+                            counterparty = DecodedCounterparty.Pool(pool),
+                            evidence = DecodedEvidence.Memo,
+                        )
+                    }
+
+            // `-:<pool>:<bps>`; a single-sided withdrawal appends its asset after the basis points.
+            "-" -> {
+                val pool = fields.getOrNull(1)?.takeIf { it.isNotEmpty() }
+                val fraction = fraction(fields.getOrNull(2))
+                if (pool != null && fraction != null)
+                    DecodedTransaction(
+                        operation = DecodedOperation.RemoveLiquidity,
+                        amount = fraction,
+                        counterparty = DecodedCounterparty.Pool(pool),
+                        evidence = DecodedEvidence.Memo,
+                    )
+                else null
+            }
+
+            else -> null
+        }
+    }
+
+    /** A node memo: the verb, the node it names, and whatever figure the transaction carries. */
+    private fun node(
+        operation: DecodedOperation,
+        fields: List<String>,
+        amount: DecodedAmount,
+    ): DecodedTransaction? {
+        val node = fields.getOrNull(1)?.takeIf { it.isNotEmpty() } ?: return null
+        return DecodedTransaction(
+            operation = operation,
+            amount = amount,
+            counterparty = DecodedCounterparty.Node(node),
+            evidence = DecodedEvidence.Memo,
+        )
+    }
+
+    /**
+     * A memo whose second field names the asset or address the operation is about — required for
+     * the memo to be that operation at all, but not a counterparty this renders.
+     */
+    private fun named(
+        operation: DecodedOperation,
+        fields: List<String>,
+        content: CorroboratedContent,
+    ): DecodedTransaction? {
+        if (fields.getOrNull(1).isNullOrEmpty()) return null
+        return DecodedTransaction(
+            operation = operation,
+            amount = carried(content.amount),
+            evidence = DecodedEvidence.Memo,
+        )
+    }
+
+    /** A Rujira account operation: `<verb>:<thor1 contract>:<raw amount>`. */
+    private fun rujira(operation: DecodedOperation, fields: List<String>): DecodedTransaction? {
+        val contract = fields[RUJIRA_CONTRACT_FIELD]
+        val raw = fields[RUJIRA_AMOUNT_FIELD].toBigIntegerOrNull() ?: return null
+        if (raw.signum() <= 0) return null
+
+        return DecodedTransaction(
+            operation = operation,
+            amount = DecodedAmount.Units(raw, DecodedAsset.Denom(contract)),
+            counterparty = DecodedCounterparty.Contract(contract),
+            evidence = DecodedEvidence.Memo,
+        )
+    }
+
+    /** Refuses out-of-range basis points rather than clamping signed intent. */
+    private fun fraction(field: String?): DecodedAmount? {
+        val bps = field?.toIntOrNull() ?: return null
+        if (bps !in 1..MAX_BASIS_POINTS) return null
+        return DecodedAmount.Fraction(bps, DecodedAsset.TransactionCoin)
+    }
+
+    // MARK: - Wire type
+
+    private fun decodeWireType(content: CorroboratedContent): DecodedTransaction? =
+        when (content.transactionType) {
+            TransactionType.TRANSACTION_TYPE_THOR_MERGE ->
+                DecodedTransaction(
+                    operation = DecodedOperation.Merge,
+                    amount = carried(content.amount),
+                    evidence = DecodedEvidence.WireTransactionType,
+                )
+
+            TransactionType.TRANSACTION_TYPE_THOR_UNMERGE ->
+                DecodedTransaction(
+                    operation = DecodedOperation.Unmerge,
+                    amount = DecodedAmount.Unstated,
+                    evidence = DecodedEvidence.WireTransactionType,
+                )
+
+            else -> null
+        }
+
+    private companion object {
+        /**
+         * Only the one THORChain network this app builds for. iOS carries chainnet and stagenet
+         * variants beside it; there is no [Chain] entry for either here.
+         */
+        val NATIVE_CHAINS = setOf(Chain.ThorChain)
+
+        /**
+         * An inbound memo travels with the earlier THORChain route rather than being an unsigned
+         * sidecar beside it: a swap out of Bitcoin carries its memo into the transaction the source
+         * chain signs.
+         */
+        val MEMO_PRECEDENCE = MemoPrecedence.MemoTravelsWithTheEarlierRoute
+
+        const val THOR_ADDRESS_PREFIX = "thor1"
+        const val RUJIRA_CONTRACT_FIELD = 1
+        const val RUJIRA_AMOUNT_FIELD = 2
+        const val MAX_BASIS_POINTS = 10_000
+
+        const val KEY_EXECUTE = "execute"
+        const val KEY_MSG = "msg"
+        const val KEY_WITHDRAW = "withdraw"
+        const val KEY_SLIPPAGE = "slippage"
+
+        /** Actions the yVault envelope carries, in the vault's own vocabulary. */
+        val VAULT_ACTIONS =
+            mapOf("deposit" to DecodedOperation.Mint, "withdraw" to DecodedOperation.Redeem)
+
+        /** Actions a Rujira execute message names, under `account` or `liquid`. */
+        val RUJIRA_ACTIONS =
+            mapOf(
+                "unbond" to DecodedOperation.Unstake,
+                "withdraw" to DecodedOperation.Unstake,
+                "bond" to DecodedOperation.Stake,
+                "deposit" to DecodedOperation.Stake,
+                "claim" to DecodedOperation.ClaimRewards,
+                "withdraw_rewards" to DecodedOperation.ClaimRewards,
+            )
+
+        /** Max sends expose no committed amount because signing computes it later. */
+        fun carried(signed: SignedAmount): DecodedAmount =
+            when (signed) {
+                is SignedAmount.Committed ->
+                    if (signed.value.signum() > 0)
+                        DecodedAmount.Units(signed.value, DecodedAsset.TransactionCoin)
+                    else DecodedAmount.Unstated
+
+                SignedAmount.ComputedAtSigning -> DecodedAmount.Unstated
+            }
+    }
+}
+
+/** The element's string content, or null when it is absent or not a JSON string. */
+private fun JsonElement.asStringOrNull(): String? =
+    (this as? JsonPrimitive)?.takeIf { it.isString }?.content

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorChainInboundVaults.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorChainInboundVaults.kt
@@ -1,0 +1,109 @@
+package com.vultisig.wallet.data.blockchain.thorchain
+
+import com.vultisig.wallet.data.api.models.thorchain.THORChainInboundAddress
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
+import com.vultisig.wallet.data.swap.limit.thorchainMemoAssetChainPrefix
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import java.util.concurrent.atomic.AtomicReference
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Whether a signed destination is somewhere THORChain actually receives. */
+interface InboundVaultCorroborating {
+
+    /** Checks a signed destination and its chain against THORChain's inbound set. */
+    fun corroborates(destination: String, chain: Chain, isNative: Boolean): Boolean
+}
+
+/**
+ * The inbound vaults already known, without asking the network.
+ *
+ * ⚠️ **Exists so a signing screen can corroborate a destination without a fetch.** An LP deposit
+ * leaves Bitcoin, so nothing about the chain it is on says THORChain — the only corroboration is
+ * that its destination *is* a THORChain inbound vault, and that answer comes from THORChain rather
+ * than from whoever composed the payload. A decoder reads synchronously and must never reach the
+ * network, so the answer has to already be here or not be given.
+ *
+ * Answers null on a cold or stale snapshot rather than blocking, and a null refuses the reading:
+ * exactly what happened before any of this existed, which makes a cold snapshot a missed
+ * improvement rather than a wrong answer.
+ *
+ * Deliberately separate from the responses [com.vultisig.wallet.data.api.ThorChainApi] hands its
+ * own callers. Those drive a fail-closed halt gate and are fetched with `no-store` precisely so a
+ * halt can never be read from a cache; this snapshot is written from the same responses but is only
+ * ever asked whether an address was a vault, which a halt does not change.
+ */
+@Singleton
+class ThorChainInboundVaultSnapshot @Inject constructor() {
+
+    private data class Held(val addresses: List<THORChainInboundAddress>, val recordedAt: Long)
+
+    private val held = AtomicReference<Held?>(null)
+
+    /** Records the addresses a live fetch returned. An empty answer is not worth holding. */
+    fun record(addresses: List<THORChainInboundAddress>) {
+        if (addresses.isEmpty()) return
+        held.set(Held(addresses, System.currentTimeMillis()))
+    }
+
+    /** The recorded addresses when they are younger than [maxAgeMillis], else null. */
+    fun current(maxAgeMillis: Long = MAX_AGE_MILLIS): List<THORChainInboundAddress>? {
+        val snapshot = held.get() ?: return null
+        val age = System.currentTimeMillis() - snapshot.recordedAt
+        return snapshot.addresses.takeIf { age in 0..maxAgeMillis }
+    }
+
+    private companion object {
+        /** Matches the iOS `cachedInboundAddresses` window. */
+        const val MAX_AGE_MILLIS = 5 * 60 * 1000L
+    }
+}
+
+/**
+ * Corroborates a signed destination against the inbound vaults THORChain last published.
+ *
+ * Mirrors the iOS `ThorchainInboundVaults`.
+ */
+@Singleton
+class ThorChainInboundVaults
+@Inject
+constructor(private val snapshot: ThorChainInboundVaultSnapshot) : InboundVaultCorroborating {
+
+    override fun corroborates(destination: String, chain: Chain, isNative: Boolean): Boolean {
+        if (destination.isEmpty()) return false
+        val known = snapshot.current() ?: return false
+
+        // Only this transaction's chain can corroborate its route, and only a chain THORChain
+        // routes at all has an inbound to be corroborated against. The prefix table is the same one
+        // the memo builders encode routes with, so the two directions cannot disagree.
+        val prefix = thorchainMemoAssetChainPrefix[chain] ?: return false
+        val candidates = known.filter { it.chain.trim().equals(prefix, ignoreCase = true) }
+        if (candidates.isEmpty()) return false
+
+        return candidates.any { entry ->
+            // Native deposits go to the vault; tokens go to the router.
+            val expected = if (isNative) entry.address else entry.router.orEmpty()
+            expected.isNotEmpty() && sameAddress(expected, destination, chain)
+        }
+    }
+
+    /** EVM addresses are case-insensitive; other address families are not. */
+    private fun sameAddress(expected: String, destination: String, chain: Chain): Boolean =
+        if (chain.standard == TokenStandard.EVM) expected.equals(destination, ignoreCase = true)
+        else expected == destination
+}
+
+/**
+ * Binds the corroborator the THORChain reader asks. The interface is the seam: a decoder that
+ * decides provenance from network-sourced state must be drivable without the network.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+internal interface ThorChainInboundVaultsModule {
+
+    @Binds @Singleton fun bindInboundVaults(impl: ThorChainInboundVaults): InboundVaultCorroborating
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainStakingContracts.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainStakingContracts.kt
@@ -1,15 +1,47 @@
 package com.vultisig.wallet.data.blockchain.thorchain
 
 /**
- * Rujira wasm contracts that more than one layer has to name.
+ * The Rujira wasm contracts this app transacts with, and the one place their addresses are spelled.
  *
- * A staking contract is usually named in one place — the builder that spends it — and the app's own
- * DeFi constants carry those. The bRUNE liquid bond is not one of them: the pricing repository
- * reads its `{"status":{}}` NAV to value the ybRUNE receipt, and the bond/unbond executes are built
- * against the same address, so a change to one that missed the other would leave a position priced
- * off a contract it no longer transacts with. Only that address lives here; the rest stay where
- * their single caller is.
+ * These began as constants beside the single builder that spent each one.
+ * [THORChainTransactionDecoder] made them shared: it reads a signed execute message back, and
+ * Rujira's verbs — `bond`, `withdraw`, `deposit`, `claim` — are ordinary CosmWasm keys any contract
+ * on THORChain may spell. What separates a staking operation from an unrelated contract that
+ * happens to use the same word is the address it is addressed to, so the reader has to know that
+ * set exactly.
+ *
+ * That makes a duplicate address a correctness bug rather than untidiness: a builder pointed at one
+ * spelling and a reader holding another would name the same signed transaction two different
+ * things. The UI and pricing layers alias these rather than restating them.
  */
 object ThorchainStakingContracts {
+    /**
+     * Rujira's RUJI staking contract: `account.bond`/`account.withdraw` and the `liquid` sibling.
+     */
+    const val STAKING_RUJI = "thor13g83nn5ef4qzqeafp0508dnvkvm0zqr3sj7eefcn5umu65gqluusrml5cr"
+
+    /** The auto-compounding TCY position, funded with `x/staking-tcy`. */
+    const val STAKING_TCY_COMPOUND =
+        "thor1z7ejlk5wk2pxh9nfwjzkkdnrq4p2f5rjcpudltv0gh282dwfz6nq9g2cr0"
+
+    /** The bRUNE liquid bond, which mints the ybRUNE receipt and whose NAV prices it. */
     const val BRUNE_LIQUID_BOND = "thor179fex2rxd45caedmz4hxsnu42sw20lu0djyh4yukyh965sq8muuqptru2g"
+
+    /** The yRUNE vault token: minted through [YVAULT_AFFILIATE], redeemed against directly. */
+    const val YRUNE = "thor1mlphkryw5g54yfkrp6xpqzlpv4f8wh6hyw27yyg4z2els8a9gxpqhfhekt"
+
+    /** The yTCY vault token, on the same two routes as [YRUNE]. */
+    const val YTCY = "thor1h0hr0rm3dawkedh44hlrmgvya6plsryehcr46yda2vj0wfwgq5xqrs86px"
+
+    /** Fronts a yVault mint, forwarding the base64 instruction on to the token contract. */
+    const val YVAULT_AFFILIATE = "thor1v3f7h384r8hw6r3dtcgfq6d5fq842u6cjzeuu8nr0cp93j7zfxyquyrfl8"
+
+    /**
+     * Every address this app may address a wasm execute to, and the allowlist
+     * [THORChainTransactionDecoder] reads Rujira's grammar under. A payload built by a newer
+     * release against a contract missing here reads as a plain contract call — the reading
+     * degrades, rather than a stranger's contract borrowing a staking verb.
+     */
+    val WASM_CONTRACTS =
+        setOf(STAKING_RUJI, STAKING_TCY_COMPOUND, BRUNE_LIQUID_BOND, YRUNE, YTCY, YVAULT_AFFILIATE)
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainStakingContracts.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/thorchain/ThorchainStakingContracts.kt
@@ -37,11 +37,20 @@ object ThorchainStakingContracts {
     const val YVAULT_AFFILIATE = "thor1v3f7h384r8hw6r3dtcgfq6d5fq842u6cjzeuu8nr0cp93j7zfxyquyrfl8"
 
     /**
-     * Every address this app may address a wasm execute to, and the allowlist
-     * [THORChainTransactionDecoder] reads Rujira's grammar under. A payload built by a newer
-     * release against a contract missing here reads as a plain contract call — the reading
-     * degrades, rather than a stranger's contract borrowing a staking verb.
+     * Where `account.*` and `liquid.*` mean staking. [THORChainTransactionDecoder] reads those
+     * namespaces only here: elsewhere they are just JSON keys a contract chose.
      */
-    val WASM_CONTRACTS =
-        setOf(STAKING_RUJI, STAKING_TCY_COMPOUND, BRUNE_LIQUID_BOND, YRUNE, YTCY, YVAULT_AFFILIATE)
+    val STAKING_CONTRACTS = setOf(STAKING_RUJI, STAKING_TCY_COMPOUND, BRUNE_LIQUID_BOND)
+
+    /**
+     * The vault tokens themselves. A bare `withdraw` carrying a slippage is a redemption only at
+     * one of these, and they are the only targets a mint envelope may forward to.
+     */
+    val VAULT_TOKEN_CONTRACTS = setOf(YRUNE, YTCY)
+
+    /**
+     * What may front a yVault envelope. The envelope forwards, so this says who carries the call
+     * and [VAULT_TOKEN_CONTRACTS] says where it may land — both have to hold.
+     */
+    val VAULT_MINT_ROUTERS = setOf(YVAULT_AFFILIATE)
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/DecodedTransaction.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/DecodedTransaction.kt
@@ -48,6 +48,13 @@ enum class DecodedOperation {
     Undelegate,
     Redelegate,
     ClaimRewards,
+
+    /**
+     * Claiming an allocation the chain already holds for the signer, as a THORChain `TCY` memo
+     * does. Distinct from [ClaimRewards]: nothing was staked to earn it, so calling it a reward
+     * would describe a position the signer never had.
+     */
+    Claim,
     Mint,
     Redeem,
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
@@ -34,14 +34,16 @@ internal object TransactionDecodingModule {
     ): SignedTransactionDecoder =
         SignedTransactionDecoder().apply {
             register(solana)
+            // THORChain is asked before the Cosmos family: its messages are its own, not the
+            // SDK's, and only its grammar names them. A signed `/types.MsgDeposit` body is read
+            // here and nowhere else, so the family's SignDoc reader can never claim a THORChain
+            // body first — not because it happens to refuse the type today, but because the order
+            // says so. The reader establishes its own provenance and declines everything it cannot
+            // prove, so being asked on every chain costs the readers behind it nothing.
+            register(thorChain)
             // The signed body outranks the sidecars that travel beside it, so the SignDoc reader
             // is asked before the memo and wire-type grammar on the same chains.
             register(cosmosSignDoc)
-            // THORChain shares the Cosmos standard, so it has to be asked first: its own grammar
-            // reads memos the family reader would either miss or read as a plain transfer. It
-            // establishes its own provenance and declines everything it cannot prove, so being
-            // asked on every chain costs the readers behind it nothing.
-            register(thorChain)
             register(cosmos)
             register(maya)
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
@@ -4,6 +4,7 @@ import com.vultisig.wallet.data.blockchain.cosmos.CosmosSignDocDecoder
 import com.vultisig.wallet.data.blockchain.cosmos.CosmosTransactionDecoder
 import com.vultisig.wallet.data.blockchain.maya.MayaChainTransactionDecoder
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaTransactionDecoder
+import com.vultisig.wallet.data.blockchain.thorchain.THORChainTransactionDecoder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -27,6 +28,7 @@ internal object TransactionDecodingModule {
     fun provideSignedTransactionDecoder(
         solana: SolanaTransactionDecoder,
         cosmosSignDoc: CosmosSignDocDecoder,
+        thorChain: THORChainTransactionDecoder,
         cosmos: CosmosTransactionDecoder,
         maya: MayaChainTransactionDecoder,
     ): SignedTransactionDecoder =
@@ -35,6 +37,11 @@ internal object TransactionDecodingModule {
             // The signed body outranks the sidecars that travel beside it, so the SignDoc reader
             // is asked before the memo and wire-type grammar on the same chains.
             register(cosmosSignDoc)
+            // THORChain shares the Cosmos standard, so it has to be asked first: its own grammar
+            // reads memos the family reader would either miss or read as a plain transfer. It
+            // establishes its own provenance and declines everything it cannot prove, so being
+            // asked on every chain costs the readers behind it nothing.
+            register(thorChain)
             register(cosmos)
             register(maya)
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenPriceRepository.kt
@@ -849,8 +849,7 @@ constructor(
         private val YBRUNE_DENOM = Coins.ThorChain.ybRUNE.contractAddress
         private val STAKING_TCY_DENOM = Coins.ThorChain.sTCY.contractAddress
         private const val BRUNE_STAKING_CONTRACT = ThorchainStakingContracts.BRUNE_LIQUID_BOND
-        private const val STAKING_TCY_CONTRACT =
-            "thor1z7ejlk5wk2pxh9nfwjzkkdnrq4p2f5rjcpudltv0gh282dwfz6nq9g2cr0"
+        private const val STAKING_TCY_CONTRACT = ThorchainStakingContracts.STAKING_TCY_COMPOUND
     }
 
     private fun mapThorPoolAsset(contractAddress: String): String {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -3,6 +3,7 @@ package com.vultisig.wallet.data.repositories
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.models.DenomMetadata
+import com.vultisig.wallet.data.blockchain.thorchain.ThorchainStakingContracts
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
@@ -272,10 +273,8 @@ constructor(
     companion object {
         private const val CUSTOM_TOKEN_RESPONSE_TICKER_ID = 2
 
-        private const val YRUNE_CONTRACT =
-            "thor1mlphkryw5g54yfkrp6xpqzlpv4f8wh6hyw27yyg4z2els8a9gxpqhfhekt"
-        private const val YTCY_CONTRACT =
-            "thor1h0hr0rm3dawkedh44hlrmgvya6plsryehcr46yda2vj0wfwgq5xqrs86px"
+        private const val YRUNE_CONTRACT = ThorchainStakingContracts.YRUNE
+        private const val YTCY_CONTRACT = ThorchainStakingContracts.YTCY
     }
 }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiContractStatusHostTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiContractStatusHostTest.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.api
 
+import com.vultisig.wallet.data.blockchain.thorchain.ThorChainInboundVaultSnapshot
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -69,6 +70,7 @@ internal class ThorChainApiContractStatusHostTest {
             thorChainSwapQuoteResponseJsonSerializer =
                 mockk<ThorChainSwapQuoteResponseJsonSerializer>(),
             json = jsonFormat,
+            inboundVaultSnapshot = ThorChainInboundVaultSnapshot(),
         )
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiImplTest.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.errors.CosmosBroadcastException
+import com.vultisig.wallet.data.blockchain.thorchain.ThorChainInboundVaultSnapshot
 import com.vultisig.wallet.data.testutils.MockHttpClient
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
 import io.ktor.client.HttpClient
@@ -45,6 +46,7 @@ class ThorChainApiImplTest {
             thorChainSwapQuoteResponseJsonSerializer =
                 mockk<ThorChainSwapQuoteResponseJsonSerializer>(),
             json = json,
+            inboundVaultSnapshot = ThorChainInboundVaultSnapshot(),
         )
 
     @Test
@@ -279,6 +281,7 @@ class ThorChainApiImplTest {
             thorChainSwapQuoteResponseJsonSerializer =
                 mockk<ThorChainSwapQuoteResponseJsonSerializer>(),
             json = json,
+            inboundVaultSnapshot = ThorChainInboundVaultSnapshot(),
         )
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainApiSlippageTest.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.quotes.ThorChainSwapQuoteRequest
+import com.vultisig.wallet.data.blockchain.thorchain.ThorChainInboundVaultSnapshot
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializer
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -46,6 +47,7 @@ class ThorChainApiSlippageTest {
             thorChainSwapQuoteResponseJsonSerializer =
                 mockk<ThorChainSwapQuoteResponseJsonSerializer>(),
             json = json,
+            inboundVaultSnapshot = ThorChainInboundVaultSnapshot(),
         )
 
     private suspend fun ThorChainApiImpl.quoteWith(toleranceBps: Int?) =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainQuoteRetryTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/ThorChainQuoteRetryTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.api
 
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuoteDeserialized
 import com.vultisig.wallet.data.api.models.quotes.ThorChainSwapQuoteRequest
+import com.vultisig.wallet.data.blockchain.thorchain.ThorChainInboundVaultSnapshot
 import com.vultisig.wallet.data.networkutils.HttpClientConfigurator
 import com.vultisig.wallet.data.utils.NetworkException
 import com.vultisig.wallet.data.utils.ThorChainSwapQuoteResponseJsonSerializerImpl
@@ -63,6 +64,7 @@ class ThorChainQuoteRetryTest {
             thorChainSwapQuoteResponseJsonSerializer =
                 ThorChainSwapQuoteResponseJsonSerializerImpl(json),
             json = json,
+            inboundVaultSnapshot = ThorChainInboundVaultSnapshot(),
         )
 
     private fun request() =


### PR DESCRIPTION
## Summary

Android mirror of iOS [#5224](https://github.com/vultisig/vultisig-ios/pull/5224), under the decoder parity ticket #5657. Follows #5829 (Cosmos).

A THORChain staking withdrawal is a memo-only `MsgDeposit`: its amount is a literal `0` and the instruction is a *share* of a position, so Verify announced "You're sending 0 TCY" over a withdrawal of a thousand of them. An LP deposit leaves Bitcoin, so nothing about the chain it is on says THORChain at all.

- `THORChainTransactionDecoder` reads THORChain memo and Rujira wasm grammar: LP add/remove, secured assets, limit orders, `TCY+`/`TCY-`, RUJI account and liquid positions, yVault mint/redeem, bond/unbond/rebond/leave, merge/unmerge.
- It declares no chain scope and establishes its own provenance — THORChain itself, an active THORChain swap route, or a destination THORChain published as an inbound vault. Everything else stays unknown, so a user-typed lookalike memo on an unrelated chain reads as nothing.
- `TcyStakedPositionReader` resolves a `TCY-:<bps>` withdrawal against the signer's own staked position, truncating in base units exactly as the unstake form derived the basis points.
- A fractional reading now replaces the surface's own hero instead of retitling it, which is what makes it safe to name a pool withdrawal at all.

## What proves the operation

A recognised THORChain memo head, or a Rujira wasm execute message addressed to a contract this app transacts with, in content that will actually be signed — plus the provenance above. A wasm payload on a foreign chain is not a THORChain contract call, and an opaque signed artifact withholds every flat sidecar beside it.

The contract is part of that proof rather than an afterthought. `bond`, `withdraw`, `deposit` and `claim` are ordinary CosmWasm keys, not a namespace Rujira owns, so being on THORChain is not enough to read them as staking: an unrelated contract's `{"withdraw":{"slippage":"…"}}` would otherwise be titled "You're redeeming" over its own attached funds. `ThorchainStakingContracts` declares the six addresses this app addresses a wasm execute to — RUJI staking, the TCY compound, the bRUNE liquid bond, yRUNE, yTCY, the yVault affiliate — once, and the builders, the pricing repository and this reader all alias it, because a builder and a reader holding different spellings would name the same signed transaction two different things. Each shape is read only where it means what it says: the `account`/`liquid` namespaces at a staking contract, the bare slippage-bearing `withdraw` at a vault token, and the yVault envelope at the affiliate router — *and* only when its `contract_addr` forwards to a vault token, since the router proves who carries the call, not where it lands. Anything else reads as a contract call and states no amount.

A signed THORChain body is read, not withheld. A dApp that asks the wallet to sign builds the `/types.MsgDeposit` itself, and the memo the chain will execute lives inside that message — a type the Cosmos family reader refuses by design, and a body behind which the payload's flat fields are correctly withheld, so nothing read it and a co-signer shown a dApp's `TCY-:5000` got whatever screen it already had. `THORChainSignDocReader` reads that one message, through the same serializable models the joining device renders the request from, so the verb and the rendered message come from one parse and cannot disagree. The memo grammar runs over it at `SignedData` evidence with the figure the deposit itself commits to — RUNE as the chain's own unit, other native assets by denom, no amount for a secured, synth, trade or multi-coin deposit rather than a wrong one. A body the reader cannot name completely is refused whole. THORChain registers ahead of the family reader for this: it reads its own bodies and nothing else's, and the order says so.

Every documented spelling of a head this reads is accepted. THORNode folds `ADD`/`+`/`a` into one verb and `WITHDRAW`/`-`/`wd` into another, so a pool memo has to read the same whichever alias built it; `withdraw` keeps its Rujira branch ahead of the pool one, which is unambiguous because a pool is named `CHAIN.ASSET` and never `thor1…`. A `TCY` claim reads as its own `Claim` verb rather than borrowing `ClaimRewards`: nothing was staked to earn an allocation, and its size is settled from chain state, so it states no amount.

## Refused deliberately

Unrelated-chain lookalikes (`TCY-:5000` on Cosmos, `BOND:thor1…` on Ethereum); malformed grammar (`UNBOND` with no unit count, `-:POOL` with no basis points, basis points outside 1–10000); ambiguous wasm (two Rujira actions in one namespace, several attached denoms); a contract call of unknown shape, which reads as a contract call and states no amount; and an inbound destination nothing corroborates — a cold snapshot refuses rather than blocking a signing screen on a fetch.

## Departures from the iOS mirror

- **No `withdrawDisplayAmount`.** iOS threads a display-only quote through `SendTransaction` because its projection path is co-signer-only. Android already resolves position readers on both the initiator and the co-signer, so the TCY reader serves both surfaces and there is no second, builder-quoted path to keep in step with it. iOS's `QuotedWithdrawalPresentation` and the five builder/transaction files behind it are not ported.
- **The wasm reader takes no memo fallback.** A memo beside a wasm payload is already withheld as an outranked sidecar — on both platforms — so iOS's Rujira memo branch inside the wasm amount reader can never fire. Documented rather than ported.
- **This app's own yVault redeem shape.** Android sends a bare `{"withdraw":{"slippage":"…"}}` straight to the token contract where iOS wraps the same instruction in the `execute` envelope. Read by the Rujira action table alone, that bare `withdraw` would name a redemption an unstake — the wrong verb over the right figure. The slippage parameter is what tells the two apart. Both shapes decode, so a cross-platform ceremony agrees.
- **Inbound corroboration reads a snapshot, not a service cache.** `ThorChainInboundVaultSnapshot` is recorded by the existing `inbound_addresses` fetches, so every current caller warms it for free. The fail-closed halt gate keeps its live, `no-store` response untouched; the snapshot is only ever asked which addresses were vaults, which a halt does not change. Chain matching goes through `thorchainMemoAssetChainPrefix` — the same table the memo builders encode routes with — rather than the swap-asset ticker, so the two directions cannot disagree.
- **A signed `/types.MsgDeposit` body is read.** iOS leaves a dApp-built THORChain body unread, because its family SignDoc reader refuses the type and its THORChain reader sees only the withheld sidecars. Scoped to `signDirect`, matching the family reader; amino bodies stay unread on both platforms.
- **Swap heads are still not read here.** `SWAP`/`=`/`s` return null on purpose: the swap surfaces own a two-sided rendering this reader would flatten. `LOAN±`, `DONATE` and THORChain `POOL±` have no verb in `DecodedOperation` and no path in this app, so they stay unread rather than being mapped onto an approximate one.
- **One THORChain network.** iOS carries chainnet and stagenet variants; there is no `Chain` entry for either here.
- **A pool withdrawal's scope says "of your liquidity position"** rather than reusing the staked-position wording iOS shares between the two. Naming a pool holding a stake is the wrong holding, in ten languages.

## Hero precedence

`VerifyHero.applyTo` gains one rung, mirroring iOS registering its quoted-withdrawal provider ahead of the simulated one: a signed *share* disowns the figure the surface resolved on its own, so the reading replaces that hero rather than retitling it. This is scoped to `Fraction` amounts only — an `Unstated` reading leaves the surface's figure alone, because for a RUJI account withdrawal that figure is the amount.

Side effect worth naming: a MAYAChain `POOL-` withdrawal, already read as a fraction, now shows "50% of your liquidity position" instead of the donated dust it was charging.

## Validation

- `:data:testDebugUnitTest`, `:app:testDebugUnitTest`, `:app:lintDebug` — all green.
- Decoder behaviour driven through a throwaway 15-case suite covering the memo grammar, the wasm namespaces, both yVault shapes, the wire discriminators, refusals, and inbound provenance with and without corroboration. All passed; deleted per repo practice. Happy to keep it in the branch if reviewers want it.
- Not exercised against a live cross-device ceremony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ryx3KDfoosD84RjL7bgpH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved decoding for THORChain and Rujira transactions, including swaps, deposits, withdrawals, claims, and contract operations.
  - Added support for displaying TCY unstaking amounts and liquidity-position changes.
  - Added clearer transaction amount, operation, and position labels.

- **Bug Fixes**
  - Improved transaction verification for liquidity removal and carrier charges.
  - Improved transaction recognition and validation to avoid unsupported or unverifiable amounts.

- **Localization**
  - Added translated claim, liquidity verification, and withdrawal messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

