### PR TITLE
feat(history): name both assets on a settled swap card

### DIFF
--- a/app/src/androidTest/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCardPairTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCardPairTest.kt
@@ -73,6 +73,27 @@ class SwapTransactionCardPairTest {
     }
 
     @Test
+    fun aRefundedSwapIsStillPairedAndSaysSo() {
+        start(
+            swap.copy(
+                status =
+                    TransactionStatusUiModel.Refunded(
+                        reason = UiText.DynamicString("pool is halted")
+                    )
+            )
+        )
+
+        // A refund is settled, not in progress, so the row owes both assets like any other closed
+        // card — the user needs to know which leg came back.
+        compose.onNodeWithText("+0.0261 BTC").assertIsDisplayed()
+        compose.onNodeWithText("-125.5 RUNE").assertIsDisplayed()
+        compose.onNodeWithText("RUNE → BTC").assertIsDisplayed()
+        compose
+            .onNodeWithText(context.getString(R.string.transaction_status_refunded_label))
+            .assertIsDisplayed()
+    }
+
+    @Test
     fun aLimitOrderRowIsPairedTheSameWayOnceItHasSettled() {
         start(swap.copy(isLimitOrder = true))
 

--- a/app/src/androidTest/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCardPairTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCardPairTest.kt
@@ -1,0 +1,127 @@
+package com.vultisig.wallet.ui.screens.transaction
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vultisig.wallet.R
+import com.vultisig.wallet.ui.models.TransactionFailureExplanation
+import com.vultisig.wallet.ui.models.TransactionHistoryItemUiModel
+import com.vultisig.wallet.ui.models.TransactionStatusUiModel
+import com.vultisig.wallet.ui.theme.OnBoardingComposeTheme
+import com.vultisig.wallet.ui.utils.UiText
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * A settled swap row has to name both assets without being opened — the destination is the half the
+ * card exists to report, and it was the half a collapsed row never showed.
+ */
+@HiltAndroidTest
+class SwapTransactionCardPairTest {
+
+    // The card needs nothing injected, but the test application's Hilt component does have to
+    // exist: anything the system starts against this process mid-run asks for it on creation.
+    @get:Rule(order = 0) val hilt = HiltAndroidRule(this)
+
+    @get:Rule(order = 1) val compose = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    @Test
+    fun aSettledSwapNamesBothLegsAndTheRouteItTook() {
+        start(swap)
+
+        compose.onNodeWithText("+0.0261 BTC").assertIsDisplayed()
+        compose.onNodeWithText("-125.5 RUNE").assertIsDisplayed()
+        compose.onNodeWithText("RUNE → BTC").assertIsDisplayed()
+    }
+
+    @Test
+    fun aSettledSwapLeavesTheRouteToThePillAloneAndDropsTheProviderBadge() {
+        start(swap)
+
+        compose
+            .onNodeWithText(
+                "${context.getString(R.string.transaction_history_via_prefix)} THORChain"
+            )
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun aFailedSwapStillNamesBothLegsAndKeepsItsReasonBesideTheStatus() {
+        start(
+            swap.copy(
+                status =
+                    TransactionStatusUiModel.Failed(
+                        reason = UiText.DynamicString("Insufficient output"),
+                        explanation = TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE,
+                    )
+            )
+        )
+
+        compose.onNodeWithText("+0.0261 BTC").assertIsDisplayed()
+        compose.onNodeWithText("-125.5 RUNE").assertIsDisplayed()
+        compose.onNodeWithText("RUNE → BTC").assertIsDisplayed()
+        compose
+            .onNodeWithText(
+                context.getString(TransactionFailureExplanation.MIN_OUTPUT_SLIPPAGE.labelRes)
+            )
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun aLimitOrderRowIsPairedTheSameWayOnceItHasSettled() {
+        start(swap.copy(isLimitOrder = true))
+
+        compose.onNodeWithText("+0.0261 BTC").assertIsDisplayed()
+        compose.onNodeWithText("RUNE → BTC").assertIsDisplayed()
+    }
+
+    @Test
+    fun anInProgressSwapKeepsItsStackedPayoutLayoutAndItsProviderBadge() {
+        start(swap.copy(status = TransactionStatusUiModel.Broadcasted))
+
+        // The two-legged pill belongs to the settled card; an in-progress card already spells the
+        // route out down the column, and still owes the user the provider it is waiting on.
+        compose.onNodeWithText("RUNE → BTC").assertDoesNotExist()
+        compose
+            .onNodeWithText(context.getString(R.string.transaction_history_expected_payout_label))
+            .assertIsDisplayed()
+        compose
+            .onNodeWithText(
+                "${context.getString(R.string.transaction_history_via_prefix)} THORChain"
+            )
+            .assertIsDisplayed()
+    }
+
+    private fun start(item: TransactionHistoryItemUiModel.Swap) {
+        compose.setContent { OnBoardingComposeTheme { SwapTransactionCard(item = item) } }
+    }
+
+    private val swap =
+        TransactionHistoryItemUiModel.Swap(
+            id = "1",
+            txHash = "0xabc123",
+            chain = "THORChain",
+            status = TransactionStatusUiModel.Confirmed,
+            explorerUrl = "",
+            timestamp = 0L,
+            fromToken = "RUNE",
+            fromAmount = "125.5",
+            fromChain = "THORChain",
+            fromTokenLogo = R.drawable.rune,
+            toToken = "BTC",
+            toAmount = "0.0261",
+            toChain = "Bitcoin",
+            toTokenLogo = R.drawable.bitcoin,
+            provider = "THORChain",
+            providerLogo = R.drawable.rune,
+            fiatValue = "$1,204.00",
+            fromAddress = null,
+            toAddress = null,
+            feeEstimate = null,
+        )
+}

--- a/app/src/androidTest/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCardPairTest.kt
+++ b/app/src/androidTest/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCardPairTest.kt
@@ -1,8 +1,12 @@
 package com.vultisig.wallet.ui.screens.transaction
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertWidthIsAtLeast
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.width
 import androidx.test.platform.app.InstrumentationRegistry
 import com.vultisig.wallet.R
 import com.vultisig.wallet.ui.models.TransactionFailureExplanation
@@ -99,6 +103,26 @@ class SwapTransactionCardPairTest {
 
         compose.onNodeWithText("+0.0261 BTC").assertIsDisplayed()
         compose.onNodeWithText("RUNE → BTC").assertIsDisplayed()
+    }
+
+    @Test
+    fun aLongRouteCannotSqueezeTheLegsBelowItsOwnHalf() {
+        start(
+            swap.copy(
+                fromToken = "USDC.eth.axl",
+                toAmount = "12,345,678.90123456",
+                toToken = "ASTRO-IBC",
+            )
+        )
+
+        // The pill used to be measured at its full intrinsic width before the legs were offered
+        // anything, so a long route left the amounts as little more than an ellipsis. Both halves
+        // of the row now get the same share of what the pair logo leaves.
+        val pill = compose.onNodeWithText("USDC.eth.axl → ASTRO-IBC").getUnclippedBoundsInRoot()
+        // Equal weights can still land a pixel apart on an odd row width, so allow a hair.
+        compose
+            .onNodeWithText("+12,345,678.90123456 ASTRO-IBC")
+            .assertWidthIsAtLeast(pill.width - 1.dp)
     }
 
     @Test

--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -103,6 +103,7 @@ import com.vultisig.wallet.ui.models.TokenInfoUiModel
 import com.vultisig.wallet.ui.models.TokenSelectionUiModel
 import com.vultisig.wallet.ui.models.TokenUiModel
 import com.vultisig.wallet.ui.models.TransactionDetailsUiModel
+import com.vultisig.wallet.ui.models.TransactionFailureExplanation
 import com.vultisig.wallet.ui.models.TransactionHistoryGroupUiModel
 import com.vultisig.wallet.ui.models.TransactionHistoryItemUiModel
 import com.vultisig.wallet.ui.models.TransactionHistoryTab
@@ -4218,6 +4219,58 @@ private fun SwapsTabPreview() {
                                         fromAddress = "0xAb...234",
                                         toAddress = "0xAb...234",
                                         feeEstimate = "$1.10",
+                                    ),
+                                    TransactionHistoryItemUiModel.Swap(
+                                        id = "S3",
+                                        txHash = "0x123",
+                                        chain = "Ethereum",
+                                        status =
+                                            TransactionStatusUiModel.Failed(
+                                                reason =
+                                                    UiText.DynamicString("Insufficient output"),
+                                                explanation =
+                                                    TransactionFailureExplanation
+                                                        .MIN_OUTPUT_SLIPPAGE,
+                                            ),
+                                        explorerUrl = "",
+                                        timestamp = 0L,
+                                        fromToken = "USDC",
+                                        fromAmount = "34,752.57",
+                                        fromChain = "Ethereum",
+                                        fromTokenLogo = R.drawable.usdc,
+                                        toToken = "ETH",
+                                        toAmount = "20.50",
+                                        toChain = "Ethereum",
+                                        toTokenLogo = R.drawable.ethereum,
+                                        provider = "LI.FI",
+                                        providerLogo = null,
+                                        fiatValue = "$34,752.57",
+                                        fromAddress = "0xAb...234",
+                                        toAddress = "0xAb...234",
+                                        feeEstimate = "$1.10",
+                                    ),
+                                    TransactionHistoryItemUiModel.Swap(
+                                        id = "S4",
+                                        txHash = "0x456",
+                                        chain = "THORChain",
+                                        status = TransactionStatusUiModel.Confirmed,
+                                        explorerUrl = "",
+                                        timestamp = 0L,
+                                        fromToken = "USDC",
+                                        fromAmount = "220.192",
+                                        fromChain = "Ethereum",
+                                        fromTokenLogo = R.drawable.usdc,
+                                        toToken = "SOL",
+                                        toAmount = "200.50",
+                                        toChain = "Solana",
+                                        toTokenLogo = R.drawable.solana,
+                                        provider = "THORChain",
+                                        providerLogo = R.drawable.rune,
+                                        fiatValue = "$220.19",
+                                        fromAddress = "0xAb...234",
+                                        toAddress = "So1anaAddr",
+                                        feeEstimate = "$0.11",
+                                        isLimitOrder = true,
                                     ),
                                 ),
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCard.kt
@@ -9,16 +9,19 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.GenericShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -26,6 +29,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.ImageModel
@@ -158,7 +162,16 @@ internal fun SwapTransactionCard(
                                 color = Theme.v2.colors.text.tertiary,
                             )
                         }
-                        SwapPairPill(fromToken = item.fromToken, toToken = item.toToken)
+                        // The pill and the legs each get half of what the logo leaves, so a long
+                        // route can no longer measure itself first and squeeze the amounts down
+                        // to an ellipsis. The box holds the pill against the card's edge whether
+                        // the route needs that half or a fraction of it.
+                        Box(
+                            modifier = Modifier.weight(1f),
+                            contentAlignment = Alignment.CenterEnd,
+                        ) {
+                            SwapPairPill(fromToken = item.fromToken, toToken = item.toToken)
+                        }
                     }
                 }
             }
@@ -237,30 +250,41 @@ private fun SwapPairLogo(
     toToken: String,
     modifier: Modifier = Modifier,
 ) {
-    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
-        SwapPairLogoHalf(logo = fromLogo, ticker = fromToken, half = Alignment.CenterStart)
-        SwapPairLogoHalf(logo = toLogo, ticker = toToken, half = Alignment.CenterEnd)
+    Box(modifier = modifier.size(swapPairLogoSize)) {
+        SwapPairLogoHalf(logo = fromLogo, ticker = fromToken, half = swapPairLeadingHalf)
+        SwapPairLogoHalf(logo = toLogo, ticker = toToken, half = swapPairTrailingHalf)
     }
 }
 
 @Composable
-private fun SwapPairLogoHalf(logo: ImageModel, ticker: String, half: Alignment) {
-    Box(
+private fun SwapPairLogoHalf(logo: ImageModel, ticker: String, half: Shape) {
+    // The plate is what lets a logo be halved at all. Most of the app's coin artwork is drawn on
+    // transparency, and half of that is a fragment of a glyph rather than half a disc, so without
+    // it the mark closes on one side and frays on the other. The design seats every coin on a
+    // plate of its own for the same reason.
+    TokenCircle(
         modifier =
-            Modifier.size(width = swapPairLogoSize / 2, height = swapPairLogoSize).clipToBounds(),
-        contentAlignment = half,
-    ) {
-        // requiredSize, not size: the logo has to keep its full diameter against a window half its
-        // width, which is precisely what makes the visible edge a half-circle rather than a
-        // squeeze.
-        TokenCircle(
-            modifier = Modifier.requiredSize(swapPairLogoSize),
-            logo = logo,
-            ticker = ticker,
-            size = SWAP_PAIR_LOGO_SIZE,
-        )
-    }
+            Modifier.clip(half)
+                .background(color = Theme.v2.colors.neutrals.n900, shape = CircleShape),
+        logo = logo,
+        ticker = ticker,
+        size = SWAP_PAIR_LOGO_SIZE,
+    )
 }
+
+/**
+ * The half of the mark a logo keeps. Both logos are drawn at their full diameter over the same
+ * 24dp, each clipped to the half that faces the other, so the two close into one circle instead of
+ * each being squeezed into a window narrower than itself.
+ */
+private fun swapPairHalfShape(leading: Boolean) = GenericShape { size, layoutDirection ->
+    val left = if (leading == (layoutDirection == LayoutDirection.Ltr)) 0f else size.width / 2f
+    addRect(Rect(left = left, top = 0f, right = left + size.width / 2f, bottom = size.height))
+}
+
+private val swapPairLeadingHalf = swapPairHalfShape(leading = true)
+
+private val swapPairTrailingHalf = swapPairHalfShape(leading = false)
 
 /** `USDC → SOL`, the route the card is about, in the corner the badge used to hold. */
 @Composable
@@ -270,6 +294,7 @@ private fun SwapPairPill(fromToken: String, toToken: String, modifier: Modifier 
         style = Theme.brockmann.supplementary.caption,
         color = Theme.v2.colors.text.primary,
         maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
         modifier =
             modifier
                 .background(

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCard.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/transaction/SwapTransactionCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -16,9 +17,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -34,7 +39,6 @@ import com.vultisig.wallet.ui.models.TransactionStatusUiModel
 import com.vultisig.wallet.ui.models.TransactionStatusUiModel.Broadcasted
 import com.vultisig.wallet.ui.models.TransactionStatusUiModel.Confirmed
 import com.vultisig.wallet.ui.models.TransactionStatusUiModel.Pending
-import com.vultisig.wallet.ui.screens.transaction.components.SendAmountText
 import com.vultisig.wallet.ui.screens.transaction.components.ToSeparator
 import com.vultisig.wallet.ui.screens.transaction.components.TokenCircle
 import com.vultisig.wallet.ui.screens.transaction.components.TransactionStatusWidget
@@ -51,6 +55,7 @@ internal fun SwapTransactionCard(
     val isInProgress =
         item.status is TransactionStatusUiModel.Broadcasted ||
             item.status is TransactionStatusUiModel.Pending
+    val failureExplanation = (item.status as? TransactionStatusUiModel.Failed)?.explanation
 
     V2Container(
         modifier = modifier,
@@ -61,14 +66,28 @@ internal fun SwapTransactionCard(
             Column(modifier = Modifier.padding(swapCardPadding)) {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     TypeBadge(
                         iconRes = R.drawable.swap,
                         label = stringResource(R.string.transaction_type_button_swap),
                     )
-                    TransactionStatusWidget(status = item.status, timestamp = item.timestamp)
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        horizontalAlignment = Alignment.End,
+                        verticalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        TransactionStatusWidget(status = item.status, timestamp = item.timestamp)
+                        if (failureExplanation != null) {
+                            Text(
+                                text = stringResource(failureExplanation.labelRes),
+                                style = Theme.brockmann.supplementary.caption,
+                                color = Theme.v2.colors.alerts.error,
+                                textAlign = TextAlign.End,
+                            )
+                        }
+                    }
                 }
 
                 if (isInProgress) {
@@ -119,38 +138,35 @@ internal fun SwapTransactionCard(
                         verticalAlignment = Alignment.CenterVertically,
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
-                        TokenCircle(logo = item.fromTokenLogo, ticker = item.fromToken, size = 24)
-                        Column(modifier = Modifier.weight(1f)) {
-                            if (!item.fiatValue.isNullOrEmpty()) {
-                                Text(
-                                    text = item.fiatValue,
-                                    style = Theme.brockmann.supplementary.footnote,
-                                    color = Theme.v2.colors.text.primary,
-                                )
-                            }
-                            SendAmountText(amount = item.fromAmount, token = item.fromToken)
-                        }
-                    }
-
-                    val explanation = (item.status as? TransactionStatusUiModel.Failed)?.explanation
-                    if (explanation != null) {
-                        UiSpacer(size = 8.dp)
-                        Text(
-                            text = stringResource(explanation.labelRes),
-                            style = Theme.brockmann.supplementary.caption,
-                            color = Theme.v2.colors.alerts.error,
-                            modifier = Modifier.fillMaxWidth(),
+                        SwapPairLogo(
+                            fromLogo = item.fromTokenLogo,
+                            fromToken = item.fromToken,
+                            toLogo = item.toTokenLogo,
+                            toToken = item.toToken,
                         )
-                        // The provider badge is anchored over this corner and overhangs the card's
-                        // own bottom padding, so a last flow child would be printed underneath it.
-                        if (item.provider.isNotEmpty()) {
-                            UiSpacer(size = viaBadgeClearance)
+                        Column(modifier = Modifier.weight(1f)) {
+                            // The destination leg leads: what the swap produced is what the row
+                            // exists to answer, and it is the half the user could not see before.
+                            SwapLegText(
+                                amount = "+${item.toAmount}",
+                                token = item.toToken,
+                                color = Theme.v2.colors.text.primary,
+                            )
+                            SwapLegText(
+                                amount = "-${item.fromAmount}",
+                                token = item.fromToken,
+                                color = Theme.v2.colors.text.tertiary,
+                            )
                         }
+                        SwapPairPill(fromToken = item.fromToken, toToken = item.toToken)
                     }
                 }
             }
 
-            if (item.provider.isNotEmpty()) {
+            // The pair pill states the route on a settled card, so the badge would be a second
+            // answer to the same question in the corner it already occupies. It stays on an
+            // in-progress card, whose row has no pill.
+            if (isInProgress && item.provider.isNotEmpty()) {
                 ViaBadge(
                     provider = item.provider,
                     providerLogo = item.providerLogo,
@@ -188,6 +204,87 @@ private fun SwapAmountText(amount: String, token: String, modifier: Modifier = M
     )
 }
 
+/**
+ * One leg of a settled swap: `+2.5 ETH` or `-4,210.00 USDC`. Both halves of the line carry the same
+ * colour — the destination leg reads as the outcome, the source leg as the receipt beneath it.
+ */
+@Composable
+private fun SwapLegText(
+    amount: String,
+    token: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = "$amount $token",
+        style = Theme.brockmann.supplementary.footnote,
+        color = color,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier,
+    )
+}
+
+/**
+ * The two assets as one coin: the facing half of each logo, so the pair reads as a single mark at
+ * the same 24dp a one-sided row spends on its single logo.
+ */
+@Composable
+private fun SwapPairLogo(
+    fromLogo: ImageModel,
+    fromToken: String,
+    toLogo: ImageModel,
+    toToken: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        SwapPairLogoHalf(logo = fromLogo, ticker = fromToken, half = Alignment.CenterStart)
+        SwapPairLogoHalf(logo = toLogo, ticker = toToken, half = Alignment.CenterEnd)
+    }
+}
+
+@Composable
+private fun SwapPairLogoHalf(logo: ImageModel, ticker: String, half: Alignment) {
+    Box(
+        modifier =
+            Modifier.size(width = swapPairLogoSize / 2, height = swapPairLogoSize).clipToBounds(),
+        contentAlignment = half,
+    ) {
+        // requiredSize, not size: the logo has to keep its full diameter against a window half its
+        // width, which is precisely what makes the visible edge a half-circle rather than a
+        // squeeze.
+        TokenCircle(
+            modifier = Modifier.requiredSize(swapPairLogoSize),
+            logo = logo,
+            ticker = ticker,
+            size = SWAP_PAIR_LOGO_SIZE,
+        )
+    }
+}
+
+/** `USDC → SOL`, the route the card is about, in the corner the badge used to hold. */
+@Composable
+private fun SwapPairPill(fromToken: String, toToken: String, modifier: Modifier = Modifier) {
+    Text(
+        text = "$fromToken → $toToken",
+        style = Theme.brockmann.supplementary.caption,
+        color = Theme.v2.colors.text.primary,
+        maxLines = 1,
+        modifier =
+            modifier
+                .background(
+                    color = Theme.v2.colors.backgrounds.tertiary_2,
+                    shape = Theme.v2.radius.pill,
+                )
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.border.normal,
+                    shape = Theme.v2.radius.pill,
+                )
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+    )
+}
+
 private val viaBadgeVerticalPadding = 8.dp
 
 /** The provider logo — the tallest thing the badge ever holds, so it sets the badge's height. */
@@ -195,15 +292,10 @@ private const val VIA_BADGE_CONTENT_SIZE = 16
 
 private val swapCardPadding = 16.dp
 
-private val failureLineGap = 8.dp
+/** Diameter of the paired coin logos; each contributes the half of itself that faces the other. */
+private const val SWAP_PAIR_LOGO_SIZE = 24
 
-/**
- * How far the failure line has to be lifted to clear the provider badge. Derived from the badge's
- * own geometry rather than eyeballed, so the two cannot drift apart: the badge is absolutely
- * positioned over the card's bottom-end corner and stands taller than the padding it overhangs.
- */
-private val viaBadgeClearance =
-    viaBadgeVerticalPadding * 2 + VIA_BADGE_CONTENT_SIZE.dp - swapCardPadding + failureLineGap
+private val swapPairLogoSize = SWAP_PAIR_LOGO_SIZE.dp
 
 @Composable
 private fun ViaBadge(provider: String, providerLogo: ImageModel?, modifier: Modifier = Modifier) {


### PR DESCRIPTION
Closes #5841

A settled swap row named one asset. `+200.50 SOL / -220.192 USDC` and the route it took now sit on the card, so the destination no longer costs a tap to learn.

Figma: [Transaction History – Swaps](https://www.figma.com/design/puB2fsVpPrBx3Sup7gaa3v/Vultisig-App?node-id=74765-110319) · siblings vultisig-ios#5325, vultisig-windows#4844 (both still open, so there was no shipped implementation to follow)

## Before / After

The Swaps tab on a Medium_Phone AVD, same four rows either side: a settled RUNE→BTC swap, an in-progress ETH→USDC swap, a slippage failure and a settled limit order. Before, three of the four name only the asset that left.

| Before | After |
|--------|-------|
| <img src="https://i.imgur.com/SyuDo9V.png" width="320" /> | <img src="https://i.imgur.com/2rZeTD2.png" width="320" /> |

Review round: the pill used to be measured at its full intrinsic width before the amount column was offered anything, so a long pair of tickers left both legs as an ellipsis. The pill and the legs now split what the pair logo leaves, and the pill is the one that gives way. Same tab with `USDC.eth.axl → ASTRO-IBC` — the "before" here is this PR's first cut, not `main`, which had no pill at all.

| Before | After |
|--------|-------|
| <img src="https://i.imgur.com/hX5rLcG.png" width="320" /> | <img src="https://i.imgur.com/bxIrhuP.png" width="320" /> |

## What changed

- **Both legs.** The destination leads (`+{toAmount} {toTicker}`, text primary), the source sits under it as the receipt (`-{fromAmount} {fromTicker}`, text tertiary). The fiat line the row used to carry is what they replace, per the frame.
- **A `FROM → TO` pill** on the right of the row — `backgrounds.tertiary_2` on `border.normal`, pill radius, caption/primary, 16×8 padding.
- **The pair as one mark** — both coin logos are drawn over the same 24dp a one-sided row already spent on its single logo, each clipped to the half facing the other. Each half carries a plate: most of our coin drawables are bare marks on transparency, and half of one of those is a fragment of a glyph rather than half a disc.
- **The failure reason moved beside the status**, top-right under "Error", where the design puts it.
- In-progress cards are untouched: the stacked `expected payout` layout and the `via {provider}` badge both stay.

## Two calls worth a reviewer's eye

**The `via {provider}` badge is gone from settled cards.** Not stated in the issue — inferred, then confirmed with @aminsato. `ViaBadge` is absolutely positioned over the card's bottom-end corner, which is exactly where the pill lands, so the two overlap by construction; the Figma frame's new cards drop it, and the iOS sibling words it as "replace the provider-as-pair cue with a pill". The badge still renders on in-progress cards, and the provider keeps its own row in `TransactionDetailBottomSheet`. Retiring it also retired `viaBadgeClearance`, a derived spacer that existed only to lift the old full-width failure line above a badge it now never meets.

**`+{toAmount}` is the expected output, not a settled receipt.** `SwapTransactionHistoryData.toAmount` is written once at keysign and nothing rewrites it on confirmation — `SwapKitTrackingService` only reads `toAmountDecimal` as a fill threshold — so there is no actual-output figure to show instead. The design does the same on its own Error card, so Confirmed / Failed / Refunded are treated uniformly and the status chip carries the outcome.

## Deliberately out of scope

The frame labels the badge `Swapped` / `Limit` (clock icon) where Android says `Swap`, and names Satoshi/Price/Footnote for the amount lines where the whole history list — the send card included — renders Brockmann footnote today. Changing either on the swap card alone would split it from the send card directly beneath it in the same list.

## Test plan

- `SwapTransactionCardPairTest` (new, 7 cases, all green on a Medium_Phone AVD): both legs and the pill on settled, failed, refunded and limit rows; the badge's absence there; the in-progress card keeping its stacked payout layout and its badge; and a long route left no wider than the legs' own share — checked to fail against the pre-fix layout before it was kept.
- `./gradlew :app:testDebugUnitTest --tests '*TransactionHistory*'` — green.
- `./gradlew :app:lintDebug` — green. `:app:ktfmtFormat` applied.
- Walked on device via `PreviewActivity --es screen swaps_tab`, which now also carries a failed-slippage and a limit card so those states are reachable without a real swap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Swap history cards now show paired token logos, source and destination amounts, and route details for settled swaps.
  - Failed swaps display clearer explanations alongside their status.
  - In-progress swaps continue to show provider badges.
  - Swap previews now provide clearer limit-order, payout, refund, and failure details.
  - Long routes are truncated cleanly while preserving route visibility.

- **Tests**
  - Added coverage for settled, failed, refunded, limit-order, long-route, and in-progress swap card presentations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

