### PR TITLE
fix(keysign): state the jetton quantity on a TonConnect transfer

### DIFF
--- a/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
+++ b/app/src/debug/java/com/vultisig/wallet/debug/PreviewActivity.kt
@@ -460,6 +460,8 @@ class PreviewActivity : ComponentActivity() {
                     "ton_display_multi" -> TonDisplayPreview(messageCount = 4)
                     "verify_ton_jetton_before" -> VerifyTonJettonPreview(decoded = false)
                     "verify_ton_jetton_after" -> VerifyTonJettonPreview(decoded = true)
+                    "verify_ton_jetton_unheld" ->
+                        VerifyTonJettonPreview(decoded = true, heldInVault = false)
                     "swap_error_before" -> SwapErrorBeforePreview()
                     "swap_error" -> SwapErrorPreview()
                     "swap_quote_loading" -> SwapFormQuoteLoadingPreview()
@@ -1503,7 +1505,7 @@ private fun TonDisplayPreview(messageCount: Int) {
                     TonMessageUiModel(
                         operation = TonMessageOperation.Transfer,
                         recipient = "EQAB0000000000ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                        amount = "0.25 TON",
+                        amount = "0.25 GRAM",
                         rawPayload = null,
                         hasStateInit = true,
                     ),
@@ -1514,10 +1516,15 @@ private fun TonDisplayPreview(messageCount: Int) {
                         rawPayload = "te6cckEBAQEADgAAGNUydtsAAAAAAAAABxylUgg=",
                         hasStateInit = false,
                     ),
+                    // A jetton the vault does not hold: no ticker resolved, raw base units.
+                    TON_JETTON_MESSAGE.copy(
+                        recipient = "EQBynBO23ywHy_CgarY9NK9FTz0yDsG82PtcbSTQgGoXwiuA",
+                        tokenAmount = "250000000000",
+                    ),
                     TonMessageUiModel(
                         operation = TonMessageOperation.NftTransfer,
                         recipient = "EQAB7777777777ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                        amount = "0.1 TON",
+                        amount = "0.1 GRAM",
                         rawPayload = "te6cckEBAQEAVAAAo1/MPRQ...",
                         hasStateInit = false,
                     ),
@@ -1538,7 +1545,8 @@ private val TON_JETTON_MESSAGE =
     TonMessageUiModel(
         operation = TonMessageOperation.JettonTransfer,
         recipient = "EQDrLq9I7m6lvP6zUGZqJ8r4y0sP3pQ1n2vWk5tXcB9aZ7eF",
-        amount = "0.05 TON",
+        amount = "0.05 GRAM",
+        tokenAmount = "100 USDT",
         rawPayload =
             "te6cckEBAQEAWQAArg+KfqUAAAAAAAAwOUBfXhAIAf//////////////////" +
                 "////////////////////////AAvDfWFG0oYX19jwNDNBBL1rKNT9XfaGP9HyTb5" +
@@ -1550,11 +1558,15 @@ private val TON_JETTON_MESSAGE =
  * Full-screen keysign verify for a TonConnect jetton transfer. [decoded] = true shows the resolved
  * jetton hero (100 USDT) + decoded message rows; false is the pre-decode state (the outer gas value
  * as the hero, opaque transfer rows).
+ *
+ * [heldInVault] = false is the dApp-supplied jetton the vault has never added: the hero resolver
+ * matches vault coins only, so nothing headlines the transfer and the message row is the only place
+ * its quantity can appear.
  */
 @Composable
-private fun VerifyTonJettonPreview(decoded: Boolean) {
+private fun VerifyTonJettonPreview(decoded: Boolean, heldInVault: Boolean = true) {
     VerifySendScreen(
-        state = tonJettonSendState(decoded),
+        state = tonJettonSendState(decoded, heldInVault),
         isConsentsEnabled = false,
         confirmTitle = "Sign",
         onFastSignClick = {},
@@ -1569,7 +1581,10 @@ private fun VerifyTonJettonPreview(decoded: Boolean) {
     )
 }
 
-private fun tonJettonSendState(decoded: Boolean): VerifyTransactionUiModel {
+private fun tonJettonSendState(
+    decoded: Boolean,
+    heldInVault: Boolean = true,
+): VerifyTransactionUiModel {
     val senderJettonWallet = "EQByz1234senderJettonWallet5678abcdEFGHijklMNOpqRsT"
     val recipient = "EQDrLq9I7m6lvP6zUGZqJ8r4y0sP3pQ1n2vWk5tXcB9aZ7eF"
     val tx =
@@ -1580,9 +1595,9 @@ private fun tonJettonSendState(decoded: Boolean): VerifyTransactionUiModel {
             srcVaultName = "Main Vault",
             dstAddress = senderJettonWallet,
             networkFeeFiatValue = "$0.04",
-            networkFeeTokenValue = "0.0066 TON",
+            networkFeeTokenValue = "0.0066 GRAM",
             heroContent =
-                if (decoded) {
+                if (decoded && heldInVault) {
                     HeroContent.Send(
                         title = null,
                         coin =
@@ -1601,7 +1616,8 @@ private fun tonJettonSendState(decoded: Boolean): VerifyTransactionUiModel {
                         TonMessageUiModel(
                             operation = TonMessageOperation.JettonTransfer,
                             recipient = recipient,
-                            amount = "0.05 TON",
+                            amount = "0.05 GRAM",
+                            tokenAmount = if (heldInVault) "100 USDT" else "250000000000",
                             rawPayload = TON_JETTON_MESSAGE.rawPayload,
                             hasStateInit = false,
                         )
@@ -1611,7 +1627,7 @@ private fun tonJettonSendState(decoded: Boolean): VerifyTransactionUiModel {
                         TonMessageUiModel(
                             operation = TonMessageOperation.Transfer,
                             recipient = senderJettonWallet,
-                            amount = "0.32 TON",
+                            amount = "0.32 GRAM",
                             rawPayload = TON_JETTON_MESSAGE.rawPayload,
                             hasStateInit = false,
                         )

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
@@ -35,8 +35,9 @@ import com.vultisig.wallet.ui.theme.Theme
 /**
  * Displays a collapsible list of decoded TonConnect messages for user review before signing. Each
  * message shows its operation (jetton transfer, NFT transfer, excess-gas refund, or plain
- * transfer), the real recipient, the forwarded TON amount, and the raw BOC payload (copyable, so
- * the full value stays recoverable behind the middle-ellipsis).
+ * transfer), the real recipient, the transferred token's quantity where the message carries one,
+ * the forwarded gas amount, and the raw BOC payload (copyable, so the full value stays recoverable
+ * behind the middle-ellipsis).
  *
  * @param messages decoded messages, built by [com.vultisig.wallet.ui.models.keysign.mapTonMessages]
  * @param initiallyExpanded preview-only override for the collapsed/expanded state; defaults to
@@ -134,6 +135,14 @@ private fun TonMessageRow(message: TonMessageUiModel, index: Int) {
                 monospace = true,
             )
         }
+        // The token's own quantity comes first: for a jetton transfer the row below it is only the
+        // forwarded gas, which is not what the user is parting with.
+        message.tokenAmount?.let { tokenAmount ->
+            TonDetailRow(
+                label = stringResource(R.string.verify_transaction_amount_title),
+                value = tokenAmount,
+            )
+        }
         message.amount?.let { amount ->
             TonDetailRow(label = stringResource(message.operation.amountLabelRes), value = amount)
         }
@@ -228,14 +237,23 @@ private fun PreviewSignTonDisplay() {
                 TonMessageUiModel(
                     operation = TonMessageOperation.JettonTransfer,
                     recipient = "EQDrLq9I7m6lvP6zUGZqJ8r4y0sP3pQ1n2vWk5tXcB9aZ7eF",
-                    amount = "0.001 TON",
+                    amount = "0.001 GRAM",
+                    tokenAmount = "100 USDT",
+                    rawPayload = "te6cckEBAQEAWQAArg+KfqUAAAAAAAAwOUBfXhAIAf...",
+                    hasStateInit = false,
+                ),
+                TonMessageUiModel(
+                    operation = TonMessageOperation.JettonTransfer,
+                    recipient = "EQBynBO23ywHy_CgarY9NK9FTz0yDsG82PtcbSTQgGoXwiuA",
+                    amount = "0.001 GRAM",
+                    tokenAmount = "250000000000",
                     rawPayload = "te6cckEBAQEAWQAArg+KfqUAAAAAAAAwOUBfXhAIAf...",
                     hasStateInit = false,
                 ),
                 TonMessageUiModel(
                     operation = TonMessageOperation.Transfer,
                     recipient = "EQAB1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-                    amount = "0.32 TON",
+                    amount = "0.32 GRAM",
                     rawPayload = null,
                     hasStateInit = true,
                 ),

--- a/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/components/SignTonDisplayView.kt
@@ -36,8 +36,9 @@ import com.vultisig.wallet.ui.theme.Theme
  * Displays a collapsible list of decoded TonConnect messages for user review before signing. Each
  * message shows its operation (jetton transfer, NFT transfer, excess-gas refund, or plain
  * transfer), the real recipient, the transferred token's quantity where the message carries one,
- * the forwarded gas amount, and the raw BOC payload (copyable, so the full value stays recoverable
- * behind the middle-ellipsis).
+ * the forwarded gas amount, and the raw BOC payload. Every row whose value has no bound — an
+ * address, an unresolved jetton's base-unit quantity, a payload — is copyable, so the full value
+ * stays recoverable behind the middle-ellipsis.
  *
  * @param messages decoded messages, built by [com.vultisig.wallet.ui.models.keysign.mapTonMessages]
  * @param initiallyExpanded preview-only override for the collapsed/expanded state; defaults to
@@ -141,6 +142,7 @@ private fun TonMessageRow(message: TonMessageUiModel, index: Int) {
             TonDetailRow(
                 label = stringResource(R.string.verify_transaction_amount_title),
                 value = tokenAmount,
+                copyableValue = tokenAmount,
             )
         }
         message.amount?.let { amount ->

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinKeysignViewModel.kt
@@ -97,6 +97,7 @@ import timber.log.Timber
 import vultisig.keysign.v1.CustomMessagePayload
 import vultisig.keysign.v1.KeysignMessage
 import vultisig.keysign.v1.TransactionType
+import wallet.core.jni.TONAddressConverter
 
 sealed class JoinKeysignError(val message: UiText) {
     data class FailedToCheck(val exceptionMessage: String) :
@@ -692,7 +693,7 @@ constructor(
                 // decoded BOC instead.
                 val chain = payload.coin.chain
                 if (chain == Chain.Ton && payload.signTon != null) {
-                    loadTonDappHero(payload, sendResult.vaultCoins)
+                    loadTonDappDisplay(payload, sendResult.vaultCoins)
                 } else {
                     loadBlockaidSimulation(payload, sendResult.functionName)
                 }
@@ -898,26 +899,62 @@ constructor(
         }
 
     /**
-     * Resolve the jetton hero for a TonConnect request from the decoded message bodies. Surfaces
-     * the first vault-held jetton transfer's real amount + ticker + logo in place of the misleading
-     * gas value. Best-effort: on a network failure or an unrecognised jetton the verify screen
-     * keeps its existing display. Mirrors [loadBlockaidSimulation] — Blockaid doesn't cover TON, so
-     * this is the TON hero path. Cancels any prior run (NSD can re-fire) and pushes the hero into
-     * both the verify model and [transactionTypeUiModel] so the done screen carries it forward.
+     * Resolve what a TonConnect request is really moving, from the decoded message bodies: each
+     * jetton row's ticker and scale, then the jetton hero — the first vault-held jetton transfer's
+     * real amount + ticker + logo in place of the misleading gas value. The rows are pushed
+     * separately because a jetton the vault does not hold resolves no hero, and its row is then the
+     * only place the transferred quantity appears at all.
+     *
+     * Best-effort: on a network failure or an unrecognised jetton the rows keep their raw
+     * quantities and the verify screen keeps its existing hero. Mirrors [loadBlockaidSimulation] —
+     * Blockaid doesn't cover TON, so this is the TON path. Cancels any prior run (NSD can re-fire)
+     * and pushes into both the verify model and [transactionTypeUiModel] so the done screen carries
+     * the same content forward.
      */
-    private fun loadTonDappHero(payload: KeysignPayload, vaultCoins: List<Coin>) {
+    private fun loadTonDappDisplay(payload: KeysignPayload, vaultCoins: List<Coin>) {
         val messages = payload.signTon?.tonMessages?.filterNotNull().orEmpty()
         if (messages.isEmpty()) return
         tonJettonHeroJob?.cancel()
         tonJettonHeroJob =
             viewModelScope.safeLaunch(
-                onError = { Timber.w(it, "TON dApp hero resolution failed during dApp signing") }
+                onError = { Timber.w(it, "TON dApp display resolution failed during dApp signing") }
             ) {
+                // Rows first, and independently of the hero: a jetton the vault does not hold
+                // resolves no hero at all, and that is precisely when the rows are the only place
+                // the transferred quantity can appear.
+                val jettonCoins =
+                    withContext(Dispatchers.IO) {
+                        tonDappHeroResolver.resolveJettonRowCoins(payload, vaultCoins)
+                    }
+                if (jettonCoins.isNotEmpty()) pushTonMessageRows(payload, jettonCoins)
+
                 val hero =
                     withContext(Dispatchers.IO) { tonDappHeroResolver(payload, vaultCoins) }
                         ?: return@safeLaunch
                 pushTonHero(hero)
             }
+    }
+
+    /**
+     * Rebuild the per-message rows now that the jetton tickers and scales are known, and mirror
+     * them into [transactionTypeUiModel] the way [pushTonHero] does. The rows are a pure function
+     * of the payload, so they are re-derived rather than patched in place.
+     */
+    private fun pushTonMessageRows(payload: KeysignPayload, jettonCoins: Map<String, TonHeroCoin>) {
+        val rows =
+            mapTonMessages(
+                payload.signTon,
+                fromAddress = payload.coin.address,
+                jettonCoins = jettonCoins,
+            ) { rawAddress ->
+                TONAddressConverter.toUserFriendly(rawAddress, true, false) ?: rawAddress
+            }
+        updateSendUiModel(verifyUiModel) { current ->
+            current.copy(transaction = current.transaction.copy(tonMessages = rows))
+        }
+        (transactionTypeUiModel as? TransactionTypeUiModel.Send)?.let { send ->
+            transactionTypeUiModel = TransactionTypeUiModel.Send(send.tx.copy(tonMessages = rows))
+        }
     }
 
     /**

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonDappHeroResolver.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonDappHeroResolver.kt
@@ -1,12 +1,17 @@
 package com.vultisig.wallet.ui.models.keysign
 
 import com.vultisig.wallet.data.api.chains.ton.TonApi
+import com.vultisig.wallet.data.crypto.ton.TonMessageBodyDecoder
+import com.vultisig.wallet.data.crypto.ton.TonMessageBodyIntent
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.ui.components.hero.HeroContent
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
 import vultisig.keysign.v1.TonMessage
 import wallet.core.jni.TONAddressConverter
 
@@ -18,12 +23,22 @@ import wallet.core.jni.TONAddressConverter
  * amount + ticker + logo in place of the misleading gas value. Best-effort — a network failure or
  * an unrecognised jetton resolves to `null` so the verify screen keeps its existing display.
  *
- * Extracted from `JoinKeysignViewModel.loadTonDappHero`; the job launching, cancellation, and
+ * Also resolves the ticker and scale behind each jetton row's quantity ([resolveJettonRowCoins]).
+ * Unlike the hero, those have to speak for a jetton the vault has never held, so they run the full
+ * ladder for every jetton transfer rather than stopping at the first vault-held one.
+ *
+ * Extracted from `JoinKeysignViewModel.loadTonDappDisplay`; the job launching, cancellation, and
  * pushing the resolved hero into the UI state stay in the ViewModel — this use case owns the
  * suspend resolution work and delegates to the top-level `resolveTonSwapHero` /
  * `resolveTonJettonHero`.
  */
 internal class TonDappHeroResolver @Inject constructor(private val tonApi: TonApi) {
+
+    /**
+     * Jetton wallet -> jetton master, memoized for the life of this resolver. The per-message rows
+     * and the hero walk the same wallets, and the mapping is fixed on chain, so it is fetched once.
+     */
+    private val jettonMasters = ConcurrentHashMap<String, String>()
 
     /**
      * Resolves the hero for [payload]'s TonConnect messages, looking tokens up against [vaultCoins]
@@ -66,12 +81,65 @@ internal class TonDappHeroResolver @Inject constructor(private val tonApi: TonAp
             },
         )
             ?: resolveTonJettonHero(messages, vaultCoins) { wallet ->
-                    tonApi.getJettonMasterAddress(wallet)?.let { master ->
-                        toUserFriendly(master) ?: master
-                    }
+                    jettonMaster(wallet)?.let { master -> toUserFriendly(master) ?: master }
                 }
                 ?.let { HeroContent.Send(title = null, coin = it) }
     }
+
+    /**
+     * Ticker and scale for every jetton wallet the jetton transfers in [payload] target, keyed by
+     * the message destination verbatim so [mapTonMessages] can look up each row by its own `to`.
+     *
+     * Feeds the per-message rows rather than the hero, so unlike [invoke] it does not stop at the
+     * first resolvable transfer and does not require the jetton to be held in the vault — the row
+     * has to state a quantity for a jetton the vault has never seen. A wallet that resolves to
+     * nothing is simply absent from the map and its row falls back to raw base units.
+     */
+    suspend fun resolveJettonRowCoins(
+        payload: KeysignPayload,
+        vaultCoins: List<Coin>,
+    ): Map<String, TonHeroCoin> {
+        val messages = payload.signTon?.tonMessages?.filterNotNull().orEmpty()
+        if (messages.isEmpty()) return emptyMap()
+        return resolveJettonRowCoins(messages, vaultCoins) {
+            TONAddressConverter.toUserFriendly(it, true, false)
+        }
+    }
+
+    /** JNI-free core of [resolveJettonRowCoins]. */
+    internal suspend fun resolveJettonRowCoins(
+        messages: List<TonMessage>,
+        vaultCoins: List<Coin>,
+        toUserFriendly: (String) -> String?,
+    ): Map<String, TonHeroCoin> =
+        messages
+            .filter {
+                TonMessageBodyDecoder.decode(it.payload) is TonMessageBodyIntent.JettonTransfer
+            }
+            .mapNotNull { it.to.takeIf(String::isNotEmpty) }
+            .distinct()
+            .mapNotNull { wallet ->
+                resolveRowCoinOrNull(wallet, vaultCoins, toUserFriendly)?.let { wallet to it }
+            }
+            .toMap()
+
+    /**
+     * [resolveTonCoinByWallet] for one row, tolerating a failed lookup. One unreachable jetton must
+     * not cost the other rows their tickers, and the row still shows its raw quantity without one.
+     */
+    private suspend fun resolveRowCoinOrNull(
+        wallet: String,
+        vaultCoins: List<Coin>,
+        toUserFriendly: (String) -> String?,
+    ): TonHeroCoin? =
+        try {
+            resolveTonCoinByWallet(wallet, vaultCoins, toUserFriendly)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "TON jetton row metadata lookup failed for %s", wallet)
+            null
+        }
 
     /**
      * Resolve a jetton wallet to its display coin for a swap leg: vault-tracked tokens first
@@ -83,9 +151,14 @@ internal class TonDappHeroResolver @Inject constructor(private val tonApi: TonAp
         vaultCoins: List<Coin>,
         toUserFriendly: (String) -> String?,
     ): TonHeroCoin? {
-        val master = tonApi.getJettonMasterAddress(wallet) ?: return null
+        val master = jettonMaster(wallet) ?: return null
         return resolveTonCoinByMaster(master, vaultCoins, toUserFriendly)
     }
+
+    /** [TonApi.getJettonMasterAddress] through [jettonMasters]. */
+    private suspend fun jettonMaster(wallet: String): String? =
+        jettonMasters[wallet]
+            ?: tonApi.getJettonMasterAddress(wallet)?.also { jettonMasters[wallet] = it }
 
     /**
      * Resolve a DeDust swap's output token. The swap addresses the liquidity **pool**, not the

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonMessageDecode.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonMessageDecode.kt
@@ -4,6 +4,7 @@ import com.vultisig.wallet.data.crypto.ton.TonMessageBodyDecoder
 import com.vultisig.wallet.data.crypto.ton.TonMessageBodyIntent
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.ui.components.hero.HeroCoinAmount
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -25,10 +26,16 @@ private val SWAP_SIDECAR_MAX_NANOTON: BigInteger = BigInteger.valueOf(10_000_000
  * When the request contains a swap, small self-addressed transfers (gas sidecars) are dropped so
  * the list mirrors the swap hero instead of repeating its gas plumbing. [fromAddress] is the
  * signer's TON address used to identify those sidecars.
+ *
+ * A jetton transfer's own quantity is always shown, keyed off the message destination (the sender's
+ * jetton wallet) in [jettonCoins] for its ticker and scale. That map costs network lookups, so this
+ * pass runs with whatever is already known — nothing on the first pass — and the quantity degrades
+ * to its raw base units rather than disappearing or borrowing a guessed ticker.
  */
 internal fun mapTonMessages(
     signTon: SignTon?,
     fromAddress: String?,
+    jettonCoins: Map<String, TonHeroCoin> = emptyMap(),
     formatAddress: (String) -> String,
 ): List<TonMessageUiModel> {
     val rawDecoded =
@@ -76,6 +83,7 @@ internal fun mapTonMessages(
                     operation = TonMessageOperation.JettonTransfer,
                     recipient = formatAddress(intent.destination),
                     amount = formatTon(intent.forwardTonAmount),
+                    tokenAmount = formatJettonQuantity(intent.amount, jettonCoins[message.to]),
                     rawPayload = rawPayload,
                     hasStateInit = hasStateInit,
                 )
@@ -167,8 +175,20 @@ internal suspend fun resolveTonJettonHero(
 private fun formatTon(nanotons: BigInteger): String {
     val whole = nanotons / NANOTON_DIVISOR
     val fraction = (nanotons % NANOTON_DIVISOR).toString().padStart(9, '0').trimEnd('0')
-    return if (fraction.isEmpty()) "$whole TON" else "$whole.$fraction TON"
+    // The app brands the native TON coin GRAM (Coins.Ton.TON.ticker), which is what the labels
+    // beside these values say, so the unit here has to agree with them.
+    val unit = Coins.Ton.TON.ticker
+    return if (fraction.isEmpty()) "$whole $unit" else "$whole.$fraction $unit"
 }
+
+/**
+ * A jetton transfer's quantity for its message row: scaled and tickered when [coin] resolved, and
+ * otherwise the raw base units on their own. An unresolved jetton is exactly the case this row
+ * exists for — the vault does not hold it, so no hero can speak for it — and a bare integer at
+ * least states the magnitude, where a guessed ticker or an omitted row would not.
+ */
+private fun formatJettonQuantity(raw: BigInteger, coin: TonHeroCoin?): String =
+    if (coin == null) raw.toString() else "${formatJettonAmount(raw, coin.decimals)} ${coin.ticker}"
 
 private fun formatJettonAmount(raw: BigInteger, decimals: Int): String =
     if (decimals <= 0) {

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonMessageUiModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/TonMessageUiModel.kt
@@ -13,14 +13,20 @@ internal enum class TonMessageOperation {
 
 /**
  * Display model for a single TonConnect message on the keysign verify screen. Built by decoding the
- * message's BOC body; [recipient] is already in user-friendly form and [amount] is pre-formatted
- * (e.g. `"0.05 TON"`).
+ * message's BOC body; [recipient] is already in user-friendly form and both amounts are
+ * pre-formatted.
+ *
+ * [amount] is the native value the message carries — for a jetton or NFT transfer that is only the
+ * forwarded gas, not what the user is parting with. [tokenAmount] carries the transferred token's
+ * own quantity (e.g. `"100 USDT"`), so the quantity is on screen whether or not the jetton is held
+ * in the vault and can resolve a hero.
  */
 @Immutable
 internal data class TonMessageUiModel(
     val operation: TonMessageOperation,
     val recipient: String?,
     val amount: String?,
+    val tokenAmount: String? = null,
     val rawPayload: String?,
     val hasStateInit: Boolean,
 )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/TonDappHeroResolverTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/TonDappHeroResolverTest.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.ui.components.hero.HeroContent
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -127,5 +128,92 @@ internal class TonDappHeroResolverTest {
         val hero = resolver.resolveHero(messages = emptyList(), vaultCoins = emptyList()) { it }
 
         assertNull(hero)
+    }
+
+    @Test
+    fun `resolves a row coin from on-chain metadata for a jetton the vault does not hold`() =
+        runTest {
+            // The case the rows exist for: no vault coin, so no hero — the row still needs the
+            // ticker and scale to state what is leaving.
+            coEvery { tonApi.getJettonMasterAddress("EQwallet") } returns "EQmaster"
+            coEvery { tonApi.getJettonMetadata("EQmaster") } returns
+                TonJettonMetadata(ticker = "USDT", decimals = 6, logo = "usdt")
+
+            val coins =
+                resolver.resolveJettonRowCoins(
+                    messages =
+                        listOf(
+                            TonMessage(
+                                to = "EQwallet",
+                                amount = "50000000",
+                                payload = jettonTransfer,
+                            )
+                        ),
+                    vaultCoins = emptyList(),
+                    toUserFriendly = { it },
+                )
+
+            assertEquals(TonHeroCoin("USDT", 6, "usdt"), coins["EQwallet"])
+        }
+
+    @Test
+    fun `leaves a row coin unresolved when the jetton has no metadata`() = runTest {
+        coEvery { tonApi.getJettonMasterAddress("EQwallet") } returns "EQmaster"
+        coEvery { tonApi.getJettonMetadata("EQmaster") } returns null
+
+        val coins =
+            resolver.resolveJettonRowCoins(
+                messages =
+                    listOf(
+                        TonMessage(to = "EQwallet", amount = "50000000", payload = jettonTransfer)
+                    ),
+                vaultCoins = emptyList(),
+                toUserFriendly = { it },
+            )
+
+        assertEquals(emptyMap(), coins)
+    }
+
+    @Test
+    fun `keeps the other rows' coins when one jetton lookup fails`() = runTest {
+        coEvery { tonApi.getJettonMasterAddress("EQwallet") } throws RuntimeException("offline")
+        coEvery { tonApi.getJettonMasterAddress("EQwallet2") } returns "EQmaster2"
+
+        val coins =
+            resolver.resolveJettonRowCoins(
+                messages =
+                    listOf(
+                        TonMessage(to = "EQwallet", amount = "50000000", payload = jettonTransfer),
+                        TonMessage(to = "EQwallet2", amount = "50000000", payload = jettonTransfer),
+                    ),
+                vaultCoins = listOf(jettonCoin("EQmaster2")),
+                toUserFriendly = { it },
+            )
+
+        assertEquals(mapOf("EQwallet2" to TonHeroCoin("USDT", 6, "usdt")), coins)
+    }
+
+    @Test
+    fun `fetches a jetton master once for both the rows and the hero`() = runTest {
+        coEvery { tonApi.getJettonMasterAddress("EQwallet") } returns "EQmaster"
+        val messages =
+            listOf(TonMessage(to = "EQwallet", amount = "50000000", payload = jettonTransfer))
+
+        resolver.resolveJettonRowCoins(messages, listOf(jettonCoin("EQmaster"))) { it }
+        resolver.resolveHero(messages, listOf(jettonCoin("EQmaster"))) { it }
+
+        coVerify(exactly = 1) { tonApi.getJettonMasterAddress("EQwallet") }
+    }
+
+    @Test
+    fun `ignores messages that are not jetton transfers`() = runTest {
+        val coins =
+            resolver.resolveJettonRowCoins(
+                messages = listOf(TonMessage(to = "EQwallet", amount = "50000000")),
+                vaultCoins = emptyList(),
+                toUserFriendly = { it },
+            )
+
+        assertEquals(emptyMap(), coins)
     }
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/TonMessageDecodeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/TonMessageDecodeTest.kt
@@ -45,27 +45,52 @@ internal class TonMessageDecodeTest {
 
     @Test
     fun `maps a jetton transfer to a labelled row with the real recipient and forward amount`() {
-        val row =
-            mapTonMessages(
-                    SignTon(
-                        tonMessages =
-                            listOf(
-                                TonMessage(
-                                    to = "EQwallet",
-                                    amount = "50000000",
-                                    payload = jettonTransfer,
-                                )
-                            )
-                    ),
-                    fromAddress = null,
-                    formatAddress = { it },
-                )
-                .single()
+        val row = jettonRow()
         assertEquals(TonMessageOperation.JettonTransfer, row.operation)
         assertEquals(recipient, row.recipient)
-        assertEquals("0.001 TON", row.amount)
+        assertEquals("0.001 GRAM", row.amount)
         assertEquals(jettonTransfer, row.rawPayload)
     }
+
+    @Test
+    fun `states a jetton transfer's own quantity with its ticker once the coin resolves`() {
+        val row = jettonRow(jettonCoins = mapOf("EQwallet" to TonHeroCoin("USDT", 6, "usdt")))
+        // The forwarded gas is not what the user is parting with; the quantity is its own row.
+        assertEquals("100 USDT", row.tokenAmount)
+        assertEquals("0.001 GRAM", row.amount)
+    }
+
+    @Test
+    fun `states a jetton transfer's raw quantity when the jetton is not in the vault`() {
+        // Nothing resolved the jetton wallet — the vault has never held it and no metadata came
+        // back. The magnitude still has to reach the screen, without a guessed ticker.
+        val row = jettonRow(jettonCoins = emptyMap())
+        assertEquals("100000000", row.tokenAmount)
+    }
+
+    @Test
+    fun `keeps a jetton row's quantity raw when a different wallet resolved`() {
+        val row = jettonRow(jettonCoins = mapOf("EQother" to TonHeroCoin("USDT", 6, "usdt")))
+        assertEquals("100000000", row.tokenAmount)
+    }
+
+    private fun jettonRow(jettonCoins: Map<String, TonHeroCoin> = emptyMap()) =
+        mapTonMessages(
+                SignTon(
+                    tonMessages =
+                        listOf(
+                            TonMessage(
+                                to = "EQwallet",
+                                amount = "50000000",
+                                payload = jettonTransfer,
+                            )
+                        )
+                ),
+                fromAddress = null,
+                jettonCoins = jettonCoins,
+                formatAddress = { it },
+            )
+            .single()
 
     @Test
     fun `maps an excesses body to an excess gas refund row with no recipient or amount`() {
@@ -84,6 +109,7 @@ internal class TonMessageDecodeTest {
         assertEquals(TonMessageOperation.ExcessGasRefund, row.operation)
         assertNull(row.recipient)
         assertNull(row.amount)
+        assertNull(row.tokenAmount)
     }
 
     @Test
@@ -97,7 +123,7 @@ internal class TonMessageDecodeTest {
                 .single()
         assertEquals(TonMessageOperation.Transfer, row.operation)
         assertEquals("EQabc", row.recipient)
-        assertEquals("1.5 TON", row.amount)
+        assertEquals("1.5 GRAM", row.amount)
         assertNull(row.rawPayload)
     }
 


### PR DESCRIPTION
Closes #5826

## Problem

Approving a TonConnect jetton transfer could show **no indication of how much was leaving**. The per-message row was built from the forwarded gas, and the quantity was decoded and then thrown away — `TonMessageBodyIntent.JettonTransfer` carries `amount`, and the row never read it.

The hero covered the intended case, but it matches vault coins only, and Android has no jetton auto-discovery: a jetton enters a vault by manual add or not at all. So for the dApp-supplied jetton a user has not added, the hero resolves to nothing and the quantity appeared **nowhere** — leaving an unknown amount of an unnamed token to approve, with only the gas figure on screen.

## Change

- The jetton quantity gets its own row above the forwarded gas, as on iOS (`to` / `amount` / `forwardTonAmount`).
- Ticker and scale come from the ladder the swap path already walks — vault coin → curated `Coins` registry → `tonApi.getJettonMetadata`. Where nothing resolves, the row shows the raw base units rather than borrowing a ticker it cannot justify.
- The lookup stays off the screen's critical path. `mapTonMessages` is a pure non-suspend function called while the verify model is built, so making it wait on a TON RPC would put the network in front of the whole screen. Instead the rows render immediately with raw quantities and the existing TON job pushes the resolved tickers in, the way it already pushes the hero.
- Rows and hero now share one memoized jetton-master lookup instead of fetching the same mapping twice.
- `formatTon` hardcoded `" TON"` while the app brands the native coin `GRAM` and all ten locales say "Forward GRAM Amount", so the value disagreed with the label above it. It now takes its unit from `Coins.Ton.TON.ticker`.

The hero is untouched: a vault-held jetton still headlines exactly as before. No new string — the quantity row reuses `verify_transaction_amount_title` ("Amount"), which is iOS's row title.

## Before / After

**The bug: a jetton the vault does not hold.** No hero resolves, so before this change nothing on the screen stated the quantity.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/8Fo5rsm.png) | ![after](https://i.imgur.com/R6Tk2R3.png) |

**A jetton the vault does hold.** The hero is unchanged; the row gains the quantity, and the forwarded-gas value stops saying "TON" under a "Forward GRAM Amount" label.

| Before | After |
|--------|-------|
| ![before](https://i.imgur.com/jyykIBV.png) | ![after](https://i.imgur.com/qapLIap.png) |

## Test plan

- `./gradlew :app:testDebugUnitTest` — green. `TonMessageDecodeTest` 17 tests, `TonDappHeroResolverTest` 10, 0 skipped.
  - New: the quantity carries its ticker once the coin resolves; a jetton absent from the vault falls back to raw base units; a row whose wallet did not resolve stays raw; metadata returning null leaves the row unresolved; one failed lookup does not cost the other rows their tickers; the jetton master is fetched once for both the rows and the hero.
- `./gradlew :app:assembleDebug`, `:app:compileDebugAndroidTestKotlin`, `:app:ktfmtCheck` — all pass.
- Rendered on a Medium_Phone emulator via `PreviewActivity` (`verify_ton_jetton_after`, `verify_ton_jetton_unheld`) — the screenshots above are real Android renders of both trees.

### Manual

1. Connect a TON dApp that transfers a jetton the vault does not hold and trigger the transfer.
2. On the keysign confirmation, the message row now states the jetton quantity — with its ticker where metadata resolves, otherwise the raw amount — above `Forward GRAM Amount`.
3. Add that jetton to the vault manually and repeat: the hero appears as before, and the row still carries the quantity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved TON transaction previews with clearer separation of token quantities and forwarded gas amounts.
  * Resolved jetton metadata now displays token amounts using the appropriate ticker and decimals.
  * Unresolved jettons retain their raw token quantities for transparency.
  * TON native amounts are displayed using the `GRAM` unit.

* **Bug Fixes**
  * Improved handling of jetton transfers when metadata is missing or lookups fail.
  * Enhanced consistency between transaction verification and completion views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->