### PR TITLE
fix(send): re-fit an EVM max send to the fee that gets signed

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategy.kt
@@ -244,15 +244,6 @@ internal class DefaultSendStrategy(
                             gasFee = spendableGasFee,
                             isMaxAmount = isMaxAmount,
                         )
-                    // The fields are only rewritten once every validation below has passed — see
-                    // the showAdjustedAmount call before Verify.
-                    val isAmountAdjusted = tokenAmountInt < enteredAmountInt
-                    val fiatAmount =
-                        if (isAmountAdjusted) {
-                            scaleFiat(enteredFiat, tokenAmountInt, enteredAmountInt, selectedToken)
-                        } else {
-                            enteredFiat
-                        }
 
                     if (chain == Chain.Tron) {
                         val isTronStakingOp =
@@ -306,6 +297,32 @@ internal class DefaultSendStrategy(
                             }
                     val specific = applyRippleDestinationTag(specificAfterPlan, destinationTag)
 
+                    // getSpecific() re-prices EVM gas against the live base fee, so the amount
+                    // sized against the earlier estimate can no longer fit under the bond that is
+                    // about to be signed. Re-fit it here, against the specific itself.
+                    val refittedAmountInt =
+                        refitToSignedEvmFee(
+                            amount = tokenAmountInt,
+                            account = selectedAccount,
+                            balance = selectedTokenValue.value,
+                            specific = specific,
+                            isMaxAmount = isMaxAmount,
+                        )
+                    // The fields are only rewritten once every validation below has passed — see
+                    // the showAdjustedAmount call before Verify.
+                    val isAmountAdjusted = refittedAmountInt < enteredAmountInt
+                    val fiatAmount =
+                        if (isAmountAdjusted) {
+                            scaleFiat(
+                                enteredFiat,
+                                refittedAmountInt,
+                                enteredAmountInt,
+                                selectedToken,
+                            )
+                        } else {
+                            enteredFiat
+                        }
+
                     // sendMaxAmount=true tells WalletCore's planner to sweep the real
                     // balance-minus-fee itself, ignoring the requested amount — so for a Max UTXO
                     // send, tokenAmountInt (built from the approximate fee estimate above) can
@@ -315,7 +332,7 @@ internal class DefaultSendStrategy(
                         if (isMaxAmount && btcPlan != null && btcPlan.error == SigningError.OK) {
                             BigInteger.valueOf(btcPlan.amount)
                         } else {
-                            tokenAmountInt
+                            refittedAmountInt
                         }
 
                     if (selectedToken.isNativeToken) {
@@ -525,7 +542,7 @@ internal class DefaultSendStrategy(
                     // Cardano clamp landing under the minimum-send floor, say.
                     if (isAmountAdjusted) {
                         showAdjustedAmount(
-                            adjusted = tokenAmountInt,
+                            adjusted = refittedAmountInt,
                             adjustedFiat = fiatAmount,
                             token = selectedToken,
                             isMaxAmount = isMaxAmount,
@@ -578,6 +595,52 @@ internal class DefaultSendStrategy(
         val available = getAvailableTokenBalance(account, gasFee.value)?.value ?: return entered
         if (available <= BigInteger.ZERO) return entered
         return entered.coerceAtMost(available)
+    }
+
+    /**
+     * Re-fits a native EVM [amount] to the fee that is about to be signed.
+     *
+     * An amount the app derived from the balance sits at exactly `balance − fee`, and that fee came
+     * from `GasFeeOrchestrator`'s cached estimate — one reading of the fee market. `getSpecific()`
+     * then takes a second, live reading to build the payload. The node admits a transaction only
+     * when `value + gasLimit × maxFeePerGas + L1 data fee ≤ balance`, so an upward tick between the
+     * two readings — near-constant on ~2s-block L2s — leaves the derived value no longer
+     * affordable, and the send is refused at broadcast with the MPC ceremony already spent.
+     *
+     * Reduces only: a fee that fell leaves more room than the user was shown, and signing more than
+     * they were shown is never right. An amount that overshoots the balance on its own is left for
+     * the balance checks in `submit` to reject, as in [clampToSpendableBalance] — that is an
+     * over-entry, not a fee edge. A fee that leaves nothing at all raises rather than signing a
+     * transaction the chain will refuse.
+     */
+    private suspend fun refitToSignedEvmFee(
+        amount: BigInteger,
+        account: Account,
+        balance: BigInteger,
+        specific: BlockChainSpecificAndUtxo,
+        isMaxAmount: Boolean,
+    ): BigInteger {
+        if (defiTypeProvider() != null) return amount
+        val token = account.token
+        // An ERC-20 pays its gas from the native sibling, so its amount is never fee-derived.
+        if (!token.isNativeToken) return amount
+        val eth = specific.blockChainSpecific as? BlockChainSpecific.Ethereum ?: return amount
+        if (!isMaxAmount && amount > balance) return amount
+        // Read off the specific rather than recomputed, so Advanced Gas Settings — patched into it
+        // by applyGasSettings — are already accounted for. l1Amount is what op-geth adds to its own
+        // balance check beyond the bond; it is zero off the OP stack.
+        val signedFee = eth.gasLimit * eth.maxFeePerGasWei + specific.l1Amount
+        val affordable = getAvailableTokenBalance(account, signedFee)?.value ?: return amount
+        if (affordable >= amount) return amount
+        if (affordable <= BigInteger.ZERO) {
+            throw InvalidTransactionDataException(
+                UiText.FormattedText(
+                    R.string.send_error_insufficient_native_balance_with_fees,
+                    listOf(token.ticker),
+                )
+            )
+        }
+        return affordable
     }
 
     /**

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/submit/DefaultSendStrategyTest.kt
@@ -2369,6 +2369,415 @@ internal class DefaultSendStrategyTest {
             isNativeToken = false,
         )
 
+    /**
+     * #5491: a native EVM Max is `balance − fee`, but the fee it is sized against and the fee that
+     * is signed are two independent readings of the same market — `AccountValidator`'s cached
+     * estimate and `getSpecific()`'s live re-price. The node admits the send only when `value +
+     * gasLimit x maxFeePerGas <= balance`, so a base fee that ticked up between the two readings
+     * makes the signed value unaffordable and the broadcast is refused with the ceremony already
+     * spent. The amount must be re-fitted to the bond in the payload.
+     */
+    @Test
+    fun `submit re-fits a native EVM Max to the gas bond that gets signed`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            // 1 ETH, sized against a 0.0010 ETH estimate, signed against a 0.0015 ETH bond.
+            val captured =
+                stubEvmSend(
+                    balance = BigInteger("1000000000000000000"),
+                    amountText = "0.999",
+                    estimateFee = BigInteger("1000000000000000"),
+                    signedMaxFeePerGas = BigInteger("71428571428"),
+                    signedGasLimit = BigInteger.valueOf(21000),
+                )
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertNull(lastError, "Expected no error; got $lastError")
+            // balance − 21000 x 71428571428 = 0.999500000000012 ETH, below the filled 0.999.
+            assertEquals(BigInteger("998500000000012000"), captured.captured.tokenValue.value)
+            assertEquals("0.998500000000012", tokenAmountFieldState.text.toString())
+            // Still the maximum, just a smaller one — the form's 100% selection has to survive it.
+            verify { amountManager.markMax(BigDecimal("0.998500000000012")) }
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /**
+     * The reported Arbitrum shortfall, from the chain's own numbers: a 120000-gas limit against a
+     * 24000-wei tick in maxFeePerGas is 2,880,000,000 wei the send no longer covers. The re-fit has
+     * to close exactly that gap — no more, or it would quietly send less than it must.
+     */
+    @Test
+    fun `submit re-fits by exactly the bond the fee tick added`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val balance = BigInteger("1000000000000000000")
+            val gasLimit = BigInteger.valueOf(120000)
+            val estimateMaxFeePerGas = BigInteger("100000")
+            val signedMaxFeePerGas = estimateMaxFeePerGas + BigInteger("24000")
+            val filled = balance - gasLimit * estimateMaxFeePerGas
+
+            val captured =
+                stubEvmSend(
+                    balance = balance,
+                    amountText = BigDecimal(filled).movePointLeft(18).toPlainString(),
+                    estimateFee = gasLimit * estimateMaxFeePerGas,
+                    signedMaxFeePerGas = signedMaxFeePerGas,
+                    signedGasLimit = gasLimit,
+                )
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertNull(lastError, "Expected no error; got $lastError")
+            assertEquals(
+                BigInteger("2880000000"),
+                filled - captured.captured.tokenValue.value,
+                "re-fit must give back exactly the bond the tick added",
+            )
+            assertEquals(
+                balance - gasLimit * signedMaxFeePerGas,
+                captured.captured.tokenValue.value,
+            )
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /**
+     * op-geth's balance check is `value + gasLimit x maxFeePerGas + L1 data fee`, and the gas bond
+     * on the payload carries only the first term. Re-fitting to the bond alone would hand back an
+     * amount that is short by the L1 fee on every OP-stack chain — a clamp that fails as reliably
+     * as the amount it replaced.
+     */
+    @Test
+    fun `submit reserves the OP-stack L1 data fee when re-fitting a Max`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val balance = BigInteger("1000000000000000000")
+            val l1Fee = BigInteger("40000000000000")
+            val captured =
+                stubEvmSend(
+                    balance = balance,
+                    amountText = "0.999",
+                    estimateFee = BigInteger("1000000000000000"),
+                    signedMaxFeePerGas = BigInteger("71428571428"),
+                    signedGasLimit = BigInteger.valueOf(21000),
+                    signedL1Fee = l1Fee,
+                )
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertNull(lastError, "Expected no error; got $lastError")
+            assertEquals(
+                balance - BigInteger.valueOf(21000) * BigInteger("71428571428") - l1Fee,
+                captured.captured.tokenValue.value,
+            )
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /** A fee that fell leaves more room than the user was shown — never sign more than that. */
+    @Test
+    fun `submit leaves a native EVM Max alone when the signed fee is lower than the estimate`() =
+        runTest {
+            mockkStatic(Dispatchers::class)
+            every { Dispatchers.IO } returns mainDispatcher
+            try {
+                val captured =
+                    stubEvmSend(
+                        balance = BigInteger("1000000000000000000"),
+                        amountText = "0.999",
+                        estimateFee = BigInteger("1000000000000000"),
+                        // 21000 x 23809523809 = 0.0005 ETH, half the estimate.
+                        signedMaxFeePerGas = BigInteger("23809523809"),
+                        signedGasLimit = BigInteger.valueOf(21000),
+                    )
+
+                build(this).submit()
+                advanceUntilIdle()
+
+                assertNull(lastError, "Expected no error; got $lastError")
+                assertEquals(BigInteger("999000000000000000"), captured.captured.tokenValue.value)
+                assertEquals("0.999", tokenAmountFieldState.text.toString())
+            } finally {
+                unmockkStatic(Dispatchers::class)
+            }
+        }
+
+    /** A fee that swallows the balance has no affordable amount to fall back to. */
+    @Test
+    fun `submit refuses a native EVM send whose signed fee exceeds the balance`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val captured =
+                stubEvmSend(
+                    balance = BigInteger("1000000000000000000"),
+                    amountText = "0.999",
+                    estimateFee = BigInteger("1000000000000000"),
+                    // 21000 x 50000000000000 = 1.05 ETH, more than the whole balance.
+                    signedMaxFeePerGas = BigInteger("50000000000000"),
+                    signedGasLimit = BigInteger.valueOf(21000),
+                )
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertEquals(
+                R.string.send_error_insufficient_native_balance_with_fees,
+                (lastError as UiText.FormattedText).resId,
+            )
+            assertTrue(!captured.isCaptured, "an unaffordable send must not be staged")
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /** A typed amount with room to spare is the user's number, not one derived from the balance. */
+    @Test
+    fun `submit does not re-fit a typed native EVM amount that still fits`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val captured =
+                stubEvmSend(
+                    balance = BigInteger("1000000000000000000"),
+                    amountText = "0.5",
+                    estimateFee = BigInteger("1000000000000000"),
+                    signedMaxFeePerGas = BigInteger("71428571428"),
+                    signedGasLimit = BigInteger.valueOf(21000),
+                    maxAmountText = "0.999",
+                )
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertNull(lastError, "Expected no error; got $lastError")
+            assertEquals(BigInteger("500000000000000000"), captured.captured.tokenValue.value)
+            assertEquals("0.5", tokenAmountFieldState.text.toString())
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /**
+     * Asking for more than the wallet holds is an over-entry, not a fee edge: it has to keep
+     * raising the balance error rather than being quietly rewritten into an affordable send.
+     */
+    @Test
+    fun `submit still refuses a typed native EVM amount above the balance`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val captured =
+                stubEvmSend(
+                    balance = BigInteger("1000000000000000000"),
+                    amountText = "2",
+                    estimateFee = BigInteger("1000000000000000"),
+                    signedMaxFeePerGas = BigInteger("71428571428"),
+                    signedGasLimit = BigInteger.valueOf(21000),
+                    maxAmountText = "0.999",
+                )
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertEquals(
+                R.string.send_error_insufficient_native_balance_with_fees,
+                (lastError as UiText.FormattedText).resId,
+            )
+            assertTrue(!captured.isCaptured, "an over-entry must not be staged")
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /** An ERC-20 pays gas from its native sibling, so its amount is never fee-derived. */
+    @Test
+    fun `submit does not re-fit an ERC-20 Max when the signed gas bond rises`() = runTest {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            val usdc =
+                ethCoin()
+                    .copy(
+                        ticker = "USDC",
+                        decimal = 6,
+                        contractAddress = "0xa0b8",
+                        isNativeToken = false,
+                        priceProviderID = "usd-coin",
+                    )
+            val ethAccount =
+                Account(
+                    token = ethCoin(),
+                    tokenValue = TokenValue(BigInteger("1000000000000000000"), ethCoin()),
+                    fiatValue = null,
+                    price = null,
+                )
+            val usdcAccount =
+                Account(
+                    token = usdc,
+                    tokenValue = TokenValue(BigInteger("1000000"), usdc),
+                    fiatValue = null,
+                    price = null,
+                )
+            accounts.value = listOf(ethAccount, usdcAccount)
+            vaultId = "vault-1"
+            selectedAccount = usdcAccount
+            addressFieldState.setTextAndPlaceCursorAtEnd("0xdest")
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("1")
+            coEvery { accountValidator.validate() } returns
+                ValidatedAccount(
+                    vaultId = "vault-1",
+                    selectedAccount = usdcAccount,
+                    chain = Chain.Ethereum,
+                    gasFee = TokenValue(BigInteger("1000000000000000"), ethCoin()),
+                    dstAddress = "0xdest",
+                )
+            coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+            coEvery {
+                blockChainSpecificRepository.getSpecific(
+                    chain = any(),
+                    address = any(),
+                    token = any(),
+                    gasFee = any(),
+                    isSwap = any(),
+                    isMaxAmountEnabled = any(),
+                    isDeposit = any(),
+                    dstAddress = any(),
+                    tokenAmountValue = any(),
+                    memo = any(),
+                    isThorchainRouterDeposit = any(),
+                )
+            } returns
+                BlockChainSpecificAndUtxo(
+                    BlockChainSpecific.Ethereum(
+                        maxFeePerGasWei = BigInteger("71428571428"),
+                        priorityFeeWei = BigInteger.ONE,
+                        nonce = BigInteger.ZERO,
+                        gasLimit = BigInteger.valueOf(21000),
+                    )
+                )
+            every { amountManager.currentMaxAmount } returns BigDecimal("1")
+            coEvery { getAvailableTokenBalance(any(), any()) } coAnswers
+                {
+                    val account = firstArg<Account>()
+                    val balance = account.tokenValue?.value ?: BigInteger.ZERO
+                    val reserved = if (account.token.isNativeToken) secondArg() else BigInteger.ZERO
+                    TokenValue((balance - reserved).coerceAtLeast(BigInteger.ZERO), account.token)
+                }
+            coEvery { gasFeeToEstimatedFee(any()) } returns
+                EstimatedGasFee(
+                    formattedFiatValue = "$0.10",
+                    formattedTokenValue = "0.0015 ETH",
+                    tokenValue = TokenValue(BigInteger.ONE, ethCoin()),
+                    fiatValue = mockk(relaxed = true),
+                )
+            val captured = slot<Transaction>()
+            coEvery { transactionRepository.addTransaction(capture(captured)) } returns Unit
+
+            build(this).submit()
+            advanceUntilIdle()
+
+            assertNull(lastError, "Expected no error; got $lastError")
+            assertEquals(BigInteger("1000000"), captured.captured.tokenValue.value)
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    /**
+     * Stubs a native-ETH send with two independent readings of the fee market: [estimateFee] is the
+     * cached estimate the amount on screen was sized against, and [signedGasLimit] x
+     * [signedMaxFeePerGas] + [signedL1Fee] is what `getSpecific()` puts in the payload.
+     * [maxAmountText] defaults to [amountText], i.e. the amount is a Max.
+     */
+    private fun stubEvmSend(
+        balance: BigInteger,
+        amountText: String,
+        estimateFee: BigInteger,
+        signedMaxFeePerGas: BigInteger,
+        signedGasLimit: BigInteger,
+        signedL1Fee: BigInteger = BigInteger.ZERO,
+        maxAmountText: String = amountText,
+    ): CapturingSlot<Transaction> {
+        val ethCoin = ethCoin()
+        val account =
+            Account(
+                token = ethCoin,
+                tokenValue = TokenValue(balance, ethCoin),
+                fiatValue = null,
+                price = null,
+            )
+        vaultId = "vault-1"
+        selectedAccount = account
+        accounts.value = listOf(account)
+        addressFieldState.setTextAndPlaceCursorAtEnd("0xdest")
+        tokenAmountFieldState.setTextAndPlaceCursorAtEnd(amountText)
+        coEvery { accountValidator.validate() } returns
+            ValidatedAccount(
+                vaultId = "vault-1",
+                selectedAccount = account,
+                chain = Chain.Ethereum,
+                gasFee = TokenValue(estimateFee, ethCoin),
+                dstAddress = "0xdest",
+            )
+        coEvery { chainAccountAddressRepository.isValid(any(), any()) } returns true
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+                dstAddress = any(),
+                tokenAmountValue = any(),
+                memo = any(),
+                isThorchainRouterDeposit = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.Ethereum(
+                    maxFeePerGasWei = signedMaxFeePerGas,
+                    priorityFeeWei = BigInteger.ONE,
+                    nonce = BigInteger.ZERO,
+                    gasLimit = signedGasLimit,
+                ),
+                l1Amount = signedL1Fee,
+            )
+        every { amountManager.currentMaxAmount } returns BigDecimal(maxAmountText)
+        // What GetAvailableTokenBalanceUseCase really does: balance minus whatever fee it is
+        // handed. A flat stub would hide the whole point — the two calls pass different fees.
+        coEvery { getAvailableTokenBalance(any(), any()) } coAnswers
+            {
+                TokenValue(
+                    (balance - secondArg<BigInteger>()).coerceAtLeast(BigInteger.ZERO),
+                    ethCoin,
+                )
+            }
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedFiatValue = "$0.10",
+                formattedTokenValue = "0.0015 ETH",
+                tokenValue = TokenValue(BigInteger.ONE, ethCoin),
+                fiatValue = mockk(relaxed = true),
+            )
+        val captured = slot<Transaction>()
+        coEvery { transactionRepository.addTransaction(capture(captured)) } returns Unit
+        return captured
+    }
+
     private fun ethCoin(): Coin =
         Coin(
             chain = Chain.Ethereum,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeService.kt
@@ -302,11 +302,14 @@ class EthereumFeeService @Inject constructor(private val evmApiFactory: EvmApiFa
         }
     }
 
+    // Carried on the fee as well as folded into the total: a max send is re-fitted to the gas bond
+    // that ends up signed, and that bond is re-priced after this point, so the L1 term has to
+    // survive on its own or the re-fit silently reserves nothing for it.
     private fun Fee.addL1Amount(l1FeesAmount: BigInteger): Fee {
         return if (this is GasFees) {
-            this.copy(amount = this.amount + l1FeesAmount)
+            this.copy(amount = this.amount + l1FeesAmount, l1Amount = this.l1Amount + l1FeesAmount)
         } else if (this is Eip1559) {
-            this.copy(amount = this.amount + l1FeesAmount)
+            this.copy(amount = this.amount + l1FeesAmount, l1Amount = this.l1Amount + l1FeesAmount)
         } else {
             error("Fee Type Not Supported")
         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/model/Fees.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/model/Fees.kt
@@ -8,6 +8,15 @@ import java.math.BigInteger
  */
 sealed interface Fee {
     val amount: BigInteger
+
+    /**
+     * The part of [amount] the chain adds to its own balance check on top of `price × limit` — the
+     * OP-stack L1 data fee today, zero everywhere else. Kept separable from the gas bond because a
+     * balance-derived amount has to reserve both, and the bond can still be re-priced (a second
+     * chain-specific fetch, Advanced Gas Settings) after this fee was calculated.
+     */
+    val l1Amount: BigInteger
+        get() = BigInteger.ZERO
 }
 
 /**
@@ -21,6 +30,7 @@ data class GasFees(
     val price: BigInteger = BigInteger.ZERO,
     val limit: BigInteger = BigInteger.ZERO,
     override val amount: BigInteger = BigInteger.ZERO,
+    override val l1Amount: BigInteger = BigInteger.ZERO,
 ) : Fee
 
 /**
@@ -38,6 +48,7 @@ data class Eip1559(
     val maxFeePerGas: BigInteger, // Max total gas price
     val maxPriorityFeePerGas: BigInteger, // Miner tip
     override val amount: BigInteger,
+    override val l1Amount: BigInteger = BigInteger.ZERO,
 ) : Fee
 
 /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -65,6 +65,13 @@ import wallet.core.jni.Base58
 data class BlockChainSpecificAndUtxo(
     val blockChainSpecific: BlockChainSpecific,
     val utxos: List<UtxoInfo> = emptyList(),
+    /**
+     * What this plan priced on top of `gasLimit × maxFeePerGas` — the OP-stack L1 data fee op-geth
+     * bills against the sender's balance before executing the transaction. Reported separately
+     * because [blockChainSpecific] carries only the gas bond, so an amount re-fitted to the signed
+     * fee would otherwise leave this term unreserved and be refused for insufficient funds.
+     */
+    val l1Amount: BigInteger = BigInteger.ZERO,
 )
 
 interface BlockChainSpecificRepository {
@@ -263,7 +270,8 @@ constructor(
                         priorityFeeWei = priorityFeeWei,
                         nonce = nonce,
                         gasLimit = gasLimitFee,
-                    )
+                    ),
+                    l1Amount = fees.l1Amount,
                 )
             }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/ethereum/EthereumFeeServiceTest.kt
@@ -480,6 +480,30 @@ internal class EthereumFeeServiceTest {
         assertEquals(fee.maxFeePerGas.multiply(fee.limit).add(BigInteger("777")), fee.amount)
     }
 
+    /**
+     * The L1 term has to stay readable on its own, not just folded into the total: a max send is
+     * re-fitted to the gas bond that ends up signed, and that bond is re-priced after this fee is
+     * calculated. Only a separable L1 amount survives that re-fit.
+     */
+    @Test
+    fun `Optimism reports the L1 data fee apart from the gas bond`() = runTest {
+        coEvery {
+            evmApi.getOpStackL1Fee(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns BigInteger("777")
+
+        val fee = service.calculateDefaultFees(transfer(Chain.Optimism)) as Eip1559
+
+        assertEquals(BigInteger("777"), fee.l1Amount)
+        assertEquals(fee.maxFeePerGas.multiply(fee.limit), fee.amount.subtract(fee.l1Amount))
+    }
+
+    @Test
+    fun `Ethereum reports no L1 data fee`() = runTest {
+        val fee = service.calculateDefaultFees(transfer(Chain.Ethereum)) as Eip1559
+
+        assertEquals(BigInteger.ZERO, fee.l1Amount)
+    }
+
     @Test
     fun `Base prices L1 against the recipient, amount and chain id for a native transfer`() =
         runTest {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -91,6 +91,42 @@ internal class BlockChainSpecificRepositoryImplTest {
         )
     }
 
+    /**
+     * The gas bond on the specific is only part of what op-geth bills a send for: an OP-stack L1
+     * data fee sits beside it in the same balance check. An amount re-fitted to the bond alone
+     * would leave that term unreserved, so the plan has to report it separately.
+     */
+    @Test
+    fun `native EVM specific reports the L1 data fee the fee service priced`() = runTest {
+        val destination = "0xdestination"
+        val coin = evmCoin(chain = Chain.Base, isNativeToken = true)
+        val result =
+            repository(
+                    evmApi =
+                        evmApi(nativeGasByRecipient = mapOf(destination to BigInteger("40000"))),
+                    evmFeeService =
+                        evmFeeService(
+                            feesByRecipient =
+                                mapOf(destination to (BigInteger("111") to BigInteger("22"))),
+                            l1Amount = BigInteger("777"),
+                        ),
+                )
+                .getSpecific(
+                    chain = Chain.Base,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = false,
+                    isMaxAmountEnabled = true,
+                    isDeposit = false,
+                    dstAddress = destination,
+                    tokenAmountValue = BigInteger.TEN,
+                    memo = null,
+                )
+
+        assertEquals(BigInteger("777"), result.l1Amount)
+    }
+
     @Test
     fun `native EVM specific falls back to default gas limit when gas estimation fails`() =
         runTest {
@@ -1147,7 +1183,8 @@ internal class BlockChainSpecificRepositoryImplTest {
     }
 
     private fun evmFeeService(
-        feesByRecipient: Map<String, Pair<BigInteger, BigInteger>>
+        feesByRecipient: Map<String, Pair<BigInteger, BigInteger>>,
+        l1Amount: BigInteger = BigInteger.ZERO,
     ): FeeService = mockk {
         coEvery { calculateFees(any()) } answers
             {
@@ -1159,7 +1196,8 @@ internal class BlockChainSpecificRepositoryImplTest {
                     networkPrice = BigInteger.ZERO,
                     maxFeePerGas = maxFee,
                     maxPriorityFeePerGas = priorityFee,
-                    amount = maxFee,
+                    amount = maxFee + l1Amount,
+                    l1Amount = l1Amount,
                 )
             }
 


### PR DESCRIPTION
Closes #5491

## Problem

A native EVM amount the app derives from the balance sits at exactly `balance − fee`, and that fee is `GasFeeOrchestrator`'s cached estimate — one reading of the fee market, debounced and refreshed only on a field edit. `getSpecific()` then takes a **second, live reading** to build the payload, and nothing reconciled the two: the amount was staged from the first, the gas bond signed from the second.

- Fetch #1 — `DefaultSendStrategy.kt` sizes the amount with `AccountValidator`'s `gasFee`.
- Fetch #2 — `BlockChainSpecificRepository`'s EVM branch ignores that `gasFee` entirely and calls `feeServiceComposite.calculateFees()`, which reads `eth_baseFee` live. Its `maxFeePerGasWei` / `gasLimit` are what get signed.

A node admits a transfer only when `value + gasLimit × maxFeePerGas ≤ balance`, which reduces to `maxFeePerGas₁ ≥ maxFeePerGas₂`: the send survived exactly when the fee happened to fall between the two readings. On L2s with ~2s blocks it usually did not, and the refusal (`insufficient funds for gas * price + value`) lands at **broadcast, with the MPC ceremony already spent**. Sibling of vultisig/vultisig-ios#5019, fixed there in #5034.

The pre-existing balance gate could not catch it either — it also checks against fetch #1. Android's larger EIP-1559 margin (`baseFee × 1.5`) is not a mitigation: it is applied proportionally at both fetches, so it cancels out of the comparison.

## Change

`DefaultSendStrategy` re-fits the amount to the specific being signed — after the plan, and after Advanced Gas Settings have been patched into it by `applyGasSettings`.

- **Reduces only.** A fee that fell leaves more room than the user was shown, and signing more than they were shown is never right.
- **An over-entry is still an error.** An amount above the balance on its own keeps raising the balance error rather than being quietly rewritten into an affordable send — that is an over-entry, not a fee edge. Same gate as `clampToSpendableBalance`.
- **A fee that leaves nothing raises**, instead of signing a transfer the chain will refuse.
- The re-fitted value is what gets staged, scaled into the fiat mirror, and reflected by `showAdjustedAmount`, so the number on Verify is the number being signed.

Untouched: ERC-20 (gas comes from the native sibling, so the amount is never fee-derived), non-EVM chains, and DeFi flows, which compute their own maxima.

## Why this is more than a clamp to `gasLimit × maxFeePerGas`

op-geth bills `value + bond + L1 data fee` against the sender's balance, and that L1 term survives only inside the fee **total** — `BlockChainSpecific.Ethereum` carries the bond and nothing else. `EthereumFeeService.calculateLayer1Fees()` folds it into `gasFee.value`, so the pre-clamp amount reserved it; a re-fit to the bond alone would have dropped it.

That would have made the OP stack **worse than before**: on Base, Blast and Optimism the L1 fee is most of what a plain transfer costs, so every re-fitted send would have come back short by exactly that term — failing as reliably as the amount it replaced.

So the term is carried, not inferred:

- `Fee.l1Amount` — the part of `amount` a chain adds beyond `price × limit`, defaulting to zero; `addL1Amount` sets it where it already folds the L1 fee into the total.
- `BlockChainSpecificAndUtxo.l1Amount` — the EVM branch reports what it just priced, since the specific itself only carries the bond.
- The re-fit reserves `gasLimit × maxFeePerGas + l1Amount`, read off the specific so raised gas settings are already in it.

## Known gap, deliberately out of scope

The Verify screen's fee row still quotes fetch #1, so after a re-fit `amount + displayed fee` sits a tick below the balance. It never over-promises, and changing it would move the fee display for every EVM send, max or not.

## Test plan

- `./gradlew :app:testDebugUnitTest :data:testDebugUnitTest` — green. `DefaultSendStrategyTest` 36 tests, `BlockChainSpecificRepositoryImplTest` 30, `EthereumFeeServiceTest` 51, 0 skipped in each.
- `./gradlew :app:compileDebugAndroidTestKotlin`, `:app:ktfmtCheck`, `:data:ktfmtCheck` — all pass.

New in `DefaultSendStrategyTest`:

- a Max is re-fitted to the bond in the payload when the base fee ticks up;
- the re-fit gives back **exactly** the bond the tick added — pinned with the issue's own Arbitrum numbers, a 120000 gas limit against a 24000-wei tick = 2,880,000,000 wei;
- the OP-stack L1 data fee is reserved through the re-fit;
- a signed fee *below* the estimate never raises the amount;
- a fee that exceeds the whole balance refuses instead of staging a transaction;
- and what must not move: a typed amount that fits, a typed amount above the balance (still errors), an ERC-20 Max.

New in `:data`: the EVM plan reports the L1 fee the fee service priced; Optimism reports it apart from the gas bond; Ethereum reports zero.

### Manual

1. Vault → **Base** → **ETH** → **Send**, paste a destination, tap **MAX**, **Continue**. With the fee flat, the amount on Verify is unchanged — the re-fit is clamp-down-only. Verified on device.
2. Repeat with **Advanced Gas Settings** raised (~2× the gas limit). Tap **MAX** → **Continue** → **Back**: the amount field has been re-fitted down by the L1 data fee, which the raised-settings path previously left unreserved.
3. Regressions: a typed ETH amount under the balance is signed verbatim; typing more ETH than held still errors; a USDC Max sends the full token balance; a Bitcoin Max still sweeps via the planner; a Polkadot Max still holds back the existential deposit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Max send calculations for native EVM transactions by accounting for final gas and network data fees.
  * Prevented transactions from being submitted when the adjusted amount is unaffordable.
  * Preserved accurate fiat values and displayed amounts after fee adjustments.
  * Kept ERC-20 and DeFi token amount handling unchanged.

* **Enhancements**
  * Improved fee reporting for networks with separate Layer 1 data fees, including Optimism and Base.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->