### PR TITLE
fix(tron): charge TRC20 bandwidth on the chain's terms and cap the fee_limit

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/TronResponseJson.kt
@@ -110,8 +110,18 @@ data class TronChainParametersJson(val chainParameter: List<TronChainParameterJs
     val bandwidthFeePrice: Long
         get() = chainParameterMapped["getTransactionFee"] ?: 0L
 
+    /**
+     * The largest `fee_limit` the chain will accept on a signed transaction. Falls back to TRON's
+     * documented default rather than to `0` like the bandwidth accessors above: this one is a
+     * ceiling, so a missing or zeroed key must leave the limit uncapped, never collapse it to
+     * nothing. https://developers.tron.network/docs/set-feelimit
+     */
+    val maxFeeLimit: Long
+        get() = chainParameterMapped["getMaxFeeLimit"]?.takeIf { it > 0L } ?: DEFAULT_MAX_FEE_LIMIT
+
     companion object {
         const val DEFAULT_ENERGY_FEE = 100L
+        private const val DEFAULT_MAX_FEE_LIMIT = 15_000_000_000L // 15,000 TRX
     }
 }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
@@ -1,5 +1,6 @@
 package com.vultisig.wallet.data.blockchain.tron
 
+import androidx.annotation.VisibleForTesting
 import com.vultisig.wallet.data.api.TronApi
 import com.vultisig.wallet.data.api.TronApiImpl.Companion.TRANSFER_FUNCTION_SELECTOR
 import com.vultisig.wallet.data.api.models.TronAccountJson
@@ -152,7 +153,8 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
     // TRC-20
     // To consider implementing a tx serializer for swaps. This can be easily achieve by :
     // headers & others(fixed) + signature(fixed) + rawCallDataSize (return by simulation)
-    private suspend fun calculateBandwidthFee(
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal suspend fun calculateBandwidthFee(
         srcAccount: TronAccountResourceJson?,
         isContract: Boolean,
     ): TronFees {
@@ -165,35 +167,26 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
 
         val bandwidthPrice = getCacheTronChainParameters().bandwidthFeePrice
 
-        // For contracts, always pay bandwidth fee
-        if (isContract) {
-            return TronFees(
-                bandwidthDiscounted = BYTES_PER_CONTRACT_TX.toBigInteger(),
-                bandwidthRequired = BYTES_PER_CONTRACT_TX.toBigInteger(),
-                amount = BigInteger.valueOf(bytesRequired * bandwidthPrice),
-            )
-        }
-
-        // For native transfers, check available bandwidth
+        // A contract call draws on the same free and staked bandwidth as a plain transfer — only
+        // the size differs — so it is charged on the same terms. Bandwidth applies all or nothing:
+        // TRX is burned for the whole transaction, or for none of it.
         val availableBandwidth = srcAccount?.calculateAvailableBandwidth() ?: 0L
-
-        // Bandwidth apply all or nothing
-        val trxAmount =
-            if (availableBandwidth >= bytesRequired) {
-                BigInteger.ZERO
-            } else {
-                BigInteger.valueOf(bytesRequired * bandwidthPrice)
-            }
+        val isCovered = availableBandwidth >= bytesRequired
 
         return TronFees(
             bandwidthDiscounted =
-                if (trxAmount == BigInteger.ZERO) {
+                if (isCovered) {
                     BigInteger.ZERO
                 } else {
-                    BYTES_PER_COIN_TX.toBigInteger()
+                    bytesRequired.toBigInteger()
                 },
-            bandwidthRequired = BYTES_PER_COIN_TX.toBigInteger(),
-            amount = trxAmount,
+            bandwidthRequired = bytesRequired.toBigInteger(),
+            amount =
+                if (isCovered) {
+                    BigInteger.ZERO
+                } else {
+                    BigInteger.valueOf(bytesRequired * bandwidthPrice)
+                },
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
@@ -289,7 +289,12 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
             maxEnergyRequired = maxEnergyUnitsRequired,
             energyRequired = energyUnitsRequired,
             energyDiscounted = energyToPay,
-            feeLimit = contractFeeLimit(energyUnitsRequired, energyPrice),
+            // A fee_limit above the chain's own ceiling is rejected outright, and one derived from
+            // a zeroed energy price would guarantee OUT_OF_ENERGY — clamp both ends rather than
+            // sign either.
+            feeLimit =
+                contractFeeLimit(energyUnitsRequired, energyPrice)
+                    .coerceIn(BigInteger.ZERO, chainParameters.maxFeeLimit.toBigInteger()),
             amount = energyToPay * energyPrice,
         )
     }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeService.kt
@@ -32,7 +32,8 @@ import kotlinx.coroutines.sync.withLock
  *     - Every transaction consumes bandwidth (measured in bytes).
  *     - Native TRX transfers typically cost ~300 bytes.
  *     - TRC20 transfers (smart contract interactions) cost slightly more (~345 bytes).
- *     - If the sender has enough free or staked bandwidth, no TRX is burned.
+ *     - If the sender's staked bandwidth covers the whole transaction, or failing that their free
+ *       bandwidth does, no TRX is burned. The two pools are never combined.
  *     - Otherwise, the cost is: bytes * bandwidthPrice (≈1000 SUN per byte).
  *
  *   How Users Earn Bandwidth:
@@ -58,6 +59,8 @@ import kotlinx.coroutines.sync.withLock
  *     - Sending TRX to a new account requires paying an activation fee.
  *     - Covers creation and system cost, typically ~1.1 TRX total.
  *     - When this applies, the bandwidth fee is waived (since activation includes it).
+ *     - A TRC20 transfer never pays it: the recipient's balance lives in the contract's storage and
+ *       the chain creates no account for them.
  *
  * Notes:
  * - Resource availability is checked first (bandwidth/energy from free quota or staking).
@@ -87,21 +90,19 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
             val toAddress = transaction.to
 
             val srcAccountDeferred = async { tronApi.getAccountResource(fromAddress) }
-            val dstAccountDeferred = async { tronApi.getAccount(toAddress) }
-
-            val srcAccount = srcAccountDeferred.await()
-            val dstAccount = dstAccountDeferred.await()
 
             if (coin.isNativeToken) {
+                // Only a plain transfer can activate its destination, so only it needs to know
+                // whether the account exists.
+                val dstAccountDeferred = async { tronApi.getAccount(toAddress) }
                 calculateNativeTrxFee(
-                    srcAccount = srcAccount,
-                    dstAccount = dstAccount,
+                    srcAccount = srcAccountDeferred.await(),
+                    dstAccount = dstAccountDeferred.await(),
                     hasMemo = transaction.paysMemoFee(),
                 )
             } else {
                 calculateTrc20Fee(
-                    srcAccount = srcAccount,
-                    dstAccount = dstAccount,
+                    srcAccount = srcAccountDeferred.await(),
                     transaction = transaction,
                 )
             }
@@ -170,8 +171,7 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
         // A contract call draws on the same free and staked bandwidth as a plain transfer — only
         // the size differs — so it is charged on the same terms. Bandwidth applies all or nothing:
         // TRX is burned for the whole transaction, or for none of it.
-        val availableBandwidth = srcAccount?.calculateAvailableBandwidth() ?: 0L
-        val isCovered = availableBandwidth >= bytesRequired
+        val isCovered = srcAccount?.coversBandwidth(bytesRequired) == true
 
         return TronFees(
             bandwidthDiscounted =
@@ -197,39 +197,43 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
         return BigInteger.valueOf(createAccountFee + systemFee)
     }
 
-    // https://developers.tron.network/docs/resource-model#account-bandwidth-balance-query
-    private fun TronAccountResourceJson.calculateAvailableBandwidth(): Long {
-        val freeBandwidth = freeNetLimit - freeNetUsed
-        val stakingBandwidth = netLimit - netUsed
-
-        return freeBandwidth + stakingBandwidth
-    }
+    /**
+     * The chain spends staked bandwidth first and free bandwidth second, and whichever pool it
+     * lands on has to cover the whole transaction by itself — java-tron's `BandwidthProcessor`
+     * tries `useAccountNet` then `useFreeNet` and never combines the two. Summing them would quote
+     * a sender with 200 of each as covered for a 345-byte call the chain burns TRX for.
+     * https://developers.tron.network/docs/resource-model#account-bandwidth-balance-query
+     */
+    private fun TronAccountResourceJson.coversBandwidth(bytes: Long): Boolean =
+        netLimit - netUsed >= bytes || freeNetLimit - freeNetUsed >= bytes
 
     private suspend fun calculateTrc20Fee(
         srcAccount: TronAccountResourceJson?,
-        dstAccount: TronAccountJson?,
         transaction: Transfer,
     ): TronFees {
-        var totalFee = BigInteger.ZERO
-
-        // 1. Bandwidth fee (always paid for TRC20)
+        // 1. Bandwidth fee
         val bandwidthFee = calculateBandwidthFee(srcAccount = srcAccount, isContract = true)
-
-        totalFee = totalFee.add(bandwidthFee.amount)
 
         // 2. Energy fee
         val energyFee = calculateEnergyFee(srcAccount = srcAccount, transaction = transaction)
 
-        totalFee = totalFee.add(energyFee.amount)
+        // 3. Memo fee — TronHelper writes the memo into `raw_data.data` of a contract call exactly
+        //    as it does for a plain transfer, and the chain bills it the same way.
+        val memoFee =
+            if (transaction.paysMemoFee()) {
+                getCacheTronChainParameters().memoFeeEstimate.toBigInteger()
+            } else {
+                BigInteger.ZERO
+            }
 
-        // 3. Account activation fee (if destination is new)
-        if (dstAccount.isNewAccount()) {
-            val activationFee = calculateActivationFee()
-            totalFee = totalFee.add(activationFee)
-        }
+        // No activation fee: a TRC20 transfer writes the recipient's balance into the contract's
+        // storage and never creates a TRON account for them (java-tron's contractCreateNewAccount
+        // is false for TriggerSmartContract), so the chain charges nothing for a fresh recipient
+        // beyond the extra energy the simulation already prices for their first storage write.
+        val totalFee = bandwidthFee.amount + energyFee.amount + memoFee
 
-        // Bandwidth, memo and activation are burnt outside contract execution, so they stay out of
-        // the ceiling TRON enforces against energy.
+        // Bandwidth and memo are burnt outside contract execution, so they stay out of the ceiling
+        // TRON enforces against energy.
         return bandwidthFee.copy(
             maxEnergyRequired = energyFee.maxEnergyRequired,
             energyDiscounted = energyFee.energyDiscounted,
@@ -321,8 +325,10 @@ class TronFeeService @Inject constructor(private val tronApi: TronApi) : FeeServ
         val hasMemo = transaction.paysMemoFee()
         val isTokenTransfer = !transaction.coin.isNativeToken
 
+        // Only a plain transfer activates its destination; a token call never does.
         val isNewAccount =
-            runCatching { tronApi.getAccount(toAddress).isNewAccount() }.getOrDefault(true)
+            isNativeCoin &&
+                runCatching { tronApi.getAccount(toAddress).isNewAccount() }.getOrDefault(true)
 
         val baseFee =
             when {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
@@ -203,6 +203,28 @@ internal class TronFeeReconciliationTest {
     }
 
     @Test
+    fun `a ceiling above the chain's own limit is clamped to it`() = runTest {
+        // #5860: TRON rejects a transaction whose fee_limit exceeds getMaxFeeLimit outright, so an
+        // energy figure large enough to breach it must be capped rather than signed.
+        stubSimulation(energyUsed = 400_000_000L, energyPenalty = 0L)
+
+        val displayed = feeService.calculateFees(trc20Transfer())
+
+        // 400,000,000 x 1.3 x 420 would be 218,400,000,000 sun, well past the 15,000 TRX cap.
+        assertEquals(BigInteger.valueOf(MAX_FEE_LIMIT), displayed.feeLimit)
+        assertEquals(MAX_FEE_LIMIT.toString(), trc20FeeLimit())
+    }
+
+    @Test
+    fun `a missing max fee limit leaves the ceiling uncapped rather than zeroing it`() = runTest {
+        // The bandwidth accessors fall back to 0. This one must not: a 0 cap would clamp every
+        // fee_limit to nothing and guarantee OUT_OF_ENERGY on every contract call.
+        stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L, maxFeeLimit = null)
+
+        assertEquals("35490000", trc20FeeLimit())
+    }
+
+    @Test
     fun `the fee_limit safety multiplier survives truncation`() {
         // 65,001 x 13 / 10 = 84,501.3 truncated to 84,501, x 420 = 35,490,420 — the
         // multiply-before-divide order must hold or this pins a different, smaller value.
@@ -241,9 +263,14 @@ internal class TronFeeReconciliationTest {
         return (specific as BlockChainSpecific.Tron).gasFeeEstimation.toString()
     }
 
-    private fun stubSimulation(energyUsed: Long, energyPenalty: Long, availableEnergy: Long = 0L) {
+    private fun stubSimulation(
+        energyUsed: Long,
+        energyPenalty: Long,
+        availableEnergy: Long = 0L,
+        maxFeeLimit: Long? = MAX_FEE_LIMIT,
+    ) {
         coEvery { tronApi.getSpecific() } returns block()
-        coEvery { tronApi.getChainParameters() } returns chainParameters()
+        coEvery { tronApi.getChainParameters() } returns chainParameters(maxFeeLimit = maxFeeLimit)
         coEvery { tronApi.getAccountResource(any()) } returns
             TronAccountResourceJson(energyLimit = availableEnergy)
         coEvery { tronApi.getAccount(any()) } answers { TronAccountJson(address = firstArg()) }
@@ -310,7 +337,7 @@ internal class TronFeeReconciliationTest {
             isNativeToken = true,
         )
 
-    private fun chainParameters(energyFee: Long? = 420L) =
+    private fun chainParameters(energyFee: Long? = 420L, maxFeeLimit: Long? = MAX_FEE_LIMIT) =
         TronChainParametersJson(
             listOfNotNull(
                 TronChainParameterJson("getTransactionFee", 1000L),
@@ -319,6 +346,7 @@ internal class TronFeeReconciliationTest {
                 TronChainParameterJson("getMemoFee", 1_000_000L),
                 energyFee?.let { TronChainParameterJson("getEnergyFee", it) },
                 TronChainParameterJson("getDynamicEnergyMaxFactor", 1200L),
+                maxFeeLimit?.let { TronChainParameterJson("getMaxFeeLimit", it) },
             )
         )
 
@@ -344,7 +372,7 @@ internal class TronFeeReconciliationTest {
         const val CONTRACT = "TDisDrQngvcMNfYurnQLW4oRnh9PzwDFxh"
         const val MARKET = "TFZ2nmDdmHuF8BxHrtrsX8nPgTX3FfuGzz"
 
-        /** 345 bytes at the test chain's 1,000 sun/byte — a contract call always pays it. */
+        /** 345 bytes at the test chain's 1,000 sun/byte, with no bandwidth to cover it. */
         const val CONTRACT_BANDWIDTH_FEE = 345_000L
 
         /**
@@ -352,6 +380,9 @@ internal class TronFeeReconciliationTest {
          * unsimulated.
          */
         const val FLAT_TOKEN_FEE_LIMIT = "30000000"
+
+        /** TRON's documented ceiling, 15,000 TRX. */
+        const val MAX_FEE_LIMIT = 15_000_000_000L
 
         val AMOUNT: BigInteger = BigInteger.valueOf(25_000_000L)
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
@@ -132,6 +132,34 @@ internal class TronFeeReconciliationTest {
     }
 
     @Test
+    fun `a TRC20 send to an address with no TRON account pays no activation fee`() = runTest {
+        // java-tron's contractCreateNewAccount is false for TriggerSmartContract: the recipient's
+        // balance lands in the contract's storage and no account is created for them, so the chain
+        // burns no activation fee. Their first storage write is already in the simulated energy.
+        stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
+        coEvery { tronApi.getAccount(RECIPIENT) } returns TronAccountJson(address = "")
+
+        val displayed = feeService.calculateFees(trc20Transfer())
+
+        assertEquals(BigInteger.valueOf(27_300_000L + CONTRACT_BANDWIDTH_FEE), displayed.amount)
+    }
+
+    @Test
+    fun `a TRC20 memo is priced like a native one and stays out of the energy ceiling`() = runTest {
+        stubSimulation(energyUsed = 65_000L, energyPenalty = 50_000L)
+
+        val displayed = feeService.calculateFees(trc20Transfer(memo = "thanks for lunch"))
+
+        // TronHelper writes the memo into raw_data.data of the contract call, and the chain bills
+        // any non-empty data the same flat fee whatever the contract type.
+        assertEquals(
+            BigInteger.valueOf(27_300_000L + CONTRACT_BANDWIDTH_FEE + MEMO_FEE),
+            displayed.amount,
+        )
+        assertEquals("35490000", displayed.feeLimit.toString())
+    }
+
+    @Test
     fun `a simulation whose penalty exceeds its own total is refused`() = runTest {
         stubSimulation(energyUsed = 65_000L, energyPenalty = 70_000L)
 
@@ -303,12 +331,13 @@ internal class TronFeeReconciliationTest {
             tronFeeService = feeService,
         )
 
-    private fun trc20Transfer(to: String = RECIPIENT) =
+    private fun trc20Transfer(to: String = RECIPIENT, memo: String? = null) =
         Transfer(
             coin = trc20Coin(),
             vault = VaultData(vaultHexPublicKey = "pub", vaultHexChainCode = "chain"),
             amount = AMOUNT,
             to = to,
+            memo = memo,
         )
 
     private fun trc20Coin() =
@@ -383,6 +412,8 @@ internal class TronFeeReconciliationTest {
 
         /** TRON's documented ceiling, 15,000 TRX. */
         const val MAX_FEE_LIMIT = 15_000_000_000L
+
+        const val MEMO_FEE = 1_000_000L
 
         val AMOUNT: BigInteger = BigInteger.valueOf(25_000_000L)
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeServiceTest.kt
@@ -104,6 +104,43 @@ class TronFeeServiceTest {
         assertEquals(MEMO_FEE, memoed.amount - staking.amount)
     }
 
+    @Test
+    fun `a contract call is free when the sender's own bandwidth covers it`() = runTest {
+        // #5859: a TRC20 send used to be charged 345 bytes unconditionally, so every account with
+        // its daily free quota intact — the common case — was quoted 0.345 TRX over what the chain
+        // takes. Confirmed on mainnet by tx 665a3a23...: net_usage 345 with no net_fee.
+        coEvery { tronApi.getChainParameters() } returns chainParameters()
+
+        val fee = service.calculateBandwidthFee(freeBandwidth(600L), isContract = true)
+
+        assertEquals(BigInteger.ZERO, fee.amount)
+    }
+
+    @Test
+    fun `a contract call burns TRX only once bandwidth runs short`() = runTest {
+        coEvery { tronApi.getChainParameters() } returns chainParameters()
+
+        val fee = service.calculateBandwidthFee(freeBandwidth(0L), isContract = true)
+
+        // 345 bytes x 1,000 sun.
+        assertEquals(BigInteger.valueOf(345_000L), fee.amount)
+    }
+
+    @Test
+    fun `each shape is measured against its own size`() = runTest {
+        // 320 bandwidth covers a 300-byte native transfer but not a 345-byte contract call, so the
+        // shared rule must not collapse the two sizes together.
+        coEvery { tronApi.getChainParameters() } returns chainParameters()
+
+        val nativeFee = service.calculateBandwidthFee(freeBandwidth(320L), isContract = false)
+        val contractFee = service.calculateBandwidthFee(freeBandwidth(320L), isContract = true)
+
+        assertEquals(BigInteger.ZERO, nativeFee.amount)
+        assertEquals(BigInteger.valueOf(345_000L), contractFee.amount)
+    }
+
+    private fun freeBandwidth(available: Long) = TronAccountResourceJson(freeNetLimit = available)
+
     private fun stubHealthyApi() {
         coEvery { tronApi.getChainParameters() } returns chainParameters()
         // Free bandwidth covers the whole transfer and the destination is already activated, so the

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeServiceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeServiceTest.kt
@@ -139,6 +139,34 @@ class TronFeeServiceTest {
         assertEquals(BigInteger.valueOf(345_000L), contractFee.amount)
     }
 
+    @Test
+    fun `staked and free bandwidth each have to cover the call on their own`() = runTest {
+        // java-tron's BandwidthProcessor tries the staked pool, then the free pool, and checks each
+        // against the whole transaction — it never adds the two. A sender left with 200 in each is
+        // burned for all 345 bytes, while 345 in either one alone is free.
+        coEvery { tronApi.getChainParameters() } returns chainParameters()
+
+        val split =
+            TronAccountResourceJson(
+                netLimit = 1_000L,
+                netUsed = 800L,
+                freeNetLimit = 600L,
+                freeNetUsed = 400L,
+            )
+        val staked = TronAccountResourceJson(netLimit = 345L)
+        val free = TronAccountResourceJson(freeNetLimit = 345L)
+
+        assertEquals(
+            BigInteger.valueOf(345_000L),
+            service.calculateBandwidthFee(split, isContract = true).amount,
+        )
+        assertEquals(
+            BigInteger.ZERO,
+            service.calculateBandwidthFee(staked, isContract = true).amount,
+        )
+        assertEquals(BigInteger.ZERO, service.calculateBandwidthFee(free, isContract = true).amount)
+    }
+
     private fun freeBandwidth(available: Long) = TronAccountResourceJson(freeNetLimit = available)
 
     private fun stubHealthyApi() {

--- a/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/TronMemoFeeMatchesSignedMemoTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/chains/helpers/TronMemoFeeMatchesSignedMemoTest.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.data.api.models.TronAccountJson
 import com.vultisig.wallet.data.api.models.TronAccountResourceJson
 import com.vultisig.wallet.data.api.models.TronChainParameterJson
 import com.vultisig.wallet.data.api.models.TronChainParametersJson
+import com.vultisig.wallet.data.api.models.TronTriggerConstantContractJson
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.blockchain.tron.TRON_WITHDRAW_EXPIRE_UNFREEZE_MEMO
@@ -93,6 +94,42 @@ class TronMemoFeeMatchesSignedMemoTest {
     }
 
     @Test
+    fun `a TRC20 memo is priced exactly when the signed contract call carries it`() = runTest {
+        // The token builder writes the memo into raw_data.data just as the coin builder does, and
+        // the chain bills any non-empty data the same flat fee whatever the contract type — so the
+        // token fee has to move by the memo fee exactly when the signed call carries one.
+        coEvery { tronApi.getTriggerConstantContractFee(any(), any(), any(), any(), any()) } returns
+            TronTriggerConstantContractJson(
+                energyUsed = 65_000L,
+                energyPenalty = 0L,
+                transaction = TronTriggerConstantContractJson.Transaction(),
+            )
+        val baseline =
+            feeService.calculateFees(transfer(Case("no memo", TRC20_RECIPIENT, null), usdt)).amount
+
+        listOf(
+                Case("empty memo", to = TRC20_RECIPIENT, memo = ""),
+                Case("user memo", to = TRC20_RECIPIENT, memo = "thanks for lunch"),
+                // The routing signal only means staking on a native self-transfer; on a token it
+                // is an ordinary memo the builder writes and the chain charges for.
+                Case("staking lookalike", to = TRC20_RECIPIENT, memo = "FREEZE:BANDWIDTH"),
+            )
+            .forEach { case ->
+                val signed =
+                    Tron.SigningInput.parseFrom(helper.getPreSignedInputData(payload(case, usdt)))
+                        .transaction
+                        .memo
+                val fee = feeService.calculateFees(transfer(case, usdt)).amount
+
+                assertEquals(
+                    if (signed.isNotEmpty()) MEMO_FEE else BigInteger.ZERO,
+                    fee - baseline,
+                    "${case.name}: signed memo=\"$signed\" but fee=$fee against $baseline",
+                )
+            }
+    }
+
+    @Test
     fun `a staking memo aimed at another address is rejected before it can be signed`() {
         // The one input the table above cannot cover: no transaction exists to compare a fee
         // against, which is why the shared predicate keeps the self-address clause.
@@ -103,9 +140,9 @@ class TronMemoFeeMatchesSignedMemoTest {
         }
     }
 
-    private fun payload(case: Case) =
+    private fun payload(case: Case, coin: Coin = trx) =
         KeysignPayload(
-            coin = trx,
+            coin = coin,
             toAddress = case.to,
             toAmount = AMOUNT,
             memo = case.memo,
@@ -127,9 +164,9 @@ class TronMemoFeeMatchesSignedMemoTest {
             wasmExecuteContractPayload = null,
         )
 
-    private fun transfer(case: Case) =
+    private fun transfer(case: Case, coin: Coin = trx) =
         Transfer(
-            coin = trx,
+            coin = coin,
             vault = VaultData(vaultHexPublicKey = "pub", vaultHexChainCode = "chain"),
             amount = AMOUNT,
             to = case.to,
@@ -151,9 +188,22 @@ class TronMemoFeeMatchesSignedMemoTest {
             isNativeToken = true,
         )
 
+    private val usdt =
+        trx.copy(
+            ticker = "USDT",
+            priceProviderID = "tether",
+            contractAddress = "TDisDrQngvcMNfYurnQLW4oRnh9PzwDFxh",
+            isNativeToken = false,
+        )
+
     private companion object {
         const val SENDER = "TSenderAddressBase58"
         const val RECIPIENT = "TRecipientAddressBase58"
+
+        /** A checksummed address: the token fee path decodes its recipient before simulating. */
+        const val TRC20_RECIPIENT = "TBthewbwcZKTd99XrfwoUzpTtvmkoFqt9q"
+
         val AMOUNT: BigInteger = BigInteger.valueOf(1_000_000L)
+        val MEMO_FEE: BigInteger = BigInteger.valueOf(1_000_000L)
     }
 }


### PR DESCRIPTION
Closes #5859, closes #5860

> **Stacked on #5858.** Based on `aminsato/5479_tron_fee_reconcile`, not `main` — the clamp below applies to `TronFees.feeLimit`, which that PR introduces. Review the two commits here; GitHub retargets this to `main` automatically once #5858 merges.

Both fixes came out of verifying #5858 on mainnet — the same receipt that confirmed that fix exposed the first of these.

---

## #5859 — a TRC20 send is charged for bandwidth its free quota covers

`TronFeeService.calculateBandwidthFee()` short-circuited every contract call to the full 345-byte charge:

```kotlin
// For contracts, always pay bandwidth fee
if (isContract) { return TronFees(..., amount = bytesRequired * bandwidthPrice) }
```

The premise is wrong. A contract transaction draws on the sender's free and staked bandwidth exactly like a plain transfer does — only its size differs. The all-or-nothing rule the native branch already applied a few lines below is the right one for both; the contract branch simply skipped it.

Every account gets 600 free bandwidth per day and a TRC20 transfer needs 345, so the common case — not an edge case — was quoted **0.345 TRX above what the chain takes**.

### Evidence

https://tronscan.org/#/transaction/665a3a2373e754b98c67762389965020c5b945de82441fd678605d6b5483f325

A 0.1 USDT send from an account showing `600 / 600` bandwidth:

| | |
|---|---|
| App quoted | **6.7726 TRX** |
| Receipt `fee` | **6,427,600 sun = 6.4276 TRX** |
| Receipt bandwidth | `net_usage: 345`, **no `net_fee`** |

The free quota absorbed the bandwidth entirely. The 0.345 TRX difference is exactly `345 × 1,000 sun`.

The send that produced it:

<img src="https://i.imgur.com/0SyY5GW.png" width="300" />

### iOS is not the reference here

`TronService.calculateTrc20Fee` omits bandwidth from a TRC20 fee altogether, under-stating whenever the sender has no quota left. Android over-stated whenever they did. Neither platform charged on the terms the chain actually uses, so this follows the receipt rather than either implementation — the same call as the top-tier overcharge in #5765, where both siblings shipped the same wrong behaviour.

### Note for review

The displayed fee gates `DefaultSendStrategy`'s balance check, so a TRC20 send now reserves 0.345 TRX less. If another transaction consumes the quota between estimate and broadcast the sender is short by that much — the same trade-off already accepted for the staked-energy discount, and the direction the chain itself takes.

`calculateBandwidthFee` is widened to `internal` behind `@VisibleForTesting(otherwise = PRIVATE)`. The alternative was reaching it through `calculateTrc20Fee`, which decodes its recipient with wallet-core's `Base58` — JNI that does not load in JVM unit tests, so the test would have been silently skipped like the ~41 other `:data` tests that already are.

---

## #5860 — the signed `fee_limit` is never clamped to `getMaxFeeLimit`

TRON rejects a transaction whose `fee_limit` exceeds the `getMaxFeeLimit` chain parameter. `TronChainParametersJson` exposed every other parameter the fee model needs but not that one, so the computed ceiling went onto the wire unclamped. iOS has clamped both ends since `TronService.cappedFeeLimit`.

**Being straight about the impact:** the upper bound is defence in depth, not a live bug. At the current 100 sun energy price against a 15,000 TRX cap it only binds above roughly 115 million energy, and real contract calls run 30,000–2,000,000. It guards a malformed `getEnergyFee` or a runaway simulation.

**The lower bound is the half that matters today.** Every accessor on `TronChainParametersJson` falls back to `0L` when the node omits a key. `maxFeeLimit` deliberately does not — a `0` read there would clamp every `fee_limit` to nothing and guarantee `OUT_OF_ENERGY` on every contract call. It falls back to TRON's documented 15,000 TRX instead, leaving the limit effectively uncapped rather than collapsing it.

---

## Test plan

- **#5859** — 3 new tests in `TronFeeServiceTest`, all executing: a contract call covered by free bandwidth is free; the same call burns 345,000 sun once the quota is gone; and 320 available bandwidth covers a 300-byte native transfer but not a 345-byte contract call, pinning that the two sizes stay distinct under the shared rule.
- **#5860** — 2 new tests in `TronFeeReconciliationTest`: a ceiling above the cap is clamped to it, and a response with no `getMaxFeeLimit` key still signs its real ceiling rather than zero.
- `:data` 3671 tests, `:app` 2481 tests, 0 failures.
- Root `assembleDebug`, `:app:compileDebugAndroidTestKotlin`, `ktfmtCheck` and `lintDebug` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TRON fee calculations for native and TRC20 transfers.
  * Corrected bandwidth coverage across free and staked resource pools.
  * Included memo fees for TRC20 transactions.
  * Applied account activation fees only where applicable.
  * Validated and constrained contract fee limits using the chain’s maximum.

* **Tests**
  * Added coverage for bandwidth handling, memo fees, account activation, and fee-limit boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->