### PR TITLE
chore: bump version to 1.0.119

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.vultisig.wallet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = 36
-        versionCode = 118
-        versionName = "1.0.118"
+        versionCode = 119
+        versionName = "1.0.119"
 
         testInstrumentationRunner = "com.vultisig.wallet.util.HiltTestRunner"
 


### PR DESCRIPTION
Bump versionCode to 119 / versionName to 1.0.119 for release v1.0.119.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android app to version 1.0.119 (version code 119).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->