### PR TITLE
feat(cardano): surface native tokens outside the curated catalog

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
@@ -64,7 +64,7 @@ import com.vultisig.wallet.data.db.models.VaultOrderEntity
             TransactionHistoryEntity::class,
             PendingLimitOrderEntity::class,
         ],
-    version = 43,
+    version = 44,
     exportSchema = false,
 )
 @TypeConverters(

--- a/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
@@ -52,6 +52,7 @@ import com.vultisig.wallet.data.db.migrations.MIGRATION_3_4
 import com.vultisig.wallet.data.db.migrations.MIGRATION_40_41
 import com.vultisig.wallet.data.db.migrations.MIGRATION_41_42
 import com.vultisig.wallet.data.db.migrations.MIGRATION_42_43
+import com.vultisig.wallet.data.db.migrations.MIGRATION_43_44
 import com.vultisig.wallet.data.db.migrations.MIGRATION_4_5
 import com.vultisig.wallet.data.db.migrations.MIGRATION_5_6
 import com.vultisig.wallet.data.db.migrations.MIGRATION_6_7
@@ -123,6 +124,7 @@ internal interface DatabaseModule {
                     MIGRATION_40_41,
                     MIGRATION_41_42,
                     MIGRATION_42_43,
+                    MIGRATION_43_44,
                 )
                 .build()
 

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -1168,3 +1168,95 @@ internal val MIGRATION_42_43 =
             )
         }
     }
+
+// Cardano native tokens were first saved with Coin.id = "$ticker-$chain", but a CNT ticker is
+// derived from the asset name its minter chose: anyone can mint an asset that decodes to "USDM"
+// and land on the curated Mehen USDM's key. Runtime Coin.id is now contract-qualified for them, so
+// rewrite existing rows and dependent id references to the same key before repository operations
+// read them back. Mirrors MIGRATION_42_43, which did this for TON and TRON.
+internal val MIGRATION_43_44 =
+    object : Migration(43, 44) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+            INSERT OR IGNORE INTO tokenPrice(tokenId, currency, price)
+            SELECT coin.ticker || '-' || coin.chain || '-' || coin.contractAddress,
+                tokenPrice.currency,
+                tokenPrice.price
+            FROM coin
+            INNER JOIN tokenPrice
+                ON tokenPrice.tokenId = coin.ticker || '-' || coin.chain
+            WHERE coin.chain = 'Cardano'
+            AND coin.contractAddress != ''
+            AND coin.id = coin.ticker || '-' || coin.chain
+            """
+                    .trimIndent()
+            )
+
+            db.execSQL(
+                """
+            DELETE FROM tokenPrice
+            WHERE tokenId IN (
+                SELECT ticker || '-' || chain
+                FROM coin
+                WHERE chain = 'Cardano'
+                AND contractAddress != ''
+                AND id = ticker || '-' || chain
+            )
+            """
+                    .trimIndent()
+            )
+
+            db.execSQL(
+                """
+            UPDATE disabledCoin
+            SET coinId = (
+                SELECT coin.ticker || '-' || coin.chain || '-' || coin.contractAddress
+                FROM coin
+                WHERE coin.vaultId = disabledCoin.vaultId
+                AND coin.chain = disabledCoin.chain
+                AND coin.id = disabledCoin.coinId
+                AND coin.contractAddress != ''
+                LIMIT 1
+            )
+            WHERE chain = 'Cardano'
+            AND coinId IN (
+                SELECT ticker || '-' || chain
+                FROM coin
+                WHERE coin.vaultId = disabledCoin.vaultId
+                AND coin.chain = disabledCoin.chain
+                AND coin.contractAddress != ''
+                AND coin.id = disabledCoin.coinId
+            )
+            """
+                    .trimIndent()
+            )
+
+            db.execSQL(
+                """
+            DELETE FROM coin
+            WHERE chain = 'Cardano'
+            AND contractAddress != ''
+            AND id = ticker || '-' || chain
+            AND EXISTS (
+                SELECT 1
+                FROM coin AS corrected
+                WHERE corrected.vaultId = coin.vaultId
+                AND corrected.id = coin.ticker || '-' || coin.chain || '-' || coin.contractAddress
+            )
+            """
+                    .trimIndent()
+            )
+
+            db.execSQL(
+                """
+            UPDATE coin
+            SET id = ticker || '-' || chain || '-' || contractAddress
+            WHERE chain = 'Cardano'
+            AND contractAddress != ''
+            AND id = ticker || '-' || chain
+            """
+                    .trimIndent()
+            )
+        }
+    }

--- a/app/src/test/java/com/vultisig/wallet/data/db/migrations/Migration43To44Test.kt
+++ b/app/src/test/java/com/vultisig/wallet/data/db/migrations/Migration43To44Test.kt
@@ -1,0 +1,73 @@
+package com.vultisig.wallet.data.db.migrations
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class Migration43To44Test {
+
+    @Test
+    fun `migrate contract-qualifies legacy Cardano native token ids`() {
+        val db = mockk<SupportSQLiteDatabase>(relaxed = true)
+        val statements = mutableListOf<String>()
+
+        MIGRATION_43_44.migrate(db)
+
+        verify(exactly = 5) { db.execSQL(capture(statements)) }
+
+        val copyTokenPrice = statements[0]
+        assertTrue(copyTokenPrice.contains("INSERT OR IGNORE INTO tokenPrice"))
+        assertTrue(copyTokenPrice.contains("tokenPrice.tokenId = coin.ticker || '-' || coin.chain"))
+        assertTrue(copyTokenPrice.contains("coin.chain = 'Cardano'"))
+        assertTrue(copyTokenPrice.contains("coin.contractAddress != ''"))
+
+        val deleteLegacyTokenPrice = statements[1]
+        assertTrue(deleteLegacyTokenPrice.contains("DELETE FROM tokenPrice"))
+        assertTrue(deleteLegacyTokenPrice.contains("tokenId IN"))
+        assertTrue(deleteLegacyTokenPrice.contains("chain = 'Cardano'"))
+        assertTrue(deleteLegacyTokenPrice.contains("contractAddress != ''"))
+
+        val updateDisabledCoin = statements[2]
+        assertTrue(updateDisabledCoin.contains("UPDATE disabledCoin"))
+        assertTrue(updateDisabledCoin.contains("SET coinId ="))
+        assertTrue(updateDisabledCoin.contains("coin.vaultId = disabledCoin.vaultId"))
+        assertTrue(updateDisabledCoin.contains("coin.chain = disabledCoin.chain"))
+        assertTrue(updateDisabledCoin.contains("coin.contractAddress != ''"))
+
+        val deleteDuplicate = statements[3]
+        assertTrue(deleteDuplicate.contains("DELETE FROM coin"))
+        assertTrue(deleteDuplicate.contains("chain = 'Cardano'"))
+        assertTrue(deleteDuplicate.contains("contractAddress != ''"))
+        assertTrue(deleteDuplicate.contains("id = ticker || '-' || chain"))
+        assertTrue(
+            deleteDuplicate.contains(
+                "corrected.id = coin.ticker || '-' || coin.chain || '-' || coin.contractAddress"
+            )
+        )
+
+        val updateLegacy = statements[4]
+        assertTrue(updateLegacy.contains("UPDATE coin"))
+        assertTrue(
+            updateLegacy.contains("SET id = ticker || '-' || chain || '-' || contractAddress")
+        )
+        assertTrue(updateLegacy.contains("chain = 'Cardano'"))
+        assertTrue(updateLegacy.contains("contractAddress != ''"))
+        assertTrue(updateLegacy.contains("id = ticker || '-' || chain"))
+    }
+
+    // Native ADA carries an empty contractAddress and keeps the plain id, so the walk must leave
+    // its row alone — every statement is gated on a non-empty contract address.
+    @Test
+    fun `migrate leaves native ADA rows untouched`() {
+        val db = mockk<SupportSQLiteDatabase>(relaxed = true)
+        val statements = mutableListOf<String>()
+
+        MIGRATION_43_44.migrate(db)
+
+        verify(exactly = 5) { db.execSQL(capture(statements)) }
+
+        assertTrue(statements.all { it.contains("contractAddress != ''") })
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/CardanoApi.kt
@@ -13,6 +13,7 @@ import com.vultisig.wallet.data.models.cardanoAssetId
 import com.vultisig.wallet.data.models.parseCardanoAssetId
 import com.vultisig.wallet.data.models.payload.CardanoTokenAsset
 import com.vultisig.wallet.data.models.payload.UtxoInfo
+import com.vultisig.wallet.data.utils.TtlCache
 import com.vultisig.wallet.data.utils.bodyOrThrow
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
@@ -23,6 +24,7 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.path
 import java.math.BigInteger
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.serialization.json.Json
@@ -44,6 +46,12 @@ interface CardanoApi {
     /** The held quantity of the native asset [coin] names through its `contractAddress`. */
     suspend fun getTokenBalance(coin: Coin): BigInteger
 
+    /**
+     * Every native-asset row Koios reports for [address], one per `(asset, UTxO group)` — the same
+     * asset can appear more than once, so a caller after a per-asset quantity must sum them.
+     */
+    suspend fun getAddressAssets(address: String): List<CardanoAssetResponseJson>
+
     suspend fun getUTXOs(coin: Coin): List<UtxoInfo>
 
     suspend fun getTxStatus(txHash: String): CardanoTxStatusResponseJson?
@@ -60,6 +68,19 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
     private val apiV1Path: String = "api/v1"
     private val ogmiosUrl = "https://api.vultisig.com/ada/"
 
+    /**
+     * One `address_assets` walk shared by every read of the same address.
+     *
+     * `AccountsRepository` fans a non-EVM chain's balances out with one concurrent `async` per
+     * coin, and each [getTokenBalance] walks the address's whole asset list — so once discovery can
+     * add an arbitrary number of native tokens (an NFT is one too), opening the chain screen would
+     * fire that many identical paginated POSTs at Koios at once and be rate-limited into spurious
+     * zeros. The coalescing is what fixes that; the TTL only bridges a straggler whose fetch starts
+     * just after the shared one resolved, and at five seconds it sits far below Cardano's ~20s
+     * block time, so it can never hide a settled balance change from a refresh.
+     */
+    private val addressAssetsCache = TtlCache<String, List<CardanoAssetResponseJson>>()
+
     private companion object {
         // Ogmios "UnknownOutputReference": the tx spends inputs the ledger no longer knows.
         const val OGMIOS_UNKNOWN_OUTPUT_REFERENCE_CODE = 3117
@@ -69,6 +90,7 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
         const val KOIOS_PAGE_SIZE = 1000
         // Stops the walk if the node ever keeps returning full pages (50k distinct assets).
         const val KOIOS_MAX_PAGES = 50
+        val ADDRESS_ASSETS_TTL_MILLIS = TimeUnit.SECONDS.toMillis(5)
     }
 
     override suspend fun getBalance(coin: Coin): BigInteger {
@@ -94,48 +116,71 @@ constructor(private val httpClient: HttpClient, private val json: Json) : Cardan
         val assetId = coin.contractAddress.lowercase()
         require(assetId.isNotBlank()) { "Cardano token ${coin.ticker} has no asset id" }
 
-        val requestBody = mapOf("_addresses" to listOf(coin.address))
         return try {
-            var total = BigInteger.ZERO
-            var walkedToLastPage = false
-            for (page in 0 until KOIOS_MAX_PAGES) {
-                val assets =
-                    httpClient
-                        .post(url) {
-                            url { path(apiV1Path, "address_assets") }
-                            parameter("offset", page * KOIOS_PAGE_SIZE)
-                            parameter("limit", KOIOS_PAGE_SIZE)
-                            setBody(requestBody)
-                        }
-                        .bodyOrThrow<List<CardanoAssetResponseJson>>()
-
-                // An address can hold the same asset across several UTXOs, so Koios may return
-                // more than one row for it; the wallet balance is their sum.
-                total =
-                    assets
-                        .filter { cardanoAssetId(it.policyId ?: "", it.assetName ?: "") == assetId }
-                        .fold(total) { sum, asset ->
-                            sum + (asset.quantity?.toBigIntegerOrNull() ?: BigInteger.ZERO)
-                        }
-
-                // A short page is the last one; a full page means there may be more rows.
-                if (assets.size < KOIOS_PAGE_SIZE) {
-                    walkedToLastPage = true
-                    break
+            // An address can hold the same asset across several UTXOs, so Koios may return
+            // more than one row for it; the wallet balance is their sum.
+            walkAddressAssets(coin.address, subject = coin.ticker)
+                .filter { cardanoAssetId(it.policyId ?: "", it.assetName ?: "") == assetId }
+                .fold(BigInteger.ZERO) { sum, asset ->
+                    sum + (asset.quantity?.toBigIntegerOrNull() ?: BigInteger.ZERO)
                 }
-            }
-            // Every page came back full, so the walk never proved it read the whole holding: the
-            // asset may sit past the ceiling. Fail rather than hand back a zero or an undercount.
-            check(walkedToLastPage) {
-                "Cardano address_assets exceeded ${KOIOS_MAX_PAGES * KOIOS_PAGE_SIZE} rows; " +
-                    "${coin.ticker} balance would be incomplete"
-            }
-            total
         } catch (e: Exception) {
             if (e is kotlinx.coroutines.CancellationException) throw e
             Timber.e("Error in Cardano getTokenBalance : %s", e.message)
             throw e
         }
+    }
+
+    override suspend fun getAddressAssets(address: String): List<CardanoAssetResponseJson> =
+        try {
+            walkAddressAssets(address, subject = "discovery")
+        } catch (e: Exception) {
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            Timber.e("Error in Cardano getAddressAssets : %s", e.message)
+            throw e
+        }
+
+    /**
+     * Reads every `address_assets` row for [address], page by page.
+     *
+     * [subject] only names the caller in the ceiling message. Throwing there rather than returning
+     * a short list is deliberate: a truncated walk understates a balance and hides held assets from
+     * discovery, and neither caller can tell the difference from a genuinely small holding.
+     */
+    private suspend fun walkAddressAssets(
+        address: String,
+        subject: String,
+    ): List<CardanoAssetResponseJson> =
+        addressAssetsCache.getOrPut(address, ADDRESS_ASSETS_TTL_MILLIS) {
+            fetchAddressAssets(address, subject)
+        }
+
+    private suspend fun fetchAddressAssets(
+        address: String,
+        subject: String,
+    ): List<CardanoAssetResponseJson> {
+        val requestBody = mapOf("_addresses" to listOf(address))
+        val rows = mutableListOf<CardanoAssetResponseJson>()
+        for (page in 0 until KOIOS_MAX_PAGES) {
+            val assets =
+                httpClient
+                    .post(url) {
+                        url { path(apiV1Path, "address_assets") }
+                        parameter("offset", page * KOIOS_PAGE_SIZE)
+                        parameter("limit", KOIOS_PAGE_SIZE)
+                        setBody(requestBody)
+                    }
+                    .bodyOrThrow<List<CardanoAssetResponseJson>>()
+            rows += assets
+
+            // A short page is the last one; a full page means there may be more rows.
+            if (assets.size < KOIOS_PAGE_SIZE) return rows
+        }
+        // Every page came back full, so the walk never proved it read the whole holding.
+        error(
+            "Cardano address_assets exceeded ${KOIOS_MAX_PAGES * KOIOS_PAGE_SIZE} rows; " +
+                "$subject would be incomplete"
+        )
     }
 
     override suspend fun getUTXOs(coin: Coin): List<UtxoInfo> {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoAssetResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/cardano/CardanoAssetResponseJson.kt
@@ -4,14 +4,20 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * One native-asset holding from Koios `address_assets`.
+ * One native-asset holding from Koios `address_assets`, or one asset row on an extended
+ * `address_utxos` entry.
  *
  * `asset_name` is hex, and empty for a policy's unnamed asset — together with [policyId] it forms
  * the `<policy_id>.<asset_name_hex>` id the curated catalog stores as a `Coin.contractAddress`.
+ *
+ * [decimals] is the Cardano token registry's value for the asset. Koios reports `0` for an asset
+ * the registry does not list, so it cannot be read as "the registry says zero" — see
+ * `CardanoTokenFinder` for why discovery takes it at face value anyway.
  */
 @Serializable
 data class CardanoAssetResponseJson(
     @SerialName("policy_id") val policyId: String? = null,
     @SerialName("asset_name") val assetName: String? = null,
     @SerialName("quantity") val quantity: String? = null,
+    @SerialName("decimals") val decimals: Int? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TokenValueEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/TokenValueEntity.kt
@@ -19,17 +19,23 @@ data class TokenValueEntity(
 ) {
     /**
      * Mirrors [com.vultisig.wallet.data.models.Coin.id] so lookups keyed on Coin.id resolve
-     * correctly. Both coin types Coin.id contract-qualifies must be qualified here too, or a cached
+     * correctly. Every coin type Coin.id contract-qualifies must be qualified here too, or a cached
      * balance row collapses onto the plain `ticker-chain` id and no longer matches its coin (e.g.
      * `BalanceRepository.getCachedTokenBalances` resolving decimals/price by id).
+     *
+     * A native coin carries an empty contractAddress on all of these chains, so the blank check is
+     * what stands in for Coin.id's `!isNativeToken`.
      */
     val tokenId: String
         get() =
-            if (isSecuredAssetLike() || isRippleIssuedTokenLike()) {
+            if (isSecuredAssetLike() || isRippleIssuedTokenLike() || isContractQualifiedLike()) {
                 "$ticker-$chain-$contractAddress"
             } else {
                 "$ticker-$chain"
             }
+
+    private fun isContractQualifiedLike(): Boolean =
+        contractAddress.isNotBlank() && chain in CONTRACT_QUALIFIED_CHAIN_IDS
 
     private fun isSecuredAssetLike(): Boolean {
         if (chain != Chain.ThorChain.id) return false
@@ -42,4 +48,9 @@ data class TokenValueEntity(
     // ("<currency>.<issuer>") qualify — matching Coin.isRippleIssuedToken.
     private fun isRippleIssuedTokenLike(): Boolean =
         chain == Chain.Ripple.id && parseRippleTokenIdentity(contractAddress) != null
+
+    private companion object {
+        // Kept in step with Coin.isContractQualifiedCustomToken.
+        val CONTRACT_QUALIFIED_CHAIN_IDS = setOf(Chain.Ton.id, Chain.Tron.id, Chain.Cardano.id)
+    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
@@ -28,7 +28,11 @@ data class Coin(
      * reason: a currency code is only unique per issuer, so several independent issuers each mint
      * their own `USD` trust line. TON jettons and TRON TRC-20 tokens are also contract-qualified:
      * their symbols are user-controlled metadata, so two unrelated contracts can both report the
-     * same ticker. Every other coin type keeps the plain `ticker-chainId` form unchanged.
+     * same ticker. Cardano native tokens qualify for the same reason and more sharply: a ticker is
+     * derived from the asset name the minter chose, and nothing stops anyone minting an asset named
+     * `USDM` — without qualification it would take the curated Mehen USDM's key, and Room's
+     * REPLACE-on-conflict insert would let whichever arrived last silently overwrite the other.
+     * Every other coin type keeps the plain `ticker-chainId` form unchanged.
      */
     val id: TokenId
         get() =
@@ -58,7 +62,9 @@ data class Coin(
 }
 
 private fun Coin.isContractQualifiedCustomToken(): Boolean =
-    !isNativeToken && contractAddress.isNotBlank() && (chain == Chain.Ton || chain == Chain.Tron)
+    !isNativeToken &&
+        contractAddress.isNotBlank() &&
+        (chain == Chain.Ton || chain == Chain.Tron || chain == Chain.Cardano)
 
 /**
  * True when this coin has a CoinGecko price-provider id, or a contract address on a chain

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -8,6 +8,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.usecases.CardanoTokenFinder
 import com.vultisig.wallet.data.usecases.CosmosBankCoinFinder
 import com.vultisig.wallet.data.usecases.EvmCoinFinder
 import com.vultisig.wallet.data.usecases.RippleTokenFinder
@@ -49,6 +50,7 @@ constructor(
     private val evmCoinFinder: EvmCoinFinder,
     private val cosmosBankCoinFinder: CosmosBankCoinFinder,
     private val rippleTokenFinder: RippleTokenFinder,
+    private val cardanoTokenFinder: CardanoTokenFinder,
 ) : TokenRepository {
 
     override suspend fun getToken(tokenId: String): Coin? =
@@ -186,6 +188,7 @@ constructor(
             Chain.Terra,
             Chain.TerraClassic -> cosmosBankCoinFinder.find(chain, address)
             Chain.Ripple -> rippleTokenFinder.find(address)
+            Chain.Cardano -> cardanoTokenFinder.find(address)
             else -> {
                 if (chain.standard != TokenStandard.EVM) emptyList()
                 else evmCoinFinder.find(chain, address)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CardanoTokenFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CardanoTokenFinder.kt
@@ -1,0 +1,161 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CardanoApi
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.cardanoAssetId
+import com.vultisig.wallet.data.models.parseCardanoAssetId
+import com.vultisig.wallet.data.utils.NetworkException
+import java.math.BigInteger
+import java.net.SocketTimeoutException
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import timber.log.Timber
+
+/**
+ * Auto-discovers Cardano native tokens (CNTs) held at an address.
+ *
+ * Companion to [EvmCoinFinder], [CosmosBankCoinFinder] and [RippleTokenFinder]: the chain-detail
+ * screen and the background token-refresh worker both route through
+ * `TokenRepository.getTokensWithBalance`, which delegates here for [Chain.Cardano]. Every
+ * `address_assets` row becomes a [Coin] keyed on its `<policy_id>.<asset_name_hex>` id, preferring
+ * the curated [Coins] catalog entry when one matches so the shipped ten keep their icon, casing and
+ * `priceProviderID`.
+ *
+ * Discovery is deliberately *not* gated to the catalog, unlike [RippleTokenFinder]. An XRPL trust
+ * line is opened by the holder, so an arbitrary one is not evidence of anything; a Cardano asset is
+ * minted by its policy and simply lands in the wallet, and the whole point of this finder is the
+ * long tail the curated ten miss. What the catalog gate bought on XRPL is bought here instead by
+ * contract-qualifying `Coin.id` for Cardano tokens, so an asset whose name decodes to `USDM` cannot
+ * take the real Mehen USDM's identity.
+ *
+ * Mirrors iOS `CardanoNativeTokensService.discoverTokens` and the SDK's `findCardanoCoins`, with
+ * the pagination the SDK has and iOS lacks — every NFT is its own native asset, so an NFT-heavy
+ * wallet runs past Koios' 1000-row page easily.
+ *
+ * Network failures are logged and yield an empty list, matching the sibling finders: a transient
+ * blip must not wipe tokens the vault already holds, and the next refresh retries.
+ */
+interface CardanoTokenFinder {
+    suspend fun find(address: String): List<Coin>
+}
+
+internal class CardanoTokenFinderImpl @Inject constructor(private val cardanoApi: CardanoApi) :
+    CardanoTokenFinder {
+
+    override suspend fun find(address: String): List<Coin> {
+        val assets =
+            try {
+                cardanoApi.getAddressAssets(address)
+            } catch (e: SocketTimeoutException) {
+                Timber.e(e, "Koios address_assets timed out")
+                return emptyList()
+            } catch (e: NetworkException) {
+                Timber.e(e, "Koios address_assets failed: status=%d", e.httpStatusCode)
+                return emptyList()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Koios address_assets failed")
+                return emptyList()
+            }
+
+        return assets
+            .mapNotNull { row ->
+                // An id that is not well-formed hex of the right length would push malformed bytes
+                // into a signing input's TokenAmount, so it is rejected here rather than at
+                // broadcast — the same contract CardanoApi applies to a UTxO's asset rows.
+                val assetId =
+                    parseCardanoAssetId(
+                        cardanoAssetId(row.policyId ?: return@mapNotNull null, row.assetName ?: "")
+                    ) ?: return@mapNotNull null
+                val quantity = row.quantity?.toBigIntegerOrNull() ?: return@mapNotNull null
+                DiscoveredAsset(
+                    assetId = cardanoAssetId(assetId.policyId, assetId.assetNameHex),
+                    policyId = assetId.policyId,
+                    assetNameHex = assetId.assetNameHex,
+                    quantity = quantity,
+                    decimals = row.decimals,
+                )
+            }
+            // Koios reports one row per asset per UTxO group, so a wallet holding the same asset in
+            // several UTxOs sees it more than once. Fold them together before the positive-quantity
+            // gate, or an asset split across a positive and a zero row could be judged on the wrong
+            // one and the surviving row would still collide on Coin.id downstream.
+            .groupBy { it.assetId }
+            .values
+            .mapNotNull { rows ->
+                val total = rows.fold(BigInteger.ZERO) { sum, row -> sum + row.quantity }
+                if (total <= BigInteger.ZERO) return@mapNotNull null
+                rows.first().toCoin()
+            }
+    }
+
+    private fun DiscoveredAsset.toCoin(): Coin =
+        // The catalog entry is what keeps the shipped ten on their bundled icon, their
+        // hand-checked casing (`iUSD`, not `IUSD`) and a working `priceProviderID` — none of which
+        // the chain itself can supply. Both sides are the lowercase `<policy_id>.<asset_name_hex>`
+        // form, so they match without normalization.
+        Coins.findCuratedByContract(Chain.Cardano, assetId)
+            ?: Coin(
+                chain = Chain.Cardano,
+                ticker = deriveTicker(assetNameHex, policyId),
+                // No bundled drawable and no registry logo on this endpoint. An empty logo falls
+                // back to the chain icon in the UI, the same as any other discovered token; the
+                // ticker must NOT be reused as the logo key, or a lookalike asset named "MIN"
+                // would borrow Minswap's icon.
+                logo = "",
+                address = "",
+                // Koios sources `decimals` from the Cardano token registry and reports 0 for an
+                // asset the registry does not list, so this endpoint cannot distinguish "the
+                // registry says zero" from "unknown" — verified live against an unregistered
+                // asset, which returns `"decimals": 0` with a null `token_registry_metadata`.
+                // Refusing every 0 would drop NFTs, which genuinely have none and which the ticket
+                // wants surfaced. So take the registry's word like iOS and the SDK do; if it later
+                // publishes a decimal, TokenRefreshWorker.needsIdentityCorrection rewrites the
+                // persisted row on the next refresh because the contract address still matches.
+                decimal = decimals ?: 0,
+                hexPublicKey = "",
+                priceProviderID = "",
+                contractAddress = assetId,
+                isNativeToken = false,
+            )
+
+    private data class DiscoveredAsset(
+        val assetId: String,
+        val policyId: String,
+        val assetNameHex: String,
+        val quantity: BigInteger,
+        val decimals: Int?,
+    )
+
+    private companion object {
+        /** Enough of a policy hash to tell two unnamed assets apart in a list. */
+        const val POLICY_TICKER_LENGTH = 8
+
+        /**
+         * A displayable ticker for an asset the curated catalog does not know.
+         *
+         * A Cardano asset name is raw bytes, not text: CIP-67 label prefixes (`0014df10` for a
+         * fungible token) are unprintable, and nothing stops a minter putting arbitrary bytes
+         * there. Keeping only printable ASCII turns USDM's `0014df105553444d` into `USDM` — iOS
+         * masks each byte with `0x7F` first, which invents a `_` out of the `0xdf` checksum byte
+         * and is why it renders `_USDM`. An asset with no printable name at all (an unnamed asset,
+         * or one named entirely out of range) falls back to a policy-id prefix, matching iOS and
+         * the SDK, so it is still distinguishable in a list.
+         */
+        fun deriveTicker(assetNameHex: String, policyId: String): String {
+            val name =
+                assetNameHex
+                    .chunked(2)
+                    .mapNotNull { byte ->
+                        byte.toIntOrNull(radix = 16)?.takeIf { it in 0x20..0x7E }
+                    }
+                    .map { it.toChar() }
+                    .joinToString(separator = "")
+                    .trim()
+            return name.ifEmpty { policyId.take(POLICY_TICKER_LENGTH).uppercase() }
+        }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/DataUsecasesModule.kt
@@ -198,6 +198,8 @@ internal interface DataUsecasesModule {
 
     @Binds @Singleton fun bindRippleTokenFinder(impl: RippleTokenFinderImpl): RippleTokenFinder
 
+    @Binds @Singleton fun bindCardanoTokenFinder(impl: CardanoTokenFinderImpl): CardanoTokenFinder
+
     @Binds @Singleton fun bindRippleTrustLines(impl: RippleTrustLinesImpl): RippleTrustLines
 
     @Binds @Singleton fun bindSuiTokenFinder(impl: SuiTokenFinderImpl): SuiTokenFinder

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiAddressAssetsTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/CardanoApiAddressAssetsTest.kt
@@ -1,0 +1,165 @@
+package com.vultisig.wallet.data.api
+
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.testutils.MockHttpClient
+import java.math.BigInteger
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * The discovery read on top of `address_assets`, and the single walk it shares with every per-token
+ * balance read of the same address.
+ *
+ * Sharing is not an optimisation: `AccountsRepository` fans a non-EVM chain's balances out with one
+ * concurrent request per coin, so without it a wallet holding N discovered tokens would fire N
+ * identical paginated walks at Koios at once.
+ */
+class CardanoApiAddressAssetsTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+    }
+
+    private fun assetRow(policyId: String, assetName: String, quantity: String, decimals: Int) =
+        """{"policy_id":"$policyId","asset_name":"$assetName","quantity":"$quantity","decimals":$decimals}"""
+
+    @Test
+    fun `getAddressAssets returns every row across pages`() = runTest {
+        val firstPage =
+            (0 until 1000).joinToString(prefix = "[", separator = ",", postfix = "]") {
+                assetRow("%056x".format(it), "%08x".format(it), "1", 0)
+            }
+        val secondPage =
+            listOf(assetRow(SNEK_POLICY_ID, SNEK_ASSET_NAME_HEX, "5", 0))
+                .joinToString(prefix = "[", separator = ",", postfix = "]")
+        val capture = MockHttpClient.RequestCapture()
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.capturingRequestSequence(
+                        capture,
+                        io.ktor.http.HttpStatusCode.OK to firstPage,
+                        io.ktor.http.HttpStatusCode.OK to secondPage,
+                        jsonFormat = json,
+                    ),
+                json = json,
+            )
+
+        val assets = api.getAddressAssets(ADDRESS)
+
+        assertEquals(1001, assets.size)
+        assertEquals(listOf("offset=0&limit=1000", "offset=1000&limit=1000"), capture.queries)
+    }
+
+    // Koios reports the registry's decimals on this endpoint; discovery reads them straight off it.
+    @Test
+    fun `getAddressAssets carries the registry decimals through`() = runTest {
+        val api = apiRespondingWith(assetRow(MELD_POLICY_ID, MELD_ASSET_NAME_HEX, "1500", 6))
+
+        assertEquals(6, api.getAddressAssets(ADDRESS).single().decimals)
+    }
+
+    // The concurrent fan-out is the case that matters: every caller must land on one walk.
+    @Test
+    fun `concurrent reads of one address share a single walk`() = runTest {
+        val calls = AtomicInteger(0)
+        val page =
+            listOf(
+                    assetRow(SNEK_POLICY_ID, SNEK_ASSET_NAME_HEX, "5", 0),
+                    assetRow(MELD_POLICY_ID, MELD_ASSET_NAME_HEX, "1500", 6),
+                )
+                .joinToString(prefix = "[", separator = ",", postfix = "]")
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWithGenerated(jsonFormat = json) {
+                        calls.incrementAndGet()
+                        page
+                    },
+                json = json,
+            )
+        val snek = Coins.Cardano.SNEK.copy(address = ADDRESS)
+
+        val results = coroutineScope {
+            listOf(
+                    async { api.getTokenBalance(snek) },
+                    async { api.getTokenBalance(snek) },
+                    async { api.getAddressAssets(ADDRESS).size.toBigInteger() },
+                )
+                .awaitAll()
+        }
+
+        assertEquals(listOf(BigInteger("5"), BigInteger("5"), BigInteger("2")), results)
+        assertEquals(1, calls.get())
+    }
+
+    // Two vaults, or a vault and a watch-only address, must not read each other's holdings.
+    @Test
+    fun `a different address is walked separately`() = runTest {
+        val calls = AtomicInteger(0)
+        val api =
+            CardanoApiImpl(
+                httpClient =
+                    MockHttpClient.respondingWithGenerated(jsonFormat = json) {
+                        calls.incrementAndGet()
+                        "[]"
+                    },
+                json = json,
+            )
+
+        api.getAddressAssets(ADDRESS)
+        api.getAddressAssets(OTHER_ADDRESS)
+
+        assertEquals(2, calls.get())
+    }
+
+    // The ceiling guard has to survive the extraction: a walk that never proves it read the whole
+    // holding must fail rather than hand discovery a truncated asset list.
+    @Test
+    fun `getAddressAssets fails rather than return a truncated list at the page ceiling`() =
+        runTest {
+            val fullPage =
+                (0 until 1000).joinToString(prefix = "[", separator = ",", postfix = "]") {
+                    assetRow("%056x".format(it), "%08x".format(it), "1", 0)
+                }
+            val api =
+                CardanoApiImpl(
+                    httpClient =
+                        MockHttpClient.respondingWithGenerated(jsonFormat = json) { fullPage },
+                    json = json,
+                )
+
+            val failure = runCatching { api.getAddressAssets(ADDRESS) }.exceptionOrNull()
+
+            assertTrue(
+                failure is IllegalStateException,
+                "expected the walk to fail at the ceiling, got $failure",
+            )
+        }
+
+    private fun apiRespondingWith(vararg rows: String): CardanoApiImpl =
+        CardanoApiImpl(
+            httpClient =
+                MockHttpClient.respondingWithGenerated(jsonFormat = json) {
+                    rows.joinToString(prefix = "[", separator = ",", postfix = "]")
+                },
+            json = json,
+        )
+
+    private companion object {
+        const val ADDRESS = "addr1test"
+        const val OTHER_ADDRESS = "addr1other"
+        const val SNEK_POLICY_ID = "279c909f348e533da5808898f87f9a14bb2c3dfbbacccd631d927a3f"
+        const val SNEK_ASSET_NAME_HEX = "534e454b"
+        const val MELD_POLICY_ID = "6ac8ef33b510ec004fe11585f7c5a9f0c07f0c23428ab4f29c1d7d10"
+        const val MELD_ASSET_NAME_HEX = "4d454c44"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/db/models/TokenValueEntityTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/db/models/TokenValueEntityTest.kt
@@ -1,5 +1,7 @@
 package com.vultisig.wallet.data.db.models
 
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Test
@@ -118,5 +120,65 @@ internal class TokenValueEntityTest {
             )
 
         assertEquals("XRP-Ripple", entity.tokenId)
+    }
+
+    // The cache row has to land on the same key Coin.id produces, or getCachedTokenBalances
+    // resolves no coin for it and renders the balance at zero decimals.
+    @Test
+    fun `a Cardano native token is contract-qualified, mirroring Coin id`() {
+        val snek = Coins.Cardano.SNEK.copy(address = CARDANO_ADDRESS)
+        val entity =
+            TokenValueEntity(
+                chain = Chain.Cardano.id,
+                address = CARDANO_ADDRESS,
+                ticker = snek.ticker,
+                tokenValue = "76715880000",
+                contractAddress = snek.contractAddress,
+            )
+
+        assertEquals(snek.id, entity.tokenId)
+    }
+
+    // TON and TRON were contract-qualified in Coin.id without this side following, so a jetton's
+    // cached row was resolving to no coin at all.
+    @Test
+    fun `TON and TRON tokens are contract-qualified, mirroring Coin id`() {
+        val jetton =
+            TokenValueEntity(
+                chain = Chain.Ton.id,
+                address = "UQTonAddress",
+                ticker = "USDJ",
+                tokenValue = "1",
+                contractAddress = "EQFirstJetton",
+            )
+        val trc20 =
+            TokenValueEntity(
+                chain = Chain.Tron.id,
+                address = "TTronAddress",
+                ticker = "USDX",
+                tokenValue = "1",
+                contractAddress = "TFirstTrc20",
+            )
+
+        assertEquals("USDJ-Ton-EQFirstJetton", jetton.tokenId)
+        assertEquals("USDX-Tron-TFirstTrc20", trc20.tokenId)
+    }
+
+    @Test
+    fun `native ADA keeps the plain ticker-chain tokenId`() {
+        val entity =
+            TokenValueEntity(
+                chain = Chain.Cardano.id,
+                address = CARDANO_ADDRESS,
+                ticker = "ADA",
+                tokenValue = "100",
+                contractAddress = "",
+            )
+
+        assertEquals("ADA-Cardano", entity.tokenId)
+    }
+
+    private companion object {
+        const val CARDANO_ADDRESS = "addr1v9g9wnzsutrxt7vcg4efdfwhagwh3x2f6hjwykk7acdpsfgyt4h2j"
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinIdTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinIdTest.kt
@@ -79,4 +79,29 @@ internal class CoinIdTest {
         assertEquals("TON-Ton", coin(Chain.Ton, "TON", "", isNativeToken = true).id)
         assertEquals("TRX-Tron", coin(Chain.Tron, "TRX", "", isNativeToken = true).id)
     }
+
+    // A Cardano ticker is derived from the asset name its minter chose, so an asset decoding to
+    // "SNEK" under any policy would otherwise take the curated SNEK's key — and Room's
+    // REPLACE-on-conflict insert would let whichever arrived last overwrite the other.
+    @Test
+    fun `an imposter Cardano asset cannot take a curated token's id`() {
+        val curated = Coins.Cardano.SNEK
+        val imposter =
+            coin(
+                Chain.Cardano,
+                curated.ticker,
+                cardanoAssetId(
+                    policyId = "6ac8ef33b510ec004fe11585f7c5a9f0c07f0c23428ab4f29c1d7d10",
+                    assetNameHex = "534e454b",
+                ),
+            )
+
+        assertNotEquals(curated.id, imposter.id)
+        assertEquals("SNEK-Cardano-${curated.contractAddress}", curated.id)
+    }
+
+    @Test
+    fun `native ADA keeps the plain ticker-chainId id`() {
+        assertEquals("ADA-Cardano", Coins.Cardano.ADA.id)
+    }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.usecases.CardanoTokenFinder
 import com.vultisig.wallet.data.usecases.CosmosBankCoinFinder
 import com.vultisig.wallet.data.usecases.EvmCoinFinder
 import com.vultisig.wallet.data.usecases.RippleTokenFinder
@@ -249,6 +250,7 @@ internal class TokenRepositoryImplTest {
         evmCoinFinder: EvmCoinFinder = mockk(relaxed = true),
         cosmosBankCoinFinder: CosmosBankCoinFinder = mockk(relaxed = true),
         rippleTokenFinder: RippleTokenFinder = mockk(relaxed = true),
+        cardanoTokenFinder: CardanoTokenFinder = mockk(relaxed = true),
     ): TokenRepositoryImpl =
         TokenRepositoryImpl(
             evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
@@ -257,6 +259,7 @@ internal class TokenRepositoryImplTest {
             evmCoinFinder = evmCoinFinder,
             cosmosBankCoinFinder = cosmosBankCoinFinder,
             rippleTokenFinder = rippleTokenFinder,
+            cardanoTokenFinder = cardanoTokenFinder,
         )
 
     private companion object {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/CardanoTokenFinderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/CardanoTokenFinderTest.kt
@@ -1,0 +1,176 @@
+package com.vultisig.wallet.data.usecases
+
+import com.vultisig.wallet.data.api.CardanoApi
+import com.vultisig.wallet.data.api.models.cardano.CardanoAssetResponseJson
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.parseCardanoAssetId
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Discovery rules for Cardano native-token holdings surfaced into the asset list.
+ *
+ * Unlike the XRPL finder, discovery here is not gated to the curated catalog — the long tail is the
+ * point — so these pin the two things that keep it honest: a curated asset must not lose its
+ * catalog identity, and an uncurated one must not be able to borrow it.
+ */
+class CardanoTokenFinderTest {
+
+    private val cardanoApi = mockk<CardanoApi>()
+    private val finder = CardanoTokenFinderImpl(cardanoApi)
+
+    private val snek = Coins.Cardano.SNEK
+    private val snekId = checkNotNull(parseCardanoAssetId(snek.contractAddress))
+
+    private fun row(policyId: String, assetName: String, quantity: String, decimals: Int? = 0) =
+        CardanoAssetResponseJson(
+            policyId = policyId,
+            assetName = assetName,
+            quantity = quantity,
+            decimals = decimals,
+        )
+
+    private suspend fun find(vararg rows: CardanoAssetResponseJson): List<Coin> {
+        coEvery { cardanoApi.getAddressAssets(ADDRESS) } returns rows.toList()
+        return finder.find(ADDRESS)
+    }
+
+    // The headline of the ticket: an asset outside the curated ten becomes a spendable row.
+    @Test
+    fun `an uncurated asset is surfaced from its on-chain identity`() = runTest {
+        val coin =
+            find(row(MELD_POLICY_ID, MELD_ASSET_NAME_HEX, quantity = "1500", decimals = 6)).single()
+
+        assertEquals(Chain.Cardano, coin.chain)
+        assertEquals("MELD", coin.ticker)
+        assertEquals("$MELD_POLICY_ID.$MELD_ASSET_NAME_HEX", coin.contractAddress)
+        assertEquals(6, coin.decimal)
+        assertEquals(false, coin.isNativeToken)
+        // No bundled drawable and no price feed for an asset nobody curated. The ticker must not
+        // leak into the logo slot, or a lookalike would borrow a real token's icon.
+        assertEquals("", coin.logo)
+        assertEquals("", coin.priceProviderID)
+    }
+
+    // The catalog entry carries the hand-checked casing, the bundled icon and the price provider,
+    // none of which the chain can supply, so it has to win over the derived identity.
+    @Test
+    fun `a curated asset keeps its catalog identity`() = runTest {
+        val coin =
+            find(row(snekId.policyId, snekId.assetNameHex, quantity = "76715880000", decimals = 0))
+                .single()
+
+        assertEquals(snek, coin)
+        assertEquals("snek", coin.logo)
+        assertEquals("snek", coin.priceProviderID)
+    }
+
+    // USDM's asset name carries the CIP-67 label-333 prefix, whose bytes are unprintable. The
+    // curated entry answers this one, but the derivation underneath must not be what saves it.
+    @Test
+    fun `a curated asset with a CIP-67 name keeps its catalog decimals and ticker`() = runTest {
+        val usdm = Coins.Cardano.USDM
+        val id = checkNotNull(parseCardanoAssetId(usdm.contractAddress))
+
+        val coin = find(row(id.policyId, id.assetNameHex, quantity = "10", decimals = 0)).single()
+
+        assertEquals(usdm, coin)
+        assertEquals(6, coin.decimal)
+        assertEquals("USDM", coin.ticker)
+    }
+
+    // An unregistered asset that decodes to a curated ticker is exactly the impersonation
+    // Coin.id's contract qualification exists to stop. It surfaces, but as its own row.
+    @Test
+    fun `an imposter asset does not take the curated entry's identity`() = runTest {
+        val coin = find(row(MELD_POLICY_ID, SNEK_ASSET_NAME_HEX, quantity = "1")).single()
+
+        assertEquals("SNEK", coin.ticker)
+        assertEquals("$MELD_POLICY_ID.$SNEK_ASSET_NAME_HEX", coin.contractAddress)
+        assertEquals("", coin.logo)
+        // Same ticker, same chain — only the contract qualification separates the two ids.
+        assertTrue(coin.id != snek.id, "imposter shares an id with the curated entry: ${coin.id}")
+    }
+
+    // Koios reports the holding once per UTxO group, so the same asset arrives several times.
+    @Test
+    fun `rows for one asset across several utxos collapse to a single coin`() = runTest {
+        val coins =
+            find(
+                row(MELD_POLICY_ID, MELD_ASSET_NAME_HEX, quantity = "500", decimals = 6),
+                row(MELD_POLICY_ID, MELD_ASSET_NAME_HEX, quantity = "1000", decimals = 6),
+            )
+
+        assertEquals(1, coins.size)
+        assertEquals("$MELD_POLICY_ID.$MELD_ASSET_NAME_HEX", coins.single().contractAddress)
+    }
+
+    // A wallet that once held an asset can keep a zero row; it is not a holding.
+    @Test
+    fun `an asset with no remaining quantity is not surfaced`() = runTest {
+        assertTrue(find(row(MELD_POLICY_ID, MELD_ASSET_NAME_HEX, quantity = "0")).isEmpty())
+    }
+
+    @Test
+    fun `an address holding no native tokens yields nothing`() = runTest {
+        assertTrue(find().isEmpty())
+    }
+
+    // A policy's unnamed asset is legal, and an all-unprintable name is possible; neither can be
+    // left with a blank ticker, which would collide with every other blank one.
+    @Test
+    fun `an unnamed asset falls back to a policy-id prefix`() = runTest {
+        val coin = find(row(MELD_POLICY_ID, assetName = "", quantity = "1")).single()
+
+        assertEquals(MELD_POLICY_ID.take(8).uppercase(), coin.ticker)
+        assertEquals("$MELD_POLICY_ID.", coin.contractAddress)
+    }
+
+    @Test
+    fun `an asset named entirely out of printable range falls back to a policy-id prefix`() =
+        runTest {
+            val coin = find(row(MELD_POLICY_ID, assetName = "00010203", quantity = "1")).single()
+
+            assertEquals(MELD_POLICY_ID.take(8).uppercase(), coin.ticker)
+        }
+
+    // A malformed id would be pushed into a signing input's TokenAmount as raw hex and rejected at
+    // broadcast, so it is refused at the point it is read instead.
+    @Test
+    fun `an asset whose id is not well-formed hex is dropped`() = runTest {
+        val coins =
+            find(
+                row(policyId = "not-a-policy-id", assetName = MELD_ASSET_NAME_HEX, quantity = "1"),
+                row(MELD_POLICY_ID, assetName = "odd", quantity = "1"),
+                row(MELD_POLICY_ID, MELD_ASSET_NAME_HEX, quantity = "1", decimals = 6),
+            )
+
+        assertEquals(1, coins.size)
+        assertEquals("MELD", coins.single().ticker)
+    }
+
+    // A transient Koios blip must not read as "this wallet holds nothing" — the worker only ever
+    // adds, so an empty list leaves the vault's existing tokens alone and the next refresh retries.
+    @Test
+    fun `a failed read yields nothing rather than propagating`() = runTest {
+        coEvery { cardanoApi.getAddressAssets(ADDRESS) } throws IOException("offline")
+
+        assertTrue(finder.find(ADDRESS).isEmpty())
+    }
+
+    private companion object {
+        const val ADDRESS = "addr1test"
+
+        // MELD, named in the ticket as an asset the curated ten miss.
+        const val MELD_POLICY_ID = "6ac8ef33b510ec004fe11585f7c5a9f0c07f0c23428ab4f29c1d7d10"
+        const val MELD_ASSET_NAME_HEX = "4d454c44"
+        const val SNEK_ASSET_NAME_HEX = "534e454b"
+    }
+}


### PR DESCRIPTION
Closes #5824

## Problem

Cardano native-token support was complete on both ends **except discovery**. `CardanoHelper` has the full token signing path, balances and a curated ten-token catalog shipped — but `TokenRepository.getTokensWithBalance` falls through to an EVM-only `else` branch, so `Chain.Cardano` returned an empty list.

A holder of MELD, LENFI, INDY, NMKR, COPI, any NFT or any airdrop therefore saw nothing: the asset never appeared in the token list, contributed nothing to the portfolio total, and could not be sent. There was no workaround either — the paste-a-contract fallback is deliberately switched off for Cardano (`canAddCustomToken`) for exactly this reason.

iOS auto-adds the same asset after every balance refresh, so a mixed vault showed two different token lists for one address and only the iOS device could initiate the send.

## Fix

`CardanoTokenFinder` walks the address's native assets and maps each to a `Coin`, preferring the curated catalog entry when the asset id matches so the shipped ten keep their icon, casing (`iUSD`, not `IUSD`) and price provider. One arm in `getTokensWithBalance` wires it in.

<img src="https://i.imgur.com/jbc1pAB.png" width="320" />

*Cardano chain screen. SNEK is listed with 3,530 held — the sum of two separate UTxOs (2,647 + 883) at that address — and contributes to the $10.75 chain total.*

## Notes for review

**Discovery is deliberately not gated to the curated catalog**, unlike `RippleTokenFinder`. An XRPL trust line is opened by the holder, so an arbitrary one is not evidence of anything; a Cardano asset is minted by its policy and simply lands in the wallet, and the long tail is the entire point of the ticket. What the catalog gate bought on XRPL is bought here instead by contract-qualifying `Coin.id` for Cardano tokens, so an asset whose name decodes to `USDM` cannot take the real Mehen USDM's identity and have Room's REPLACE-on-conflict insert silently overwrite it.

**This also fixes TON and TRON, which is wider than the ticket title.** Qualifying `Coin.id` means `TokenValueEntity.tokenId` has to match it — and that was still qualifying only secured-asset and Ripple-issued rows, even though TON and TRON have been contract-qualified since `MIGRATION_42_43`. Their cached balance rows were collapsing onto the plain `ticker-chain` id and no longer resolving against their coin. `MIGRATION_43_44` rewrites existing Cardano rows and their dependent id references the same way `42_43` did for TON and TRON.

**No `GetChainTokensUseCase` arm**, despite the ticket asking for one. That use case calls `getRefreshTokens` *unconditionally* before its `when` block, and `getRefreshTokens` already routes through `getTokensWithBalance` — so the single arm reaches the chain screen. A second arm in the `when` would only double-fetch. The ticket assumed the SOL/SUI shape, where the finder is reachable only from the `when`.

**The `address_assets` walk is shared and coalesced behind a 5s TTL.** `AccountsRepository` fans a non-EVM chain's balances out with one concurrent `async` per coin, and each token balance read walks the whole asset list. Once discovery can add an arbitrary number of tokens (an NFT is one too), opening the chain screen would otherwise fire that many identical paginated POSTs at Koios at once and be rate-limited into spurious zeros. Five seconds sits far below Cardano's ~20s block time, so it cannot hide a settled balance change from a refresh.

**Decimals are taken at face value.** Koios sources `decimals` from the Cardano token registry and reports `0` for an asset the registry does not list, so the endpoint cannot distinguish "the registry says zero" from "unknown" — verified live against an unregistered asset, which returns `"decimals": 0` with a null `token_registry_metadata`. Refusing every `0` would drop NFTs, which genuinely have none and which the ticket wants surfaced. iOS and the SDK both take the registry's word; if it later publishes a decimal, `TokenRefreshWorker.needsIdentityCorrection` rewrites the persisted row on the next refresh because the contract address still matches.

**Ticker derivation keeps only printable ASCII.** A Cardano asset name is raw bytes: CIP-67 label prefixes are unprintable. This turns USDM's `0014df105553444d` into `USDM` — iOS masks each byte with `0x7F` first, which invents a `_` out of the `0xdf` checksum byte and is why it renders `_USDM`. An asset with no printable name falls back to a policy-id prefix, matching iOS and the SDK.

`canAddCustomToken`'s Cardano exclusion stays — its reason (no `SearchTokenUseCase` branch for a pasted asset id) is still true, and the ticket lists lifting it as out of scope.

## Out of scope, worth a follow-up

`address_info` — already fetched on every balance load — carries the full `asset_list` per UTxO inline. Discovery makes a second, separate paginated `address_assets` POST for data the app just received. Folding the two together would drop a round trip per chain-screen open, but `address_assets` is the purpose-built endpoint and is what iOS and the SDK both use, so it is left alone here.

## Test plan

- [x] `./gradlew assembleDebug` succeeds
- [x] `./gradlew :data:testDebugUnitTest` — 3655 tests, 0 failures
- [x] `./gradlew :app:testDebugUnitTest` — 2479 tests, 0 failures
- [x] `./gradlew ktfmtCheck` clean
- [x] New coverage: `CardanoTokenFinderTest` (11), `CardanoApiAddressAssetsTest` (5), `TokenValueEntityTest` (10), `CoinIdTest` (9), `Migration43To44Test` (2), `TokenRepositoryImplTest` (12) — a held non-curated asset surfaces, a curated asset keeps its catalog identity, an address with no native tokens yields an empty list, and the migration leaves native ADA rows untouched
- [x] **On device:** vault imported fresh onto a clean install; opening the Cardano screen auto-added the held native token without the Tokens picker ever being opened. On `main` the same import shows bare ADA
- [x] **On device:** the curated entry keeps its bundled icon, its `SNEK` casing and a live fiat price, and the balance is summed correctly across both UTxOs holding it
- [x] **On device:** upgrade over an existing install (no uninstall) — the migration preserves the token row and its balance


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Cardano token discovery across paginated wallet asset data.
  - Added support for token decimals and improved handling of duplicate or dynamically identified assets.
  - Improved token identity handling for Cardano, TON, and TRON assets to prevent collisions.

- **Bug Fixes**
  - Migrated existing Cardano token records and references to their corrected identities.
  - Preserved native ADA identification while separating similarly named custom tokens.

- **Tests**
  - Added coverage for pagination, caching, token discovery, identity handling, migration behavior, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->