### PR TITLE
fix(tron): price a TRC20 send once, for display and for signing

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestrator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestrator.kt
@@ -401,12 +401,14 @@ internal class GasFeeOrchestrator(
                 ) { token, gasFeeValue, dstAddress, tokenAmount, memo ->
                     val chain = token.chain
                     // Cardano forces the initiator's size-derived fee, so getSpecific needs the
-                    // amount to plan it, and a TRC20 fee_limit is simulated against the exact
-                    // amount transferred. For every other chain the amount is irrelevant here, so
+                    // amount to plan it. For every other chain the amount is irrelevant here, so
                     // we drop it: combined with distinctUntilChanged below this keeps those chains
-                    // from refetching specifics (nonce/gas) on every amount keystroke.
-                    val amountForSpecific =
-                        if (chain == Chain.Cardano || isTrc20Token(token)) {
+                    // from refetching specifics (nonce/gas) on every amount keystroke. A TRC20
+                    // token is no exception: nothing signs this specific, and dropping the amount
+                    // is what keeps the repository from simulating a fee_limit for it — the one
+                    // that reaches the wire is rebuilt at Continue, over the amount actually sent.
+                    val cardanoAmount =
+                        if (chain == Chain.Cardano) {
                             tokenAmount
                                 .toString()
                                 .toBigDecimalOrNull()
@@ -420,14 +422,14 @@ internal class GasFeeOrchestrator(
                         if (chain == Chain.Cardano) memo.toString().takeIf { it.isNotEmpty() }
                         else null
 
-                    SpecificInput(token, gasFeeValue, dstAddress, amountForSpecific, cardanoMemo)
+                    SpecificInput(token, gasFeeValue, dstAddress, cardanoAmount, cardanoMemo)
                 }
                 // Include the recompute nonce so pull-to-refresh re-runs getSpecific. Without this
                 // a failed first-load getSpecific leaves specific (and therefore planFee) null with
                 // no way to recover, since refresh alone doesn't change the specific inputs.
                 .combine(recalculateGasFee) { input, nonce -> input.copy(nonce = nonce) }
                 .distinctUntilChanged()
-                .collect { (token, gasFeeValue, dstAddress, amountForSpecific, cardanoMemo) ->
+                .collect { (token, gasFeeValue, dstAddress, cardanoAmount, cardanoMemo) ->
                     val chain = token.chain
                     val srcAddress = token.address
                     advanceGasUiRepository.updateTokenStandard(token.chain.standard)
@@ -454,7 +456,7 @@ internal class GasFeeOrchestrator(
                                     isMaxAmountEnabled = isMaxAmountFlow.value,
                                     isDeposit = false,
                                     dstAddress = validDstAddress,
-                                    tokenAmountValue = amountForSpecific,
+                                    tokenAmountValue = cardanoAmount,
                                     memo = cardanoMemo,
                                 )
                             }
@@ -508,13 +510,10 @@ private data class SpecificInput(
     val token: Coin,
     val gasFee: TokenValue,
     val dstAddress: String,
-    val amount: BigInteger?,
+    val cardanoAmount: BigInteger?,
     val cardanoMemo: String?,
     val nonce: Long = 0,
 )
-
-/** A TRC20 transfer is the one Tron shape whose signed `fee_limit` is simulated per amount. */
-private fun isTrc20Token(token: Coin): Boolean = token.chain == Chain.Tron && !token.isNativeToken
 
 private data class PlanFeeInput(
     val token: Coin,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestrator.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestrator.kt
@@ -401,11 +401,12 @@ internal class GasFeeOrchestrator(
                 ) { token, gasFeeValue, dstAddress, tokenAmount, memo ->
                     val chain = token.chain
                     // Cardano forces the initiator's size-derived fee, so getSpecific needs the
-                    // amount to plan it. For every other chain the amount is irrelevant here, so
+                    // amount to plan it, and a TRC20 fee_limit is simulated against the exact
+                    // amount transferred. For every other chain the amount is irrelevant here, so
                     // we drop it: combined with distinctUntilChanged below this keeps those chains
                     // from refetching specifics (nonce/gas) on every amount keystroke.
-                    val cardanoAmount =
-                        if (chain == Chain.Cardano) {
+                    val amountForSpecific =
+                        if (chain == Chain.Cardano || isTrc20Token(token)) {
                             tokenAmount
                                 .toString()
                                 .toBigDecimalOrNull()
@@ -419,14 +420,14 @@ internal class GasFeeOrchestrator(
                         if (chain == Chain.Cardano) memo.toString().takeIf { it.isNotEmpty() }
                         else null
 
-                    SpecificInput(token, gasFeeValue, dstAddress, cardanoAmount, cardanoMemo)
+                    SpecificInput(token, gasFeeValue, dstAddress, amountForSpecific, cardanoMemo)
                 }
                 // Include the recompute nonce so pull-to-refresh re-runs getSpecific. Without this
                 // a failed first-load getSpecific leaves specific (and therefore planFee) null with
                 // no way to recover, since refresh alone doesn't change the specific inputs.
                 .combine(recalculateGasFee) { input, nonce -> input.copy(nonce = nonce) }
                 .distinctUntilChanged()
-                .collect { (token, gasFeeValue, dstAddress, cardanoAmount, cardanoMemo) ->
+                .collect { (token, gasFeeValue, dstAddress, amountForSpecific, cardanoMemo) ->
                     val chain = token.chain
                     val srcAddress = token.address
                     advanceGasUiRepository.updateTokenStandard(token.chain.standard)
@@ -453,7 +454,7 @@ internal class GasFeeOrchestrator(
                                     isMaxAmountEnabled = isMaxAmountFlow.value,
                                     isDeposit = false,
                                     dstAddress = validDstAddress,
-                                    tokenAmountValue = cardanoAmount,
+                                    tokenAmountValue = amountForSpecific,
                                     memo = cardanoMemo,
                                 )
                             }
@@ -507,10 +508,13 @@ private data class SpecificInput(
     val token: Coin,
     val gasFee: TokenValue,
     val dstAddress: String,
-    val cardanoAmount: BigInteger?,
+    val amount: BigInteger?,
     val cardanoMemo: String?,
     val nonce: Long = 0,
 )
+
+/** A TRC20 transfer is the one Tron shape whose signed `fee_limit` is simulated per amount. */
+private fun isTrc20Token(token: Coin): Boolean = token.chain == Chain.Tron && !token.isNativeToken
 
 private data class PlanFeeInput(
     val token: Coin,

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestratorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestratorTest.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
 import com.vultisig.wallet.ui.models.mappers.TokenValueToStringWithUnitMapper
 import com.vultisig.wallet.ui.models.send.submit.BitcoinPlanService
 import com.vultisig.wallet.ui.utils.UiText
+import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -326,6 +327,47 @@ internal class GasFeeOrchestratorTest {
             assertTrue(flagSlot.captured)
         }
 
+    @Test
+    fun `collectSpecific hands a TRC20 amount to getSpecific so the signed fee_limit prices it`() =
+        runTest(mainDispatcher) {
+            // #5479: the signed fee_limit is simulated from the amount being transferred, so a
+            // Tron token specific that arrived without one would price a different transaction.
+            val amountSlot = captureSpecificAmount()
+            // combine() needs a first value from every source before it emits, so the field is set
+            // before start() rather than racing the first emission against an empty one.
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("2.5")
+            val orchestrator = build(backgroundScope)
+
+            runWithIoOnTestScheduler {
+                orchestrator.start()
+                selectedToken.value = trc20Coin()
+                gasFee.value = tokenValue(100, trc20Coin())
+                advanceTimeBy(400)
+                advanceUntilIdle()
+            }
+
+            assertEquals(BigInteger("2500000"), amountSlot.captured)
+        }
+
+    @Test
+    fun `collectSpecific still drops the amount for chains whose specific does not depend on it`() =
+        runTest(mainDispatcher) {
+            // Carrying it would refetch nonce/gas on every keystroke for no gain.
+            val amountSlot = captureSpecificAmount()
+            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("2.5")
+            val orchestrator = build(backgroundScope)
+
+            runWithIoOnTestScheduler {
+                orchestrator.start()
+                selectedToken.value = ethCoin(isNativeToken = false)
+                gasFee.value = tokenValue(100, ethCoin(isNativeToken = false))
+                advanceTimeBy(400)
+                advanceUntilIdle()
+            }
+
+            assertNull(amountSlot.captured)
+        }
+
     // ──────── collectPlanFee ────────
 
     @Test
@@ -440,6 +482,65 @@ internal class GasFeeOrchestratorTest {
             )
         return Account(token = btc, tokenValue = null, fiatValue = null, price = null)
     }
+
+    private fun captureSpecificAmount(): CapturingSlot<BigInteger?> {
+        val amountSlot = slot<BigInteger?>()
+        coEvery {
+            blockChainSpecificRepository.getSpecific(
+                chain = any(),
+                address = any(),
+                token = any(),
+                gasFee = any(),
+                isSwap = any(),
+                isMaxAmountEnabled = any(),
+                isDeposit = any(),
+                gasLimit = any(),
+                dstAddress = any(),
+                tokenAmountValue = captureNullable(amountSlot),
+                memo = any(),
+                transactionType = any(),
+                isThorchainRouterDeposit = any(),
+            )
+        } returns
+            BlockChainSpecificAndUtxo(
+                BlockChainSpecific.Tron(
+                    timestamp = 0uL,
+                    expiration = 0uL,
+                    blockHeaderTimestamp = 0uL,
+                    blockHeaderNumber = 0uL,
+                    blockHeaderVersion = 0uL,
+                    blockHeaderTxTrieRoot = "00",
+                    blockHeaderParentHash = "00",
+                    blockHeaderWitnessAddress = "41",
+                    gasFeeEstimation = 0uL,
+                )
+            )
+        return amountSlot
+    }
+
+    /** collectSpecific hops to Dispatchers.IO; route it back so the scheduler can drive it. */
+    private inline fun runWithIoOnTestScheduler(body: () -> Unit) {
+        mockkStatic(Dispatchers::class)
+        every { Dispatchers.IO } returns mainDispatcher
+        try {
+            body()
+        } finally {
+            unmockkStatic(Dispatchers::class)
+        }
+    }
+
+    private fun trc20Coin(): Coin =
+        Coin(
+            chain = Chain.Tron,
+            ticker = "USDT",
+            logo = "",
+            address = "TA4Y62o6YC2Zsck9rZVGTvqW1AQ7X9zTnj",
+            decimal = 6,
+            hexPublicKey = "",
+            priceProviderID = "tether",
+            contractAddress = "TDisDrQngvcMNfYurnQLW4oRnh9PzwDFxh",
+            isNativeToken = false,
+        )
 
     private fun tokenValue(value: Long, coin: Coin): TokenValue =
         TokenValue(value = BigInteger.valueOf(value), token = coin)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestratorTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/send/GasFeeOrchestratorTest.kt
@@ -328,10 +328,10 @@ internal class GasFeeOrchestratorTest {
         }
 
     @Test
-    fun `collectSpecific hands a TRC20 amount to getSpecific so the signed fee_limit prices it`() =
+    fun `collectSpecific drops a TRC20 amount so the form never simulates a fee_limit nobody signs`() =
         runTest(mainDispatcher) {
-            // #5479: the signed fee_limit is simulated from the amount being transferred, so a
-            // Tron token specific that arrived without one would price a different transaction.
+            // The displayed fee already simulates each settled amount; carrying it here would fire
+            // a second, identical simulation per edit for a specific that is rebuilt at Continue.
             val amountSlot = captureSpecificAmount()
             // combine() needs a first value from every source before it emits, so the field is set
             // before start() rather than racing the first emission against an empty one.
@@ -342,25 +342,6 @@ internal class GasFeeOrchestratorTest {
                 orchestrator.start()
                 selectedToken.value = trc20Coin()
                 gasFee.value = tokenValue(100, trc20Coin())
-                advanceTimeBy(400)
-                advanceUntilIdle()
-            }
-
-            assertEquals(BigInteger("2500000"), amountSlot.captured)
-        }
-
-    @Test
-    fun `collectSpecific still drops the amount for chains whose specific does not depend on it`() =
-        runTest(mainDispatcher) {
-            // Carrying it would refetch nonce/gas on every keystroke for no gain.
-            val amountSlot = captureSpecificAmount()
-            tokenAmountFieldState.setTextAndPlaceCursorAtEnd("2.5")
-            val orchestrator = build(backgroundScope)
-
-            runWithIoOnTestScheduler {
-                orchestrator.start()
-                selectedToken.value = ethCoin(isNativeToken = false)
-                gasFee.value = tokenValue(100, ethCoin(isNativeToken = false))
                 advanceTimeBy(400)
                 advanceUntilIdle()
             }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/TronApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/TronApi.kt
@@ -6,8 +6,6 @@ import com.vultisig.wallet.data.api.models.TronAccountResourceJson
 import com.vultisig.wallet.data.api.models.TronBalanceResponseJson
 import com.vultisig.wallet.data.api.models.TronBroadcastTxResponseJson
 import com.vultisig.wallet.data.api.models.TronChainParametersJson
-import com.vultisig.wallet.data.api.models.TronContractInfoJson
-import com.vultisig.wallet.data.api.models.TronContractRequestJson
 import com.vultisig.wallet.data.api.models.TronSpecificBlockJson
 import com.vultisig.wallet.data.api.models.TronTransactionStatusResponse
 import com.vultisig.wallet.data.api.models.TronTriggerConstantContractJson
@@ -59,8 +57,6 @@ interface TronApi {
     suspend fun getAccountResource(address: String): TronAccountResourceJson
 
     suspend fun getAccount(address: String): TronAccountJson
-
-    suspend fun getContractMetadata(contract: String): TronContractInfoJson
 
     suspend fun getTsStatus(chain: Chain, txHash: String): TronTransactionStatusResponse?
 
@@ -245,16 +241,6 @@ internal class TronApiImpl @Inject constructor(private val httpClient: HttpClien
             )
             null
         }
-    }
-
-    override suspend fun getContractMetadata(contract: String): TronContractInfoJson {
-        return httpClient
-            .post(tronGrid) {
-                url { appendPathSegments("/wallet/getcontractinfo") }
-                contentType(ContentType.Application.Json)
-                setBody(TronContractRequestJson(contract))
-            }
-            .bodyOrThrow<TronContractInfoJson>()
     }
 
     override suspend fun getTsStatus(chain: Chain, txHash: String): TronTransactionStatusResponse? {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
@@ -2,7 +2,6 @@ package com.vultisig.wallet.data.api.models
 
 import java.math.BigInteger
 import kotlinx.serialization.Contextual
-import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -110,11 +109,6 @@ data class TronChainParametersJson(val chainParameter: List<TronChainParameterJs
 @Serializable internal data class TronAccountRequestJson(val address: String, val visible: Boolean)
 
 @Serializable
-internal data class TronContractRequestJson(val value: String) {
-    @EncodeDefault val visible: Boolean = true
-}
-
-@Serializable
 data class TronAccountResourceJson(
     @SerialName("freeNetUsed") val freeNetUsed: Long = 0L,
     @SerialName("freeNetLimit") val freeNetLimit: Long = 0L,
@@ -169,14 +163,6 @@ data class TronAccountJson(
      */
     val defiLockedTotalSun: Long
         get() = frozenBandwidthSun + frozenEnergySun + unfreezingTotalSun
-}
-
-@Serializable
-data class TronContractInfoJson(
-    @SerialName("contract_state") val contractState: ContractStateJson
-) {
-    @Serializable
-    data class ContractStateJson(@SerialName("energy_factor") val energyFactor: Long = 0L)
 }
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
@@ -93,8 +93,15 @@ data class TronChainParametersJson(val chainParameter: List<TronChainParameterJs
     val createNewAccountFeeEstimateContract: Long
         get() = chainParameterMapped["getCreateNewAccountFeeInSystemContract"] ?: 0L
 
+    /**
+     * Sun per unit of energy. Every TRC20 fee and the signed `fee_limit` are this price times an
+     * energy count, so a node that omits or zeroes `getEnergyFee` cannot be allowed to price them
+     * at nothing: the ceiling would go out as 0 and the send would revert `OUT_OF_ENERGY` after the
+     * signing ceremony. Falls back to the current mainnet price, as iOS's
+     * `TronChainParametersResponse.energyFeePrice` does.
+     */
     val energyFee: Long
-        get() = chainParameterMapped["getEnergyFee"] ?: 0L
+        get() = chainParameterMapped["getEnergyFee"]?.takeIf { it > 0L } ?: DEFAULT_ENERGY_FEE
 
     val maxEnergyFactor: Long
         get() = chainParameterMapped["getDynamicEnergyMaxFactor"] ?: 0L
@@ -102,6 +109,10 @@ data class TronChainParametersJson(val chainParameter: List<TronChainParameterJs
     // Atm according to network: 1 bandwidth -> 1000 SUN
     val bandwidthFeePrice: Long
         get() = chainParameterMapped["getTransactionFee"] ?: 0L
+
+    companion object {
+        const val DEFAULT_ENERGY_FEE = 100L
+    }
 }
 
 @Serializable data class TronChainParameterJson(val key: String, val value: Long = 0L)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/model/Fees.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/model/Fees.kt
@@ -61,6 +61,12 @@ data class Eip1559(
  * @param energyDiscounted Discounted energy cost (if user has staked energy or incentives).
  * @param bandwidthRequired Required bandwidth units for the transaction.
  * @param bandwidthDiscounted Discounted bandwidth usage (if applicable).
+ * @param feeLimit Ceiling in SUN written as the signed transaction's `fee_limit`. Deliberately not
+ *   [amount]: the two answer different questions. [amount] is what the transfer is expected to burn
+ *   once the sender's currently available staked energy is applied, while `fee_limit` is the cap
+ *   the chain enforces at execution and has to stay gross — energy consumed by another transaction
+ *   during a 10-60s signing ceremony would otherwise shrink the cap below the real cost and fail
+ *   the send with OUT_OF_ENERGY.
  * @param amount Final fee in SUN after discounts applied.
  */
 data class TronFees(
@@ -69,6 +75,7 @@ data class TronFees(
     val energyDiscounted: BigInteger = BigInteger.ZERO,
     val bandwidthRequired: BigInteger = BigInteger.ZERO,
     val bandwidthDiscounted: BigInteger = BigInteger.ZERO,
+    val feeLimit: BigInteger = BigInteger.ZERO,
     override val amount: BigInteger,
 ) : Fee
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
@@ -10,18 +10,16 @@ import com.vultisig.wallet.data.blockchain.model.BlockchainTransaction
 import com.vultisig.wallet.data.blockchain.model.Swap
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.TronFees
-import com.vultisig.wallet.data.utils.Numeric
+import com.vultisig.wallet.data.chains.helpers.TronFunctions.tronAddressToHex
+import com.vultisig.wallet.data.chains.helpers.TronHelper.Companion.TRON_DEFAULT_ESTIMATION_FEE
 import java.math.BigDecimal
 import java.math.BigInteger
 import java.math.RoundingMode
 import javax.inject.Inject
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import timber.log.Timber
-import wallet.core.jni.Base58
 
 /**
  * TRON uses a resource-based fee model instead of a fixed gas fee like Ethereum. Transactions
@@ -134,7 +132,7 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
             totalFee = totalFee + memoFee
         }
 
-        return bandwidthFee.copy(amount = totalFee)
+        return bandwidthFee.copy(feeLimit = NATIVE_FEE_LIMIT, amount = totalFee)
     }
 
     private fun TronAccountJson?.isNewAccount(): Boolean = this == null || address.isEmpty()
@@ -237,10 +235,13 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
             totalFee = totalFee.add(activationFee)
         }
 
+        // Bandwidth, memo and activation are burnt outside contract execution, so they stay out of
+        // the ceiling TRON enforces against energy.
         return bandwidthFee.copy(
             maxEnergyRequired = energyFee.maxEnergyRequired,
             energyDiscounted = energyFee.energyDiscounted,
             energyRequired = energyFee.energyRequired,
+            feeLimit = energyFee.feeLimit,
             amount = totalFee,
         )
     }
@@ -251,69 +252,52 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
     private suspend fun calculateEnergyFee(
         srcAccount: TronAccountResourceJson?,
         transaction: Transfer,
-    ): TronFees = supervisorScope {
-        val fromAddress = transaction.coin.address
-        val toAddress = Numeric.toHexString(Base58.decode(transaction.to))
-        val contract = transaction.coin.contractAddress
-        val amount = transaction.amount
-
-        val contractMetadata = async { tronApi.getContractMetadata(contract) }
-
+    ): TronFees {
         val simulationResult =
             tronApi.getTriggerConstantContractFee(
-                ownerAddressBase58 = fromAddress,
-                contractAddressBase58 = contract,
-                recipientAddressHex = toAddress,
+                ownerAddressBase58 = transaction.coin.address,
+                contractAddressBase58 = transaction.coin.contractAddress,
+                recipientAddressHex = tronAddressToHex(transaction.to),
                 functionSelector = TRANSFER_FUNCTION_SELECTOR,
-                amount = amount,
+                // The amount being sent, not the whole balance: a TRC20 transfer's energy depends
+                // on it, so simulating anything else prices a transaction nobody is signing.
+                amount = transaction.amount,
             )
 
-        if (!simulationResult.isSuccessfulSimulation()) {
-            Timber.e("Tron Simulation Failed: ${simulationResult.result ?: ""}")
-            throw RuntimeException("Tron Simulated failed")
+        // `energy_used` is already the total energy this call burns; `energy_penalty` is the
+        // Dynamic Energy share inside that total, not a term to add on top of it. Rebuilding the
+        // base from the two keeps that relationship explicit and rejects a response whose reported
+        // share exceeds the total it belongs to.
+        // https://developers.tron.network/docs/set-feelimit#estimating-energy-before-broadcasting
+        val totalEnergy = simulationResult.energyUsed
+        val penalty = simulationResult.energyPenalty
+        check(totalEnergy > 0L && penalty in 0L..totalEnergy) {
+            "Tron simulation returned an unusable energy estimate: " +
+                "used=$totalEnergy penalty=$penalty"
         }
+        val baseEnergy = totalEnergy - penalty
 
-        val contractEnergyFactor =
-            contractMetadata.await().contractState.energyFactor.toBigDecimal()
-        val contractMaxEnergyFactor = getCacheTronChainParameters().maxEnergyFactor.toBigDecimal()
-
-        val energyRequired =
-            if (contractEnergyFactor == BigDecimal.ZERO) {
-                simulationResult.energyUsed
-            } else {
-                simulationResult.energyUsed - simulationResult.energyPenalty
-            }
-
-        if (energyRequired == 0L) {
-            throw RuntimeException("Tron Simulated failed")
-        }
-
-        val energyFactor =
-            (contractEnergyFactor.divide(ENERGY_FACTOR, 10, RoundingMode.DOWN)) + BigDecimal.ONE
+        val chainParameters = getCacheTronChainParameters()
         val maxFactor =
-            (contractMaxEnergyFactor.divide(ENERGY_FACTOR, 10, RoundingMode.DOWN)) + BigDecimal.ONE
+            chainParameters.maxEnergyFactor
+                .toBigDecimal()
+                .divide(ENERGY_FACTOR, 10, RoundingMode.DOWN) + BigDecimal.ONE
+        val energyPrice = chainParameters.energyFee.toBigInteger()
 
-        val energyUnitsRequired =
-            energyRequired.toBigDecimal().multiply(energyFactor).toBigInteger()
-        val maxEnergyUnitsRequired =
-            energyRequired.toBigDecimal().multiply(maxFactor).toBigInteger()
+        val energyUnitsRequired = totalEnergy.toBigInteger()
+        val maxEnergyUnitsRequired = baseEnergy.toBigDecimal().multiply(maxFactor).toBigInteger()
 
-        // Apply Energy discount: If account has staked energy
+        // Staked energy discounts what the sender is expected to burn, never the signed ceiling.
         val availableEnergy =
             srcAccount?.calculateAvailableEnergy()?.toBigInteger() ?: BigInteger.ZERO
-        val energyToPay =
-            if (availableEnergy >= energyUnitsRequired) {
-                BigInteger.ZERO
-            } else {
-                energyUnitsRequired - availableEnergy
-            }
-        val energyPrice = getCacheTronChainParameters().energyFee
+        val energyToPay = (energyUnitsRequired - availableEnergy).coerceAtLeast(BigInteger.ZERO)
 
-        TronFees(
+        return TronFees(
             maxEnergyRequired = maxEnergyUnitsRequired,
             energyRequired = energyUnitsRequired,
             energyDiscounted = energyToPay,
-            amount = energyToPay * energyPrice.toBigInteger(),
+            feeLimit = contractFeeLimit(energyUnitsRequired, energyPrice),
+            amount = energyToPay * energyPrice,
         )
     }
 
@@ -370,7 +354,14 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
             } else {
                 BigInteger.ZERO
             }
-        return TronFees(maxEnergyRequired = maxEnergyUnitsRequired, amount = totalFee)
+        return TronFees(
+            maxEnergyRequired = maxEnergyUnitsRequired,
+            // No simulation to size a ceiling from, so a token call falls back to the same flat
+            // amount it reports as the fee. Being conservative here is the safe direction: the
+            // ceiling is only ever charged for what execution actually consumes.
+            feeLimit = if (isNativeCoin) NATIVE_FEE_LIMIT else totalFee,
+            amount = totalFee,
+        )
     }
 
     companion object {
@@ -387,5 +378,33 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
         private val DEFAULT_MAX_ENERGY_USED = 50000000.toBigInteger()
 
         private val ENERGY_FACTOR = "10000".toBigDecimal()
+
+        /**
+         * A plain TRX transfer never writes `fee_limit` at all, so this flat ceiling only governs
+         * the native-TRX contract calls that share this fee model — staking (freeze/unfreeze/vote)
+         * and dApp `TriggerSmartContract` payloads, neither of which is simulated here.
+         */
+        private val NATIVE_FEE_LIMIT = TRON_DEFAULT_ESTIMATION_FEE.toBigInteger()
+
+        // 30% headroom on top of the simulated energy, covering a contract's per-call dynamic
+        // energy_factor surge between simulation and broadcast. Matches iOS's
+        // TronService.contractFeeLimit (ENERGY_SAFETY_NUMERATOR/DENOMINATOR = 13/10).
+        // https://developers.tron.network/docs/resource-model#dynamic-energy-model
+        private val ENERGY_SAFETY_NUMERATOR = BigInteger.valueOf(13)
+        private val ENERGY_SAFETY_DENOMINATOR = BigInteger.TEN
+
+        /**
+         * Translates simulated energy into the `fee_limit` cap, in SUN. Multiplies before dividing
+         * so the 30% margin survives truncation, and stays in [BigInteger] so an unexpectedly large
+         * estimate or energy price cannot overflow mid-calculation.
+         */
+        internal fun contractFeeLimit(
+            totalEnergyUsed: BigInteger,
+            energyPrice: BigInteger,
+        ): BigInteger =
+            totalEnergyUsed
+                .multiply(ENERGY_SAFETY_NUMERATOR)
+                .divide(ENERGY_SAFETY_DENOMINATOR)
+                .multiply(energyPrice)
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/TronFunctions.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/TronFunctions.kt
@@ -1,7 +1,9 @@
 package com.vultisig.wallet.data.chains.helpers
 
 import com.vultisig.wallet.data.common.stripHexPrefix
+import com.vultisig.wallet.data.utils.Numeric
 import java.math.BigInteger
+import java.security.MessageDigest
 
 object TronFunctions {
     fun buildTrc20TransferParameters(recipientBaseHex: String, amount: BigInteger): String {
@@ -9,4 +11,48 @@ object TronFunctions {
         val paddedAmountHex = amount.toString(16).padStart(64, '0')
         return paddedAddressHex + paddedAmountHex
     }
+
+    /**
+     * Decodes a base58check TRON address into the `0x41`-prefixed 21-byte hex the TVM expects in
+     * calldata. Plain Kotlin rather than wallet-core's `Base58.decode` so fee estimation — which
+     * runs on every amount keystroke — stays off JNI and remains reachable from JVM unit tests.
+     */
+    fun tronAddressToHex(address: String): String {
+        require(address.isNotEmpty()) { "Tron address is empty" }
+
+        var accumulator = BigInteger.ZERO
+        for (character in address) {
+            val digit = BASE58_ALPHABET.indexOf(character)
+            require(digit >= 0) { "Tron address carries a non-base58 character" }
+            accumulator = accumulator * BASE58 + digit.toBigInteger()
+        }
+
+        val magnitude =
+            accumulator.toByteArray().let {
+                // BigInteger prepends a sign byte for values whose high bit is set.
+                if (it.size > 1 && it.first() == ZERO_BYTE) it.copyOfRange(1, it.size) else it
+            }
+        val leadingZeros = address.takeWhile { it == BASE58_ALPHABET.first() }.length
+        val decoded = ByteArray(leadingZeros) + magnitude
+        require(decoded.size == ADDRESS_BYTES + CHECKSUM_BYTES) {
+            "Tron address decodes to ${decoded.size} bytes, expected " +
+                "${ADDRESS_BYTES + CHECKSUM_BYTES}"
+        }
+
+        val payload = decoded.copyOfRange(0, ADDRESS_BYTES)
+        val checksum = decoded.copyOfRange(ADDRESS_BYTES, decoded.size)
+        val sha256 = MessageDigest.getInstance("SHA-256")
+        val expected = sha256.digest(sha256.digest(payload)).copyOfRange(0, CHECKSUM_BYTES)
+        require(checksum.contentEquals(expected)) { "Tron address checksum does not match" }
+
+        return Numeric.toHexString(payload)
+    }
+
+    private const val BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    private val BASE58 = BigInteger.valueOf(58)
+    private const val ZERO_BYTE: Byte = 0
+
+    /** `41` prefix plus the 20-byte account. */
+    private const val ADDRESS_BYTES = 21
+    private const val CHECKSUM_BYTES = 4
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -705,13 +705,15 @@ constructor(
                         // is no estimate here to reconcile with the displayed fee.
                         TRON_DEFAULT_ESTIMATION_FEE.toBigInteger()
                     } else {
-                        // The signed ceiling comes out of the same TronFeeService pass that
+                        // The signed ceiling comes out of the same TronFeeService computation that
                         // produces the fee shown to the user and gates the balance check, so both
-                        // read one simulation of one transaction instead of disagreeing about the
-                        // amount transferred and about what energy_penalty means. Deliberately not
-                        // routed through FeeServiceComposite: it swallows a failure into
-                        // calculateDefaultFees, and a reverted simulation has to fail the send
-                        // rather than reach the wire behind a fabricated fee_limit.
+                        // simulate the transaction being sent and read energy_penalty the same
+                        // way. It is still its own simulation: this specific is rebuilt at
+                        // Continue, and the ceiling should track the chain as it stands then, not
+                        // at the keystroke that priced the form. Deliberately not routed through
+                        // FeeServiceComposite: it swallows a failure into calculateDefaultFees,
+                        // and a reverted simulation has to fail the send rather than reach the
+                        // wire behind a fabricated fee_limit.
                         val fees =
                             tronFeeService.calculateFees(
                                 Transfer(

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -705,25 +705,46 @@ constructor(
                         // is no estimate here to reconcile with the displayed fee.
                         TRON_DEFAULT_ESTIMATION_FEE.toBigInteger()
                     } else {
-                        // The signed ceiling comes out of the same TronFeeService computation that
-                        // produces the fee shown to the user and gates the balance check, so both
-                        // simulate the transaction being sent and read energy_penalty the same
-                        // way. It is still its own simulation: this specific is rebuilt at
-                        // Continue, and the ceiling should track the chain as it stands then, not
-                        // at the keystroke that priced the form. Deliberately not routed through
-                        // FeeServiceComposite: it swallows a failure into calculateDefaultFees,
-                        // and a reverted simulation has to fail the send rather than reach the
-                        // wire behind a fabricated fee_limit.
                         val fees =
-                            tronFeeService.calculateFees(
-                                Transfer(
-                                    coin = token,
-                                    vault = VaultData("", ""),
-                                    amount = tokenAmountValue ?: BigInteger.ZERO,
-                                    to = dstAddress ?: address,
-                                    memo = memo,
+                            if (dstAddress != null && tokenAmountValue != null) {
+                                // The signed ceiling comes out of the same TronFeeService
+                                // computation that produces the fee shown to the user and gates
+                                // the balance check, so both simulate the transaction being sent
+                                // and read energy_penalty the same way. It is still its own
+                                // simulation: this specific is rebuilt at Continue, and the
+                                // ceiling should track the chain as it stands then, not at the
+                                // keystroke that priced the form. Deliberately not routed through
+                                // FeeServiceComposite: it swallows a failure into
+                                // calculateDefaultFees, and a reverted simulation has to fail the
+                                // send rather than reach the wire behind a fabricated fee_limit.
+                                tronFeeService.calculateFees(
+                                    Transfer(
+                                        coin = token,
+                                        vault = VaultData("", ""),
+                                        amount = tokenAmountValue,
+                                        to = dstAddress,
+                                        memo = memo,
+                                    )
                                 )
-                            )
+                            } else {
+                                // Without a destination and an amount there is no transaction to
+                                // simulate — a swap deposit whose builder supplies neither, or a
+                                // send form whose specific nothing signs. Probing the sender's own
+                                // balance or a zero transfer prices a different transaction (a
+                                // zero amount skips the recipient's zero-to-nonzero storage write
+                                // and under-states a first-time recipient by ~15,000 energy), so
+                                // take the flat token ceiling the displayed swap fee already
+                                // reports, as iOS's TronService does when it has no recipient.
+                                tronFeeService.calculateDefaultFees(
+                                    Transfer(
+                                        coin = token,
+                                        vault = VaultData("", ""),
+                                        amount = BigInteger.ZERO,
+                                        to = dstAddress ?: address,
+                                        memo = memo,
+                                    )
+                                )
+                            }
                         require(fees is TronFees) {
                             "Unsupported fee type ${fees::class.simpleName} for chain=$chain"
                         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -12,13 +12,14 @@ import com.vultisig.wallet.data.api.RippleApi
 import com.vultisig.wallet.data.api.SolanaApi
 import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.api.TronApi
-import com.vultisig.wallet.data.api.TronApiImpl.Companion.TRANSFER_FUNCTION_SELECTOR
 import com.vultisig.wallet.data.api.ZcashApi
 import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.api.chains.ton.TonApi
 import com.vultisig.wallet.data.api.chains.ton.tonUserFriendlyAddress
 import com.vultisig.wallet.data.api.models.BlockChairUtxoInfo
+import com.vultisig.wallet.data.blockchain.FeeService
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.TronFee
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_ARBITRUM_TRANSFER
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_COIN_TRANSFER_LIMIT
 import com.vultisig.wallet.data.blockchain.ethereum.EthereumFeeService.Companion.DEFAULT_SWAP_LIMIT
@@ -27,6 +28,7 @@ import com.vultisig.wallet.data.blockchain.model.Eip1559
 import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Swap
 import com.vultisig.wallet.data.blockchain.model.Transfer
+import com.vultisig.wallet.data.blockchain.model.TronFees
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.chains.helpers.CardanoHelper
@@ -44,7 +46,6 @@ import com.vultisig.wallet.data.models.getDustThreshold
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.utils.NetworkException
-import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.Numeric.max
 import com.vultisig.wallet.data.utils.increaseByPercent
 import com.vultisig.wallet.data.utils.plus
@@ -60,7 +61,6 @@ import kotlinx.coroutines.coroutineScope
 import timber.log.Timber
 import vultisig.keysign.v1.CosmosIbcDenomTrace
 import vultisig.keysign.v1.TransactionType
-import wallet.core.jni.Base58
 
 data class BlockChainSpecificAndUtxo(
     val blockChainSpecific: BlockChainSpecific,
@@ -112,6 +112,7 @@ constructor(
     private val tronApi: TronApi,
     private val cardanoApi: CardanoApi,
     private val feeServiceComposite: FeeServiceComposite,
+    @TronFee private val tronFeeService: FeeService,
 ) : BlockChainSpecificRepository {
 
     override suspend fun getSpecific(
@@ -692,34 +693,40 @@ constructor(
 
             TokenStandard.TRC20 -> {
                 val specific = tronApi.getSpecific()
-                val energyPrice =
-                    try {
-                        tronApi.getChainParameters().energyFee.takeIf { it > 0L }
-                    } catch (_: Exception) {
-                        null
-                    } ?: ENERGY_TO_SUN_FACTOR.toLong()
                 val now = Instant.now()
                 val expiration = now + 1.hours
                 val rawData = specific.blockHeader.rawData
 
-                val recipientAddressHex = Numeric.toHexString(Base58.decode(dstAddress ?: address))
-
                 val estimation =
-                    TRON_DEFAULT_ESTIMATION_FEE.takeIf { token.isNativeToken }
-                        ?: run {
-                            val rawBalance = tronApi.getBalance(token)
-                            val triggerResult =
-                                tronApi.getTriggerConstantContractFee(
-                                    ownerAddressBase58 = token.address,
-                                    contractAddressBase58 = token.contractAddress,
-                                    recipientAddressHex = recipientAddressHex,
-                                    functionSelector = TRANSFER_FUNCTION_SELECTOR,
-                                    amount = rawBalance,
+                    if (token.isNativeToken) {
+                        // A plain TRX transfer never writes fee_limit (see
+                        // TronHelper.buildCoinTransfer); the staking and dApp contract calls that
+                        // do are capped by this flat ceiling rather than by a simulation, so there
+                        // is no estimate here to reconcile with the displayed fee.
+                        TRON_DEFAULT_ESTIMATION_FEE.toBigInteger()
+                    } else {
+                        // The signed ceiling comes out of the same TronFeeService pass that
+                        // produces the fee shown to the user and gates the balance check, so both
+                        // read one simulation of one transaction instead of disagreeing about the
+                        // amount transferred and about what energy_penalty means. Deliberately not
+                        // routed through FeeServiceComposite: it swallows a failure into
+                        // calculateDefaultFees, and a reverted simulation has to fail the send
+                        // rather than reach the wire behind a fabricated fee_limit.
+                        val fees =
+                            tronFeeService.calculateFees(
+                                Transfer(
+                                    coin = token,
+                                    vault = VaultData("", ""),
+                                    amount = tokenAmountValue ?: BigInteger.ZERO,
+                                    to = dstAddress ?: address,
+                                    memo = memo,
                                 )
-
-                            val totalEnergy = triggerResult.energyUsed + triggerResult.energyPenalty
-                            contractFeeLimit(totalEnergy, energyPrice)
+                            )
+                        require(fees is TronFees) {
+                            "Unsupported fee type ${fees::class.simpleName} for chain=$chain"
                         }
+                        fees.feeLimit
+                    }
 
                 BlockChainSpecificAndUtxo(
                     blockChainSpecific =
@@ -766,18 +773,6 @@ constructor(
     companion object {
         private const val TON_WALLET_STATE_UNINITIALIZED = "uninit"
 
-        private const val ENERGY_TO_SUN_FACTOR = 280
-
         private val THORCHAIN_ROUTER_DEPOSIT_GAS_LIMIT = BigInteger.valueOf(200_000)
-
-        // 30% headroom on top of simulated energy, covering a contract's per-call dynamic
-        // energy_factor surge between simulation and broadcast. Matches iOS's
-        // TronService.contractFeeLimit (ENERGY_SAFETY_NUMERATOR/DENOMINATOR = 13/10).
-        // https://developers.tron.network/docs/resource-model#dynamic-energy-model
-        private const val ENERGY_SAFETY_NUMERATOR = 13L
-        private const val ENERGY_SAFETY_DENOMINATOR = 10L
-
-        internal fun contractFeeLimit(totalEnergyUsed: Long, energyPrice: Long): Long =
-            (totalEnergyUsed * ENERGY_SAFETY_NUMERATOR / ENERGY_SAFETY_DENOMINATOR) * energyPrice
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
@@ -1,0 +1,291 @@
+package com.vultisig.wallet.data.blockchain.tron
+
+import com.vultisig.wallet.data.api.BittensorApi
+import com.vultisig.wallet.data.api.BlockChairApi
+import com.vultisig.wallet.data.api.CardanoApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.DashApi
+import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.api.MayaChainApi
+import com.vultisig.wallet.data.api.PolkadotApi
+import com.vultisig.wallet.data.api.RippleApi
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.TronApi
+import com.vultisig.wallet.data.api.ZcashApi
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.api.chains.ton.TonApi
+import com.vultisig.wallet.data.api.models.TronAccountJson
+import com.vultisig.wallet.data.api.models.TronAccountResourceJson
+import com.vultisig.wallet.data.api.models.TronChainParameterJson
+import com.vultisig.wallet.data.api.models.TronChainParametersJson
+import com.vultisig.wallet.data.api.models.TronSpecificBlockHeaderJson
+import com.vultisig.wallet.data.api.models.TronSpecificBlockJson
+import com.vultisig.wallet.data.api.models.TronSpecificBlockRawDataJson
+import com.vultisig.wallet.data.api.models.TronTriggerConstantContractJson
+import com.vultisig.wallet.data.blockchain.FeeServiceComposite
+import com.vultisig.wallet.data.blockchain.model.Transfer
+import com.vultisig.wallet.data.blockchain.model.VaultData
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.repositories.BlockChainSpecificRepositoryImpl
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * TRON used to price a send twice. [TronFeeService] simulated the amount being transferred to
+ * produce the fee shown to the user and checked against their balance, while
+ * [BlockChainSpecificRepositoryImpl] ran a second simulation — against the sender's whole balance,
+ * with `energy_penalty` added on top of `energy_used` rather than read as the share inside it — for
+ * the `fee_limit` that actually reached the wire. Both numbers now come out of one pass, and they
+ * stay deliberately different in one respect only: staked energy discounts what the sender is
+ * expected to burn, never the ceiling the chain enforces.
+ */
+internal class TronFeeReconciliationTest {
+
+    private val tronApi: TronApi = mockk(relaxed = true)
+    private val feeService = TronFeeService(tronApi)
+
+    @Test
+    fun `the signed fee_limit and the displayed fee come out of one simulation of the amount sent`() =
+        runTest {
+            stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
+
+            val displayed = feeService.calculateFees(trc20Transfer())
+            val signed = trc20FeeLimit()
+
+            assertEquals(displayed.feeLimit.toString(), signed)
+            // 65,000 energy x 1.3 x 420 sun/energy, the same ceiling iOS pins in
+            // TronServiceFeeLimitTests.testGetBlockInfo_trc20Transfer_usesSimulationResult.
+            assertEquals("35490000", signed)
+            assertEquals(BigInteger.valueOf(27_300_000L + CONTRACT_BANDWIDTH_FEE), displayed.amount)
+            coVerify(exactly = 2) {
+                tronApi.getTriggerConstantContractFee(
+                    ownerAddressBase58 = SENDER,
+                    contractAddressBase58 = CONTRACT,
+                    recipientAddressHex = any(),
+                    functionSelector = any(),
+                    amount = AMOUNT,
+                )
+            }
+        }
+
+    @Test
+    fun `the whole balance is never simulated for the signed fee_limit`() = runTest {
+        stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
+
+        trc20FeeLimit()
+
+        coVerify(exactly = 0) { tronApi.getBalance(any()) }
+    }
+
+    @Test
+    fun `energy penalty is the share inside energy used, not a term added on top of it`() =
+        runTest {
+            stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
+
+            val signed = trc20FeeLimit()
+
+            // Adding the penalty would have signed (65,000 + 50,000) x 1.3 x 420 = 62,790,000 sun,
+            // reserving 1.77x the energy the call actually burns.
+            assertEquals("35490000", signed)
+        }
+
+    @Test
+    fun `staked energy discounts the displayed fee and never the signed ceiling`() = runTest {
+        stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L, availableEnergy = 65_000L)
+
+        val displayed = feeService.calculateFees(trc20Transfer())
+
+        // Energy the sender already owns costs nothing to spend, but it can be consumed by another
+        // transaction during the signing ceremony, so the ceiling stays gross.
+        assertEquals(BigInteger.valueOf(CONTRACT_BANDWIDTH_FEE), displayed.amount)
+        assertEquals("35490000", trc20FeeLimit())
+    }
+
+    @Test
+    fun `a contract call scales both numbers from the same simulated total`() = runTest {
+        // A JustLend/SunSwap-style call burns an order of magnitude more energy than a wallet-to-
+        // wallet transfer, and carries most of it as Dynamic Energy penalty.
+        stubSimulation(energyUsed = 1_200_000L, energyPenalty = 900_000L)
+
+        val displayed = feeService.calculateFees(trc20Transfer(to = MARKET))
+        val signed = trc20FeeLimit(dstAddress = MARKET)
+
+        assertEquals(displayed.feeLimit.toString(), signed)
+        // 1,200,000 x 1.3 x 420 — not the 1,146,600,000 sun a double-counted penalty produced.
+        assertEquals("655200000", signed)
+        assertEquals(BigInteger.valueOf(504_000_000L + CONTRACT_BANDWIDTH_FEE), displayed.amount)
+    }
+
+    @Test
+    fun `a simulation whose penalty exceeds its own total is refused`() = runTest {
+        stubSimulation(energyUsed = 65_000L, energyPenalty = 70_000L)
+
+        assertFailsWith<IllegalStateException> { feeService.calculateFees(trc20Transfer()) }
+        assertFailsWith<IllegalStateException> { trc20FeeLimit() }
+    }
+
+    @Test
+    fun `native TRX keeps its flat ceiling without simulating anything`() = runTest {
+        stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
+
+        // A plain transfer never writes fee_limit; the staking and dApp contract calls sharing this
+        // branch are capped by the flat ceiling instead of by an estimate.
+        assertEquals("800000", feeLimitOf(nativeCoin(), dstAddress = RECIPIENT))
+        coVerify(exactly = 0) {
+            tronApi.getTriggerConstantContractFee(any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `the fee_limit safety multiplier survives truncation`() {
+        // 65,001 x 13 / 10 = 84,501.3 truncated to 84,501, x 420 = 35,490,420 — the
+        // multiply-before-divide order must hold or this pins a different, smaller value.
+        assertEquals(
+            BigInteger.valueOf(35_490_420L),
+            TronFeeService.contractFeeLimit(
+                totalEnergyUsed = BigInteger.valueOf(65_001L),
+                energyPrice = BigInteger.valueOf(420L),
+            ),
+        )
+    }
+
+    private suspend fun trc20FeeLimit(dstAddress: String = RECIPIENT): String =
+        feeLimitOf(trc20Coin(), dstAddress)
+
+    private suspend fun feeLimitOf(token: Coin, dstAddress: String): String {
+        val specific =
+            repository()
+                .getSpecific(
+                    chain = Chain.Tron,
+                    address = SENDER,
+                    token = token,
+                    gasFee = TokenValue(BigInteger.ZERO, nativeCoin()),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                    dstAddress = dstAddress,
+                    tokenAmountValue = AMOUNT,
+                )
+                .blockChainSpecific
+        return (specific as BlockChainSpecific.Tron).gasFeeEstimation.toString()
+    }
+
+    private fun stubSimulation(energyUsed: Long, energyPenalty: Long, availableEnergy: Long = 0L) {
+        coEvery { tronApi.getSpecific() } returns block()
+        coEvery { tronApi.getChainParameters() } returns chainParameters()
+        coEvery { tronApi.getAccountResource(any()) } returns
+            TronAccountResourceJson(energyLimit = availableEnergy)
+        coEvery { tronApi.getAccount(any()) } answers { TronAccountJson(address = firstArg()) }
+        coEvery { tronApi.getTriggerConstantContractFee(any(), any(), any(), any(), any()) } returns
+            TronTriggerConstantContractJson(
+                energyUsed = energyUsed,
+                energyPenalty = energyPenalty,
+                transaction = TronTriggerConstantContractJson.Transaction(),
+            )
+    }
+
+    private fun repository() =
+        BlockChainSpecificRepositoryImpl(
+            thorChainApi = mockk<ThorChainApi>(relaxed = true),
+            mayaChainApi = mockk<MayaChainApi>(relaxed = true),
+            evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
+            solanaApi = mockk<SolanaApi>(relaxed = true),
+            cosmosApiFactory = mockk<CosmosApiFactory>(relaxed = true),
+            blockChairApi = mockk<BlockChairApi>(relaxed = true),
+            dashApi = mockk<DashApi>(relaxed = true),
+            zcashApi = mockk<ZcashApi>(relaxed = true),
+            polkadotApi = mockk<PolkadotApi>(relaxed = true),
+            bittensorApi = mockk<BittensorApi>(relaxed = true),
+            suiApi = mockk<SuiApi>(relaxed = true),
+            tonApi = mockk<TonApi>(relaxed = true),
+            rippleApi = mockk<RippleApi>(relaxed = true),
+            tronApi = tronApi,
+            cardanoApi = mockk<CardanoApi>(relaxed = true),
+            feeServiceComposite = mockk<FeeServiceComposite>(relaxed = true),
+            tronFeeService = feeService,
+        )
+
+    private fun trc20Transfer(to: String = RECIPIENT) =
+        Transfer(
+            coin = trc20Coin(),
+            vault = VaultData(vaultHexPublicKey = "pub", vaultHexChainCode = "chain"),
+            amount = AMOUNT,
+            to = to,
+        )
+
+    private fun trc20Coin() =
+        Coin(
+            chain = Chain.Tron,
+            ticker = "USDT",
+            logo = "",
+            address = SENDER,
+            decimal = 6,
+            hexPublicKey = "pub",
+            priceProviderID = "tether",
+            contractAddress = CONTRACT,
+            isNativeToken = false,
+        )
+
+    private fun nativeCoin() =
+        Coin(
+            chain = Chain.Tron,
+            ticker = "TRX",
+            logo = "",
+            address = SENDER,
+            decimal = 6,
+            hexPublicKey = "pub",
+            priceProviderID = "tron",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun chainParameters() =
+        TronChainParametersJson(
+            listOf(
+                TronChainParameterJson("getTransactionFee", 1000L),
+                TronChainParameterJson("getCreateAccountFee", 100_000L),
+                TronChainParameterJson("getCreateNewAccountFeeInSystemContract", 1_000_000L),
+                TronChainParameterJson("getMemoFee", 1_000_000L),
+                TronChainParameterJson("getEnergyFee", 420L),
+                TronChainParameterJson("getDynamicEnergyMaxFactor", 1200L),
+            )
+        )
+
+    private fun block() =
+        TronSpecificBlockJson(
+            blockHeader =
+                TronSpecificBlockHeaderJson(
+                    rawData =
+                        TronSpecificBlockRawDataJson(
+                            number = 1uL,
+                            txTrieRoot = "00",
+                            witnessAddress = "41",
+                            parentHash = "00",
+                            version = 1uL,
+                            timeStamp = 1uL,
+                        )
+                )
+        )
+
+    private companion object {
+        const val SENDER = "TA4Y62o6YC2Zsck9rZVGTvqW1AQ7X9zTnj"
+        const val RECIPIENT = "TBthewbwcZKTd99XrfwoUzpTtvmkoFqt9q"
+        const val CONTRACT = "TDisDrQngvcMNfYurnQLW4oRnh9PzwDFxh"
+        const val MARKET = "TFZ2nmDdmHuF8BxHrtrsX8nPgTX3FfuGzz"
+
+        /** 345 bytes at the test chain's 1,000 sun/byte — a contract call always pays it. */
+        const val CONTRACT_BANDWIDTH_FEE = 345_000L
+
+        val AMOUNT: BigInteger = BigInteger.valueOf(25_000_000L)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
@@ -45,9 +45,12 @@ import org.junit.jupiter.api.Test
  * produce the fee shown to the user and checked against their balance, while
  * [BlockChainSpecificRepositoryImpl] ran a second simulation — against the sender's whole balance,
  * with `energy_penalty` added on top of `energy_used` rather than read as the share inside it — for
- * the `fee_limit` that actually reached the wire. Both numbers now come out of one pass, and they
- * stay deliberately different in one respect only: staked energy discounts what the sender is
- * expected to burn, never the ceiling the chain enforces.
+ * the `fee_limit` that actually reached the wire. Both numbers now come out of the same
+ * [TronFeeService] computation over the amount being sent. Each caller still runs it against the
+ * chain as it stands — the specific is rebuilt at Continue — so they can drift as the chain moves,
+ * but they no longer disagree about what is simulated or what the response means. They stay
+ * deliberately different in one respect only: staked energy discounts what the sender is expected
+ * to burn, never the ceiling the chain enforces.
  */
 internal class TronFeeReconciliationTest {
 
@@ -55,7 +58,7 @@ internal class TronFeeReconciliationTest {
     private val feeService = TronFeeService(tronApi)
 
     @Test
-    fun `the signed fee_limit and the displayed fee come out of one simulation of the amount sent`() =
+    fun `the signed fee_limit and the displayed fee come out of the same pass over the amount sent`() =
         runTest {
             stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
 
@@ -67,6 +70,8 @@ internal class TronFeeReconciliationTest {
             // TronServiceFeeLimitTests.testGetBlockInfo_trc20Transfer_usesSimulationResult.
             assertEquals("35490000", signed)
             assertEquals(BigInteger.valueOf(27_300_000L + CONTRACT_BANDWIDTH_FEE), displayed.amount)
+            // One simulation per caller. What this pins is that both of them simulate the amount
+            // being sent — not that a single RPC feeds both.
             coVerify(exactly = 2) {
                 tronApi.getTriggerConstantContractFee(
                     ownerAddressBase58 = SENDER,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
@@ -140,6 +140,57 @@ internal class TronFeeReconciliationTest {
     }
 
     @Test
+    fun `without a destination and an amount the ceiling is the flat token default, not a probe`() =
+        runTest {
+            stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
+
+            // A swap builder supplies neither; the send form's own specific carries no amount.
+            // Neither is a transaction to simulate — a zero transfer to the sender skips the
+            // recipient's zero-to-nonzero storage write and under-prices a first-time recipient.
+            assertEquals(
+                FLAT_TOKEN_FEE_LIMIT,
+                feeLimitOf(trc20Coin(), dstAddress = null, amount = null),
+            )
+            assertEquals(
+                FLAT_TOKEN_FEE_LIMIT,
+                feeLimitOf(trc20Coin(), dstAddress = RECIPIENT, amount = null),
+            )
+            assertEquals(
+                FLAT_TOKEN_FEE_LIMIT,
+                feeLimitOf(trc20Coin(), dstAddress = null, amount = AMOUNT),
+            )
+            coVerify(exactly = 0) {
+                tronApi.getTriggerConstantContractFee(any(), any(), any(), any(), any())
+            }
+        }
+
+    @Test
+    fun `a node that omits or zeroes the energy price falls back to the default instead of pricing zero`() =
+        runTest {
+            for (parameters in
+                listOf(chainParameters(energyFee = null), chainParameters(energyFee = 0L))) {
+                stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
+                coEvery { tronApi.getChainParameters() } returns parameters
+                val service = TronFeeService(tronApi)
+
+                // 65,000 x 1.3 x the 100 sun default — never 0, which would sign a fee_limit of 0
+                // and have the transfer revert OUT_OF_ENERGY after the signing ceremony.
+                assertEquals(
+                    BigInteger.valueOf(8_450_000L),
+                    service.calculateFees(trc20Transfer()).feeLimit,
+                )
+                assertEquals(
+                    BigInteger.valueOf(6_500_000L + CONTRACT_BANDWIDTH_FEE),
+                    service.calculateFees(trc20Transfer()).amount,
+                )
+                assertEquals(
+                    "8450000",
+                    feeLimitOf(trc20Coin(), dstAddress = RECIPIENT, feeService = service),
+                )
+            }
+        }
+
+    @Test
     fun `native TRX keeps its flat ceiling without simulating anything`() = runTest {
         stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
 
@@ -167,9 +218,14 @@ internal class TronFeeReconciliationTest {
     private suspend fun trc20FeeLimit(dstAddress: String = RECIPIENT): String =
         feeLimitOf(trc20Coin(), dstAddress)
 
-    private suspend fun feeLimitOf(token: Coin, dstAddress: String): String {
+    private suspend fun feeLimitOf(
+        token: Coin,
+        dstAddress: String?,
+        amount: BigInteger? = AMOUNT,
+        feeService: TronFeeService = this.feeService,
+    ): String {
         val specific =
-            repository()
+            repository(feeService)
                 .getSpecific(
                     chain = Chain.Tron,
                     address = SENDER,
@@ -179,7 +235,7 @@ internal class TronFeeReconciliationTest {
                     isMaxAmountEnabled = false,
                     isDeposit = false,
                     dstAddress = dstAddress,
-                    tokenAmountValue = AMOUNT,
+                    tokenAmountValue = amount,
                 )
                 .blockChainSpecific
         return (specific as BlockChainSpecific.Tron).gasFeeEstimation.toString()
@@ -199,7 +255,7 @@ internal class TronFeeReconciliationTest {
             )
     }
 
-    private fun repository() =
+    private fun repository(feeService: TronFeeService = this.feeService) =
         BlockChainSpecificRepositoryImpl(
             thorChainApi = mockk<ThorChainApi>(relaxed = true),
             mayaChainApi = mockk<MayaChainApi>(relaxed = true),
@@ -254,14 +310,14 @@ internal class TronFeeReconciliationTest {
             isNativeToken = true,
         )
 
-    private fun chainParameters() =
+    private fun chainParameters(energyFee: Long? = 420L) =
         TronChainParametersJson(
-            listOf(
+            listOfNotNull(
                 TronChainParameterJson("getTransactionFee", 1000L),
                 TronChainParameterJson("getCreateAccountFee", 100_000L),
                 TronChainParameterJson("getCreateNewAccountFeeInSystemContract", 1_000_000L),
                 TronChainParameterJson("getMemoFee", 1_000_000L),
-                TronChainParameterJson("getEnergyFee", 420L),
+                energyFee?.let { TronChainParameterJson("getEnergyFee", it) },
                 TronChainParameterJson("getDynamicEnergyMaxFactor", 1200L),
             )
         )
@@ -290,6 +346,12 @@ internal class TronFeeReconciliationTest {
 
         /** 345 bytes at the test chain's 1,000 sun/byte — a contract call always pays it. */
         const val CONTRACT_BANDWIDTH_FEE = 345_000L
+
+        /**
+         * TronFeeService.DEFAULT_TOKEN_TRANSFER_FEE: the 30 TRX a token call is capped at
+         * unsimulated.
+         */
+        const val FLAT_TOKEN_FEE_LIMIT = "30000000"
 
         val AMOUNT: BigInteger = BigInteger.valueOf(25_000_000L)
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/TronAddressToHexTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/TronAddressToHexTest.kt
@@ -1,0 +1,53 @@
+package com.vultisig.wallet.data.chains.helpers
+
+import com.vultisig.wallet.data.chains.helpers.TronFunctions.tronAddressToHex
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.jupiter.api.Test
+
+/**
+ * The TRC20 fee simulation addresses its recipient by the `41`-prefixed hex the TVM expects, so a
+ * decode that silently produced the wrong bytes would price a transfer to somebody else. Pinned
+ * against published mainnet addresses rather than against the decoder's own output.
+ */
+class TronAddressToHexTest {
+
+    @Test
+    fun `a mainnet address decodes to its published hex`() {
+        // The USDT-TRC20 contract, whose hex form is published in TRON's own token listings.
+        assertEquals(
+            "0x41a614f803b6fd780986a42c78ec9c7f77e6ded13c",
+            tronAddressToHex("TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"),
+        )
+    }
+
+    @Test
+    fun `the 41 prefix and all twenty account bytes survive the decode`() {
+        assertEquals(
+            "0x410102030405060708090a0b0c0d0e0f1011121314",
+            tronAddressToHex("TA4Y62o6YC2Zsck9rZVGTvqW1AQ7X9zTnj"),
+        )
+    }
+
+    @Test
+    fun `a mistyped address is rejected instead of decoding to a different account`() {
+        // One character off the address above: base58check exists precisely to catch this.
+        assertFailsWith<IllegalArgumentException> {
+            tronAddressToHex("TA4Y62o6YC2Zsck9rZVGTvqW1AQ7X9zTnk")
+        }
+    }
+
+    @Test
+    fun `a non-base58 character is rejected`() {
+        // `0`, `O`, `I` and `l` are excluded from the alphabet to keep look-alikes apart.
+        assertFailsWith<IllegalArgumentException> {
+            tronAddressToHex("TA4Y62o6YC2Zsck9rZVGTvqW1AQ7X9zTn0")
+        }
+    }
+
+    @Test
+    fun `an address of the wrong length is rejected`() {
+        assertFailsWith<IllegalArgumentException> { tronAddressToHex("TA4Y62o6YC2Zsck9") }
+        assertFailsWith<IllegalArgumentException> { tronAddressToHex("") }
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -821,33 +821,6 @@ internal class BlockChainSpecificRepositoryImplTest {
         }
     }
 
-    @Test
-    fun `Tron TRC20 fee_limit applies iOS's 30 percent energy safety multiplier`() {
-        // 65,000 energy x 1.3 x 420 sun/energy = 35,490,000 sun — pins the same value as iOS's
-        // TronServiceFeeLimitTests.testContractFeeLimit_appliesSafetyMultiplierToEnergyAtChainPrice.
-        assertEquals(
-            35_490_000L,
-            BlockChainSpecificRepositoryImpl.contractFeeLimit(
-                totalEnergyUsed = 65_000L,
-                energyPrice = 420L,
-            ),
-        )
-    }
-
-    @Test
-    fun `Tron TRC20 fee_limit safety multiplier survives truncation for energy not divisible by 10`() {
-        // 65,001 x 13 / 10 = 84,501.3 truncated to 84,501, x 420 = 35,490,420 — the
-        // multiply-before-
-        // divide order must be preserved or this pins a different (smaller) value.
-        assertEquals(
-            35_490_420L,
-            BlockChainSpecificRepositoryImpl.contractFeeLimit(
-                totalEnergyUsed = 65_001L,
-                energyPrice = 420L,
-            ),
-        )
-    }
-
     private fun suiApi(referenceGasPrice: BigInteger, coins: List<SuiCoin> = emptyList()): SuiApi =
         mockk {
             coEvery { getReferenceGasPrice() } returns referenceGasPrice
@@ -1130,6 +1103,7 @@ internal class BlockChainSpecificRepositoryImplTest {
             rippleApi = mockk<RippleApi>(relaxed = true),
             tronApi = mockk<TronApi>(relaxed = true),
             cardanoApi = mockk<CardanoApi>(relaxed = true),
+            tronFeeService = NoOpFeeService,
             feeServiceComposite =
                 FeeServiceComposite(
                     ethereumFeeService = evmFeeService,


### PR DESCRIPTION
Closes #5479

## Problem

TRON priced a send twice, and the two calculations never met.

`TronFeeService.calculateFees()` simulated **the amount being transferred** to produce the fee shown to the user and to gate `DefaultSendStrategy`'s balance check. `BlockChainSpecificRepository.getSpecific()` ran a **second, independent simulation — against the sender's whole balance** — for the `fee_limit` that actually reached the wire, and added `energy_penalty` on top of `energy_used` while the fee service subtracted it. `getSpecific()`'s own `gasFee` parameter, which every caller already passes in, was never read inside the Tron branch.

The issue body is superseded by @realpaaao's re-scope comment; this PR implements that comment.

## Why the penalty term was the expensive half

`triggerconstantcontract.energy_used` is **already the total** energy a call burns. `energy_penalty` is the Dynamic Energy share *inside* that total, not a term to add to it — the same reading iOS pins in `TronService.simulatedTotalEnergy` and `TronServiceFeeLimitTests`. Adding it double-counts.

The fee service's own `energy_used − penalty`, then `× (1 + contractEnergyFactor)`, was a fragile reconstruction of the same identity: exactly equal to `energy_used` when the fetched contract metadata agrees with the node's simulation, and inflated by up to `1 + maxFactor` when the node reports no penalty. Both are gone; the total is `energy_used`, validated as `0 ≤ penalty ≤ total`. That left `TronApi.getContractMetadata` — an RPC per fee estimate — with no callers, so it is deleted.

## Verified on mainnet

A 0.1 USDT send from a vault holding 11.94 TRX, 9 staked energy and 600/600 bandwidth:

https://tronscan.org/#/transaction/665a3a2373e754b98c67762389965020c5b945de82441fd678605d6b5483f325

| | |
|---|---|
| `energy_usage_total` | 64,285 |
| `energy_penalty_total` | **49,635** (77% of the energy) |
| signed `fee_limit` | **8,357,000 sun** = `64,285 × 13/10 × 100`, exact |
| `fee_limit` ÷ (energy × price) | **1.29997** — the 30% headroom and nothing else |
| what the old code would have signed | `(64,285 + 49,635) × 13/10 × 100` = **14,809,600 sun = 14.81 TRX** |

At 1.772× the correct ceiling, the old `fee_limit` on this ordinary transfer was larger than the entire account it was drawn on.

The reconciliation itself is visible in the receipt: `energy_usage: 9` — the sender's staked energy was consumed, and the burn was `energy_fee: 6,427,600` = `(64,285 − 9) × 100`, exactly the energy component the app had quoted. The displayed fee and the signed ceiling both derive from the same `64,285`.

The send that produced that transaction:

<img src="https://i.imgur.com/0SyY5GW.png" width="300" />

## Changes

- `TronFees` gains `feeLimit` — the gross ceiling in sun, kept separate from `amount` because the two answer different questions.
- `BlockChainSpecificRepository`'s TRC20 branch takes that field instead of simulating. It injects `@TronFee FeeService` **directly rather than going through `FeeServiceComposite`**: the composite catches every exception and falls back to `calculateDefaultFees`, which would silently undo the fail-closed guard on a reverted simulation added in #5776. A reverted simulation must fail the send, not reach the wire behind a fabricated ceiling.
- The ceiling stays **gross**. Staked energy discounts only what the sender is expected to burn — energy consumed by another transaction during a 10-60s signing ceremony would otherwise shrink the cap below the real cost and fail the send with `OUT_OF_ENERGY`.
- The TRC20 branch simulates **only when it has both a destination and an amount** — the send at Continue. Without them it takes the flat token ceiling from `calculateDefaultFees` instead of probing a transfer nobody signs: every swap builder passes neither, so a THORChain Tron-USDT swap was getting a `fee_limit` simulated from `transfer(self, balance)`, and a zero probe would be worse (it skips the recipient's zero→nonzero storage write and under-prices a first-time recipient by ~15k energy). Same rule iOS's `calculateTrc20Fee` applies when it has no recipient.
- `GasFeeOrchestrator.collectSpecific` keeps dropping the amount for TRC20. Nothing reads the form's Tron specific — `BlockChainSpecific.Tron` is consumed only by `TronHelper` at signing, and `DefaultSendStrategy` rebuilds it at Continue — so carrying the amount only added a second, identical simulation per amount edit. A TRC20 send is now N display simulations + 1 signing simulation, none duplicated.
- `TronChainParametersJson.energyFee` is floored at 100 sun (iOS's `defaultEnergyFeePrice`, the live mainnet price) when a node omits or zeroes `getEnergyFee`. `main` floored this at a stale 280 on the signing path only; deleting the repository's own reading had dropped it, and a zero price would have signed `fee_limit = 0`. The other zero-defaulting parameters and the `getMaxFeeLimit` clamp are #5860.
- The fee path decodes its recipient with a plain-Kotlin base58check (`TronFunctions.tronAddressToHex`) instead of wallet-core's `Base58`. wallet-core JNI does not load in JVM unit tests and `mockkStatic` cannot mock a native method, so the tests below would have been silently skipped like the ~41 other `:data` tests that already are. It also takes a JNI call off a per-keystroke path.

**No `adjustGasFee` arm.** The issue offered it as an alternative, and it would be wrong here: `adjustGasFee` pulls the *signed* number into the *displayed* fee, which for TRON means showing the user the gross ceiling plus 30% headroom instead of what they will actually burn. UTXO and Cardano reconciliation are untouched.

## Out of scope, found while working

- Android over-states a TRC20 fee by 0.345 TRX (345 bytes × 1,000 sun) whenever free bandwidth covers the transaction — `calculateBandwidthFee(isContract = true)` charges it unconditionally. Confirmed by the receipt above: `net_usage: 345` with no `net_fee`, and a burn 0.345 TRX under the quote. iOS omits bandwidth from TRC20 entirely.
- iOS clamps `fee_limit` to the chain's `getMaxFeeLimit` parameter; Android does not parse that parameter at all.

Both left alone under the issue's "don't change TRC20 signing logic beyond the fee_limit source": the bandwidth one is #5859 (PR #5861), the clamp is #5860.

## Test plan

- `:data` 3666 tests, `:app` 2481 tests, 0 failures.
- 16 new tests, all executing (0 skipped): 10 in `TronFeeReconciliationTest` covering the shared pass, the amount actually simulated, the penalty not being double-counted, staked energy discounting the display but not the ceiling, a high-energy contract call, a malformed simulation, the native flat ceiling, the flat fallback with no simulation for an incomplete transfer, and the energy-price floor for an absent and a zero `getEnergyFee`; 5 in `TronAddressToHexTest` pinned against published mainnet addresses; 1 in `GasFeeOrchestratorTest` pinning that the form drops the TRC20 amount.
- Root `assembleDebug`, `:app:compileDebugAndroidTestKotlin`, `ktfmtCheck` and `lintDebug` all pass.
- Mainnet TRC20 send confirmed on Tronscan, as above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved TRON and TRC20 fee estimation using transfer details, energy usage, staking benefits, and penalties.
  - Added clearer fee-limit handling for native TRX transfers, token transactions, and contract calls.
  - Added validation for TRON Base58Check addresses.
  - Added a fallback energy fee when network data is missing or invalid.

- **Bug Fixes**
  - Improved consistency between displayed fees and transaction fee limits.

- **Refactor**
  - Removed unused TRON contract metadata functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->