### PR TITLE
fix(bittensor): refuse the all-zero AccountId as a TAO destination

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/blockchain/ChainHelpersTest.kt
@@ -44,6 +44,7 @@ import org.bouncycastle.crypto.digests.Blake2bDigest
 import org.junit.AfterClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Test
@@ -556,6 +557,26 @@ class ChainHelpersTest {
                 helper.getPreSignedImageHash(transaction.keysignPayload.toInternalKeySignPayload())
 
             assertEquals(preImageHashes, transaction.expectedImageHash)
+        }
+    }
+
+    /**
+     * The last line of defence for issue #5844: the form refuses the all-zero AccountId, but the
+     * extrinsic builder is what every signing path funnels through, so it refuses it too rather
+     * than trusting that the only caller checked. Reuses a corpus payload with the destination
+     * swapped, so the shared golden vectors stay untouched.
+     */
+    @Test
+    fun bittensorRefusesTheBurnAddress() {
+        val payload =
+            loadTransactionData(BITTENSOR_JSON_FILE)
+                .first()
+                .keysignPayload
+                .toInternalKeySignPayload()
+                .copy(toAddress = BittensorHelper.BURN_ADDRESS)
+
+        assertThrows(IllegalArgumentException::class.java) {
+            BittensorHelper(HEX_PUBLIC_KEY_EDDSA).getPreSignedImageHash(payload)
         }
     }
 

--- a/app/src/androidTest/java/com/vultisig/wallet/data/chains/helpers/BittensorHelperSs58ParityTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/data/chains/helpers/BittensorHelperSs58ParityTest.kt
@@ -3,7 +3,9 @@ package com.vultisig.wallet.data.chains.helpers
 import java.math.BigInteger
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import wallet.core.jni.AnyAddress
 import wallet.core.jni.CoinType
@@ -92,6 +94,37 @@ class BittensorHelperSs58ParityTest {
             val pubkey = randomEdwardsPubkey(seed)
             val referenceAddress = ReferenceImpl.encode(pubkey)
             assertArrayEquals("seed $seed", pubkey, BittensorHelper.ss58Decode(referenceAddress))
+        }
+    }
+
+    /**
+     * `BURN_ADDRESS` is spelled out as a literal so a recipient check can compare strings without a
+     * JNI call, which is what makes it unit-testable. That only holds while the literal really is
+     * the all-zero AccountId — pinned here, against the codec, rather than trusted.
+     */
+    @Test
+    fun the_burn_address_literal_decodes_to_the_all_zero_account_id() {
+        assertArrayEquals(ByteArray(32), BittensorHelper.ss58Decode(BittensorHelper.BURN_ADDRESS))
+        assertTrue(
+            BittensorHelper.isBurnAccountId(
+                BittensorHelper.ss58Decode(BittensorHelper.BURN_ADDRESS)
+            )
+        )
+    }
+
+    /**
+     * The reason the guard has to exist: WalletCore is perfectly happy with the burn address, so
+     * nothing upstream of the check would have stopped a send to it.
+     */
+    @Test
+    fun the_burn_address_passes_chain_validation() {
+        assertTrue(AnyAddress.isValidSS58(BittensorHelper.BURN_ADDRESS, CoinType.POLKADOT, 42))
+    }
+
+    @Test
+    fun a_spendable_account_is_not_read_as_the_burn_account() {
+        for (seed in 1L..20L) {
+            assertFalse("seed $seed", BittensorHelper.isBurnAccountId(randomEdwardsPubkey(seed)))
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/AddressManager.kt
@@ -138,7 +138,7 @@ internal class AddressManager(
             return
         }
 
-        when (chainAccountAddressRepository.validateRecipient(chain, addressStr)) {
+        when (val validity = chainAccountAddressRepository.validateRecipient(chain, addressStr)) {
             RecipientValidity.Valid -> {
                 // Only clear ENS label if the user typed a new raw address,
                 // not when we programmatically set the field to the resolved address.
@@ -149,12 +149,14 @@ internal class AddressManager(
                 _addressError.value = null
                 _onAddressValidated.tryEmit(Unit)
             }
-            // A token account or program address is a well-formed address, so there is no name for
-            // the resolver to find — reject it here instead of sending it round that path.
-            RecipientValidity.NotAWalletAddress -> {
+            // A token account, program address or burn address is a well-formed address, so
+            // there is no name for the resolver to find — reject it here instead of sending it
+            // round that path.
+            RecipientValidity.NotAWalletAddress,
+            RecipientValidity.BurnAddress -> {
                 _resolvedDstAddress.value = null
                 _dstAddressLabel.value = null
-                _addressError.value = RecipientValidity.NotAWalletAddress
+                _addressError.value = validity
             }
             RecipientValidity.InvalidForChain -> {
                 // Clear stale resolved address while async resolution is in-flight

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/SendFormGraph.kt
@@ -456,6 +456,10 @@ internal class SendFormGraph(
                                         com.vultisig.wallet.R.string
                                             .error_recipient_not_a_wallet_address
                                     )
+                                RecipientValidity.BurnAddress ->
+                                    UiText.StringResource(
+                                        com.vultisig.wallet.R.string.error_recipient_burn_address
+                                    )
                                 RecipientValidity.Valid,
                                 null -> null
                             }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -154,6 +154,10 @@ internal class DefaultSendStrategy(
                             throw InvalidTransactionDataException(
                                 UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
                             )
+                        RecipientValidity.BurnAddress ->
+                            throw InvalidTransactionDataException(
+                                UiText.StringResource(R.string.error_recipient_burn_address)
+                            )
                     }
 
                     val selectedTokenValue =

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapFormViewModel.kt
@@ -659,6 +659,8 @@ constructor(
                 UiText.StringResource(R.string.swap_external_recipient_invalid)
             RecipientValidity.NotAWalletAddress ->
                 UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
+            RecipientValidity.BurnAddress ->
+                UiText.StringResource(R.string.error_recipient_burn_address)
         }
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/transaction/AddressEntryViewModel.kt
@@ -268,6 +268,8 @@ constructor(
             RecipientValidity.InvalidForChain -> invalidForChain(chain)
             RecipientValidity.NotAWalletAddress ->
                 UiText.StringResource(R.string.error_recipient_not_a_wallet_address)
+            RecipientValidity.BurnAddress ->
+                UiText.StringResource(R.string.error_recipient_burn_address)
         }
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -252,6 +252,7 @@
     <string name="send_error_no_address">Adresse ist ungültig</string>
     <string name="send_error_invalid_recipient_address">Dieser Empfänger ist keine gültige Adresse für diese Blockchain.</string>
     <string name="error_recipient_not_a_wallet_address">Dieser Empfänger ist ein Token-Konto oder eine Programmadresse, keine Wallet. Geben Sie die Wallet-Adresse des Inhabers ein.</string>
+    <string name="error_recipient_burn_address">Dieser Empfänger ist eine Burn-Adresse — niemand besitzt den zugehörigen Schlüssel, alles Gesendete ist unwiederbringlich verloren. Geben Sie eine andere Adresse ein.</string>
     <string name="send_error_memo_too_long">Memo ist zu lang: %1$d Bytes (Maximum %2$d).</string>
     <string name="vault_settings_error_backup_file">ein Fehler ist aufgetreten</string>
     <string name="vault_settings_error_backup_failed">Backup fehlgeschlagen. Es wurde keine Datei gespeichert. Bitte versuchen Sie es erneut.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -249,6 +249,7 @@
     <string name="send_error_no_address">La dirección no es válida</string>
     <string name="send_error_invalid_recipient_address">Ese destinatario no es una dirección válida para esta cadena.</string>
     <string name="error_recipient_not_a_wallet_address">Ese destinatario es una cuenta de token o una dirección de programa, no una billetera. Introduce la dirección de billetera del propietario.</string>
+    <string name="error_recipient_burn_address">Ese destinatario es una dirección de quema: nadie tiene su clave, así que todo lo enviado allí se destruye. Introduce una dirección diferente.</string>
     <string name="send_error_memo_too_long">El memo es demasiado largo: %1$d bytes (máximo %2$d).</string>
     <string name="verify_transaction_value">Valor</string>
     <string name="camera_permission_open_settings">Abrir configuración</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -252,6 +252,7 @@
     <string name="send_error_no_address">Adresa je nevažeća</string>
     <string name="send_error_invalid_recipient_address">Taj primatelj nije valjana adresa za ovaj lanac.</string>
     <string name="error_recipient_not_a_wallet_address">Taj primatelj je token račun ili adresa programa, a ne novčanik. Unesite adresu novčanika vlasnika.</string>
+    <string name="error_recipient_burn_address">Taj primatelj je adresa za spaljivanje — nitko nema njezin ključ, pa je sve poslano na nju nepovratno izgubljeno. Unesite drugu adresu.</string>
     <string name="send_error_memo_too_long">Memo je predugačak: %1$d bajtova (najviše %2$d).</string>
     <string name="vault_settings_error_backup_file">dogodila se pogreška</string>
     <string name="vault_settings_error_backup_failed">Sigurnosno kopiranje nije uspjelo. Nijedna datoteka nije spremljena. Pokušajte ponovno.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -252,6 +252,7 @@
     <string name="send_error_no_address">L\'indirizzo non è valido</string>
     <string name="send_error_invalid_recipient_address">Quel destinatario non è un indirizzo valido per questa catena.</string>
     <string name="error_recipient_not_a_wallet_address">Questo destinatario è un account token o un indirizzo di programma, non un portafoglio. Inserisci l\'indirizzo del portafoglio del proprietario.</string>
+    <string name="error_recipient_burn_address">Questo destinatario è un indirizzo di burn: nessuno ne possiede la chiave, quindi tutto ciò che vi viene inviato è perduto. Inserisci un indirizzo diverso.</string>
     <string name="send_error_memo_too_long">Il memo è troppo lungo: %1$d byte (massimo %2$d).</string>
     <string name="vault_settings_error_backup_file">si è verificato un errore</string>
     <string name="vault_settings_error_backup_failed">Backup non riuscito. Nessun file è stato salvato. Riprova.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -205,6 +205,7 @@
     <string name="send_error_no_address">주소가 유효하지 않습니다</string>
     <string name="send_error_invalid_recipient_address">해당 수신자는 이 체인에 유효한 주소가 아닙니다.</string>
     <string name="error_recipient_not_a_wallet_address">해당 수신자는 지갑이 아니라 토큰 계정 또는 프로그램 주소입니다. 소유자의 지갑 주소를 입력하세요.</string>
+    <string name="error_recipient_burn_address">해당 수신자는 소각 주소입니다. 아무도 이 주소의 키를 가지고 있지 않아 보낸 자산은 영구히 사라집니다. 다른 주소를 입력하세요.</string>
     <string name="send_error_memo_too_long">메모가 너무 깁니다: %1$d바이트 (최대 %2$d바이트).</string>
     <string name="send_error_no_amount">금액은 양수여야 합니다</string>
     <string name="send_error_too_many_decimals">금액은 소수점 이하 최대 %1$d자리까지 입력할 수 있습니다</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -106,6 +106,7 @@
     <string name="send_error_no_address">Adres is ongeldig</string>
     <string name="send_error_invalid_recipient_address">Die ontvanger is geen geldig adres voor deze keten.</string>
     <string name="error_recipient_not_a_wallet_address">Die ontvanger is een tokenaccount of programma-adres, geen wallet. Voer het walletadres van de eigenaar in.</string>
+    <string name="error_recipient_burn_address">Die ontvanger is een burn-adres — niemand heeft de sleutel, dus alles wat je ernaartoe stuurt is definitief verloren. Voer een ander adres in.</string>
     <string name="send_error_memo_too_long">Memo is te lang: %1$d bytes (maximaal %2$d).</string>
     <string name="send_error_no_amount">Het bedrag moet een positief getal zijn</string>
     <string name="send_error_too_many_decimals">Het bedrag mag maximaal %1$d decimalen hebben</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -252,6 +252,7 @@
     <string name="send_error_no_address">Endereço inválido</string>
     <string name="send_error_invalid_recipient_address">Esse destinatário não é um endereço válido para esta cadeia.</string>
     <string name="error_recipient_not_a_wallet_address">Esse destinatário é uma conta de token ou endereço de programa, não uma carteira. Insira o endereço da carteira do proprietário.</string>
+    <string name="error_recipient_burn_address">Esse destinatário é um endereço de queima: ninguém tem a chave dele, então tudo enviado para lá é destruído. Insira um endereço diferente.</string>
     <string name="send_error_memo_too_long">O memorando é muito longo: %1$d bytes (máximo %2$d).</string>
     <string name="vault_settings_error_backup_file">um erro ocorreu</string>
     <string name="vault_settings_error_backup_failed">O backup falhou. Nenhum ficheiro foi guardado. Tente novamente.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -106,6 +106,7 @@
     <string name="send_error_no_address">Адрес недействителен</string>
     <string name="send_error_invalid_recipient_address">Этот получатель не является действительным адресом для этой сети.</string>
     <string name="error_recipient_not_a_wallet_address">Этот получатель — токен-аккаунт или адрес программы, а не кошелёк. Введите адрес кошелька владельца.</string>
+    <string name="error_recipient_burn_address">Этот получатель — адрес сжигания: ключа от него ни у кого нет, поэтому всё отправленное будет безвозвратно утеряно. Введите другой адрес.</string>
     <string name="send_error_memo_too_long">Мемо слишком длинное: %1$d байт (максимум %2$d).</string>
     <string name="send_error_no_amount">Сумма должна быть положительным числом</string>
     <string name="send_error_too_many_decimals">Сумма может содержать не более %1$d знаков после запятой</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -225,6 +225,7 @@
     <string name="send_error_no_address">地址无效</string>
     <string name="send_error_invalid_recipient_address">该收款人不是此链的有效地址。</string>
     <string name="error_recipient_not_a_wallet_address">该收款方是代币账户或程序地址，而非钱包。请输入所有者的钱包地址。</string>
+    <string name="error_recipient_burn_address">该收款方是销毁地址——无人持有其私钥，转入的资产将永久丢失。请输入其他地址。</string>
     <string name="send_error_memo_too_long">备注过长：%1$d 个字节（最多 %2$d 个）。</string>
     <string name="send_error_no_amount">金额必须是正数</string>
     <string name="send_error_too_many_decimals">金额最多可保留 %1$d 位小数</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -209,6 +209,7 @@
     <string name="send_error_no_address">Address is invalid</string>
     <string name="send_error_invalid_recipient_address">That recipient is not a valid address for this chain.</string>
     <string name="error_recipient_not_a_wallet_address">That recipient is a token account or program address, not a wallet. Enter the owner\'s wallet address.</string>
+    <string name="error_recipient_burn_address">That recipient is a burn address — nobody holds its key, so anything sent there is destroyed. Enter a different address.</string>
     <string name="send_error_memo_too_long">Memo is too long: %1$d bytes (maximum %2$d).</string>
     <string name="send_error_no_amount">Amount must be a positive number</string>
     <string name="send_error_too_many_decimals">Amount can have at most %1$d decimal places</string>

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/BittensorHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/BittensorHelper.kt
@@ -103,6 +103,10 @@ class BittensorHelper(private val vaultHexPublicKey: String) {
      */
     private fun buildCallData(keysignPayload: KeysignPayload): ByteArray {
         val destBytes = ss58Decode(keysignPayload.toAddress)
+        require(!isBurnAccountId(destBytes)) {
+            "Refusing to sign a transfer to the all-zero AccountId ($BURN_ADDRESS): " +
+                "no key can produce that account, so the transferred TAO is unrecoverable"
+        }
         val amount = keysignPayload.toAmount
         require(amount >= BigInteger.ZERO) { "Transfer amount must be non-negative, got $amount" }
 
@@ -174,6 +178,25 @@ class BittensorHelper(private val vaultHexPublicKey: String) {
         private const val METADATA_HASH_DISABLED: Byte = 0x00
         const val DEFAULT_FEE_RAO = 200_000L
         private const val SS58_PREFIX = 42
+
+        /**
+         * The all-zero 32-byte AccountId under Bittensor's SS58 prefix, the Substrate equivalent of
+         * `0x0` — no private key derives it, so anything transferred there is destroyed.
+         *
+         * Spelled out rather than derived from [ZERO_ACCOUNT_ID] so a recipient check stays a pure
+         * string comparison off the JNI, which is what lets it be unit tested; the SS58 parity test
+         * pins this constant against [ss58Decode] so the two cannot drift.
+         *
+         * Only this spelling can reach a Bittensor recipient check: an address is admitted by
+         * `isValidSS58(…, SS58_PREFIX)`, and SS58 admits exactly one encoding per prefix.
+         */
+        const val BURN_ADDRESS = "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM"
+
+        private val ZERO_ACCOUNT_ID = ByteArray(32)
+
+        /** Whether [accountId] is the unspendable all-zero account behind [BURN_ADDRESS]. */
+        fun isBurnAccountId(accountId: ByteArray): Boolean =
+            accountId.contentEquals(ZERO_ACCOUNT_ID)
 
         private fun compactEncode(value: BigInteger): ByteArray {
             require(value >= BigInteger.ZERO) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepository.kt
@@ -65,6 +65,16 @@ enum class RecipientValidity {
      * account sits on the curve like any wallet. Only what the cluster reports is refused.
      */
     NotAWalletAddress,
+
+    /**
+     * A well-formed address that provably nobody holds the key to, so funds sent there are
+     * destroyed: on Bittensor, the all-zero Substrate AccountId ([BittensorHelper.BURN_ADDRESS]).
+     *
+     * Distinct from [NotAWalletAddress] because the two are not the same claim and do not deserve
+     * the same wording: a Solana token account is real and owned, it just strands the transfer,
+     * whereas this account cannot be signed for by anyone.
+     */
+    BurnAddress,
 }
 
 private const val EDDSA_PUB_KEY_HEX_LENGTH = 64
@@ -186,6 +196,8 @@ constructor(private val solanaApi: SolanaApi) : ChainAccountAddressRepository {
     override suspend fun validateRecipient(chain: Chain, address: String): RecipientValidity =
         when {
             !isValid(chain, address) -> RecipientValidity.InvalidForChain
+            chain == Chain.Bittensor && address == BittensorHelper.BURN_ADDRESS ->
+                RecipientValidity.BurnAddress
             chain != Chain.Solana -> RecipientValidity.Valid
             else -> solanaRecipientVerdict(address)
         }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryRecipientTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/ChainAccountAddressRepositoryRecipientTest.kt
@@ -2,6 +2,7 @@ package com.vultisig.wallet.data.repositories
 
 import com.vultisig.wallet.data.api.SolanaAccountOwnership
 import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.chains.helpers.BittensorHelper
 import com.vultisig.wallet.data.models.Chain
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -158,6 +159,50 @@ class ChainAccountAddressRepositoryRecipientTest {
         coVerify(exactly = 0) { solanaApi.getAccountOwnership(any()) }
     }
 
+    @Test
+    fun `the bittensor burn address is refused`() = runTest {
+        // The all-zero AccountId: well-formed SS58-42, so chain validation admits it, and no key
+        // derives it, so the TAO would be destroyed rather than merely stranded.
+        every { repository.isValid(Chain.Bittensor, BittensorHelper.BURN_ADDRESS) } returns true
+
+        assertEquals(
+            RecipientValidity.BurnAddress,
+            repository.validateRecipient(Chain.Bittensor, BittensorHelper.BURN_ADDRESS),
+        )
+    }
+
+    @Test
+    fun `an ordinary bittensor address is a valid recipient`() = runTest {
+        every { repository.isValid(Chain.Bittensor, BITTENSOR_WALLET) } returns true
+
+        assertEquals(
+            RecipientValidity.Valid,
+            repository.validateRecipient(Chain.Bittensor, BITTENSOR_WALLET),
+        )
+    }
+
+    @Test
+    fun `the burn rule is scoped to bittensor`() = runTest {
+        // Polkadot encodes the same account under its own prefix, so this spelling cannot be a
+        // Polkadot recipient at all; the rule stays where the address it names can actually arrive.
+        every { repository.isValid(Chain.Polkadot, BittensorHelper.BURN_ADDRESS) } returns true
+
+        assertEquals(
+            RecipientValidity.Valid,
+            repository.validateRecipient(Chain.Polkadot, BittensorHelper.BURN_ADDRESS),
+        )
+    }
+
+    @Test
+    fun `chain validation is still what rejects a malformed bittensor address`() = runTest {
+        every { repository.isValid(Chain.Bittensor, "garbage") } returns false
+
+        assertEquals(
+            RecipientValidity.InvalidForChain,
+            repository.validateRecipient(Chain.Bittensor, "garbage"),
+        )
+    }
+
     private companion object {
         /** The wallet's wrapped-SOL associated token account, pinned in the derivation test. */
         const val TOKEN_ACCOUNT = "GppmkdEmuqNgS7uY5SSN3gXEamJrcPG9197wBdQ37NLc"
@@ -172,5 +217,8 @@ class ChainAccountAddressRepositoryRecipientTest {
         const val TOKEN_2022_PROGRAM = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
 
         const val SYSTEM_PROGRAM = "11111111111111111111111111111111"
+
+        /** A spendable SS58-42 account, to contrast with [BittensorHelper.BURN_ADDRESS]. */
+        const val BITTENSOR_WALLET = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
     }
 }


### PR DESCRIPTION
Closes #5844

## Problem

`5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM` is the all-zero Substrate AccountId under Bittensor's SS58 prefix — the chain's `0x0`. No private key derives it, so anything sent there is destroyed.

WalletCore accepts it: `AnyAddress.isValidSS58(…, POLKADOT, 42)` returns true, confirmed on device by the new instrumented test. Android had no dangerous-address screening of any kind, so the send went through the form, through fee estimation, and onto the wire like any other transfer.

## Change

Two layers, because they fail differently.

**A verdict, so the user sees why.** `RecipientValidity` gains `BurnAddress`, distinct from `NotAWalletAddress` — a Solana token account is real and owned, it just strands the transfer, whereas this account cannot be signed for by anyone, and the two do not deserve the same wording. Adding the value broke all five exhaustive `when`s at compile time, which is how every consumer was found: send form, send submit, address book, swap external recipient, and the address manager's resolver path.

**A `require` in the extrinsic builder, so nothing can route around it.** `BittensorHelper.buildCallData` already decoded the destination, so the guard costs nothing and sits where every signing path funnels through.

`BURN_ADDRESS` is spelled out rather than derived, deliberately: that keeps the recipient check a pure string comparison off the JNI, which is what makes it unit-testable. An instrumented test pins the literal against `ss58Decode` so the two cannot drift.

## Scoping

Polkadot is untouched. It encodes the same account under prefix 0, and Bittensor admits addresses only through `isValidSS58(…, 42)`, so this spelling cannot reach a Polkadot recipient check at all. A test pins that.

SDK sibling vultisig-sdk#2336 frames this as "the dangerous-address registry has no Bittensor branch". There is no such registry on Android — no burn screening for EVM, Solana, UTXO or XRP either — so this stays narrow rather than inventing one. Building the registry so the other chains can follow is a reasonable next ticket.

## Verification

| | Result |
|---|---|
| `:data:testDebugUnitTest` | 3605 run, 0 failures (4 new) |
| `:app:testDebugUnitTest` | 2441 run, 0 failures |
| `ChainHelpersTest` (Medium_Phone AVD) | 38/38, 0 skipped |
| `BittensorHelperSs58ParityTest` (Medium_Phone AVD) | 7/7, 3 new |
| `:app:lintDebug` | clean |

The pre-sign test reuses a corpus payload with `toAddress` swapped rather than adding a case to `bittensor.json`, so the cross-repo golden vectors stay byte-identical and `scripts/check_golden_corpus_sync.py` keeps passing.

## Screenshots

Verified on device. The guard fires on the address field, before any amount or fee — no TAO balance needed to reproduce.

| Send | Address Book |
|--------|--------|
| ![send](https://i.imgur.com/wd6BYGt.png) | ![address book](https://i.imgur.com/R4g7Knz.png) |

## Test plan

1. Vault home → **Bittensor** → **Send** → paste `5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM`. Error shows, **Continue** stays disabled.
2. Replace with `5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY`. Error clears, **Continue** enables.
3. Settings → **Address Book** → **Add Address** → chain **Bittensor** → same address. Same error, save blocked.
4. Same address with the chain set to **Polkadot** → rejected as invalid for the chain, *not* as a burn address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F78W4eTPN2Cts5CjFCJuJd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added burn-address detection for Bittensor recipients.
  * Prevented sending or swapping assets to burn addresses, with clear validation errors.
  * Added localized warnings explaining that funds sent to burn addresses are permanently lost.

* **Bug Fixes**
  * Improved recipient validation to prevent burn addresses from being treated as spendable accounts.

* **Tests**
  * Added coverage for burn-address detection, rejection, validation, and ordinary-address handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->