### PR TITLE
build: fix :data's stale Compose and dependency declaration hygiene

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,14 +49,6 @@ android {
         }
         jniLibs { keepDebugSymbols += "**/*.so" }
     }
-    tasks.withType<Test> {
-        useJUnitPlatform()
-        // Amount and APY rendering follows the user's locale, so assertions on formatted strings
-        // are only stable once the JVM the tests run on has one. Tests that care about another
-        // locale set it themselves.
-        systemProperty("user.language", "en")
-        systemProperty("user.country", "US")
-    }
     lint {
         abortOnError = true
         absolutePaths = false
@@ -65,6 +57,15 @@ android {
 }
 
 kotlin { jvmToolchain(21) }
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+    // Amount and APY rendering follows the user's locale, so assertions on formatted strings are
+    // only stable once the JVM the tests run on has one. Tests that care about another locale set
+    // it themselves.
+    systemProperty("user.language", "en")
+    systemProperty("user.country", "US")
+}
 
 dependencies {
     implementation(project(":data"))
@@ -158,6 +159,8 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.androidx.work.testing)
+    testImplementation(kotlin("test-junit5"))
+    testRuntimeOnly(libs.junit.platform.launcher)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
@@ -168,5 +171,4 @@ dependencies {
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.wallet.core)
     androidTestImplementation(libs.ktor.client.mock)
-    testImplementation(kotlin("test"))
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ tasks.withType<Test> {
 dependencies {
     implementation(project(":data"))
 
+    implementation(files("libs/mobile-tss-lib.aar"))
     implementation(files("libs/dkls-release.aar"))
     implementation(files("libs/goschnorr-release.aar"))
     implementation(files("libs/dilithium-release.aar"))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,6 @@ tasks.withType<Test> {
 dependencies {
     implementation(project(":data"))
 
-    implementation(files("libs/mobile-tss-lib.aar"))
     implementation(files("libs/dkls-release.aar"))
     implementation(files("libs/goschnorr-release.aar"))
     implementation(files("libs/dilithium-release.aar"))
@@ -106,8 +105,6 @@ dependencies {
     androidTestImplementation(libs.androidx.test.core.ktx)
 
     // room
-    implementation(libs.androidx.room.runtime)
-    implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
 
     // camera
@@ -124,11 +121,8 @@ dependencies {
     kspAndroidTest(libs.hilt.android.compiler)
 
     // ktor
-    implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.okhttp)
     implementation(libs.ktor.client.logging)
-    implementation(libs.ktor.client.negotiation)
-    implementation(libs.ktor.client.serialization.kotlinx)
 
     // other
     implementation(libs.accompanist.permissions)
@@ -137,9 +131,6 @@ dependencies {
     implementation(libs.mlkit.barcode)
     implementation(platform(libs.okhttp.bom))
     implementation(libs.okhttp)
-    implementation(libs.timber)
-    implementation(libs.spark.core)
-    implementation(libs.wallet.core)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.coil)
     implementation(libs.coil.network.okhttp)
@@ -147,7 +138,6 @@ dependencies {
     implementation(libs.play.update)
     implementation(libs.play.review)
     implementation(libs.androidx.work.ktx)
-    implementation(libs.bcprov.jdk18on)
 
     // animation
     implementation(libs.lottie.compose)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -120,7 +120,9 @@ dependencies {
     api(libs.bcprov.jdk18on)
 
     // other
-    api(files("../app/libs/mobile-tss-lib.aar"))
+    // compileOnly because AGP rejects a direct local .aar dependency in a module that
+    // builds its own AAR. :app provides it at runtime; see #5793 for the real fix.
+    compileOnly(files("../app/libs/mobile-tss-lib.aar"))
     api(libs.timber)
     implementation(libs.spark.core)
     implementation(libs.apache.compress)
@@ -129,6 +131,11 @@ dependencies {
     implementation(libs.androidx.security)
 
     // test
+    // Not compileOnly: TssMessenger implements the gomobile `tss.Messenger` interface, so JUnit
+    // cannot even resolve a test class that names it unless the AAR's classes are on the test
+    // runtime classpath too. Only the interface is loaded — instantiating a native tss type still
+    // needs the gojni library and stays out of unit tests.
+    testImplementation(files("../app/libs/mobile-tss-lib.aar"))
     testImplementation(libs.ktor.client.mock)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -89,34 +89,39 @@ dependencies {
 
     // hilt di
     implementation(libs.hilt.android)
-    implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.hilt.common)
     ksp(libs.hilt.android.compiler)
     ksp(libs.hilt.compiler)
     implementation(libs.androidx.hilt.work)
 
+    // compose: @Immutable on two data models, and Color/toArgb in GenerateQrBitmap. No
+    // composables here, so the Compose compiler plugin is deliberately not applied.
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.compose.runtime)
+    implementation(libs.androidx.ui.graphics)
+
     // room
-    implementation(libs.androidx.room.runtime)
-    implementation(libs.androidx.room.ktx)
+    api(libs.androidx.room.runtime)
+    api(libs.androidx.room.ktx)
 
     // ktor
-    implementation(libs.ktor.client.core)
-    implementation(libs.ktor.client.negotiation)
-    implementation(libs.ktor.client.serialization.kotlinx)
+    api(libs.ktor.client.core)
+    api(libs.ktor.client.negotiation)
+    api(libs.ktor.client.serialization.kotlinx)
 
     // serialization
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.protobuf)
 
     // crypto
-    implementation(libs.wallet.core)
+    api(libs.wallet.core)
 
     // encryption
-    implementation(libs.bcprov.jdk18on)
+    api(libs.bcprov.jdk18on)
 
     // other
-    compileOnly(files("../app/libs/mobile-tss-lib.aar"))
-    implementation(libs.timber)
+    api(files("../app/libs/mobile-tss-lib.aar"))
+    api(libs.timber)
     implementation(libs.spark.core)
     implementation(libs.apache.compress)
     implementation(libs.apache.compress.xz)
@@ -124,11 +129,6 @@ dependencies {
     implementation(libs.androidx.security)
 
     // test
-    // Not compileOnly: TssMessenger implements the gomobile `tss.Messenger` interface, so JUnit
-    // cannot even resolve a test class that names it unless the AAR's classes are on the test
-    // runtime classpath too. Only the interface is loaded — instantiating a native tss type still
-    // needs the gojni library and stays out of unit tests.
-    testImplementation(files("../app/libs/mobile-tss-lib.aar"))
     testImplementation(libs.ktor.client.mock)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockk)
@@ -142,8 +142,8 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(kotlin("test-junit"))
     androidTestImplementation(libs.wallet.core)
-    // `testInstrumentationRunner` above names AndroidJUnitRunner, but nothing put it on the
-    // classpath, so every instrumented test in this module failed to start.
+    // The runner named by `testInstrumentationRunner` has to be on the androidTest classpath
+    // itself; nothing else puts it there.
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.kotlinx.coroutines.test)
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -43,7 +43,6 @@ android {
             excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
         }
     }
-    tasks.withType<Test> { useJUnitPlatform() }
     lint {
         abortOnError = true
         absolutePaths = false
@@ -53,6 +52,8 @@ android {
 }
 
 kotlin { jvmToolchain(21) }
+
+tasks.withType<Test> { useJUnitPlatform() }
 
 protobuf {
     protoc { artifact = "com.google.protobuf:protoc:3.23.4" }
@@ -114,7 +115,6 @@ dependencies {
     implementation(libs.bcprov.jdk18on)
 
     // other
-    implementation(libs.okhttp)
     compileOnly(files("../app/libs/mobile-tss-lib.aar"))
     implementation(libs.timber)
     implementation(libs.spark.core)
@@ -135,11 +135,12 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.androidx.work.testing)
-    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit5"))
+    testRuntimeOnly(libs.junit.platform.launcher)
 
     androidTestImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(kotlin("test"))
+    androidTestImplementation(kotlin("test-junit"))
     androidTestImplementation(libs.wallet.core)
     // `testInstrumentationRunner` above names AndroidJUnitRunner, but nothing put it on the
     // classpath, so every instrumented test in this module failed to start.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -95,6 +95,7 @@ kotlinx-serialization-protobuf = { module = "org.jetbrains.kotlinx:kotlinx-seria
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-compose-runtime = { group = "androidx.compose.runtime", name = "runtime" }
 androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", version.ref = "camera" }
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camera" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camera" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,8 @@ coreSplashscreen = "1.2.0"
 espresso = "3.6.1"
 datastorePreferences = "1.1.4"
 junitJupiter = "5.11.4"
+# Tracks junitJupiter: jupiter 5.N.x pairs with platform 1.N.x. Move both together.
+junitPlatform = "1.11.4"
 kotest = "5.9.1"
 mockk = "1.13.16"
 junit = "4.13.2"
@@ -77,6 +79,7 @@ hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", vers
 hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hilt" }
 hilt-common = { group = "androidx.hilt", name = "hilt-common", version.ref = "hilt" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesCore" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
Resolves #5793. All build-file only, and each claim was checked against resolved Gradle classpaths rather than inferred.

## What changes

**`:data` no longer compiles against Compose 1.0.1.** It declared no Compose at all — `androidx.compose.runtime.Immutable` (two models) and `Color`/`toArgb` (`GenerateQrBitmap`) were resolving through `hilt-navigation-compose`, a UI artifact the module references nowhere, which dragged in Compose 1.0.1 and navigation 2.5.1 while `:app` pins `composeBom 2026.05.01`. Dropped it and declared what is actually used through the same BOM.

| `:data` compile classpath | before | after |
|---|---|---|
| `compose.runtime` / `compose.ui` | **1.0.1** | **1.11.2** |
| `navigation-*` | 2.5.1 | *gone* |

The `@Immutable` annotations are kept deliberately. `:data` does not apply the Compose compiler plugin, so `:app`'s compiler cannot infer stability for `:data` types — the annotation is the only thing making them skippable, and `DAppMetadata` goes straight into composables. (`activity`/`fragment` 1.5.1 remain on the classpath; those come from `hilt-android` itself and are unused by `:data`.)

**Pinned the `kotlin("test")` framework variant.** It picks its variant by inspecting the module's `Test` task rather than by declaration. If that inference ever falls back, `kotlin.test.Test` re-aliases to `org.junit.Test`, no vintage engine is present, and those classes vanish from the run: green build, zero tests executed, no warning. #5748 already cleaned up one round of exactly that. `:data` has 5 such files and `:app` 1; another 157 and 95 use `kotlin.test.*` assertions. Also declared `junit-platform-launcher` (transitive-only today, required by Gradle 9) and moved `tasks.withType<Test>` out of the `android { }` blocks, where it configures the project task container and reads as the Android DSL.

**`api` for the types `:data` actually exposes.** Room, Ktor, wallet-core, bcprov and Timber appear in `:data`'s public API but were `implementation`, so `:app` re-declared each — a version-drift seam per library. Promoted and duplicates deleted. `:app`'s `spark-core` went too: it has no `spark` import at all.

**Dropped `:data`'s unused okhttp** — zero `import okhttp3` in `data/src`; the only hits are prose in two comments.

## Verification

Unit test execution compared per-class against `main` on the same machine:

| | `main` | this branch |
|---|---|---|
| `:data` | 3634 tests / 361 classes / 41 skipped / 0 failures | **identical** |
| `:app` | 2477 tests / 220 classes / 8 skipped / 0 failures | **identical** |

No class appears, disappears, or changes count — including the 6 `kotlin.test.Test` classes the pinning protects.

**The shipped app is unchanged**: `:app:debugRuntimeClasspath` resolves to the same 325 modules as `main`, with no additions or removals, and the debug APK still ships `libgojni.so` and all the `tss/` classes.

Also green on the exact CI invocation (`./gradlew assembleDebug testDebugUnitTest --parallel --build-cache`), plus `lintDebug` and `ktfmtCheck` on both modules with baselines untouched.

## One thing reviewers should know

Removing OkHttp from `:data` is not classpath-neutral for that module — OkHttp had been silently lifting its transitives, so `kotlin-stdlib` goes 2.2.21 → 2.1.20 (the Kotlin plugin's own version), `okio` 3.17.0 → 3.4.0, `androidx.annotation` 1.10.0 → 1.9.1 and `startup-runtime` 1.2.0 → 1.1.1. Each lands back on what `:data`'s remaining declarations ask for, and the APK is unaffected since `:app` still declares OkHttp. Flagging it because "removing an unused dependency is free" turned out not to hold here.

## What this deliberately does not touch

The TSS AAR stays `compileOnly` in `:data`. Declaring it `api` so the runtime edge is real — the original suggestion in #5793 — is not achievable while the AAR is a loose file: AGP rejects a direct local `.aar` dependency in a module that builds its own AAR, and `:data:bundleDebugAar` fails outright. A real edge needs the AAR published as an artifact, which touches the TSS build pipeline and wants maintainer review, so it is out of scope here and has been withdrawn from the issue.

Three further findings in the original issue were verified as wrong and withdrawn rather than implemented: `androidx.work` and `androidTestImplementation(libs.junit)` are both genuinely used (9 and 5 files respectively, importing them directly), and `isReturnDefaultValues` would turn `Stub!` throws into silent defaults, masking the class of bug the issue exists to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTKS5KNKjVHbem4r5XaPye


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the automated testing setup to use JUnit 5 and the JUnit Platform.
  - Improved test support across Android modules for more consistent validation.

- **Maintenance**
  - Refined library configuration and module dependency exposure to improve build consistency and integration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->