### PR TITLE
fix(defi): say a staking read failed instead of showing it as zero

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/DefiTabUiModels.kt
@@ -39,6 +39,23 @@ internal sealed interface LpLegTotal {
     data object Unavailable : LpLegTotal
 }
 
+/**
+ * What one staking leg contributes to the header total.
+ *
+ * [Unavailable] is a *reported* state, not a pending one, and carries the same meaning it does for
+ * [LpLegTotal]: the read that would have valued this leg failed, so its cards hold nothing, and
+ * folding it in as a zero would understate the header while looking exactly as settled as a correct
+ * total. `null` — the absence of either — still means "this leg has not reported yet".
+ *
+ * A leg the user has deselected, or one belonging to a vault with no THORChain account, is [Loaded]
+ * with a zero: those are answers, not failures.
+ */
+internal sealed interface StakeLegTotal<out T> {
+    data class Loaded<T>(val value: T) : StakeLegTotal<T>
+
+    data object Unavailable : StakeLegTotal<Nothing>
+}
+
 internal data class BondedTabUiModel(
     val isLoading: Boolean = false,
     val totalBondedAmount: String = "0 ${Chain.ThorChain.coinType.symbol}",
@@ -133,6 +150,14 @@ internal data class StakePositionUiModel(
     // Maya CACAO pool only: true when the maturity RPC returned UNKNOWN so the staking tab can
     // surface "Couldn't verify position" instead of an unexplained disabled Unstake button.
     val isUnstakeMaturityUnknown: Boolean = false,
+    /**
+     * True when the read behind this card failed, so nothing here is a figure the app can stand
+     * behind. [stakedAmountDisplay] and [stakedFiatDisplay] are both zero on this path — the card
+     * never learned the position — and a settled "0 RUJI / $0.00" is indistinguishable from a vault
+     * that genuinely holds nothing. The card renders the unavailable marker and says the service is
+     * down instead, which is the one thing that is actually known.
+     */
+    val isUnavailable: Boolean = false,
 )
 
 internal data class BondedNodeUiModel(

--- a/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModel.kt
@@ -117,9 +117,9 @@ internal data class ThorchainDefiPositionsUiModel(
 /** A complete set of leg values: only built once every leg has reported. */
 internal data class TotalDefiValue(
     val bondAmount: BigInteger = BigInteger.ZERO,
-    val defaultStakeValues: StakeDefaultValues = StakeDefaultValues(),
-    val rujiStakeAmount: BigInteger = BigInteger.ZERO,
-    val tcyStakeAmount: BigInteger = BigInteger.ZERO,
+    val defaultStakeValues: StakeLegTotal<StakeDefaultValues>,
+    val rujiStakeAmount: StakeLegTotal<BigInteger>,
+    val tcyStakeAmount: StakeLegTotal<BigInteger>,
     val lpFiatValue: LpLegTotal,
 )
 
@@ -158,18 +158,19 @@ constructor(
     // whichever leg finished first cleared it for everyone. Every terminal path in a leg — the
     // success collect, each .catch, and every early bail-out — must therefore assign here.
     private val _totalValueBond = MutableStateFlow<BigInteger?>(null)
-    private val _totalValueDefaultStake = MutableStateFlow<StakeDefaultValues?>(null)
-    private val _totalValueRujiStake = MutableStateFlow<BigInteger?>(null)
-    private val _totalValueTCYStake = MutableStateFlow<BigInteger?>(null)
+    private val _totalValueDefaultStake = MutableStateFlow<StakeLegTotal<StakeDefaultValues>?>(null)
+    private val _totalValueRujiStake = MutableStateFlow<StakeLegTotal<BigInteger>?>(null)
+    private val _totalValueTCYStake = MutableStateFlow<StakeLegTotal<BigInteger>?>(null)
     // LP is priced per pool from two different assets, so it joins the total already converted to
     // fiat rather than as a raw chain amount like the other legs — see [LpLegTotal] for why it
     // carries a currency and why a failed pool reports as unavailable rather than as zero.
     private val _totalValueLpFiat = MutableStateFlow<LpLegTotal?>(null)
 
     val totalValueBond: StateFlow<BigInteger?> = _totalValueBond
-    val totalValueDefaultStake: StateFlow<StakeDefaultValues?> = _totalValueDefaultStake
-    val totalValueRujiStake: StateFlow<BigInteger?> = _totalValueRujiStake
-    val totalValueTCYStake: StateFlow<BigInteger?> = _totalValueTCYStake
+    val totalValueDefaultStake: StateFlow<StakeLegTotal<StakeDefaultValues>?> =
+        _totalValueDefaultStake
+    val totalValueRujiStake: StateFlow<StakeLegTotal<BigInteger>?> = _totalValueRujiStake
+    val totalValueTCYStake: StateFlow<StakeLegTotal<BigInteger>?> = _totalValueTCYStake
     val totalValueLpFiat: StateFlow<LpLegTotal?> = _totalValueLpFiat
 
     // Cached "available" pool list shared by the Manage-Positions dialog and the LP tab loader so
@@ -324,9 +325,21 @@ constructor(
      * stop the header spinner, because the other legs may still be in flight.
      */
     private suspend fun handleTotalValueUpdate(totalValue: TotalDefiValue) {
+        // A staking leg whose read failed knows nothing about its positions — its cards render as
+        // unavailable rather than as zero — so folding its zero into the sum here would understate
+        // the header while looking exactly as settled as a correct total. Same rule the LP leg
+        // applies below, and the same reason.
+        val rujiStakeAmount = totalValue.rujiStakeAmount.valueOrNull()
+        val tcyStakeAmount = totalValue.tcyStakeAmount.valueOrNull()
+        val defaultStakeValues = totalValue.defaultStakeValues.valueOrNull()
+        if (rujiStakeAmount == null || tcyStakeAmount == null || defaultStakeValues == null) {
+            state.update { it.copy(totalAmountPrice = null, isTotalAmountLoading = false) }
+            return
+        }
+
         val totalInRune = CoinType.THORCHAIN.toValue(totalValue.bondAmount)
-        val totalInRuji = CoinType.THORCHAIN.toValue(totalValue.rujiStakeAmount)
-        val totalInTCY = CoinType.THORCHAIN.toValue(totalValue.tcyStakeAmount)
+        val totalInRuji = CoinType.THORCHAIN.toValue(rujiStakeAmount)
+        val totalInTCY = CoinType.THORCHAIN.toValue(tcyStakeAmount)
 
         try {
             val currency = appCurrencyRepository.currency.first()
@@ -339,7 +352,7 @@ constructor(
                 fiatValueCalculator.createFiatValue(totalInTCY, Coins.ThorChain.TCY, currency)
 
             val defaultStakingFiatValues =
-                totalValue.defaultStakeValues.stakeElements.map { position ->
+                defaultStakeValues.stakeElements.map { position ->
                     val decimalAmount = CoinType.THORCHAIN.toValue(position.amount)
                     fiatValueCalculator.createFiatValue(decimalAmount, position.coin, currency)
                 }
@@ -393,6 +406,13 @@ constructor(
             state.update { it.copy(isTotalAmountLoading = false) }
         }
     }
+
+    /** The leg's value, or `null` when its read failed and it has nothing to contribute. */
+    private fun <T> StakeLegTotal<T>.valueOrNull(): T? =
+        when (this) {
+            is StakeLegTotal.Loaded -> value
+            StakeLegTotal.Unavailable -> null
+        }
 
     private suspend fun calculateStakingFiatPrice(amount: BigDecimal, coin: Coin): String? {
         return try {
@@ -498,14 +518,26 @@ constructor(
     }
 
     /**
-     * Reports every staking leg as zero. Used where no staking source will run at all — nothing
-     * selected, no RUNE coin, or the whole load threw — so the header total isn't left waiting on
-     * legs that will never arrive.
+     * Reports every staking leg as a settled zero, so the header total isn't left waiting on legs
+     * that will never run. Only for the paths where zero is the *answer* — no staking position
+     * selected, or a vault with no THORChain account. A read that failed has no answer and uses
+     * [markStakingTotalsUnavailable] instead.
      */
     private fun settleStakingTotals() {
-        _totalValueDefaultStake.update { StakeDefaultValues() }
-        _totalValueRujiStake.update { BigInteger.ZERO }
-        _totalValueTCYStake.update { BigInteger.ZERO }
+        _totalValueDefaultStake.update { StakeLegTotal.Loaded(StakeDefaultValues()) }
+        _totalValueRujiStake.update { StakeLegTotal.Loaded(BigInteger.ZERO) }
+        _totalValueTCYStake.update { StakeLegTotal.Loaded(BigInteger.ZERO) }
+    }
+
+    /**
+     * Reports every staking leg as unavailable, for a failure that took the whole staking load down
+     * before any individual leg could run. The header then shows its unavailable marker rather than
+     * a total that silently counts all of staking as zero.
+     */
+    private fun markStakingTotalsUnavailable() {
+        _totalValueDefaultStake.update { StakeLegTotal.Unavailable }
+        _totalValueRujiStake.update { StakeLegTotal.Unavailable }
+        _totalValueTCYStake.update { StakeLegTotal.Unavailable }
     }
 
     /**
@@ -526,6 +558,33 @@ constructor(
                                         isLoading = false,
                                         stakedFiatDisplay = position.stakedFiatDisplay ?: zero,
                                     )
+                                } else {
+                                    position
+                                }
+                            }
+                    )
+            )
+        }
+    }
+
+    /**
+     * Marks the cards a failed read left mid-flight as unavailable.
+     *
+     * The alternative — [settleStakingPositions], which stops the spinner and fills a formatted
+     * zero in — makes a card that learned nothing look exactly like a position the vault genuinely
+     * does not hold. That is the whole of #5837: with the staking service down, a funded RUJI
+     * position rendered a settled "0 RUJI / $0.00" and read as lost funds. The amount and fiat are
+     * left for the card to replace with its unavailable marker.
+     */
+    private fun markStakingPositionsUnavailable(matches: (StakePositionUiModel) -> Boolean) {
+        state.update { current ->
+            current.copy(
+                staking =
+                    current.staking.copy(
+                        positions =
+                            current.staking.positions.map { position ->
+                                if (matches(position)) {
+                                    position.copy(isLoading = false, isUnavailable = true)
                                 } else {
                                     position
                                 }
@@ -861,7 +920,10 @@ constructor(
                 // collapse the two into one and render it twice.
                 val settled =
                     state.value.staking.positions
-                        .filterNot { it.isLoading }
+                        // An unavailable card is settled but holds nothing, so reusing it would
+                        // leave the failure copy up through the whole of the next read instead of
+                        // showing that one is in flight.
+                        .filterNot { it.isLoading || it.isUnavailable }
                         .associateBy { it.coin.id }
                 val defaultLoadingPositions =
                     loadDefaultStakingPositions()
@@ -902,20 +964,20 @@ constructor(
                     if (coinsToLoad.contains(Coins.ThorChain.RUJI.id)) {
                         createRujiStakePosition(address, vaultId)
                     } else {
-                        _totalValueRujiStake.update { BigInteger.ZERO }
+                        _totalValueRujiStake.update { StakeLegTotal.Loaded(BigInteger.ZERO) }
                     }
                     if (coinsToLoad.contains(Coins.ThorChain.TCY.id)) {
                         createTCYStakePosition(address, vaultId)
                     } else {
-                        _totalValueTCYStake.update { BigInteger.ZERO }
+                        _totalValueTCYStake.update { StakeLegTotal.Loaded(BigInteger.ZERO) }
                     }
 
                     createGenericStakePosition(address, vaultId, coinsToLoad)
                 } catch (t: Throwable) {
                     if (t is CancellationException) throw t
                     Timber.e(t, "Failed to load staking positions")
-                    settleStakingTotals()
-                    settleStakingPositions { true }
+                    markStakingTotalsUnavailable()
+                    markStakingPositionsUnavailable { true }
                 }
             }
     }
@@ -929,11 +991,13 @@ constructor(
                 .getStakingDetails(address, vaultId)
                 .catch { t ->
                     Timber.e(t, "Failed to load staking positions RUJI")
-                    // Report the leg as zero rather than leaving it unset: the header sums it, so
-                    // an unreported failure would keep the total spinning, and a stale prior value
-                    // would survive a refresh whose cards have already fallen back to zero.
-                    _totalValueRujiStake.update { BigInteger.ZERO }
-                    settleStakingPositions { it.coin.id in RUJI_POSITION_COIN_IDS }
+                    // Report the leg rather than leaving it unset: the header waits on every leg,
+                    // so an unreported failure would keep the total spinning, and a stale prior
+                    // value would survive a refresh whose cards no longer stand behind it. It
+                    // reports *unavailable*, not zero — the read failed, so the position is
+                    // unknown, and both the cards and the header say so.
+                    _totalValueRujiStake.update { StakeLegTotal.Unavailable }
+                    markStakingPositionsUnavailable { it.coin.id in RUJI_POSITION_COIN_IDS }
                 }
                 // A source that finishes without ever emitting is done, not pending, and has to
                 // report or the header waits forever. Cancellation is the exception: this load has
@@ -941,7 +1005,10 @@ constructor(
                 // still-pending leg a zero it never reported.
                 .onCompletion { cause ->
                     if (cause !is CancellationException) {
-                        _totalValueRujiStake.compareAndSet(null, BigInteger.ZERO)
+                        _totalValueRujiStake.compareAndSet(
+                            null,
+                            StakeLegTotal.Loaded(BigInteger.ZERO),
+                        )
                     }
                 }
                 .collect { detailsList ->
@@ -951,9 +1018,11 @@ constructor(
 
                     // Both positions are denominated in RUJI, so the tab's RUJI total is their sum.
                     _totalValueRujiStake.update {
-                        detailsList.fold(BigInteger.ZERO) { acc, details ->
-                            acc + details.stakeAmount
-                        }
+                        StakeLegTotal.Loaded(
+                            detailsList.fold(BigInteger.ZERO) { acc, details ->
+                                acc + details.stakeAmount
+                            }
+                        )
                     }
                 }
         }
@@ -1007,12 +1076,15 @@ constructor(
                 .getStakingDetails(address = address, vaultId = vaultId)
                 .catch { t ->
                     Timber.e(t, "Failed to load staking positions TCY Stake")
-                    _totalValueTCYStake.update { BigInteger.ZERO }
-                    settleStakingPositions { it.coin.id == Coins.ThorChain.TCY.id }
+                    _totalValueTCYStake.update { StakeLegTotal.Unavailable }
+                    markStakingPositionsUnavailable { it.coin.id == Coins.ThorChain.TCY.id }
                 }
                 .onCompletion { cause ->
                     if (cause !is CancellationException) {
-                        _totalValueTCYStake.compareAndSet(null, BigInteger.ZERO)
+                        _totalValueTCYStake.compareAndSet(
+                            null,
+                            StakeLegTotal.Loaded(BigInteger.ZERO),
+                        )
                     }
                 }
                 .collect { position ->
@@ -1039,7 +1111,7 @@ constructor(
 
                     updateExistingPosition(stakePosition)
 
-                    _totalValueTCYStake.update { position.stakeAmount }
+                    _totalValueTCYStake.update { StakeLegTotal.Loaded(position.stakeAmount) }
                 }
         }
     }
@@ -1054,8 +1126,8 @@ constructor(
                 .getStakingDetails(address, vaultId)
                 .catch { t ->
                     Timber.e(t, "Failed to load staking positions")
-                    _totalValueDefaultStake.update { StakeDefaultValues() }
-                    settleStakingPositions {
+                    _totalValueDefaultStake.update { StakeLegTotal.Unavailable }
+                    markStakingPositionsUnavailable {
                         it.coin.id == Coins.ThorChain.yRUNE.id ||
                             it.coin.id == Coins.ThorChain.yTCY.id ||
                             it.coin.id == Coins.ThorChain.sTCY.id ||
@@ -1064,7 +1136,10 @@ constructor(
                 }
                 .onCompletion { cause ->
                     if (cause !is CancellationException) {
-                        _totalValueDefaultStake.compareAndSet(null, StakeDefaultValues())
+                        _totalValueDefaultStake.compareAndSet(
+                            null,
+                            StakeLegTotal.Loaded(StakeDefaultValues()),
+                        )
                     }
                 }
                 .collect { defaultPositions ->
@@ -1166,14 +1241,16 @@ constructor(
                         }
 
                     _totalValueDefaultStake.update {
-                        StakeDefaultValues(
-                            stakeElements =
-                                positions.map { position ->
-                                    StakeDefaultValues.StakingElement(
-                                        coin = position.first.coin,
-                                        amount = position.second,
-                                    )
-                                }
+                        StakeLegTotal.Loaded(
+                            StakeDefaultValues(
+                                stakeElements =
+                                    positions.map { position ->
+                                        StakeDefaultValues.StakingElement(
+                                            coin = position.first.coin,
+                                            amount = position.second,
+                                        )
+                                    }
+                            )
                         )
                     }
                 }

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/v2/defi/StakingTabComponents.kt
@@ -27,6 +27,7 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.ui.components.UiHorizontalDivider
+import com.vultisig.wallet.ui.components.UiIcon
 import com.vultisig.wallet.ui.components.UiSpacer
 import com.vultisig.wallet.ui.components.buttons.VsButton
 import com.vultisig.wallet.ui.components.buttons.VsButtonState
@@ -112,20 +113,41 @@ internal fun StakingWidget(
                 } else {
                     Text(
                         text =
-                            if (isBalanceVisible) state.stakedAmountDisplay else HIDE_BALANCE_CHARS,
+                            when {
+                                !isBalanceVisible -> HIDE_BALANCE_CHARS
+                                // The read failed, so there is no amount to show — and the zero
+                                // this card holds is the absence of one, not a balance.
+                                state.isUnavailable -> FIAT_VALUE_UNAVAILABLE
+                                else -> state.stakedAmountDisplay
+                            },
                         style = Theme.brockmann.headings.title1,
                         color = Theme.v2.colors.text.primary,
                     )
 
                     Text(
                         text =
-                            if (isBalanceVisible) state.stakedFiatDisplay ?: FIAT_VALUE_UNAVAILABLE
-                            else HIDE_BALANCE_CHARS,
+                            when {
+                                // Shown even with balances hidden: it says nothing about what the
+                                // vault holds, only that the app could not find out.
+                                state.isUnavailable ->
+                                    stringResource(R.string.defi_position_unavailable)
+                                isBalanceVisible ->
+                                    state.stakedFiatDisplay ?: FIAT_VALUE_UNAVAILABLE
+                                else -> HIDE_BALANCE_CHARS
+                            },
                         style = Theme.brockmann.body.s.medium,
-                        color = Theme.v2.colors.text.tertiary,
+                        color =
+                            if (state.isUnavailable) Theme.v2.colors.alerts.warning
+                            else Theme.v2.colors.text.tertiary,
                     )
                 }
             }
+        }
+
+        if (state.isUnavailable) {
+            UiSpacer(16.dp)
+
+            PositionUnavailableNotice()
         }
 
         if (state.apy != null || (state.nextReward != null || state.nextPayout != null)) {
@@ -277,6 +299,40 @@ internal fun StakingWidget(
     }
 }
 
+/**
+ * Says why a staking card carries no figures: the read behind it failed, which is a service outage
+ * rather than anything about the vault. Without it the card is a bare unavailable marker, and the
+ * reasonable reading of that is that the position is gone — which is how #5837 was reported.
+ */
+@Composable
+private fun PositionUnavailableNotice() {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier =
+            Modifier.fillMaxWidth()
+                .clip(Theme.v2.radius.md)
+                .background(color = Theme.v2.colors.backgrounds.surface1)
+                .border(
+                    width = 1.dp,
+                    color = Theme.v2.colors.alerts.warning,
+                    shape = Theme.v2.radius.md,
+                )
+                .padding(all = 12.dp),
+    ) {
+        UiIcon(
+            drawableResId = R.drawable.ic_triangle_alert,
+            tint = Theme.v2.colors.alerts.warning,
+            size = 16.dp,
+        )
+
+        Text(
+            text = stringResource(R.string.defi_position_unavailable_desc),
+            style = Theme.brockmann.body.s.medium,
+            color = Theme.v2.colors.alerts.warning,
+        )
+    }
+}
+
 @Composable
 internal fun StakingHeader(title: String, amount: String, icon: Int) {
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -395,6 +451,31 @@ private fun StakingWidgetCacaoUnstakeLockedPreview() {
                     canUnstake = false,
                     // 5 days, 3 hours
                     unstakeUnlocksInSeconds = (5L * 24L * 3_600L) + (3L * 3_600L),
+                ),
+            onClickStake = {},
+            onClickUnstake = {},
+            onClickWithdraw = {},
+            onClickTransfer = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Staking Widget - Unavailable State")
+@Composable
+private fun StakingWidgetUnavailablePreview() {
+    Box(modifier = Modifier.background(Theme.v2.colors.backgrounds.primary).padding(16.dp)) {
+        StakingWidget(
+            state =
+                StakePositionUiModel(
+                    coin = Coins.ThorChain.RUJI,
+                    stakeAssetHeader = UiText.DynamicString("Staked RUJI"),
+                    // What the view-model leaves behind when a read fails: the placeholder's zero,
+                    // which the card must not present as a balance.
+                    stakeAmount = BigDecimal.ZERO,
+                    stakedAmountDisplay = "0 RUJI",
+                    stakedFiatDisplay = "$0.00",
+                    apy = null,
+                    isUnavailable = true,
                 ),
             onClickStake = {},
             onClickUnstake = {},

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -964,6 +964,8 @@
     <string name="banxa_continue">Weiter zu Banxa</string>
     <string name="defi_no_positions_selected">Keine Positionen ausgewählt</string>
     <string name="defi_no_positions_selected_desc">Sie haben alle Positionen für diese Chain deaktiviert. Aktivieren Sie mindestens eine Position, um Salden anzuzeigen und Aktionen zu verwalten.</string>
+    <string name="defi_position_unavailable">Saldo nicht verfügbar</string>
+    <string name="defi_position_unavailable_desc">Der Staking-Dienst hat nicht geantwortet, daher konnte diese Position nicht geladen werden. Ihre gestakten Mittel sind on-chain sicher — dies ist ein vorübergehendes Serverproblem und keine Änderung Ihres Saldos.</string>
     <string name="manage_positions">Positionen verwalten</string>
     <string name="bond_node_state_whitelisted">Auf Whitelist</string>
     <string name="bond_node_state_standby">Bereitschaft</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -962,6 +962,8 @@
     <string name="banxa_continue">Continuar a Banxa</string>
     <string name="defi_no_positions_selected">No hay posiciones seleccionadas</string>
     <string name="defi_no_positions_selected_desc">Has deshabilitado todas las posiciones para esta cadena. Habilita al menos una posición para ver saldos y gestionar acciones.</string>
+    <string name="defi_position_unavailable">Saldo no disponible</string>
+    <string name="defi_position_unavailable_desc">El servicio de staking no respondió, por lo que no se pudo cargar esta posición. Tus fondos en staking están seguros on-chain: es un problema temporal del servidor, no un cambio en tu saldo.</string>
     <string name="manage_positions">Gestionar Posiciones</string>
     <string name="bond_node_state_whitelisted">En Lista Blanca</string>
     <string name="bond_node_state_standby">En Espera</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -966,6 +966,8 @@
     <string name="banxa_continue">Nastavi na Banxu</string>
     <string name="defi_no_positions_selected">Nema odabranih pozicija</string>
     <string name="defi_no_positions_selected_desc">Onemogućili ste sve pozicije za ovaj lanac. Omogućite barem jednu poziciju za pregled stanja i upravljanje akcijama.</string>
+    <string name="defi_position_unavailable">Stanje nije dostupno</string>
+    <string name="defi_position_unavailable_desc">Usluga stakinga nije odgovorila pa se ova pozicija nije mogla učitati. Vaša uložena sredstva sigurna su na lancu — riječ je o privremenom problemu poslužitelja, a ne o promjeni stanja.</string>
     <string name="manage_positions">Upravljanje Pozicijama</string>
     <string name="bond_node_state_whitelisted">Na Bijeloj Listi</string>
     <string name="bond_node_state_standby">U Pripravnosti</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -962,6 +962,8 @@
     <string name="banxa_continue">Continua su Banxa</string>
     <string name="defi_no_positions_selected">Nessuna posizione selezionata</string>
     <string name="defi_no_positions_selected_desc">Hai disabilitato tutte le posizioni per questa catena. Abilita almeno una posizione per visualizzare i saldi e gestire le azioni.</string>
+    <string name="defi_position_unavailable">Saldo non disponibile</string>
+    <string name="defi_position_unavailable_desc">Il servizio di staking non ha risposto, quindi non è stato possibile caricare questa posizione. I tuoi fondi in staking sono al sicuro on-chain: è un problema temporaneo del server, non una variazione del tuo saldo.</string>
     <string name="manage_positions">Gestisci Posizioni</string>
     <string name="bond_node_state_whitelisted">In Lista Bianca</string>
     <string name="bond_node_state_standby">In Attesa</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1278,6 +1278,8 @@
     <string name="banxa_continue">Banxa로 이동</string>
     <string name="defi_no_positions_selected">선택된 포지션 없음</string>
     <string name="defi_no_positions_selected_desc">이 체인의 모든 포지션을 비활성화했습니다. 잔액을 확인하고 작업을 관리하려면 최소 하나의 포지션을 활성화하세요.</string>
+    <string name="defi_position_unavailable">잔액을 불러올 수 없음</string>
+    <string name="defi_position_unavailable_desc">스테이킹 서비스가 응답하지 않아 이 포지션을 불러오지 못했습니다. 스테이킹된 자산은 온체인에 안전하게 있습니다. 잔액이 바뀐 것이 아니라 일시적인 서버 문제입니다.</string>
     <string name="manage_positions">포지션 관리</string>
     <string name="bond_node_state_whitelisted">화이트리스트</string>
     <string name="bond_node_state_standby">대기</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -959,6 +959,8 @@
     <string name="banxa_continue">Doorgaan naar Banxa</string>
     <string name="defi_no_positions_selected">Geen posities geselecteerd</string>
     <string name="defi_no_positions_selected_desc">Je hebt alle posities voor deze keten uitgeschakeld. Schakel ten minste één positie in om saldi te bekijken en acties te beheren.</string>
+    <string name="defi_position_unavailable">Saldo niet beschikbaar</string>
+    <string name="defi_position_unavailable_desc">De stakingdienst reageerde niet, dus deze positie kon niet worden geladen. Je gestakete tegoeden staan veilig on-chain — dit is een tijdelijk serverprobleem, geen wijziging van je saldo.</string>
     <string name="manage_positions">Posities Beheren</string>
     <string name="bond_node_state_whitelisted">Op Whitelist</string>
     <string name="bond_node_state_standby">Stand-by</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -961,6 +961,8 @@
     <string name="banxa_continue">Continuar para Banxa</string>
     <string name="defi_no_positions_selected">Nenhuma posição selecionada</string>
     <string name="defi_no_positions_selected_desc">Você desativou todas as posições para esta cadeia. Ative pelo menos uma posição para visualizar saldos e gerenciar ações.</string>
+    <string name="defi_position_unavailable">Saldo indisponível</string>
+    <string name="defi_position_unavailable_desc">O serviço de staking não respondeu, então não foi possível carregar esta posição. Seus fundos em staking estão seguros on-chain — é um problema temporário do servidor, não uma mudança no seu saldo.</string>
     <string name="manage_positions">Gerenciar Posições</string>
     <string name="bond_node_state_whitelisted">Na Lista Branca</string>
     <string name="bond_node_state_standby">Em Espera</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -965,6 +965,8 @@
     <string name="banxa_continue">Продолжить в Banxa</string>
     <string name="defi_no_positions_selected">Позиции не выбраны</string>
     <string name="defi_no_positions_selected_desc">Вы отключили все позиции для этой сети. Включите хотя бы одну позицию для просмотра балансов и управления действиями.</string>
+    <string name="defi_position_unavailable">Баланс недоступен</string>
+    <string name="defi_position_unavailable_desc">Сервис стейкинга не ответил, поэтому эту позицию не удалось загрузить. Ваши средства в стейкинге в безопасности в сети — это временная проблема сервера, а не изменение баланса.</string>
     <string name="manage_positions">Управление Позициями</string>
     <string name="bond_node_state_whitelisted">В Белом Списке</string>
     <string name="bond_node_state_standby">В Ожидании</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1294,6 +1294,8 @@
     <string name="banxa_continue">继续到 Banxa</string>
     <string name="defi_no_positions_selected">未选择任何仓位</string>
     <string name="defi_no_positions_selected_desc">您已禁用此链的所有仓位。请至少启用一个仓位以查看余额和管理操作。</string>
+    <string name="defi_position_unavailable">余额不可用</string>
+    <string name="defi_position_unavailable_desc">质押服务未响应，无法加载该仓位。您质押的资产在链上是安全的——这是暂时的服务器问题，并非您的余额发生变化。</string>
     <string name="manage_positions">管理仓位</string>
     <string name="bond_node_state_whitelisted">已列入白名单</string>
     <string name="bond_node_state_standby">待命</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1308,6 +1308,8 @@
     <string name="banxa_continue">Continue to Banxa</string>
     <string name="defi_no_positions_selected">No positions selected</string>
     <string name="defi_no_positions_selected_desc">You\'ve disabled all positions for this chain. Enable at least one position to view balances and manage actions.</string>
+    <string name="defi_position_unavailable">Balance unavailable</string>
+    <string name="defi_position_unavailable_desc">The staking service didn\'t respond, so this position couldn\'t be loaded. Your staked funds are safe on-chain — this is a temporary server problem, not a change to your balance.</string>
     <string name="manage_positions">Manage Positions</string>
     <string name="bond_node_state_whitelisted">Whitelisted</string>
     <string name="bond_node_state_standby">Standby</string>

--- a/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/defi/ThorchainDefiPositionsViewModelTest.kt
@@ -243,7 +243,7 @@ internal class ThorchainDefiPositionsViewModelTest {
         assertEquals("20.00%", position.apy)
         assertTrue(position.canWithdraw)
         assertTrue(position.canUnstake)
-        assertEquals(BigInteger("500000000"), vm.totalValueRujiStake.value)
+        assertEquals(StakeLegTotal.Loaded(BigInteger("500000000")), vm.totalValueRujiStake.value)
     }
 
     @Test
@@ -281,7 +281,7 @@ internal class ThorchainDefiPositionsViewModelTest {
         assertFalse(compounded.canWithdraw)
         assertEquals(null, compounded.apy)
         // Both are RUJI-denominated, so the tab's RUJI total is their sum.
-        assertEquals(BigInteger("800000000"), vm.totalValueRujiStake.value)
+        assertEquals(StakeLegTotal.Loaded(BigInteger("800000000")), vm.totalValueRujiStake.value)
     }
 
     @Test
@@ -345,7 +345,7 @@ internal class ThorchainDefiPositionsViewModelTest {
         assertFalse(tcy.canWithdraw)
         assertTrue(tcy.canUnstake)
         assertEquals("3 TCY", tcy.stakedAmountDisplay)
-        assertEquals(BigInteger("300000000"), vm.totalValueTCYStake.value)
+        assertEquals(StakeLegTotal.Loaded(BigInteger("300000000")), vm.totalValueTCYStake.value)
     }
 
     @Test
@@ -600,22 +600,100 @@ internal class ThorchainDefiPositionsViewModelTest {
     }
 
     @Test
-    fun `a failed staking load leaves the card priced at zero rather than blank`() = runTest {
-        // Cards used to be seeded with a bare ticker and no fiat, so a failed load rendered as a
-        // lone "RUJI" with the dollar line hidden entirely.
+    fun `a failed staking load marks the card unavailable rather than pricing it at zero`() =
+        runTest {
+            // #5837: with the staking service down, the card settled on "0 RUJI / $0.00" — which is
+            // exactly what a vault holding nothing renders — and was reported as vanished funds.
+            // The services emit their cache on failure and only throw when there is none, so
+            // reaching the .catch means nothing is known about the position, not that it is empty.
+            selectPositions("RUJI")
+            coEvery { rujiStakingService.getStakingDetails(any(), any()) } returns
+                flow { throw RuntimeException("thornode down") }
+
+            val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+            val positions = vm.state.value.staking.positions
+            positions.isNotEmpty() shouldBe true
+            positions.forEach { position ->
+                position.isLoading shouldBe false
+                position.isUnavailable shouldBe true
+            }
+        }
+
+    @Test
+    fun `a failed staking leg leaves the header unavailable instead of summing it as zero`() =
+        runTest {
+            // The card saying "unavailable" while the header states a confident total that counts
+            // the position as zero contradicts itself, and the total is the figure people read
+            // first. Same rule the LP leg already applies to a pool it could not price.
+            selectPositions("TCY")
+            coEvery { tcyStakingService.getStakingDetails(any(), any()) } returns
+                flow { throw RuntimeException("thornode down") }
+
+            val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+            vm.totalValueTCYStake.value shouldBe StakeLegTotal.Unavailable
+            vm.state.value.isTotalAmountLoading shouldBe false
+            vm.state.value.totalAmountPrice shouldBe null
+        }
+
+    @Test
+    fun `a deselected staking leg reports a zero the header can still price`() = runTest {
+        // Unavailable is for a read that failed. A leg the user switched off in Manage Positions
+        // has been answered — it holds nothing — so it must stay summable, or turning a position
+        // off would blank the header.
+        selectPositions("TCY")
+        coEvery { tcyStakingService.getStakingDetails(any(), any()) } returns
+            flowOf(stakingDetails(Coins.ThorChain.TCY, BigInteger("100000000")))
+
+        val vm = createViewModel().also { it.setData(VAULT_ID) }
+
+        vm.totalValueRujiStake.value shouldBe StakeLegTotal.Loaded(BigInteger.ZERO)
+        vm.state.value.isTotalAmountLoading shouldBe false
+        vm.state.value.totalAmountPrice shouldBe "$2.00"
+    }
+
+    @Test
+    fun `an unavailable card shimmers again on the next load rather than keeping the failure`() =
+        runTest {
+            // Cards that are settled are reused across loads so the tab does not blank on re-entry.
+            // An unavailable one is settled but holds nothing, so reusing it would leave the
+            // failure notice up for the whole of a read that is genuinely in flight again.
+            selectPositions("RUJI")
+            coEvery { rujiStakingService.getStakingDetails(any(), any()) } returns
+                flow { throw RuntimeException("thornode down") }
+
+            val vm = createViewModel().also { it.setData(VAULT_ID) }
+            vm.state.value.staking.positions.forEach { it.isUnavailable shouldBe true }
+
+            coEvery { rujiStakingService.getStakingDetails(any(), any()) } returns
+                flow { awaitCancellation() }
+            vm.setData(VAULT_ID)
+
+            vm.state.value.staking.positions.forEach { position ->
+                position.isUnavailable shouldBe false
+                position.isLoading shouldBe true
+            }
+        }
+
+    @Test
+    fun `a read that succeeds after a failure clears the unavailable state`() = runTest {
         selectPositions("RUJI")
         coEvery { rujiStakingService.getStakingDetails(any(), any()) } returns
             flow { throw RuntimeException("thornode down") }
 
         val vm = createViewModel().also { it.setData(VAULT_ID) }
+        vm.state.value.staking.positions.single { it.coin.id == RUJI_ID }.isUnavailable shouldBe
+            true
 
-        val positions = vm.state.value.staking.positions
-        positions.isNotEmpty() shouldBe true
-        positions.forEach { position ->
-            position.isLoading shouldBe false
-            position.stakedAmountDisplay shouldBe "0 ${position.coin.ticker}"
-            position.stakedFiatDisplay shouldBe "$0.00"
-        }
+        coEvery { rujiStakingService.getStakingDetails(any(), any()) } returns
+            flowOf(listOf(stakingDetails(Coins.ThorChain.RUJI, BigInteger("500000000"))))
+        vm.setData(VAULT_ID)
+
+        val ruji = vm.state.value.staking.positions.single { it.coin.id == RUJI_ID }
+        ruji.isUnavailable shouldBe false
+        ruji.stakedAmountDisplay shouldBe "5 RUJI"
+        vm.state.value.totalAmountPrice shouldBe "$10.00"
     }
 
     @Test
@@ -636,15 +714,18 @@ internal class ThorchainDefiPositionsViewModelTest {
         val germanFormat = NumberFormat.getCurrencyInstance(Locale.GERMANY)
         coEvery { appCurrencyRepository.getCurrencyFormat() } returns germanFormat
         selectPositions("RUJI")
+        // A genuinely empty position, not a failed read: a failure has nothing to format and
+        // renders the unavailable marker instead.
         coEvery { rujiStakingService.getStakingDetails(any(), any()) } returns
-            flow { throw RuntimeException("thornode down") }
+            flowOf(listOf(stakingDetails(Coins.ThorChain.RUJI, BigInteger.ZERO)))
 
         val vm = createViewModel().also { it.setData(VAULT_ID) }
 
         // Compare against the locale's own zero rather than merely asserting the absence of "$":
         // the unavailable dash would pass that weaker check while meaning the opposite.
-        vm.state.value.staking.positions.first().stakedFiatDisplay shouldBe
-            germanFormat.format(BigDecimal.ZERO)
+        val ruji = vm.state.value.staking.positions.single { it.coin.id == RUJI_ID }
+        ruji.isUnavailable shouldBe false
+        ruji.stakedFiatDisplay shouldBe germanFormat.format(BigDecimal.ZERO)
     }
 
     @Test
@@ -695,7 +776,9 @@ internal class ThorchainDefiPositionsViewModelTest {
     @Test
     fun `a failed RUJI load resets its leg instead of keeping the previous total`() = runTest {
         // The .catch settled the cards but left the RUJI raw total untouched, so a refresh that
-        // failed kept pricing the header off the amount from the run before it.
+        // failed kept pricing the header off the amount from the run before it. It now reports
+        // unavailable rather than zero: the read told us nothing, so the header says so instead of
+        // publishing a total that quietly drops the position.
         selectPositions("RUJI")
         coEvery { rujiStakingService.getStakingDetails(any(), any()) } returns
             flowOf(listOf(stakingDetails(Coins.ThorChain.RUJI, BigInteger("100000000"))))
@@ -707,9 +790,9 @@ internal class ThorchainDefiPositionsViewModelTest {
             flow { throw RuntimeException("thornode down") }
         vm.setData(VAULT_ID)
 
-        vm.totalValueRujiStake.value shouldBe BigInteger.ZERO
+        vm.totalValueRujiStake.value shouldBe StakeLegTotal.Unavailable
         vm.state.value.isTotalAmountLoading shouldBe false
-        vm.state.value.totalAmountPrice shouldBe "$0.00"
+        vm.state.value.totalAmountPrice shouldBe null
     }
 
     @Test
@@ -867,13 +950,13 @@ internal class ThorchainDefiPositionsViewModelTest {
             NumberFormat.getCurrencyInstance(Locale.GERMANY)
         currency.value = AppCurrency.EUR
 
-        vm.totalValueTCYStake.value shouldBe BigInteger("200000000")
+        vm.totalValueTCYStake.value shouldBe StakeLegTotal.Loaded(BigInteger("200000000"))
         vm.state.value.totalAmountPrice shouldBe germanFormat.format(BigDecimal("6.00"))
 
         // The first load's fetch lands at last, carrying the amount it read before the switch.
         supersededLoad.value = stakingDetails(Coins.ThorChain.TCY, BigInteger("100000000"))
 
-        vm.totalValueTCYStake.value shouldBe BigInteger("200000000")
+        vm.totalValueTCYStake.value shouldBe StakeLegTotal.Loaded(BigInteger("200000000"))
         vm.state.value.totalAmountPrice shouldBe germanFormat.format(BigDecimal("6.00"))
     }
 
@@ -909,7 +992,7 @@ internal class ThorchainDefiPositionsViewModelTest {
 
         replacementLoad.value = stakingDetails(Coins.ThorChain.TCY, BigInteger("100000000"))
 
-        vm.totalValueTCYStake.value shouldBe BigInteger("100000000")
+        vm.totalValueTCYStake.value shouldBe StakeLegTotal.Loaded(BigInteger("100000000"))
         vm.state.value.isTotalAmountLoading shouldBe false
     }
 


### PR DESCRIPTION
Closes #5837.

## The report, and what is actually wrong

Staked RUJI/sRUJI stopped appearing on 1.0.118. The root cause is not in the app: `https://api.vultisig.com/ruji/api/graphql` is returning **401 `token expired`** for every request, and has been throughout this work.

```
POST https://api.vultisig.com/ruji/api/graphql   → 401  "token expired"
POST https://api.rujira.network/api/graphql      → 200  correct data
```

It fails for a bare `{ __typename }` and for a plain `GET`, so it is not query-shaped. Every other proxy route is healthy (`/eth` 400 on an empty body, `/ton` and `/jup` 301, `/feature/release.json` 200) — `/ruji` is the only one refusing. The app sends no auth on any request (`HttpClientConfigurator` sets Content-Type and nothing else), so there is no token the client can supply.

iOS (`THORChainStakingAPI.swift:23`, `ThorchainMainnetAPI.swift:124`) and the extension (`core/ui/defi/chain/queries/constants.ts:7`) hardcode the same URL with no failover and no auth, so all three platforms are equally blind.

**The proxy still needs a backend fix — this PR is not that fix.** Staked RUJI will not reappear on any platform until `/ruji` answers again. What this PR removes is the part that was Android's own: reporting that outage as a balance of zero. Worth re-checking with the reporter once the endpoint is restored.

## What this PR does fix

The app answered that failure by settling the cards with a formatted zero, rendering **`0 RUJI` / `$0.00`** — character for character what a vault holding nothing shows. That is why an outage was reported as missing funds.

All three staking services (`RujiStakingService`, `TCYStakingService`, `DefaultStakingPositionService`) emit their cached positions on failure and only throw when there is no cache, so reaching the view-model's `.catch` proves the app knows *nothing* about the position — not that the position is empty. Those paths now mark the cards unavailable instead.

![staked RUJI and compounded RUJI cards showing the unavailable state](https://i.imgur.com/uv3TG5u.png)

Verified on device against the live 401.

## Parity

iOS `THORChainStakeInteractor.positions(for:)` returns `[]` on a throw — *"storage upserts only what is returned, so the persisted row keeps its last good value"* — and the extension's `fetchRujiStakePositions` does the same (`if ('error' in snapshot) return []`). Two of three siblings decline to assert anything on a failed read; Android was alone in rendering a confident zero. Android's equivalent of "keep the last good value" is the service-layer cache, which is why this only changes the no-cache path.

## The header total

A card reading "unavailable" above a total that silently counts it as zero contradicts itself, and the total is the figure people read first. The three staking legs now report `Loaded`/`Unavailable`, the way `LpLegTotal` already does for a pool it could not price (`ThorchainDefiPositionsViewModel:1347-1367`). A leg the user switched **off** in Manage Positions still reports `Loaded(ZERO)` — that is an answer, not a failure — so turning a position off does not blank the header.

## Scope left alone, deliberately

- **The Bonded tab** — different service, unaffected by this outage, and it has its own tested `"$0.00"` contract.
- **The Maya screen** — shares the card component, never sets the flag, unchanged.
- **The portfolio home row** — `ThorchainDeFiBalanceService` already drops a failed RUJI position entirely rather than zeroing it, and blanking a whole vault's total over one DeFi position would be far too aggressive.

## Two existing tests were rewritten

- `a failed staking load leaves the card priced at zero rather than blank` asserted `"0 RUJI"` / `"$0.00"` on a thrown read — it **pinned the bug**. It was written to fix an earlier problem (a blank card) and overshot into asserting a confident zero. Renamed and re-pointed at the unavailable state; its original intent, that the card is not blank, still holds.
- `the zero balance is formatted in the users currency, not hardcoded dollars` used a *failed* read to produce a zero to format. A failure no longer produces one, so it now uses a genuinely empty position — which is what it was actually testing.

## Test plan

- `:app:testDebugUnitTest` — 2477 tests, 0 failures. Four new cases: cards marked unavailable rather than priced at zero; the header refusing to sum a failed leg; a deselected leg still pricing; an unavailable card shimmering again on the next load; and a successful read clearing the state.
- `:app:lintDebug` — 0 errors, no `MissingTranslation` (both strings in all 10 locales).
- `:app:compileDebugAndroidTestKotlin` — green.
- `ktfmtFormat` applied.

**Manual:** open a vault with a THORChain account that has never opened the DeFi Staked tab (so nothing is cached) → DeFi toggle → THORChain → **Staked** → RUJI on in Manage Positions. Both RUJI cards show the dash, "Balance unavailable" and the notice; the header shows a dash. Switch **TCY** on — it reads from a healthy host and prices normally beside them. Switch RUJI off — the header prices again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017MMWAj7MtDB2eytjY8Ewpp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DeFi staking positions now clearly indicate when balances cannot be loaded instead of displaying misleading zero values.
  - Header totals show an unavailable state when any staking source fails.
  - Unavailable positions reload correctly and recover after a successful refresh.
  - Added warning messaging confirming staked funds remain safe on-chain during temporary service issues.

- **Localization**
  - Added unavailable-balance messaging in multiple supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->