### PR TITLE
feat(search): match assets by name, not ticker alone

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
@@ -64,7 +64,7 @@ import com.vultisig.wallet.data.db.models.VaultOrderEntity
             TransactionHistoryEntity::class,
             PendingLimitOrderEntity::class,
         ],
-    version = 44,
+    version = 45,
     exportSchema = false,
 )
 @TypeConverters(

--- a/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
@@ -53,6 +53,7 @@ import com.vultisig.wallet.data.db.migrations.MIGRATION_40_41
 import com.vultisig.wallet.data.db.migrations.MIGRATION_41_42
 import com.vultisig.wallet.data.db.migrations.MIGRATION_42_43
 import com.vultisig.wallet.data.db.migrations.MIGRATION_43_44
+import com.vultisig.wallet.data.db.migrations.MIGRATION_44_45
 import com.vultisig.wallet.data.db.migrations.MIGRATION_4_5
 import com.vultisig.wallet.data.db.migrations.MIGRATION_5_6
 import com.vultisig.wallet.data.db.migrations.MIGRATION_6_7
@@ -125,6 +126,7 @@ internal interface DatabaseModule {
                     MIGRATION_41_42,
                     MIGRATION_42_43,
                     MIGRATION_43_44,
+                    MIGRATION_44_45,
                 )
                 .build()
 

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -1260,3 +1260,19 @@ internal val MIGRATION_43_44 =
             )
         }
     }
+
+// Coins gain a display name so the pickers can be searched by it. Rows written before this
+// column existed carry an empty name; VaultRepository fills those from the curated catalogue on
+// read, the same way it already fills an empty logo, so nothing has to be backfilled here — and a
+// backfill from the catalogue would tie the migration to definitions that are free to change.
+internal val MIGRATION_44_45 =
+    object : Migration(44, 45) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+            ALTER TABLE `coin` ADD COLUMN `name` TEXT NOT NULL DEFAULT ""
+            """
+                    .trimIndent()
+            )
+        }
+    }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/ChainTokensViewModel.kt
@@ -23,6 +23,7 @@ import com.vultisig.wallet.data.models.isBuySupported
 import com.vultisig.wallet.data.models.isDepositSupported
 import com.vultisig.wallet.data.models.isSwapSupported
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.matchesSearch
 import com.vultisig.wallet.data.models.monoToneLogo
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.BalanceRepository
@@ -351,28 +352,32 @@ constructor(
                         val tokensFromAccounts = accounts.map { it.token }
                         tokens.update { it + tokensFromAccounts }
                         val uiTokens =
-                            accounts.map { account ->
-                                val token = account.token
-                                ChainTokenUiModel(
-                                    id = token.id,
-                                    name = token.ticker,
-                                    balance =
-                                        account.tokenValue?.let(mapTokenValueToStringWithUnitMapper)
-                                            ?: "",
-                                    fiatBalance =
-                                        account.fiatValue?.let { fiatValueToStringMapper(it) },
-                                    tokenLogo = getCoinLogo(token.logo),
-                                    chainLogo = chain.logo,
-                                    monotoneChainLogo = chain.monoToneLogo,
-                                    mergeBalance = mergeBalances.findMergeBalance(token).toString(),
-                                    price =
-                                        account.price?.let {
-                                            fiatValueToStringMapper(it, asPrice = true)
-                                        },
-                                    network = token.chain.raw,
-                                    canActivateTrustLine = token.id in needsTrustLine,
-                                )
-                            }
+                            accounts
+                                .filter { it.token.matchesSearch(searchQuery.toString()) }
+                                .map { account ->
+                                    val token = account.token
+                                    ChainTokenUiModel(
+                                        id = token.id,
+                                        name = token.ticker,
+                                        balance =
+                                            account.tokenValue?.let(
+                                                mapTokenValueToStringWithUnitMapper
+                                            ) ?: "",
+                                        fiatBalance =
+                                            account.fiatValue?.let { fiatValueToStringMapper(it) },
+                                        tokenLogo = getCoinLogo(token.logo),
+                                        chainLogo = chain.logo,
+                                        monotoneChainLogo = chain.monoToneLogo,
+                                        mergeBalance =
+                                            mergeBalances.findMergeBalance(token).toString(),
+                                        price =
+                                            account.price?.let {
+                                                fiatValueToStringMapper(it, asPrice = true)
+                                            },
+                                        network = token.chain.raw,
+                                        canActivateTrustLine = token.id in needsTrustLine,
+                                    )
+                                }
 
                         val accountAddress = address.address
                         val explorerUrl =
@@ -384,11 +389,7 @@ constructor(
                                 chainName = chainRaw,
                                 chainAddress = accountAddress,
                                 chainLogo = chain.logo,
-                                tokens =
-                                    uiTokens.filter { uiToken ->
-                                        searchQuery.isBlank() ||
-                                            uiToken.name.contains(searchQuery, ignoreCase = true)
-                                    },
+                                tokens = uiTokens,
                                 explorerURL = explorerUrl,
                                 totalBalance = totalBalance,
                                 canDeposit = chain.isDepositSupported,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TokenSelectionViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TokenSelectionViewModel.kt
@@ -10,6 +10,7 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.canAddCustomToken
+import com.vultisig.wallet.data.models.matchesSearch
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.usecases.EnableTokenUseCase
@@ -156,17 +157,10 @@ constructor(
                 searchTextFieldState.textAsFlow().map { it.toString() },
             ) { tempSelections, enabledTokenIds, enabledTokens, disabledTokens, query ->
                 val selectedUiTokens =
-                    enabledTokens
-                        .filter { it.ticker.contains(query, ignoreCase = true) }
-                        .asUiTokens(enabledTokenIds)
+                    enabledTokens.filter { it.matchesSearch(query) }.asUiTokens(enabledTokenIds)
 
                 val otherUiTokens =
-                    if (query.isNotBlank()) {
-                            disabledTokens.filter { it.ticker.contains(query, ignoreCase = true) }
-                        } else {
-                            disabledTokens
-                        }
-                        .asUiTokens(enabledTokenIds)
+                    disabledTokens.filter { it.matchesSearch(query) }.asUiTokens(enabledTokenIds)
 
                 val tokens =
                     (selectedUiTokens + otherUiTokens + tempSelections)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/TransactionHistoryViewModel.kt
@@ -10,6 +10,8 @@ import com.vultisig.wallet.R
 import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
 import com.vultisig.wallet.data.db.models.TransactionStatus
 import com.vultisig.wallet.data.db.models.isInFlight
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.data.models.SendTransactionHistoryData
 import com.vultisig.wallet.data.models.SwapTransactionHistoryData
@@ -162,9 +164,21 @@ sealed interface TransactionHistoryItemUiModel {
     ) : TransactionHistoryItemUiModel
 }
 
-data class TransactionAssetUiModel(val ticker: String, val chain: String, val logo: ImageModel) {
+data class TransactionAssetUiModel(
+    val ticker: String,
+    val chain: String,
+    val logo: ImageModel,
+    /** The curated asset's name, or empty for a token the catalogue does not carry. */
+    val name: String = "",
+) {
     val tokenId: String
         get() = "$chain:$ticker"
+
+    /** Ticker, name and chain are the three things a user has to identify an asset by here. */
+    fun matchesSearch(query: String): Boolean =
+        ticker.contains(query, ignoreCase = true) ||
+            name.contains(query, ignoreCase = true) ||
+            chain.contains(query, ignoreCase = true)
 }
 
 @Immutable
@@ -588,6 +602,13 @@ constructor(
                 "$fromChain:$fromToken" in assetIds || "$toChain:$toToken" in assetIds
         }
 
+    // History rows store the ticker and chain as text, so the name a search can match is the
+    // catalogue's for that pair; a swap leg in a token the catalogue never carried has none.
+    private fun curatedName(chainRaw: String, ticker: String): String {
+        val chain = Chain.fromRawOrNull(chainRaw) ?: return ""
+        return Coins.findCurated(chain, ticker, contractAddress = "")?.name.orEmpty()
+    }
+
     private fun observeAssetSearchItems() {
         viewModelScope.launch {
             transactionHistoryRepository
@@ -607,6 +628,7 @@ constructor(
                                                 ticker = p.token,
                                                 chain = entity.chain,
                                                 logo = getCoinLogo(p.tokenLogo),
+                                                name = curatedName(entity.chain, p.token),
                                             )
                                         )
 
@@ -616,6 +638,7 @@ constructor(
                                                 ticker = p.fromToken,
                                                 chain = p.fromChain,
                                                 logo = getCoinLogo(p.fromTokenLogo),
+                                                name = curatedName(p.fromChain, p.fromToken),
                                             )
                                         )
                                         add(
@@ -623,6 +646,7 @@ constructor(
                                                 ticker = p.toToken,
                                                 chain = p.toChain,
                                                 logo = getCoinLogo(p.toTokenLogo),
+                                                name = curatedName(p.toChain, p.toToken),
                                             )
                                         )
                                     }
@@ -635,12 +659,7 @@ constructor(
                 }
                 .combine(assetSearchTextFieldState.textAsFlow()) { items, query ->
                     val q = query.toString().trim()
-                    if (q.isBlank()) items
-                    else
-                        items.filter {
-                            it.ticker.contains(q, ignoreCase = true) ||
-                                it.chain.contains(q, ignoreCase = true)
-                        }
+                    if (q.isBlank()) items else items.filter { it.matchesSearch(q) }
                 }
                 .collect { items -> _uiState.update { it.copy(assetSearchItems = items) } }
         }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/referral/ReferralPayoutAssetViewModel.kt
@@ -9,6 +9,7 @@ import androidx.navigation.toRoute
 import com.vultisig.wallet.data.models.ImageModel
 import com.vultisig.wallet.data.models.ThorChainPoolCoin
 import com.vultisig.wallet.data.models.getCoinLogo
+import com.vultisig.wallet.data.models.matchesSearch
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.usecases.GetThorChainPoolAssetsUseCase
 import com.vultisig.wallet.data.utils.safeLaunch
@@ -88,7 +89,7 @@ constructor(
 
     private fun filterAssets(query: String): List<PayoutAssetUiModel> =
         assets
-            .filter { query.isBlank() || it.coin.ticker.contains(query.trim(), ignoreCase = true) }
+            .filter { it.coin.matchesSearch(query) }
             .map {
                 PayoutAssetUiModel(
                     asset = it.asset,

--- a/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModel.kt
@@ -20,6 +20,7 @@ import com.vultisig.wallet.data.models.isRippleIssuedToken
 import com.vultisig.wallet.data.models.isSecuredAsset
 import com.vultisig.wallet.data.models.isSwapSupported
 import com.vultisig.wallet.data.models.logo
+import com.vultisig.wallet.data.models.matchesSearch
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -147,7 +148,7 @@ constructor(
                         val filteredAssets =
                             account.accounts
                                 .asSequence()
-                                .filter { it.token.id.contains(query, ignoreCase = true) }
+                                .filter { it.token.matchesSearch(query) }
                                 .filterNot {
                                     filter == Route.SelectNetwork.Filters.SwapAvailable &&
                                         (it.token.isLpToken || it.token.isRippleIssuedToken)
@@ -176,8 +177,7 @@ constructor(
                         val filteredTokenIds = filteredAssets.map { it.token.id }.toSet()
                         val additionalAssets =
                             allTokens.filter {
-                                it.token.id.contains(query, ignoreCase = true) &&
-                                    it.token.id !in filteredTokenIds
+                                it.token.matchesSearch(query) && it.token.id !in filteredTokenIds
                             }
 
                         filteredAssets + additionalAssets

--- a/app/src/test/java/com/vultisig/wallet/ui/models/TokenSelectionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/TokenSelectionViewModelTest.kt
@@ -16,12 +16,12 @@ import com.vultisig.wallet.data.usecases.chaintokens.GetChainTokensUseCase
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import kotlin.test.assertEquals
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
@@ -79,10 +79,8 @@ internal class TokenSelectionViewModelTest {
             Snapshot.sendApplyNotifications()
             advanceUntilIdle()
 
-            assertEquals(
-                listOf(usdc.id to true, bridgedUsdc.id to false),
-                vm.uiState.value.tokens.map { it.coin.id to it.isEnabled },
-            )
+            vm.uiState.value.tokens.map { it.coin.id to it.isEnabled } shouldBe
+                listOf(usdc.id to true, bridgedUsdc.id to false)
         }
 
     @Test
@@ -95,7 +93,7 @@ internal class TokenSelectionViewModelTest {
             val vm = createViewModel()
             advanceUntilIdle()
 
-            assertEquals(listOf(usdc.id, arb.id), vm.uiState.value.tokens.map { it.coin.id })
+            vm.uiState.value.tokens.map { it.coin.id } shouldBe listOf(usdc.id, arb.id)
         }
 
     private fun createViewModel() =

--- a/app/src/test/java/com/vultisig/wallet/ui/models/TokenSelectionViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/TokenSelectionViewModelTest.kt
@@ -1,0 +1,114 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models
+
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.repositories.RequestResultRepository
+import com.vultisig.wallet.data.repositories.VaultRepository
+import com.vultisig.wallet.data.usecases.EnableTokenUseCase
+import com.vultisig.wallet.data.usecases.chaintokens.GetChainTokensUseCase
+import com.vultisig.wallet.ui.navigation.Destination
+import com.vultisig.wallet.ui.navigation.Navigator
+import com.vultisig.wallet.ui.navigation.Route
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.test.assertEquals
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class TokenSelectionViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    private val navigator: Navigator<Destination> = mockk(relaxed = true)
+    private val vaultRepository: VaultRepository = mockk(relaxed = true)
+    private val requestResultRepository: RequestResultRepository = mockk(relaxed = true)
+    private val enableTokenUseCase: EnableTokenUseCase = mockk(relaxed = true)
+    private val getChainTokens: GetChainTokensUseCase = mockk(relaxed = true)
+
+    private val vault = Vault(id = VAULT_ID, name = "Main")
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        mockkStatic("androidx.navigation.SavedStateHandleKt")
+        every { any<SavedStateHandle>().toRoute<Route.SelectTokens>() } returns
+            Route.SelectTokens(vaultId = VAULT_ID, chainId = Chain.Arbitrum.id)
+        coEvery { vaultRepository.get(VAULT_ID) } returns vault
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic("androidx.navigation.SavedStateHandleKt")
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `a name finds both an enabled and a not-yet-enabled token`() =
+        runTest(testDispatcher) {
+            val usdc = Coins.Arbitrum.USDC
+            val bridgedUsdc = Coins.Arbitrum.USDC_e
+            val arb = Coins.Arbitrum.ARB
+            every { vaultRepository.getEnabledTokens(VAULT_ID) } returns flowOf(listOf(usdc))
+            every { getChainTokens(Chain.Arbitrum, vault) } returns
+                flowOf(listOf(usdc, bridgedUsdc, arb))
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.searchTextFieldState.setTextAndPlaceCursorAtEnd("usd coin")
+            // Nothing composes in a JVM test, so the snapshot the edit lands in has to be
+            // published by hand before `snapshotFlow` sees it.
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            assertEquals(
+                listOf(usdc.id to true, bridgedUsdc.id to false),
+                vm.uiState.value.tokens.map { it.coin.id to it.isEnabled },
+            )
+        }
+
+    @Test
+    fun `a blank query lists every token`() =
+        runTest(testDispatcher) {
+            val usdc = Coins.Arbitrum.USDC
+            val arb = Coins.Arbitrum.ARB
+            every { vaultRepository.getEnabledTokens(VAULT_ID) } returns flowOf(listOf(usdc))
+            every { getChainTokens(Chain.Arbitrum, vault) } returns flowOf(listOf(usdc, arb))
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertEquals(listOf(usdc.id, arb.id), vm.uiState.value.tokens.map { it.coin.id })
+        }
+
+    private fun createViewModel() =
+        TokenSelectionViewModel(
+            savedStateHandle = mockk(relaxed = true),
+            navigator = navigator,
+            vaultRepository = vaultRepository,
+            requestResultRepository = requestResultRepository,
+            enableTokenUseCase = enableTokenUseCase,
+            getChainTokens = getChainTokens,
+        )
+
+    private companion object {
+        const val VAULT_ID = "vault-1"
+    }
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModelTest.kt
@@ -2,10 +2,16 @@
 
 package com.vultisig.wallet.ui.screens.select
 
+import androidx.compose.foundation.text.input.setTextAndPlaceCursorAtEnd
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
+import com.vultisig.wallet.data.models.Account
+import com.vultisig.wallet.data.models.Address
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.repositories.AccountsRepository
 import com.vultisig.wallet.data.repositories.RequestResultRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
@@ -29,6 +35,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -175,8 +182,69 @@ internal class SelectAssetViewModelTest {
             coVerify(exactly = 1) { enableTokenUseCase.invoke(VAULT_ID, customToken) }
         }
 
-    private fun createViewModel() =
-        SelectAssetViewModel(
+    /**
+     * The native asset on an L2 is the whole point of name search: the only ticker on Base is
+     * `ETH`, so a user who types the asset's name used to get nothing.
+     */
+    @Test
+    fun `typing an asset's name on an L2 surfaces the native coin the ticker hides`() =
+        runTest(testDispatcher) {
+            val vault = Vault(id = VAULT_ID, name = "Main")
+            val eth = Coins.Base.ETH
+            val usdc = Coins.Base.USDC
+            coEvery { vaultRepository.get(VAULT_ID) } returns vault
+            every { accountRepository.loadAddress(VAULT_ID, Chain.Base) } returns
+                flowOf(
+                    Address(chain = Chain.Base, address = "0xabc", accounts = accountsOf(eth, usdc))
+                )
+            every { getChainTokens(Chain.Base, vault) } returns flowOf(emptyList())
+            val vm = createViewModel(preselectedChain = Chain.Base)
+
+            advanceUntilIdle()
+            assertEquals(listOf(eth.id, usdc.id), vm.state.value.assets.map { it.token.id })
+
+            vm.searchFieldState.setTextAndPlaceCursorAtEnd("ethereum")
+            // Nothing composes in a JVM test, so the snapshot the edit lands in has to be
+            // published by hand before `snapshotFlow` sees it.
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            assertEquals(listOf(eth.id), vm.state.value.assets.map { it.token.id })
+        }
+
+    @Test
+    fun `an unheld token from the chain catalogue is found by name too`() =
+        runTest(testDispatcher) {
+            val vault = Vault(id = VAULT_ID, name = "Main")
+            val eth = Coins.Base.ETH
+            val usdc = Coins.Base.USDC
+            coEvery { vaultRepository.get(VAULT_ID) } returns vault
+            every { accountRepository.loadAddress(VAULT_ID, Chain.Base) } returns
+                flowOf(Address(chain = Chain.Base, address = "0xabc", accounts = accountsOf(eth)))
+            every { getChainTokens(Chain.Base, vault) } returns flowOf(listOf(usdc))
+            val vm = createViewModel(preselectedChain = Chain.Base)
+
+            vm.searchFieldState.setTextAndPlaceCursorAtEnd("usd coin")
+            Snapshot.sendApplyNotifications()
+            advanceUntilIdle()
+
+            val found = vm.state.value.assets.single()
+            assertEquals(usdc.id, found.token.id)
+            assertTrue(found.isDisabled)
+        }
+
+    private fun accountsOf(vararg coins: Coin) =
+        coins.map { Account(token = it, tokenValue = null, fiatValue = null, price = null) }
+
+    private fun createViewModel(preselectedChain: Chain = Chain.ThorChain): SelectAssetViewModel {
+        every { any<SavedStateHandle>().toRoute<Route.SelectAsset>() } returns
+            Route.SelectAsset(
+                vaultId = VAULT_ID,
+                preselectedNetworkId = preselectedChain.id,
+                networkFilters = Route.SelectNetwork.Filters.SwapAvailable,
+                requestId = REQUEST_ID,
+            )
+        return SelectAssetViewModel(
             savedStateHandle = mockk(relaxed = true),
             navigator = navigator,
             mapTokenValueToDecimalUiString = mockk(relaxed = true),
@@ -187,6 +255,7 @@ internal class SelectAssetViewModelTest {
             vaultRepository = vaultRepository,
             enableTokenUseCase = enableTokenUseCase,
         )
+    }
 
     private fun usdcCoin() =
         Coin(

--- a/app/src/test/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModelTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/screens/select/SelectAssetViewModelTest.kt
@@ -21,15 +21,15 @@ import com.vultisig.wallet.ui.models.TokenSelectionViewModel.Companion.REQUEST_S
 import com.vultisig.wallet.ui.navigation.Destination
 import com.vultisig.wallet.ui.navigation.Navigator
 import com.vultisig.wallet.ui.navigation.Route
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -137,13 +137,13 @@ internal class SelectAssetViewModelTest {
             val vm = createViewModel()
 
             // ThorChain is the preselected chain and supports custom tokens.
-            assertTrue(vm.state.value.canAddCustomToken)
+            vm.state.value.canAddCustomToken.shouldBeTrue()
 
             vm.selectChain(Chain.ZkSync)
-            assertFalse(vm.state.value.canAddCustomToken)
+            vm.state.value.canAddCustomToken.shouldBeFalse()
 
             vm.selectChain(Chain.Ethereum)
-            assertTrue(vm.state.value.canAddCustomToken)
+            vm.state.value.canAddCustomToken.shouldBeTrue()
         }
 
     @Test
@@ -160,7 +160,7 @@ internal class SelectAssetViewModelTest {
             coVerify(exactly = 1) { navigator.route(Route.CustomToken(Chain.Ethereum.raw)) }
             coVerify(exactly = 1) { enableTokenUseCase.invoke(VAULT_ID, customToken) }
             // The query that found nothing would keep hiding the token that was just added.
-            assertEquals(customToken.ticker, vm.searchFieldState.text.toString())
+            vm.searchFieldState.text.toString() shouldBe customToken.ticker
         }
 
     @Test
@@ -201,7 +201,7 @@ internal class SelectAssetViewModelTest {
             val vm = createViewModel(preselectedChain = Chain.Base)
 
             advanceUntilIdle()
-            assertEquals(listOf(eth.id, usdc.id), vm.state.value.assets.map { it.token.id })
+            vm.state.value.assets.map { it.token.id } shouldBe listOf(eth.id, usdc.id)
 
             vm.searchFieldState.setTextAndPlaceCursorAtEnd("ethereum")
             // Nothing composes in a JVM test, so the snapshot the edit lands in has to be
@@ -209,7 +209,7 @@ internal class SelectAssetViewModelTest {
             Snapshot.sendApplyNotifications()
             advanceUntilIdle()
 
-            assertEquals(listOf(eth.id), vm.state.value.assets.map { it.token.id })
+            vm.state.value.assets.map { it.token.id } shouldBe listOf(eth.id)
         }
 
     @Test
@@ -229,8 +229,8 @@ internal class SelectAssetViewModelTest {
             advanceUntilIdle()
 
             val found = vm.state.value.assets.single()
-            assertEquals(usdc.id, found.token.id)
-            assertTrue(found.isDisabled)
+            found.token.id shouldBe usdc.id
+            found.isDisabled.shouldBeTrue()
         }
 
     private fun accountsOf(vararg coins: Coin) =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
@@ -568,6 +568,7 @@ data class SuiCoinMetadata(
     @SerialName("decimals") val decimals: Int,
     @SerialName("symbol") val symbol: String,
     @SerialName("iconUrl") val iconUrl: String? = null,
+    @SerialName("name") val name: String? = null,
 )
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/SuiApi.kt
@@ -186,7 +186,12 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
         // than shown at a guessed magnitude or under a placeholder ticker.
         val decimals = metadata.decimals ?: return null
         val symbol = metadata.symbol ?: return null
-        return SuiCoinMetadata(decimals = decimals, symbol = symbol, iconUrl = metadata.iconUrl)
+        return SuiCoinMetadata(
+            decimals = decimals,
+            symbol = symbol,
+            iconUrl = metadata.iconUrl,
+            name = metadata.name,
+        )
     }
 
     override suspend fun executeTransactionBlock(
@@ -346,7 +351,7 @@ internal class SuiApiImpl @Inject constructor(http: HttpClient, private val json
         val COIN_METADATA_QUERY =
             """
             query getCoinMetadata(${'$'}coinType: String!) {
-              coinMetadata(coinType: ${'$'}coinType) { decimals symbol iconUrl }
+              coinMetadata(coinType: ${'$'}coinType) { decimals symbol iconUrl name }
             }
             """
                 .trimIndent()
@@ -454,6 +459,7 @@ private data class CoinMetadataFields(
     val decimals: Int? = null,
     val symbol: String? = null,
     val iconUrl: String? = null,
+    val name: String? = null,
 )
 
 @Serializable

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApi.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApi.kt
@@ -15,7 +15,12 @@ import kotlinx.serialization.Serializable
 import wallet.core.jni.TONAddressConverter
 
 /** Display metadata for a jetton, resolved from its master contract. */
-data class TonJettonMetadata(val ticker: String, val decimals: Int, val logo: String?)
+data class TonJettonMetadata(
+    val ticker: String,
+    val decimals: Int,
+    val logo: String?,
+    val name: String? = null,
+)
 
 /**
  * An incoming jetton transfer, with addresses canonicalized to their user-friendly (`EQ…`) form so
@@ -196,6 +201,7 @@ internal class TonApiImpl @Inject constructor(private val http: HttpClient) : To
             ticker = ticker,
             decimals = content.decimals?.trim()?.toIntOrNull() ?: 9,
             logo = content.image?.takeIf { it.isNotBlank() },
+            name = content.name?.trim()?.takeIf { it.isNotBlank() },
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApiDto.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/chains/ton/TonApiDto.kt
@@ -136,6 +136,7 @@ data class JettonMasterJson(
 @Serializable
 data class JettonContentJson(
     @SerialName("symbol") val symbol: String? = null,
+    @SerialName("name") val name: String? = null,
     // toncenter encodes decimals as a string (e.g. "6").
     @SerialName("decimals") val decimals: String? = null,
     @SerialName("image") val image: String? = null,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SplTokenJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/SplTokenJson.kt
@@ -57,6 +57,7 @@ data class SplTokenListJson(
     @SerialName("symbol") val ticker: String,
     @SerialName("image") val logo: String?,
     @SerialName("extensions") val extensions: SplExtensionsJson?,
+    @SerialName("name") val name: String? = null,
 )
 
 @Serializable data class SplExtensionsJson(@SerialName("coingeckoId") val coingeckoId: String?)
@@ -97,6 +98,7 @@ data class SplAmountRpcResponseResultJson(@SerialName("value") val value: List<S
 data class JupiterTokenResponseJson(
     @SerialName("id") val contractAddress: String,
     @SerialName("symbol") val ticker: String,
+    @SerialName("name") val name: String? = null,
     @SerialName("decimals") val decimals: Int,
     @SerialName("icon") val logo: String?,
     @SerialName("extensions") val extensions: JupiterTokenCoinGeckoIdJson?,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/ThorMetadata.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/ThorMetadata.kt
@@ -11,6 +11,7 @@ data class DenomMetadata(
     val symbol: String?,
     val display: String?,
     @SerialName("denom_units") val denomUnits: List<DenomUnit>?,
+    val name: String? = null,
 )
 
 @Serializable data class MetadataResponse(val metadata: DenomMetadata?)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/CoinEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/CoinEntity.kt
@@ -31,4 +31,5 @@ data class CoinEntity(
     @ColumnInfo("contractAddress") val contractAddress: String,
     @ColumnInfo("address") val address: String,
     @ColumnInfo("hexPublicKey") val hexPublicKey: String,
+    @ColumnInfo("name") val name: String,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/SplTokenJsonFromSplTokenInfo.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/SplTokenJsonFromSplTokenInfo.kt
@@ -18,6 +18,7 @@ internal class SplTokenJsonFromSplTokenInfoImpl @Inject constructor() :
                     logo = from.logoURI,
                     ticker = from.symbol,
                     extensions = from.extensions,
+                    name = from.name,
                 ),
             mint = from.address,
             usdPrice = from.usdPrice,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coin.kt
@@ -16,6 +16,13 @@ data class Coin(
     val contractAddress: String,
     val isNativeToken: Boolean,
     val usdPrice: BigDecimal? = null,
+    /**
+     * The asset's display name ("Ethereum", "USD Coin"), as opposed to its [ticker]. Empty when the
+     * source that produced the coin had none — a custom token looked up by contract, or a row
+     * persisted before names were stored — so consumers must treat blank as "unknown", not as a
+     * name. Never part of a coin's identity; see [id].
+     */
+    val name: String = "",
 ) {
     /**
      * Identity used for persistence (the [com.vultisig.wallet.data.db.models.CoinEntity] primary
@@ -65,6 +72,24 @@ private fun Coin.isContractQualifiedCustomToken(): Boolean =
     !isNativeToken &&
         contractAddress.isNotBlank() &&
         (chain == Chain.Ton || chain == Chain.Tron || chain == Chain.Cardano)
+
+/**
+ * Whether [query] should surface this coin in a search: a case-insensitive substring of the
+ * [Coin.ticker], the [Coin.name] or the [Coin.contractAddress]. Blank matches everything, so a
+ * search field can be piped through unconditionally.
+ *
+ * Name is what makes the native asset findable on the chains that call it something else — "eth" is
+ * the only ticker on Base, Arbitrum, Optimism and zkSync, but a user looking for it types
+ * "ethereum". The contract address is matched so an address pasted into the search box lands on the
+ * token it identifies, the same way the extension's token picker resolves one.
+ */
+fun Coin.matchesSearch(query: String): Boolean {
+    val needle = query.trim()
+    if (needle.isEmpty()) return true
+    return ticker.contains(needle, ignoreCase = true) ||
+        name.contains(needle, ignoreCase = true) ||
+        contractAddress.contains(needle, ignoreCase = true)
+}
 
 /**
  * True when this coin has a CoinGecko price-provider id, or a contract address on a chain

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/Coins.kt
@@ -57,6 +57,7 @@ object Coins {
             Coin(
                 chain = Chain.Akash,
                 ticker = "AKT",
+                name = "Akash Network",
                 logo = "akash",
                 address = "",
                 decimal = 6,
@@ -74,6 +75,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "ARB",
+                name = "Arbitrum",
                 logo = "arbitrum",
                 address = "",
                 decimal = 18,
@@ -87,6 +89,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "DAI",
+                name = "Dai Stablecoin",
                 logo = "dai",
                 address = "",
                 decimal = 18,
@@ -100,6 +103,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "ETH",
+                name = "Ethereum",
                 logo = "eth",
                 address = "",
                 decimal = 18,
@@ -113,6 +117,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "FOX",
+                name = "ShapeShift FOX",
                 logo = "fox",
                 address = "",
                 decimal = 18,
@@ -126,6 +131,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "GRT",
+                name = "The Graph",
                 logo = "grt",
                 address = "",
                 decimal = 18,
@@ -139,6 +145,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "LDO",
+                name = "Lido DAO",
                 logo = "ldo",
                 address = "",
                 decimal = 18,
@@ -152,6 +159,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "LINK",
+                name = "Chainlink",
                 logo = "link",
                 address = "",
                 decimal = 18,
@@ -165,6 +173,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "PEPE",
+                name = "Pepe",
                 logo = "pepe",
                 address = "",
                 decimal = 18,
@@ -178,6 +187,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "PYTH",
+                name = "Pyth Network",
                 logo = "pyth",
                 address = "",
                 decimal = 6,
@@ -191,6 +201,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "TGT",
+                name = "THORWallet",
                 logo = "tgt",
                 address = "",
                 decimal = 18,
@@ -204,6 +215,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "UNI",
+                name = "Uniswap",
                 logo = "uni",
                 address = "",
                 decimal = 18,
@@ -217,6 +229,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -230,6 +243,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "USDC.e",
+                name = "Bridged USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -243,6 +257,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -256,6 +271,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "WBTC",
+                name = "Wrapped Bitcoin",
                 logo = "wbtc",
                 address = "",
                 decimal = 8,
@@ -269,6 +285,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "ezETH",
+                name = "Renzo Restaked ETH",
                 logo = "ezeth",
                 address = "",
                 decimal = 18,
@@ -282,6 +299,7 @@ object Coins {
             Coin(
                 chain = Chain.Arbitrum,
                 ticker = "USDS",
+                name = "USDS Stablecoin",
                 logo = "usds",
                 address = "",
                 decimal = 18,
@@ -318,6 +336,7 @@ object Coins {
             Coin(
                 chain = Chain.Mantle,
                 ticker = "MNT",
+                name = "Mantle",
                 logo = "mantle",
                 address = "",
                 decimal = 18,
@@ -331,6 +350,7 @@ object Coins {
             Coin(
                 chain = Chain.Mantle,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -344,6 +364,7 @@ object Coins {
             Coin(
                 chain = Chain.Mantle,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -361,6 +382,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "AVAX",
+                name = "Avalanche",
                 logo = "avax",
                 address = "",
                 decimal = 18,
@@ -374,6 +396,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "BLS",
+                name = "BloodLoop Shard",
                 logo = "bls",
                 address = "",
                 decimal = 18,
@@ -387,6 +410,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "BTC.b",
+                name = "Bitcoin (Avalanche Bridge)",
                 logo = "btc",
                 address = "",
                 decimal = 8,
@@ -400,6 +424,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "COQ",
+                name = "Coq Inu",
                 logo = "coq",
                 address = "",
                 decimal = 18,
@@ -413,6 +438,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "JOE",
+                name = "Trader Joe",
                 logo = "joe",
                 address = "",
                 decimal = 18,
@@ -426,6 +452,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "PNG",
+                name = "Pangolin",
                 logo = "png",
                 address = "",
                 decimal = 18,
@@ -439,6 +466,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -452,6 +480,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -465,6 +494,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "WAVAX",
+                name = "Wrapped AVAX",
                 logo = "avax",
                 address = "",
                 decimal = 18,
@@ -478,6 +508,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "aAvaUSDC",
+                name = "Aave Avalanche USDC",
                 logo = "aave",
                 address = "",
                 decimal = 6,
@@ -491,6 +522,7 @@ object Coins {
             Coin(
                 chain = Chain.Avalanche,
                 ticker = "sAVAX",
+                name = "BENQI Staked AVAX",
                 logo = "savax",
                 address = "",
                 decimal = 18,
@@ -508,6 +540,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "AERO",
+                name = "Aerodrome",
                 logo = "aero",
                 address = "",
                 decimal = 18,
@@ -521,6 +554,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "DAI",
+                name = "Dai Stablecoin",
                 logo = "dai",
                 address = "",
                 decimal = 18,
@@ -534,6 +568,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "ETH",
+                name = "Ethereum",
                 logo = "eth",
                 address = "",
                 decimal = 18,
@@ -547,6 +582,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "OM",
+                name = "MANTRA",
                 logo = "om",
                 address = "",
                 decimal = 18,
@@ -560,6 +596,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "PYTH",
+                name = "Pyth Network",
                 logo = "pyth",
                 address = "",
                 decimal = 6,
@@ -573,6 +610,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "SNX",
+                name = "Synthetix",
                 logo = "snx",
                 address = "",
                 decimal = 18,
@@ -586,6 +624,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -599,6 +638,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "W",
+                name = "Wormhole",
                 logo = "w",
                 address = "",
                 decimal = 18,
@@ -612,6 +652,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "cbETH",
+                name = "Coinbase Wrapped Staked ETH",
                 logo = "cbeth",
                 address = "",
                 decimal = 18,
@@ -625,6 +666,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "ezETH",
+                name = "Renzo Restaked ETH",
                 logo = "ezeth",
                 address = "",
                 decimal = 18,
@@ -638,6 +680,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "rETH",
+                name = "Rocket Pool ETH",
                 logo = "reth",
                 address = "",
                 decimal = 18,
@@ -651,6 +694,7 @@ object Coins {
             Coin(
                 chain = Chain.Base,
                 ticker = "USDS",
+                name = "USDS Stablecoin",
                 logo = "usds",
                 address = "",
                 decimal = 18,
@@ -668,6 +712,7 @@ object Coins {
             Coin(
                 chain = Chain.Bitcoin,
                 ticker = "BTC",
+                name = "Bitcoin",
                 logo = "btc",
                 address = "",
                 decimal = 8,
@@ -685,6 +730,7 @@ object Coins {
             Coin(
                 chain = Chain.BitcoinCash,
                 ticker = "BCH",
+                name = "Bitcoin Cash",
                 logo = "bch",
                 address = "",
                 decimal = 8,
@@ -702,6 +748,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "AI",
+                name = "Any Inu",
                 logo = "anyinu",
                 address = "",
                 decimal = 18,
@@ -715,6 +762,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "BAG",
+                name = "Bag",
                 logo = "bag",
                 address = "",
                 decimal = 18,
@@ -728,6 +776,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "BLAST",
+                name = "Blast",
                 logo = "blast",
                 address = "",
                 decimal = 18,
@@ -741,6 +790,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "DACKIE",
+                name = "Dackie",
                 logo = "dackie",
                 address = "",
                 decimal = 18,
@@ -754,6 +804,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "ETH",
+                name = "Ethereum",
                 logo = "eth",
                 address = "",
                 decimal = 18,
@@ -767,6 +818,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "JUICE",
+                name = "Juice Finance",
                 logo = "juice",
                 address = "",
                 decimal = 18,
@@ -780,6 +832,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "MIM",
+                name = "Magic Internet Money",
                 logo = "mim",
                 address = "",
                 decimal = 18,
@@ -793,6 +846,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "OMNI",
+                name = "OmniCat",
                 logo = "omni",
                 address = "",
                 decimal = 18,
@@ -806,6 +860,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "USDB",
+                name = "USDB",
                 logo = "usdb",
                 address = "",
                 decimal = 18,
@@ -819,6 +874,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "WBTC",
+                name = "Wrapped Bitcoin",
                 logo = "wbtc",
                 address = "",
                 decimal = 8,
@@ -832,6 +888,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "WETH",
+                name = "Wrapped Ether",
                 logo = "weth",
                 address = "",
                 decimal = 18,
@@ -845,6 +902,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "ZERO",
+                name = "ZeroLend",
                 logo = "zero",
                 address = "",
                 decimal = 18,
@@ -858,6 +916,7 @@ object Coins {
             Coin(
                 chain = Chain.Blast,
                 ticker = "bLOOKS",
+                name = "Blast LooksRare",
                 logo = "blooks",
                 address = "",
                 decimal = 18,
@@ -876,6 +935,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "AAVE",
+                name = "Aave",
                 logo = "aave",
                 address = "",
                 decimal = 18,
@@ -889,6 +949,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "BNB",
+                name = "BNB",
                 logo = "bsc",
                 address = "",
                 decimal = 18,
@@ -902,6 +963,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "COMP",
+                name = "Compound",
                 logo = "comp",
                 address = "",
                 decimal = 18,
@@ -915,6 +977,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "DAI",
+                name = "Dai Stablecoin",
                 logo = "dai",
                 address = "",
                 decimal = 18,
@@ -928,6 +991,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "ETH",
+                name = "Ethereum",
                 logo = "eth",
                 address = "",
                 decimal = 18,
@@ -941,6 +1005,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "KNC",
+                name = "Kyber Network Crystal",
                 logo = "knc",
                 address = "",
                 decimal = 18,
@@ -954,6 +1019,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "PEPE",
+                name = "Pepe",
                 logo = "pepe",
                 address = "",
                 decimal = 18,
@@ -967,6 +1033,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "SUSHI",
+                name = "SushiSwap",
                 logo = "sushi",
                 address = "",
                 decimal = 18,
@@ -980,6 +1047,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 18,
@@ -993,6 +1061,7 @@ object Coins {
             Coin(
                 chain = Chain.BscChain,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 18,
@@ -1010,6 +1079,7 @@ object Coins {
             Coin(
                 chain = Chain.CronosChain,
                 ticker = "CRO",
+                name = "Cronos",
                 logo = "cro",
                 address = "",
                 decimal = 18,
@@ -1027,6 +1097,7 @@ object Coins {
             Coin(
                 chain = Chain.Dash,
                 ticker = "DASH",
+                name = "Dash",
                 logo = "dash",
                 address = "",
                 decimal = 8,
@@ -1044,6 +1115,7 @@ object Coins {
             Coin(
                 chain = Chain.Dogecoin,
                 ticker = "DOGE",
+                name = "Dogecoin",
                 logo = "doge",
                 address = "",
                 decimal = 8,
@@ -1061,6 +1133,7 @@ object Coins {
             Coin(
                 chain = Chain.Dydx,
                 ticker = "DYDX",
+                name = "dYdX",
                 logo = "dydx",
                 address = "",
                 decimal = 18,
@@ -1078,6 +1151,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "AAVE",
+                name = "Aave",
                 logo = "aave",
                 address = "",
                 decimal = 18,
@@ -1091,6 +1165,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "BAL",
+                name = "Balancer",
                 logo = "bal",
                 address = "",
                 decimal = 18,
@@ -1104,6 +1179,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "BAT",
+                name = "Basic Attention Token",
                 logo = "bat",
                 address = "",
                 decimal = 18,
@@ -1117,6 +1193,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "COMP",
+                name = "Compound",
                 logo = "comp",
                 address = "",
                 decimal = 18,
@@ -1130,6 +1207,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "DAI",
+                name = "Dai Stablecoin",
                 logo = "dai",
                 address = "",
                 decimal = 18,
@@ -1143,6 +1221,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "ETH",
+                name = "Ethereum",
                 logo = "eth",
                 address = "",
                 decimal = 18,
@@ -1156,6 +1235,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "FLIP",
+                name = "Chainflip",
                 logo = "flip",
                 address = "",
                 decimal = 18,
@@ -1169,6 +1249,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "FOX",
+                name = "ShapeShift FOX",
                 logo = "fox",
                 address = "",
                 decimal = 18,
@@ -1182,6 +1263,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "GRT",
+                name = "The Graph",
                 logo = "grt",
                 address = "",
                 decimal = 18,
@@ -1195,6 +1277,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "KNC",
+                name = "Kyber Network Crystal",
                 logo = "knc",
                 address = "",
                 decimal = 18,
@@ -1208,6 +1291,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "LINK",
+                name = "Chainlink",
                 logo = "link",
                 address = "",
                 decimal = 18,
@@ -1221,6 +1305,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "MATIC",
+                name = "Polygon (MATIC)",
                 logo = "matic",
                 address = "",
                 decimal = 18,
@@ -1234,6 +1319,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "MKR",
+                name = "Maker",
                 logo = "mkr",
                 address = "",
                 decimal = 18,
@@ -1247,6 +1333,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "PEPE",
+                name = "Pepe",
                 logo = "pepe",
                 address = "",
                 decimal = 18,
@@ -1260,6 +1347,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "POL",
+                name = "Polygon Ecosystem Token",
                 logo = "pol",
                 address = "",
                 decimal = 18,
@@ -1273,6 +1361,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "SNX",
+                name = "Synthetix",
                 logo = "snx",
                 address = "",
                 decimal = 18,
@@ -1286,6 +1375,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "SUSHI",
+                name = "SushiSwap",
                 logo = "sushi",
                 address = "",
                 decimal = 18,
@@ -1299,6 +1389,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "TGT",
+                name = "THORWallet",
                 logo = "tgt",
                 address = "",
                 decimal = 18,
@@ -1312,6 +1403,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "UNI",
+                name = "Uniswap",
                 logo = "uni",
                 address = "",
                 decimal = 18,
@@ -1325,6 +1417,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -1338,6 +1431,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -1351,6 +1445,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "VULT",
+                name = "Vultisig",
                 logo = "vulti",
                 address = "",
                 decimal = 18,
@@ -1364,6 +1459,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "WBTC",
+                name = "Wrapped Bitcoin",
                 logo = "wbtc",
                 address = "",
                 decimal = 8,
@@ -1377,6 +1473,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "WETH",
+                name = "Wrapped Ether",
                 logo = "weth",
                 address = "",
                 decimal = 18,
@@ -1390,6 +1487,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "YFI",
+                name = "yearn.finance",
                 logo = "yfi",
                 address = "",
                 decimal = 18,
@@ -1403,6 +1501,7 @@ object Coins {
             Coin(
                 chain = Chain.Ethereum,
                 ticker = "USDS",
+                name = "USDS Stablecoin",
                 logo = "usds",
                 address = "",
                 decimal = 18,
@@ -1448,6 +1547,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "ATOM",
+                name = "Cosmos Hub",
                 logo = "atom",
                 address = "",
                 decimal = 6,
@@ -1461,6 +1561,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "FUZN",
+                name = "Fuzion",
                 logo = "fuzn",
                 address = "",
                 decimal = 6,
@@ -1475,6 +1576,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "KUJI",
+                name = "Kujira",
                 logo = "kuji",
                 address = "",
                 decimal = 6,
@@ -1489,6 +1591,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "LVN",
+                name = "Levana",
                 logo = "levana",
                 address = "",
                 decimal = 6,
@@ -1503,6 +1606,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "NAMI",
+                name = "Nami Protocol",
                 logo = "nami",
                 address = "",
                 decimal = 6,
@@ -1517,6 +1621,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "NSTK",
+                name = "Unstake",
                 logo = "nstk",
                 address = "",
                 decimal = 6,
@@ -1531,6 +1636,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -1545,6 +1651,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "USK",
+                name = "USK",
                 logo = "usk",
                 address = "",
                 decimal = 6,
@@ -1559,6 +1666,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "WINK",
+                name = "WINK",
                 logo = "wink",
                 address = "",
                 decimal = 6,
@@ -1573,6 +1681,7 @@ object Coins {
             Coin(
                 chain = Chain.GaiaChain,
                 ticker = "rKUJI",
+                name = "Rujira KUJI",
                 logo = "rkuji",
                 address = "",
                 decimal = 6,
@@ -1591,6 +1700,7 @@ object Coins {
             Coin(
                 chain = Chain.Litecoin,
                 ticker = "LTC",
+                name = "Litecoin",
                 logo = "ltc",
                 address = "",
                 decimal = 8,
@@ -1608,6 +1718,7 @@ object Coins {
             Coin(
                 chain = Chain.MayaChain,
                 ticker = "CACAO",
+                name = "Cacao",
                 logo = "cacao",
                 address = "",
                 decimal = 10,
@@ -1621,6 +1732,7 @@ object Coins {
             Coin(
                 chain = Chain.MayaChain,
                 ticker = "MAYA",
+                name = "Maya",
                 logo = "maya",
                 address = "",
                 decimal = 4,
@@ -1634,6 +1746,7 @@ object Coins {
             Coin(
                 chain = Chain.MayaChain,
                 ticker = "AZTEC",
+                name = "Aztec",
                 logo = "aztec",
                 address = "",
                 decimal = 4,
@@ -1651,6 +1764,7 @@ object Coins {
             Coin(
                 chain = Chain.Noble,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -1668,6 +1782,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "DAI",
+                name = "Dai Stablecoin",
                 logo = "dai",
                 address = "",
                 decimal = 18,
@@ -1681,6 +1796,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "ETH",
+                name = "Ethereum",
                 logo = "eth",
                 address = "",
                 decimal = 18,
@@ -1694,6 +1810,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "FOX",
+                name = "ShapeShift FOX",
                 logo = "fox",
                 address = "",
                 decimal = 18,
@@ -1707,6 +1824,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "LDO",
+                name = "Lido DAO",
                 logo = "ldo",
                 address = "",
                 decimal = 18,
@@ -1720,6 +1838,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "LINK",
+                name = "Chainlink",
                 logo = "link",
                 address = "",
                 decimal = 18,
@@ -1733,6 +1852,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "OP",
+                name = "Optimism",
                 logo = "optimism",
                 address = "",
                 decimal = 18,
@@ -1746,6 +1866,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "PYTH",
+                name = "Pyth Network",
                 logo = "pyth",
                 address = "",
                 decimal = 6,
@@ -1759,6 +1880,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -1772,6 +1894,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "USDC.e",
+                name = "Bridged USD Coin",
                 logo = "USDC.e",
                 address = "",
                 decimal = 6,
@@ -1785,6 +1908,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -1798,6 +1922,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "WBTC",
+                name = "Wrapped Bitcoin",
                 logo = "wbtc",
                 address = "",
                 decimal = 8,
@@ -1811,6 +1936,7 @@ object Coins {
             Coin(
                 chain = Chain.Optimism,
                 ticker = "ezETH",
+                name = "Renzo Restaked ETH",
                 logo = "ezeth",
                 address = "",
                 decimal = 18,
@@ -1828,6 +1954,7 @@ object Coins {
             Coin(
                 chain = Chain.Osmosis,
                 ticker = "ION",
+                name = "Ion",
                 logo = "ion",
                 address = "",
                 decimal = 6,
@@ -1841,6 +1968,7 @@ object Coins {
             Coin(
                 chain = Chain.Osmosis,
                 ticker = "LVN",
+                name = "Levana",
                 logo = "levana",
                 address = "",
                 decimal = 6,
@@ -1855,6 +1983,7 @@ object Coins {
             Coin(
                 chain = Chain.Osmosis,
                 ticker = "OSMO",
+                name = "Osmosis",
                 logo = "osmo",
                 address = "",
                 decimal = 6,
@@ -1868,6 +1997,7 @@ object Coins {
             Coin(
                 chain = Chain.Osmosis,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -1882,6 +2012,7 @@ object Coins {
             Coin(
                 chain = Chain.Osmosis,
                 ticker = "USDC.eth.axl",
+                name = "Axelar Bridged USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -1896,6 +2027,7 @@ object Coins {
             Coin(
                 chain = Chain.Osmosis,
                 ticker = "allBTC",
+                name = "Alloyed Bitcoin",
                 logo = "btc",
                 address = "",
                 decimal = 8,
@@ -1914,6 +2046,7 @@ object Coins {
             Coin(
                 chain = Chain.Polkadot,
                 ticker = "DOT",
+                name = "Polkadot",
                 logo = "dot",
                 address = "",
                 decimal = 10,
@@ -1931,6 +2064,7 @@ object Coins {
             Coin(
                 chain = Chain.Bittensor,
                 ticker = "TAO",
+                name = "Bittensor",
                 logo = "bittensor",
                 address = "",
                 decimal = 9,
@@ -1948,6 +2082,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "AVAX",
+                name = "Avalanche",
                 logo = "avax",
                 address = "",
                 decimal = 18,
@@ -1961,6 +2096,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "BNB",
+                name = "BNB",
                 logo = "bsc",
                 address = "",
                 decimal = 18,
@@ -1974,6 +2110,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "BUSD",
+                name = "Binance USD",
                 logo = "busd",
                 address = "",
                 decimal = 18,
@@ -1987,6 +2124,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "FOX",
+                name = "ShapeShift FOX",
                 logo = "fox",
                 address = "",
                 decimal = 18,
@@ -2000,6 +2138,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "LINK",
+                name = "Chainlink",
                 logo = "link",
                 address = "",
                 decimal = 18,
@@ -2013,6 +2152,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "POL",
+                name = "Polygon",
                 logo = "matic",
                 address = "",
                 decimal = 18,
@@ -2026,6 +2166,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "SHIB",
+                name = "Shiba Inu",
                 logo = "shib",
                 address = "",
                 decimal = 18,
@@ -2039,6 +2180,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "SOL",
+                name = "Wrapped Solana",
                 logo = "sol",
                 address = "",
                 decimal = 9,
@@ -2052,6 +2194,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -2065,6 +2208,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "USDC.e",
+                name = "Bridged USD Coin",
                 logo = "USDC.e",
                 address = "",
                 decimal = 6,
@@ -2078,6 +2222,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -2091,6 +2236,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "WBTC",
+                name = "Wrapped Bitcoin",
                 logo = "wbtc",
                 address = "",
                 decimal = 8,
@@ -2104,6 +2250,7 @@ object Coins {
             Coin(
                 chain = Chain.Polygon,
                 ticker = "WETH",
+                name = "Wrapped Ether",
                 logo = "weth",
                 address = "",
                 decimal = 18,
@@ -2121,6 +2268,7 @@ object Coins {
             Coin(
                 chain = Chain.Ripple,
                 ticker = "XRP",
+                name = "XRP",
                 logo = "xrp",
                 address = "",
                 decimal = 6,
@@ -2140,6 +2288,7 @@ object Coins {
             Coin(
                 chain = Chain.Ripple,
                 ticker = "RLUSD",
+                name = "Ripple USD",
                 logo = "rlusd",
                 address = "",
                 decimal = RIPPLE_TOKEN_DECIMALS,
@@ -2161,6 +2310,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "JUP",
+                name = "Jupiter",
                 logo = "jupiter",
                 address = "",
                 decimal = 6,
@@ -2174,6 +2324,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "KWEEN",
+                name = "KWEEN",
                 logo = "kween",
                 address = "",
                 decimal = 6,
@@ -2187,6 +2338,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "PYTH",
+                name = "Pyth Network",
                 logo = "pyth",
                 address = "",
                 decimal = 6,
@@ -2200,6 +2352,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "RAY",
+                name = "Raydium",
                 logo = "raydium-ray-seeklogo-2",
                 address = "",
                 decimal = 6,
@@ -2213,6 +2366,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "SOL",
+                name = "Solana",
                 logo = "solana",
                 address = "",
                 decimal = 9,
@@ -2226,6 +2380,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -2239,6 +2394,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -2252,6 +2408,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "WIF",
+                name = "dogwifhat",
                 logo = "dogwifhat-wif-logo",
                 address = "",
                 decimal = 6,
@@ -2265,6 +2422,7 @@ object Coins {
             Coin(
                 chain = Chain.Solana,
                 ticker = "USDS",
+                name = "USDS Stablecoin",
                 logo = "usds",
                 address = "",
                 decimal = 6,
@@ -2282,6 +2440,7 @@ object Coins {
             Coin(
                 chain = Chain.Sei,
                 ticker = "SEI",
+                name = "Sei",
                 logo = "sei",
                 address = "",
                 decimal = 18,
@@ -2298,6 +2457,7 @@ object Coins {
             Coin(
                 chain = Chain.Robinhood,
                 ticker = "ETH",
+                name = "Ethereum",
                 logo = "eth",
                 address = "",
                 decimal = 18,
@@ -2310,6 +2470,7 @@ object Coins {
             Coin(
                 chain = Chain.Robinhood,
                 ticker = "USDG",
+                name = "Global Dollar",
                 logo = "usdg",
                 address = "",
                 decimal = 6,
@@ -2322,6 +2483,7 @@ object Coins {
             Coin(
                 chain = Chain.Robinhood,
                 ticker = "USDe",
+                name = "Ethena USDe",
                 logo = "usde",
                 address = "",
                 decimal = 18,
@@ -2334,6 +2496,7 @@ object Coins {
             Coin(
                 chain = Chain.Robinhood,
                 ticker = "WETH",
+                name = "Wrapped Ether",
                 logo = "weth",
                 address = "",
                 decimal = 18,
@@ -2346,6 +2509,7 @@ object Coins {
             Coin(
                 chain = Chain.Robinhood,
                 ticker = "LINK",
+                name = "Chainlink",
                 logo = "link",
                 address = "",
                 decimal = 18,
@@ -2359,6 +2523,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "AAOI",
+                    name = "Applied Optoelectronics",
                     logo = "https://financialmodelingprep.com/image-stock/AAOI.png",
                     address = "",
                     decimal = 18,
@@ -2370,6 +2535,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "AAPL",
+                    name = "Apple",
                     logo = "https://financialmodelingprep.com/image-stock/AAPL.png",
                     address = "",
                     decimal = 18,
@@ -2381,6 +2547,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "AMAT",
+                    name = "Applied Materials",
                     logo = "https://financialmodelingprep.com/image-stock/AMAT.png",
                     address = "",
                     decimal = 18,
@@ -2392,6 +2559,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "AMD",
+                    name = "Advanced Micro Devices",
                     logo = "https://financialmodelingprep.com/image-stock/AMD.png",
                     address = "",
                     decimal = 18,
@@ -2403,6 +2571,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "AMZN",
+                    name = "Amazon",
                     logo = "https://financialmodelingprep.com/image-stock/AMZN.png",
                     address = "",
                     decimal = 18,
@@ -2414,6 +2583,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "APLD",
+                    name = "Applied Digital",
                     logo = "https://financialmodelingprep.com/image-stock/APLD.png",
                     address = "",
                     decimal = 18,
@@ -2425,6 +2595,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "ASML",
+                    name = "ASML Holding",
                     logo = "https://financialmodelingprep.com/image-stock/ASML.png",
                     address = "",
                     decimal = 18,
@@ -2436,6 +2607,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "ASTS",
+                    name = "AST SpaceMobile",
                     logo = "https://financialmodelingprep.com/image-stock/ASTS.png",
                     address = "",
                     decimal = 18,
@@ -2447,6 +2619,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "AVGO",
+                    name = "Broadcom",
                     logo = "https://financialmodelingprep.com/image-stock/AVGO.png",
                     address = "",
                     decimal = 18,
@@ -2458,6 +2631,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "BA",
+                    name = "Boeing",
                     logo = "https://financialmodelingprep.com/image-stock/BA.png",
                     address = "",
                     decimal = 18,
@@ -2469,6 +2643,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "BABA",
+                    name = "Alibaba",
                     logo = "https://financialmodelingprep.com/image-stock/BABA.png",
                     address = "",
                     decimal = 18,
@@ -2480,6 +2655,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "BE",
+                    name = "Bloom Energy",
                     logo = "https://financialmodelingprep.com/image-stock/BE.png",
                     address = "",
                     decimal = 18,
@@ -2491,6 +2667,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "CBRS",
+                    name = "Cerebras Systems",
                     logo = "https://financialmodelingprep.com/image-stock/CBRS.png",
                     address = "",
                     decimal = 18,
@@ -2502,6 +2679,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "CCL",
+                    name = "Carnival",
                     logo = "https://financialmodelingprep.com/image-stock/CCL.png",
                     address = "",
                     decimal = 18,
@@ -2513,6 +2691,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "CELH",
+                    name = "Celsius Holdings",
                     logo = "https://financialmodelingprep.com/image-stock/CELH.png",
                     address = "",
                     decimal = 18,
@@ -2524,6 +2703,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "CLSK",
+                    name = "CleanSpark",
                     logo = "https://financialmodelingprep.com/image-stock/CLSK.png",
                     address = "",
                     decimal = 18,
@@ -2535,6 +2715,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "COIN",
+                    name = "Coinbase",
                     logo = "https://financialmodelingprep.com/image-stock/COIN.png",
                     address = "",
                     decimal = 18,
@@ -2546,6 +2727,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "COST",
+                    name = "Costco",
                     logo = "https://financialmodelingprep.com/image-stock/COST.png",
                     address = "",
                     decimal = 18,
@@ -2557,6 +2739,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "CRCL",
+                    name = "Circle Internet Group",
                     logo = "https://financialmodelingprep.com/image-stock/CRCL.png",
                     address = "",
                     decimal = 18,
@@ -2568,6 +2751,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "CRWD",
+                    name = "CrowdStrike",
                     logo = "https://financialmodelingprep.com/image-stock/CRWD.png",
                     address = "",
                     decimal = 18,
@@ -2579,6 +2763,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "CRWV",
+                    name = "CoreWeave",
                     logo = "https://financialmodelingprep.com/image-stock/CRWV.png",
                     address = "",
                     decimal = 18,
@@ -2590,6 +2775,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "DDOG",
+                    name = "Datadog",
                     logo = "https://financialmodelingprep.com/image-stock/DDOG.png",
                     address = "",
                     decimal = 18,
@@ -2601,6 +2787,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "DELL",
+                    name = "Dell Technologies",
                     logo = "https://financialmodelingprep.com/image-stock/DELL.png",
                     address = "",
                     decimal = 18,
@@ -2612,6 +2799,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "ELF",
+                    name = "e.l.f. Beauty",
                     logo = "https://financialmodelingprep.com/image-stock/ELF.png",
                     address = "",
                     decimal = 18,
@@ -2623,6 +2811,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "EWY",
+                    name = "iShares MSCI South Korea ETF",
                     logo = "https://financialmodelingprep.com/image-stock/EWY.png",
                     address = "",
                     decimal = 18,
@@ -2634,6 +2823,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "F",
+                    name = "Ford Motor",
                     logo = "https://financialmodelingprep.com/image-stock/F.png",
                     address = "",
                     decimal = 18,
@@ -2645,6 +2835,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "FLNC",
+                    name = "Fluence Energy",
                     logo = "https://financialmodelingprep.com/image-stock/FLNC.png",
                     address = "",
                     decimal = 18,
@@ -2656,6 +2847,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "FUTU",
+                    name = "Futu Holdings",
                     logo = "https://financialmodelingprep.com/image-stock/FUTU.png",
                     address = "",
                     decimal = 18,
@@ -2667,6 +2859,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "GLW",
+                    name = "Corning",
                     logo = "https://financialmodelingprep.com/image-stock/GLW.png",
                     address = "",
                     decimal = 18,
@@ -2678,6 +2871,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "GME",
+                    name = "GameStop",
                     logo = "https://financialmodelingprep.com/image-stock/GME.png",
                     address = "",
                     decimal = 18,
@@ -2689,6 +2883,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "GOOGL",
+                    name = "Alphabet Class A",
                     logo = "https://financialmodelingprep.com/image-stock/GOOGL.png",
                     address = "",
                     decimal = 18,
@@ -2700,6 +2895,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "INOD",
+                    name = "Innodata",
                     logo = "https://financialmodelingprep.com/image-stock/INOD.png",
                     address = "",
                     decimal = 18,
@@ -2711,6 +2907,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "INTC",
+                    name = "Intel",
                     logo = "https://financialmodelingprep.com/image-stock/INTC.png",
                     address = "",
                     decimal = 18,
@@ -2722,6 +2919,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "INTU",
+                    name = "Intuit",
                     logo = "https://financialmodelingprep.com/image-stock/INTU.png",
                     address = "",
                     decimal = 18,
@@ -2733,6 +2931,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "IONQ",
+                    name = "IonQ",
                     logo = "https://financialmodelingprep.com/image-stock/IONQ.png",
                     address = "",
                     decimal = 18,
@@ -2744,6 +2943,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "IREN",
+                    name = "IREN",
                     logo = "https://financialmodelingprep.com/image-stock/IREN.png",
                     address = "",
                     decimal = 18,
@@ -2755,6 +2955,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "LITE",
+                    name = "Lumentum",
                     logo = "https://financialmodelingprep.com/image-stock/LITE.png",
                     address = "",
                     decimal = 18,
@@ -2766,6 +2967,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "LLY",
+                    name = "Eli Lilly",
                     logo = "https://financialmodelingprep.com/image-stock/LLY.png",
                     address = "",
                     decimal = 18,
@@ -2777,6 +2979,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "LULU",
+                    name = "Lululemon",
                     logo = "https://financialmodelingprep.com/image-stock/LULU.png",
                     address = "",
                     decimal = 18,
@@ -2788,6 +2991,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "LUNR",
+                    name = "Intuitive Machines",
                     logo = "https://financialmodelingprep.com/image-stock/LUNR.png",
                     address = "",
                     decimal = 18,
@@ -2799,6 +3003,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "MDB",
+                    name = "MongoDB",
                     logo = "https://financialmodelingprep.com/image-stock/MDB.png",
                     address = "",
                     decimal = 18,
@@ -2810,6 +3015,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "META",
+                    name = "Meta Platforms",
                     logo = "https://financialmodelingprep.com/image-stock/META.png",
                     address = "",
                     decimal = 18,
@@ -2821,6 +3027,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "MRVL",
+                    name = "Marvell Technology",
                     logo = "https://financialmodelingprep.com/image-stock/MRVL.png",
                     address = "",
                     decimal = 18,
@@ -2832,6 +3039,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "MSFT",
+                    name = "Microsoft",
                     logo = "https://financialmodelingprep.com/image-stock/MSFT.png",
                     address = "",
                     decimal = 18,
@@ -2843,6 +3051,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "MSTR",
+                    name = "Strategy (MicroStrategy)",
                     logo = "https://financialmodelingprep.com/image-stock/MSTR.png",
                     address = "",
                     decimal = 18,
@@ -2854,6 +3063,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "MU",
+                    name = "Micron Technology",
                     logo = "https://financialmodelingprep.com/image-stock/MU.png",
                     address = "",
                     decimal = 18,
@@ -2865,6 +3075,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "MXL",
+                    name = "MaxLinear",
                     logo = "https://financialmodelingprep.com/image-stock/MXL.png",
                     address = "",
                     decimal = 18,
@@ -2876,6 +3087,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "NBIS",
+                    name = "Nebius Group",
                     logo = "https://financialmodelingprep.com/image-stock/NBIS.png",
                     address = "",
                     decimal = 18,
@@ -2887,6 +3099,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "NFLX",
+                    name = "Netflix",
                     logo = "https://financialmodelingprep.com/image-stock/NFLX.png",
                     address = "",
                     decimal = 18,
@@ -2898,6 +3111,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "NNE",
+                    name = "Nano Nuclear Energy",
                     logo = "https://financialmodelingprep.com/image-stock/NNE.png",
                     address = "",
                     decimal = 18,
@@ -2909,6 +3123,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "NOW",
+                    name = "ServiceNow",
                     logo = "https://financialmodelingprep.com/image-stock/NOW.png",
                     address = "",
                     decimal = 18,
@@ -2920,6 +3135,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "NU",
+                    name = "Nu Holdings",
                     logo = "https://financialmodelingprep.com/image-stock/NU.png",
                     address = "",
                     decimal = 18,
@@ -2931,6 +3147,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "NVDA",
+                    name = "NVIDIA",
                     logo = "https://financialmodelingprep.com/image-stock/NVDA.png",
                     address = "",
                     decimal = 18,
@@ -2942,6 +3159,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "NVTS",
+                    name = "Navitas Semiconductor",
                     logo = "https://financialmodelingprep.com/image-stock/NVTS.png",
                     address = "",
                     decimal = 18,
@@ -2953,6 +3171,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "ORCL",
+                    name = "Oracle",
                     logo = "https://financialmodelingprep.com/image-stock/ORCL.png",
                     address = "",
                     decimal = 18,
@@ -2964,6 +3183,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "P",
+                    name = "Everpure",
                     logo =
                         "https://cdn.robinhood.com/ncw_assets/logos/0x1cdad396db64bda184d5182a97dd9b3c62100b7d.png",
                     address = "",
@@ -2976,6 +3196,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "PENG",
+                    name = "Penguin Solutions",
                     logo = "https://financialmodelingprep.com/image-stock/PENG.png",
                     address = "",
                     decimal = 18,
@@ -2987,6 +3208,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "PLTR",
+                    name = "Palantir Technologies",
                     logo = "https://financialmodelingprep.com/image-stock/PLTR.png",
                     address = "",
                     decimal = 18,
@@ -2998,6 +3220,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "POET",
+                    name = "POET Technologies",
                     logo = "https://financialmodelingprep.com/image-stock/POET.png",
                     address = "",
                     decimal = 18,
@@ -3009,6 +3232,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "PR",
+                    name = "Permian Resources",
                     logo = "https://financialmodelingprep.com/image-stock/PR.png",
                     address = "",
                     decimal = 18,
@@ -3020,6 +3244,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "QBTS",
+                    name = "D-Wave Quantum",
                     logo = "https://financialmodelingprep.com/image-stock/QBTS.png",
                     address = "",
                     decimal = 18,
@@ -3031,6 +3256,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "QCOM",
+                    name = "Qualcomm",
                     logo = "https://financialmodelingprep.com/image-stock/QCOM.png",
                     address = "",
                     decimal = 18,
@@ -3042,6 +3268,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "QQQ",
+                    name = "Invesco QQQ Trust",
                     logo = "https://financialmodelingprep.com/image-stock/QQQ.png",
                     address = "",
                     decimal = 18,
@@ -3053,6 +3280,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "QUBT",
+                    name = "Quantum Computing Inc.",
                     logo = "https://financialmodelingprep.com/image-stock/QUBT.png",
                     address = "",
                     decimal = 18,
@@ -3064,6 +3292,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "RBLX",
+                    name = "Roblox",
                     logo = "https://financialmodelingprep.com/image-stock/RBLX.png",
                     address = "",
                     decimal = 18,
@@ -3075,6 +3304,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "RDDT",
+                    name = "Reddit",
                     logo = "https://financialmodelingprep.com/image-stock/RDDT.png",
                     address = "",
                     decimal = 18,
@@ -3086,6 +3316,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "RDW",
+                    name = "Redwire",
                     logo = "https://financialmodelingprep.com/image-stock/RDW.png",
                     address = "",
                     decimal = 18,
@@ -3097,6 +3328,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "RGTI",
+                    name = "Rigetti Computing",
                     logo = "https://financialmodelingprep.com/image-stock/RGTI.png",
                     address = "",
                     decimal = 18,
@@ -3108,6 +3340,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "RIVN",
+                    name = "Rivian Automotive",
                     logo = "https://financialmodelingprep.com/image-stock/RIVN.png",
                     address = "",
                     decimal = 18,
@@ -3119,6 +3352,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "RKLB",
+                    name = "Rocket Lab",
                     logo = "https://financialmodelingprep.com/image-stock/RKLB.png",
                     address = "",
                     decimal = 18,
@@ -3130,6 +3364,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SATS",
+                    name = "EchoStar",
                     logo = "https://financialmodelingprep.com/image-stock/SATS.png",
                     address = "",
                     decimal = 18,
@@ -3141,6 +3376,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SGOV",
+                    name = "iShares 0-3 Month Treasury Bond ETF",
                     logo = "https://financialmodelingprep.com/image-stock/SGOV.png",
                     address = "",
                     decimal = 18,
@@ -3152,6 +3388,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SHOP",
+                    name = "Shopify",
                     logo = "https://financialmodelingprep.com/image-stock/SHOP.png",
                     address = "",
                     decimal = 18,
@@ -3163,6 +3400,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SKHY",
+                    name = "SK hynix",
                     logo =
                         "https://cdn.robinhood.com/ncw_assets/logos/0x84cab63bc87912e71ad199ff14a0ba45de68fef8.png",
                     address = "",
@@ -3175,6 +3413,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SLV",
+                    name = "iShares Silver Trust",
                     logo = "https://financialmodelingprep.com/image-stock/SLV.png",
                     address = "",
                     decimal = 18,
@@ -3186,6 +3425,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SMCI",
+                    name = "Super Micro Computer",
                     logo = "https://financialmodelingprep.com/image-stock/SMCI.png",
                     address = "",
                     decimal = 18,
@@ -3197,6 +3437,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SNDK",
+                    name = "Sandisk",
                     logo = "https://financialmodelingprep.com/image-stock/SNDK.png",
                     address = "",
                     decimal = 18,
@@ -3208,6 +3449,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SOFI",
+                    name = "SoFi Technologies",
                     logo = "https://financialmodelingprep.com/image-stock/SOFI.png",
                     address = "",
                     decimal = 18,
@@ -3219,6 +3461,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SOXX",
+                    name = "iShares Semiconductor ETF",
                     logo = "https://financialmodelingprep.com/image-stock/SOXX.png",
                     address = "",
                     decimal = 18,
@@ -3230,6 +3473,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SPCX",
+                    name = "SpaceX",
                     logo = "https://financialmodelingprep.com/image-stock/SPCX.png",
                     address = "",
                     decimal = 18,
@@ -3241,6 +3485,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SPMO",
+                    name = "Invesco S&P 500 Momentum ETF",
                     logo = "https://financialmodelingprep.com/image-stock/SPMO.png",
                     address = "",
                     decimal = 18,
@@ -3252,6 +3497,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "SPY",
+                    name = "SPDR S&P 500 ETF Trust",
                     logo = "https://financialmodelingprep.com/image-stock/SPY.png",
                     address = "",
                     decimal = 18,
@@ -3263,6 +3509,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "TSEM",
+                    name = "Tower Semiconductor",
                     logo =
                         "https://cdn.robinhood.com/ncw_assets/logos/0x89776d4cd68193597a2fc132cfac1fde36ccea8a.png",
                     address = "",
@@ -3275,6 +3522,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "TSLA",
+                    name = "Tesla",
                     logo = "https://financialmodelingprep.com/image-stock/TSLA.png",
                     address = "",
                     decimal = 18,
@@ -3286,6 +3534,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "TSM",
+                    name = "Taiwan Semiconductor Manufacturing",
                     logo = "https://financialmodelingprep.com/image-stock/TSM.png",
                     address = "",
                     decimal = 18,
@@ -3297,6 +3546,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "TTWO",
+                    name = "Take-Two Interactive Software",
                     logo = "https://financialmodelingprep.com/image-stock/TTWO.png",
                     address = "",
                     decimal = 18,
@@ -3308,6 +3558,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "UMC",
+                    name = "United Microelectronics",
                     logo = "https://financialmodelingprep.com/image-stock/UMC.png",
                     address = "",
                     decimal = 18,
@@ -3319,6 +3570,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "UPS",
+                    name = "United Parcel Service",
                     logo = "https://financialmodelingprep.com/image-stock/UPS.png",
                     address = "",
                     decimal = 18,
@@ -3330,6 +3582,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "USAR",
+                    name = "USA Rare Earth",
                     logo = "https://financialmodelingprep.com/image-stock/USAR.png",
                     address = "",
                     decimal = 18,
@@ -3341,6 +3594,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "USO",
+                    name = "United States Oil Fund",
                     logo =
                         "https://cdn.robinhood.com/ncw_assets/logos/0xa30fa36db767ad9ed3f7a60fc79526fb4d56d344.png",
                     address = "",
@@ -3353,6 +3607,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "WDAY",
+                    name = "Workday",
                     logo = "https://financialmodelingprep.com/image-stock/WDAY.png",
                     address = "",
                     decimal = 18,
@@ -3364,6 +3619,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "XLK",
+                    name = "Technology Select Sector SPDR ETF",
                     logo = "https://financialmodelingprep.com/image-stock/XLK.png",
                     address = "",
                     decimal = 18,
@@ -3375,6 +3631,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "XNDU",
+                    name = "Xanadu Quantum",
                     logo =
                         "https://cdn.robinhood.com/ncw_assets/logos/0xa8eb3bccbf2017ee7cbfb652eb51cf2e1b153289.png",
                     address = "",
@@ -3387,6 +3644,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "XOM",
+                    name = "ExxonMobil",
                     logo = "https://financialmodelingprep.com/image-stock/XOM.png",
                     address = "",
                     decimal = 18,
@@ -3398,6 +3656,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "ZM",
+                    name = "Zoom Communications",
                     logo = "https://financialmodelingprep.com/image-stock/ZM.png",
                     address = "",
                     decimal = 18,
@@ -3409,6 +3668,7 @@ object Coins {
                 Coin(
                     chain = Chain.Robinhood,
                     ticker = "ZS",
+                    name = "Zscaler",
                     logo = "https://financialmodelingprep.com/image-stock/ZS.png",
                     address = "",
                     decimal = 18,
@@ -3426,6 +3686,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "HYPE",
+                name = "Hyperliquid",
                 logo = "hype",
                 address = "",
                 decimal = 18,
@@ -3439,6 +3700,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "kHYPE",
+                name = "Kinetiq Staked HYPE",
                 logo = "khype",
                 address = "",
                 decimal = 18,
@@ -3452,6 +3714,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "wstHYPE",
+                name = "Staked HYPE Shares",
                 logo = "wsthype",
                 address = "",
                 decimal = 18,
@@ -3465,6 +3728,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "WHYPE",
+                name = "Wrapped HYPE",
                 logo = "whype",
                 address = "",
                 decimal = 18,
@@ -3478,6 +3742,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "UFART",
+                name = "Unit Fartcoin",
                 logo = "ufart",
                 address = "",
                 decimal = 6,
@@ -3491,6 +3756,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "USDT0",
+                name = "Tether USD (USDT0)",
                 logo = "usdt0",
                 address = "",
                 decimal = 6,
@@ -3504,6 +3770,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "vkHYPE",
+                name = "Kinetiq Earn Vault",
                 logo = "vkhype",
                 address = "",
                 decimal = 18,
@@ -3517,6 +3784,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "UBTC",
+                name = "Unit Bitcoin",
                 logo = "ubtc",
                 address = "",
                 decimal = 8,
@@ -3530,6 +3798,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "vHYPE",
+                name = "Ventuals vHYPE",
                 logo = "vhype",
                 address = "",
                 decimal = 18,
@@ -3543,6 +3812,7 @@ object Coins {
             Coin(
                 chain = Chain.Hyperliquid,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -3560,6 +3830,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "ETH",
+                name = "Ethereum (Sui Bridge)",
                 logo = "eth",
                 address = "",
                 decimal = 8,
@@ -3574,6 +3845,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "SUI",
+                name = "Sui",
                 logo = "sui",
                 address = "",
                 decimal = 9,
@@ -3587,6 +3859,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "DEEP",
+                name = "DeepBook",
                 logo = "https://s2.coinmarketcap.com/static/img/coins/64x64/33391.png",
                 address = "",
                 decimal = 6,
@@ -3601,6 +3874,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "WAL",
+                name = "Walrus",
                 logo = "https://coin-images.coingecko.com/coins/images/54914/large/WAL_logo.png",
                 address = "",
                 decimal = 9,
@@ -3615,6 +3889,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "CETUS",
+                name = "Cetus Protocol",
                 logo =
                     "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/sui/asset/cetus.png",
                 address = "",
@@ -3630,6 +3905,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "NAVX",
+                name = "NAVI Protocol",
                 logo =
                     "https://raw.githubusercontent.com/cosmostation/chainlist/main/chain/sui/asset/navx.png",
                 address = "",
@@ -3645,6 +3921,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "BLUE",
+                name = "Bluefin",
                 logo =
                     "https://coin-images.coingecko.com/coins/images/30883/large/BLUE_200x200.png",
                 address = "",
@@ -3660,6 +3937,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "SEND",
+                name = "Suilend",
                 logo = "https://coin-images.coingecko.com/coins/images/50989/large/SEND.png",
                 address = "",
                 decimal = 6,
@@ -3674,6 +3952,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -3688,6 +3967,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "AXOL",
+                name = "Axol",
                 logo = "https://coin-images.coingecko.com/coins/images/50412/large/AXOL.png",
                 address = "",
                 decimal = 9,
@@ -3702,6 +3982,7 @@ object Coins {
             Coin(
                 chain = Chain.Sui,
                 ticker = "LOFI",
+                name = "Lofi",
                 logo = "https://s2.coinmarketcap.com/static/img/coins/64x64/34187.png",
                 address = "",
                 decimal = 9,
@@ -3720,6 +4001,7 @@ object Coins {
             Coin(
                 chain = Chain.Terra,
                 ticker = "ASTRO",
+                name = "Astroport",
                 logo = "terra-astroport",
                 address = "",
                 decimal = 6,
@@ -3734,6 +4016,7 @@ object Coins {
             Coin(
                 chain = Chain.Terra,
                 ticker = "ASTRO-IBC",
+                name = "Astroport (IBC)",
                 logo = "terra-astroport",
                 address = "",
                 decimal = 6,
@@ -3748,6 +4031,7 @@ object Coins {
             Coin(
                 chain = Chain.Terra,
                 ticker = "LUNA",
+                name = "Terra",
                 logo = "luna",
                 address = "",
                 decimal = 6,
@@ -3761,6 +4045,7 @@ object Coins {
             Coin(
                 chain = Chain.Terra,
                 ticker = "TPT",
+                name = "Terra Poker Token",
                 logo = "terra-poker-token",
                 address = "",
                 decimal = 6,
@@ -3779,6 +4064,7 @@ object Coins {
             Coin(
                 chain = Chain.TerraClassic,
                 ticker = "ASTROC",
+                name = "Astroport Classic",
                 logo = "terra-astroport",
                 address = "",
                 decimal = 6,
@@ -3792,6 +4078,7 @@ object Coins {
             Coin(
                 chain = Chain.TerraClassic,
                 ticker = "LUNC",
+                name = "Terra Luna Classic",
                 logo = "lunc",
                 address = "",
                 decimal = 6,
@@ -3805,6 +4092,7 @@ object Coins {
             Coin(
                 chain = Chain.TerraClassic,
                 ticker = "USTC",
+                name = "TerraClassicUSD",
                 logo = "ustc",
                 address = "",
                 decimal = 6,
@@ -3822,6 +4110,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "RUNE",
+                name = "THORChain",
                 logo = "rune",
                 address = "",
                 decimal = 8,
@@ -3835,6 +4124,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "TCY",
+                name = "TCY",
                 logo = "tcy",
                 address = "",
                 decimal = 8,
@@ -3848,6 +4138,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "RUJI",
+                name = "Rujira",
                 logo = "ruji",
                 address = "",
                 decimal = 8,
@@ -3863,6 +4154,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "KUJI",
+                name = "Kujira",
                 logo = "kuji",
                 address = "",
                 decimal = 8,
@@ -3876,6 +4168,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "FUZN",
+                name = "Fuzion",
                 logo = "fuzn",
                 address = "",
                 decimal = 8,
@@ -3889,6 +4182,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "NSTK",
+                name = "Unstake",
                 logo = "nstk",
                 address = "",
                 decimal = 8,
@@ -3902,6 +4196,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "WINK",
+                name = "WINK",
                 logo = "wink",
                 address = "",
                 decimal = 8,
@@ -3915,6 +4210,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "LVN",
+                name = "Levana",
                 logo = "levana",
                 address = "",
                 decimal = 8,
@@ -3928,6 +4224,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "RKUJI",
+                name = "Rujira KUJI",
                 logo = "rkuji",
                 address = "",
                 decimal = 8,
@@ -3943,6 +4240,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "sRUJI",
+                name = "Staked Rujira",
                 logo = "ruji",
                 address = "",
                 decimal = 8,
@@ -3956,6 +4254,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "sTCY",
+                name = "Staked TCY",
                 logo = "stcy",
                 address = "",
                 decimal = 8,
@@ -3969,6 +4268,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "yRUNE",
+                name = "Nami Index yRUNE",
                 logo = "yrune",
                 address = "",
                 decimal = 8,
@@ -3983,6 +4283,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "yTCY",
+                name = "Nami Index yTCY",
                 logo = "ytcy",
                 address = "",
                 decimal = 8,
@@ -3997,6 +4298,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "bRUNE",
+                name = "Rujira Liquid Bonded RUNE",
                 logo = "brune",
                 address = "",
                 decimal = 8,
@@ -4012,6 +4314,7 @@ object Coins {
             Coin(
                 chain = Chain.ThorChain,
                 ticker = "ybRUNE",
+                name = "Auto-compounding Bonded RUNE",
                 logo = "ybrune",
                 address = "",
                 decimal = 8,
@@ -4030,6 +4333,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "GRAM",
+                name = "Gram",
                 logo = "gram",
                 address = "",
                 decimal = 9,
@@ -4043,6 +4347,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -4056,6 +4361,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "NOT",
+                name = "Notcoin",
                 logo = "not",
                 address = "",
                 decimal = 9,
@@ -4069,6 +4375,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "DOGS",
+                name = "Dogs",
                 logo = "dogs",
                 address = "",
                 decimal = 9,
@@ -4082,6 +4389,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "CATI",
+                name = "Catizen",
                 logo = "cati",
                 address = "",
                 decimal = 9,
@@ -4095,6 +4403,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "HMSTR",
+                name = "Hamster Kombat",
                 logo = "hmstr",
                 address = "",
                 decimal = 9,
@@ -4108,6 +4417,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "STON",
+                name = "STON.fi",
                 logo = "ston",
                 address = "",
                 decimal = 9,
@@ -4121,6 +4431,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "stTON",
+                name = "bemo Staked TON",
                 logo = "stton",
                 address = "",
                 decimal = 9,
@@ -4134,6 +4445,7 @@ object Coins {
             Coin(
                 chain = Chain.Ton,
                 ticker = "tsTON",
+                name = "Tonstakers TON",
                 logo = "tston",
                 address = "",
                 decimal = 9,
@@ -4151,6 +4463,7 @@ object Coins {
             Coin(
                 chain = Chain.Tron,
                 ticker = "TRX",
+                name = "TRON",
                 logo = "tron",
                 address = "",
                 decimal = 6,
@@ -4164,6 +4477,7 @@ object Coins {
             Coin(
                 chain = Chain.Tron,
                 ticker = "USDT",
+                name = "Tether USD",
                 logo = "usdt",
                 address = "",
                 decimal = 6,
@@ -4177,6 +4491,7 @@ object Coins {
             Coin(
                 chain = Chain.Tron,
                 ticker = "USDC",
+                name = "USD Coin",
                 logo = "usdc",
                 address = "",
                 decimal = 6,
@@ -4190,6 +4505,7 @@ object Coins {
             Coin(
                 chain = Chain.Tron,
                 ticker = "USDD",
+                name = "USDD",
                 logo = "usdd",
                 address = "",
                 decimal = 18,
@@ -4203,6 +4519,7 @@ object Coins {
             Coin(
                 chain = Chain.Tron,
                 ticker = "stUSDT",
+                name = "Staked USDT",
                 logo = "stusdt",
                 address = "",
                 decimal = 18,
@@ -4220,6 +4537,7 @@ object Coins {
             Coin(
                 chain = Chain.ZkSync,
                 ticker = "ETH",
+                name = "Ethereum",
                 logo = "zsync_era",
                 address = "",
                 decimal = 18,
@@ -4237,6 +4555,7 @@ object Coins {
             Coin(
                 chain = Chain.Zcash,
                 ticker = "ZEC",
+                name = "Zcash",
                 logo = "zec",
                 decimal = 8,
                 address = "",
@@ -4254,6 +4573,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "ADA",
+                name = "Cardano",
                 logo = "ada",
                 address = "",
                 decimal = 6,
@@ -4272,6 +4592,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "USDM",
+                name = "USDM",
                 logo = "usdm",
                 address = "",
                 decimal = 6,
@@ -4290,6 +4611,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "iUSD",
+                name = "Indigo iUSD",
                 logo = "iusd",
                 address = "",
                 decimal = 6,
@@ -4308,6 +4630,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "DJED",
+                name = "Djed",
                 logo = "djed",
                 address = "",
                 decimal = 6,
@@ -4325,6 +4648,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "LQ",
+                name = "Liqwid",
                 logo = "lq",
                 address = "",
                 decimal = 6,
@@ -4342,6 +4666,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "MIN",
+                name = "Minswap",
                 logo = "min",
                 address = "",
                 decimal = 6,
@@ -4359,6 +4684,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "SNEK",
+                name = "Snek",
                 logo = "snek",
                 address = "",
                 decimal = 0,
@@ -4376,6 +4702,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "SUNDAE",
+                name = "SundaeSwap",
                 logo = "sundae",
                 address = "",
                 decimal = 6,
@@ -4393,6 +4720,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "IAG",
+                name = "Iagon",
                 logo = "iag",
                 address = "",
                 decimal = 6,
@@ -4410,6 +4738,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "HOSKY",
+                name = "Hosky",
                 logo = "hosky",
                 address = "",
                 decimal = 0,
@@ -4428,6 +4757,7 @@ object Coins {
             Coin(
                 chain = Chain.Cardano,
                 ticker = "WMTX",
+                name = "World Mobile Token",
                 logo = "wmtx",
                 address = "",
                 decimal = 6,
@@ -4449,6 +4779,7 @@ object Coins {
             Coin(
                 chain = Chain.Qbtc,
                 ticker = "QBTC",
+                name = "Quantum Bitcoin",
                 logo = "qbtc",
                 address = "",
                 decimal = 8,
@@ -4570,6 +4901,20 @@ object Coins {
                 (contractAddress.isEmpty() ||
                     coin.contractAddress.equals(contractAddress, ignoreCase = true))
         }
+
+    /**
+     * [coin] carrying the catalogue's [Coin.name] when its own source supplied none.
+     *
+     * Discovery builds coins from what a node or indexer reports, and most of those report no name
+     * — a THORChain denom, a bank balance, an XRPL trust line. It is the curated coins a user
+     * searches by name, so the lookup lives here rather than in each finder; one the catalogue does
+     * not carry comes back exactly as it went in.
+     */
+    fun withCuratedName(coin: Coin): Coin {
+        if (coin.name.isNotEmpty()) return coin
+        val curated = findCurated(coin.chain, coin.ticker, coin.contractAddress) ?: return coin
+        return if (curated.name.isEmpty()) coin else coin.copy(name = curated.name)
+    }
 
     /**
      * The curated [Coin] for a contract address on [chain], when the caller has no ticker to go

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SPLTokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/SPLTokenRepository.kt
@@ -135,6 +135,7 @@ constructor(
         Coin(
             chain = Chain.Solana,
             ticker = tokenResponse.tokenList.ticker,
+            name = tokenResponse.tokenList.name?.trim().orEmpty(),
             logo = tokenResponse.tokenList.logo ?: "",
             decimal = tokenResponse.decimals,
             priceProviderID = tokenResponse.tokenList.extensions?.coingeckoId ?: "",
@@ -152,6 +153,7 @@ constructor(
                     contractAddress = it.contractAddress,
                     chain = Chain.Solana,
                     ticker = it.ticker,
+                    name = it.name?.trim().orEmpty(),
                     address = "",
                     logo = it.logo ?: "",
                     decimal = it.decimals,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorChainSecuredAssetRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/ThorChainSecuredAssetRepository.kt
@@ -5,6 +5,8 @@ import com.vultisig.wallet.data.api.ThorChainApi
 import com.vultisig.wallet.data.crypto.ThorChainHelper.Companion.SECURE_ASSETS_TICKERS
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.swapAssetName
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.sync.Mutex
@@ -94,11 +96,18 @@ constructor(private val thorChainApi: ThorChainApi) : ThorChainSecuredAssetRepos
                 securedAssetCoin(chainCode = chainCode, ticker = ticker, denomTail = ticker)
             }
 
-        /** Builds a secured-asset [Coin] with denom `<chainCode>-<denomTail>`, both lowercased. */
+        /**
+         * Builds a secured-asset [Coin] with denom `<chainCode>-<denomTail>`, both lowercased.
+         *
+         * The name is the underlying L1 asset's, taken from the catalogue so a search for "bitcoin"
+         * on THORChain lands on `BTC.BTC` the way it lands on BTC itself; a pool for a token the
+         * catalogue does not carry stays nameless rather than guessing one.
+         */
         fun securedAssetCoin(chainCode: String, ticker: String, denomTail: String): Coin =
             Coin(
                 chain = Chain.ThorChain,
                 ticker = ticker,
+                name = underlyingCuratedName(chainCode, ticker, denomTail),
                 logo = ticker.lowercase(),
                 address = "",
                 // Every THORChain secured asset uses RUNE's 8-decimal precision, not the
@@ -109,5 +118,19 @@ constructor(private val thorChainApi: ThorChainApi) : ThorChainSecuredAssetRepos
                 contractAddress = "${chainCode.lowercase()}-${denomTail.lowercase()}",
                 isNativeToken = false,
             )
+
+        private fun underlyingCuratedName(
+            chainCode: String,
+            ticker: String,
+            denomTail: String,
+        ): String {
+            val chain =
+                Chain.entries.firstOrNull {
+                    it.swapAssetName().equals(chainCode, ignoreCase = true)
+                } ?: return ""
+            // `usdc-0xa0b8…` carries the contract after the ticker; a bare `btc` carries none.
+            val contractAddress = denomTail.substringAfter('-', missingDelimiterValue = "")
+            return Coins.findCurated(chain, ticker, contractAddress)?.name.orEmpty()
+        }
     }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TokenRepository.kt
@@ -175,6 +175,7 @@ constructor(
                             contractAddress = contractAddress,
                             chain = chain,
                             ticker = symbol,
+                            name = metadata?.name?.trim().orEmpty(),
                             logo = symbol,
                             decimal = decimal,
                             isNativeToken = false,
@@ -257,7 +258,10 @@ constructor(
         return (getTokensWithBalance(chain, address, enabledDenoms) +
                 enabledByDefaultTokens.getOrDefault(chain, emptyList()))
             .filterNot { it.isNativeToken }
-            .map { token -> token.copy(address = address, hexPublicKey = derivedPublicKey) }
+            .map { token ->
+                Coins.withCuratedName(token)
+                    .copy(address = address, hexPublicKey = derivedPublicKey)
+            }
     }
 
     override val builtInTokens: Flow<List<Coin>> = flowOf(Coins.coins.flatMap { it.value })

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/VaultRepository.kt
@@ -272,21 +272,28 @@ constructor(
                             return@mapNotNull null
                         }
 
-                    val logo =
-                        try {
-                            coinEntity.logo.takeIf { it.isNotBlank() }
-                                ?: tokenRepository.getToken(coinEntity.id)?.logo
-                                ?: ""
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            Timber.w(e, "Failed to resolve logo for coin %s", coinEntity.id)
-                            ""
+                    // A row written before the logo or name column existed carries a blank
+                    // there; the curated catalogue fills it in on read.
+                    val curated =
+                        if (coinEntity.logo.isBlank() || coinEntity.name.isBlank()) {
+                            try {
+                                tokenRepository.getToken(coinEntity.id)
+                            } catch (e: CancellationException) {
+                                throw e
+                            } catch (e: Exception) {
+                                Timber.w(e, "Failed to resolve coin %s", coinEntity.id)
+                                null
+                            }
+                        } else {
+                            null
                         }
+                    val logo = coinEntity.logo.takeIf { it.isNotBlank() } ?: curated?.logo ?: ""
+                    val name = coinEntity.name.takeIf { it.isNotBlank() } ?: curated?.name ?: ""
 
                     Coin(
                         chain = chain,
                         ticker = coinEntity.ticker,
+                        name = name,
                         logo = logo,
                         address = coinEntity.address,
                         decimal = coinEntity.decimals,
@@ -367,5 +374,6 @@ constructor(
             priceProviderID = this.priceProviderID,
             contractAddress = this.contractAddress,
             logo = this.logo,
+            name = this.name,
         )
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/CosmosBankCoinFinder.kt
@@ -121,6 +121,7 @@ constructor(private val cosmosApiFactory: CosmosApiFactory) : CosmosBankCoinFind
         Coin(
             chain = chain,
             ticker = metadata?.symbolOrDisplay() ?: fallbackTicker,
+            name = metadata?.name?.trim().orEmpty(),
             logo = "",
             address = "",
             decimal = metadata?.decimalsFromUnits() ?: COSMOS_DEFAULT_DECIMALS,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/EvmCoinFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/EvmCoinFinder.kt
@@ -168,6 +168,7 @@ constructor(private val oneInchApi: OneInchApi, private val evmApiFactory: EvmAp
             chain = chain,
             // Decode legacy bytes32-as-hex symbols (e.g. MKR) back to text (issue #4873).
             ticker = token.symbol.decodeBytes32HexOrSelf(),
+            name = token.name.decodeBytes32HexOrSelf(),
             logo = logo,
             address = "",
             decimal = token.decimals,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/OneInchToCoinsUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/OneInchToCoinsUseCase.kt
@@ -30,6 +30,7 @@ internal class OneInchToCoinsUseCaseImpl @Inject constructor() : OneInchToCoinsU
                     contractAddress = it.address,
                     chain = chain,
                     ticker = ticker,
+                    name = it.name.decodeBytes32HexOrSelf(),
                     logo = it.logoURI ?: "",
                     decimal = it.decimals,
                     isNativeToken = supportedCoin?.isNativeToken == true,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCase.kt
@@ -32,6 +32,7 @@ constructor(private val suiApi: SuiApi, private val tokenPriceRepository: TokenP
             Coin(
                 chain = Chain.Sui,
                 ticker = metadata.symbol.trim(),
+                name = metadata.name?.trim().orEmpty(),
                 logo = metadata.iconUrl.orEmpty(),
                 address = "",
                 decimal = metadata.decimals,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTerraTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTerraTokenUseCase.kt
@@ -43,6 +43,7 @@ constructor(private val cosmosApiFactory: CosmosApiFactory) : SearchTerraTokenUs
                 ?: Coin(
                     chain = chain,
                     ticker = symbol,
+                    name = tokenInfo.name?.trim().orEmpty(),
                     logo = "",
                     address = "",
                     hexPublicKey = "",

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTonTokenUseCase.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SearchTonTokenUseCase.kt
@@ -35,6 +35,7 @@ constructor(private val tonApi: TonApi, private val tokenPriceRepository: TokenP
             Coin(
                 chain = Chain.Ton,
                 ticker = metadata.ticker,
+                name = metadata.name.orEmpty(),
                 logo = metadata.logo.orEmpty(),
                 address = "",
                 decimal = metadata.decimals,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinder.kt
@@ -121,6 +121,7 @@ internal class SuiTokenFinderImpl @Inject constructor(private val suiApi: SuiApi
         return Coin(
             chain = Chain.Sui,
             ticker = ticker,
+            name = metadata.name?.trim().orEmpty(),
             logo = metadata.iconUrl.orEmpty(),
             address = "",
             decimal = metadata.decimals,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/api/chains/SuiApiTest.kt
@@ -357,7 +357,7 @@ class SuiApiTest {
     fun `getCoinMetadata returns the parsed metadata on success`() = runTest {
         val api =
             api(
-                """{"data":{"coinMetadata":{"decimals":6,"symbol":"GOLD","iconUrl":"https://example.test/gold.png"}}}"""
+                """{"data":{"coinMetadata":{"decimals":6,"symbol":"GOLD","iconUrl":"https://example.test/gold.png","name":"Gold Coin"}}}"""
             )
 
         val metadata = api.getCoinMetadata(COIN_TYPE)
@@ -365,13 +365,17 @@ class SuiApiTest {
         assertEquals(6, metadata?.decimals)
         assertEquals("GOLD", metadata?.symbol)
         assertEquals("https://example.test/gold.png", metadata?.iconUrl)
+        assertEquals("Gold Coin", metadata?.name)
     }
 
     @Test
-    fun `getCoinMetadata leaves an absent iconUrl null`() = runTest {
+    fun `getCoinMetadata leaves an absent iconUrl and name null`() = runTest {
         val api = api("""{"data":{"coinMetadata":{"decimals":9,"symbol":"SILVER"}}}""")
 
-        assertNull(api.getCoinMetadata(COIN_TYPE)?.iconUrl)
+        val metadata = api.getCoinMetadata(COIN_TYPE)
+
+        assertNull(metadata?.iconUrl)
+        assertNull(metadata?.name)
     }
 
     // A coin the node cannot fully describe must be dropped rather than rendered at a guessed
@@ -401,6 +405,7 @@ class SuiApiTest {
 
         assertTrue(capture.lastBody.contains("coinMetadata"), capture.lastBody)
         assertTrue(capture.lastBody.contains(COIN_TYPE), capture.lastBody)
+        assertTrue(capture.lastBody.contains("decimals symbol iconUrl name"), capture.lastBody)
     }
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinMatchesSearchTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinMatchesSearchTest.kt
@@ -1,0 +1,74 @@
+package com.vultisig.wallet.data.models
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * [Coin.matchesSearch] is the one filter every asset search goes through, so what it matches on is
+ * pinned here rather than in each ViewModel that calls it.
+ */
+internal class CoinMatchesSearchTest {
+
+    @Test
+    fun `a name matches where the ticker would not`() {
+        val eth = Coins.Base.ETH
+
+        assertTrue(eth.matchesSearch("ethereum"))
+        assertTrue(eth.matchesSearch("Ethereum"))
+        assertTrue(eth.matchesSearch("eth"))
+        assertFalse(eth.matchesSearch("bitcoin"))
+    }
+
+    @Test
+    fun `a multi-word name matches on any substring`() {
+        val usdc = Coins.Arbitrum.USDC
+
+        assertTrue(usdc.matchesSearch("usd coin"))
+        assertTrue(usdc.matchesSearch("coin"))
+        assertFalse(usdc.matchesSearch("usdcoin"))
+    }
+
+    @Test
+    fun `a contract address matches whatever case it is pasted in`() {
+        val usdc = Coins.Ethereum.USDC
+
+        assertTrue(usdc.matchesSearch(usdc.contractAddress.lowercase()))
+        assertTrue(usdc.matchesSearch(usdc.contractAddress.uppercase()))
+        assertTrue(usdc.matchesSearch(usdc.contractAddress.drop(2).take(12)))
+    }
+
+    @Test
+    fun `blank and whitespace queries match everything`() {
+        val nameless = Coins.Bitcoin.BTC.copy(name = "")
+
+        assertTrue(nameless.matchesSearch(""))
+        assertTrue(nameless.matchesSearch("   "))
+    }
+
+    @Test
+    fun `surrounding whitespace in the query is ignored`() {
+        assertTrue(Coins.Bitcoin.BTC.matchesSearch("  bitcoin "))
+    }
+
+    @Test
+    fun `a nameless coin still matches on its ticker`() {
+        val custom =
+            Coin(
+                chain = Chain.Ethereum,
+                ticker = "PENGU",
+                logo = "",
+                address = "",
+                decimal = 18,
+                hexPublicKey = "",
+                priceProviderID = "",
+                contractAddress = "0x1234",
+                isNativeToken = false,
+            )
+
+        assertEquals("", custom.name)
+        assertTrue(custom.matchesSearch("pengu"))
+        assertFalse(custom.matchesSearch("pudgy"))
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinsNameTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/CoinsNameTest.kt
@@ -1,0 +1,69 @@
+package com.vultisig.wallet.data.models
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Every curated coin carries a name so the pickers can be searched by it. Nothing else fails when
+ * an entry is added without one — search just silently falls back to the ticker for it — so the
+ * catalogue is checked whole here.
+ */
+internal class CoinsNameTest {
+
+    @Test
+    fun `every curated coin has a name`() {
+        val nameless = Coins.allResolvable.filter { it.name.isBlank() }.map { it.id }
+
+        assertTrue(nameless.isEmpty(), "curated coins without a name: $nameless")
+    }
+
+    @Test
+    fun `the native asset of an L2 is named after the asset, not the chain`() {
+        listOf(Coins.Base.ETH, Coins.Arbitrum.ETH, Coins.Optimism.ETH, Coins.ZkSync.ETH).forEach {
+            assertEquals("Ethereum", it.name, it.id)
+        }
+    }
+
+    @Test
+    fun `withCuratedName fills a discovered coin's name from the catalogue`() {
+        val discovered = Coins.ThorChain.TCY.copy(name = "", address = "thor1abc")
+
+        val named = Coins.withCuratedName(discovered)
+
+        assertEquals(Coins.ThorChain.TCY.name, named.name)
+        assertEquals("thor1abc", named.address)
+    }
+
+    @Test
+    fun `withCuratedName keeps a name the source already supplied`() {
+        val discovered = Coins.Ethereum.USDC.copy(name = "USD Coin (Bridged)")
+
+        assertEquals("USD Coin (Bridged)", Coins.withCuratedName(discovered).name)
+    }
+
+    @Test
+    fun `withCuratedName leaves a coin the catalogue does not carry unchanged`() {
+        val unknown =
+            Coin(
+                chain = Chain.Ethereum,
+                ticker = "PENGU",
+                logo = "",
+                address = "",
+                decimal = 18,
+                hexPublicKey = "",
+                priceProviderID = "",
+                contractAddress = "0x1234",
+                isNativeToken = false,
+            )
+
+        assertEquals(unknown, Coins.withCuratedName(unknown))
+    }
+
+    @Test
+    fun `withCuratedName does not name a lookalike sharing a curated ticker`() {
+        val lookalike = Coins.Ethereum.USDC.copy(name = "", contractAddress = "0xdeadbeef")
+
+        assertEquals("", Coins.withCuratedName(lookalike).name)
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/TokenRepositoryImplTest.kt
@@ -9,6 +9,7 @@ import com.vultisig.wallet.data.api.models.cosmos.CosmosBalance
 import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.usecases.CardanoTokenFinder
 import com.vultisig.wallet.data.usecases.CosmosBankCoinFinder
 import com.vultisig.wallet.data.usecases.EvmCoinFinder
@@ -245,17 +246,63 @@ internal class TokenRepositoryImplTest {
         coVerify(exactly = 0) { cosmosBankCoinFinder.find(any(), any()) }
     }
 
+    /**
+     * A THORChain balance is described by its denom and whatever the LCD says about it — never a
+     * display name — so the coin the picker searches has to borrow the curated one's.
+     */
+    @Test
+    fun `getRefreshTokens names a discovered curated denom from the catalogue`() = runTest {
+        val thorApi: ThorChainApi = mockk(relaxed = true)
+        coEvery { thorApi.getBalance(ADDRESS) } returns
+            listOf(CosmosBalance(denom = "x/ruji", amount = "200"))
+        coEvery { thorApi.getDenomMetaFromLCD(any()) } returns null
+        val addresses: ChainAccountAddressRepository = mockk()
+        coEvery { addresses.getAddress(Chain.ThorChain, any()) } returns (ADDRESS to "pub")
+
+        val coins =
+            newRepository(thorApi, chainAccountAddressRepository = addresses)
+                .getRefreshTokens(Chain.ThorChain, Vault(id = "vault-1", name = "Main"))
+
+        val ruji = coins.single { it.contractAddress == "x/ruji" }
+        assertEquals(Coins.ThorChain.RUJI.name, ruji.name)
+        assertEquals(ADDRESS, ruji.address)
+    }
+
+    @Test
+    fun `getRefreshTokens keeps the name the node reported over the catalogue's`() = runTest {
+        val thorApi: ThorChainApi = mockk(relaxed = true)
+        coEvery { thorApi.getBalance(ADDRESS) } returns
+            listOf(CosmosBalance(denom = "x/ruji", amount = "200"))
+        coEvery { thorApi.getDenomMetaFromLCD("x/ruji") } returns
+            DenomMetadata(
+                base = "x/ruji",
+                symbol = "RUJI",
+                display = "ruji",
+                denomUnits = null,
+                name = "Rujira Token",
+            )
+        val addresses: ChainAccountAddressRepository = mockk()
+        coEvery { addresses.getAddress(Chain.ThorChain, any()) } returns (ADDRESS to "pub")
+
+        val coins =
+            newRepository(thorApi, chainAccountAddressRepository = addresses)
+                .getRefreshTokens(Chain.ThorChain, Vault(id = "vault-1", name = "Main"))
+
+        assertEquals("Rujira Token", coins.single { it.contractAddress == "x/ruji" }.name)
+    }
+
     private fun newRepository(
         thorApi: ThorChainApi = mockk(relaxed = true),
         evmCoinFinder: EvmCoinFinder = mockk(relaxed = true),
         cosmosBankCoinFinder: CosmosBankCoinFinder = mockk(relaxed = true),
         rippleTokenFinder: RippleTokenFinder = mockk(relaxed = true),
         cardanoTokenFinder: CardanoTokenFinder = mockk(relaxed = true),
+        chainAccountAddressRepository: ChainAccountAddressRepository = mockk(relaxed = true),
     ): TokenRepositoryImpl =
         TokenRepositoryImpl(
             evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
             thorApi = thorApi,
-            chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
+            chainAccountAddressRepository = chainAccountAddressRepository,
             evmCoinFinder = evmCoinFinder,
             cosmosBankCoinFinder = cosmosBankCoinFinder,
             rippleTokenFinder = rippleTokenFinder,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/VaultRepositoryImplTest.kt
@@ -99,6 +99,7 @@ internal class VaultRepositoryImplTest {
             contractAddress = "",
             address = "0xabc",
             hexPublicKey = "pub",
+            name = "",
         )
 
     /** Returns a [Coin] representing native ETH on Ethereum. */
@@ -279,6 +280,7 @@ internal class VaultRepositoryImplTest {
                 contractAddress = "",
                 address = "0x0",
                 hexPublicKey = "",
+                name = "",
             )
         coEvery { vaultDao.loadAll() } returns
             listOf(makeVaultWithTokens(coins = listOf(makeEthCoin(), unknownChainCoin)))

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/EvmCoinFinderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/EvmCoinFinderTest.kt
@@ -202,6 +202,7 @@ internal class EvmCoinFinderTest {
                     oneInchToken(
                         address = GOOD_CONTRACT,
                         symbol = "GOOD",
+                        name = "Good Token",
                         logoURI = "https://tokens.example.com/good.png",
                         providers = listOf("1inch", "CoinGecko"),
                     ),
@@ -227,6 +228,7 @@ internal class EvmCoinFinderTest {
         val coin = coins.single()
         assertEquals(GOOD_CONTRACT, coin.contractAddress)
         assertEquals("GOOD", coin.ticker)
+        assertEquals("Good Token", coin.name)
         assertEquals("https://tokens.example.com/good.png", coin.logo)
         assertEquals(Chain.BscChain, coin.chain)
     }
@@ -393,12 +395,13 @@ internal class EvmCoinFinderTest {
         symbol: String,
         logoURI: String?,
         providers: List<String>?,
+        name: String = symbol,
     ): OneInchTokenJson =
         OneInchTokenJson(
             address = address,
             symbol = symbol,
             decimals = 18,
-            name = symbol,
+            name = name,
             logoURI = logoURI,
             providers = providers,
         )

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCaseImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SearchSuiTokenUseCaseImplTest.kt
@@ -42,11 +42,17 @@ internal class SearchSuiTokenUseCaseImplTest {
     fun `uncatalogued coin type falls back to on-chain metadata with zero price`() = runTest {
         val coinType = "0xabc::widget::WIDGET"
         coEvery { suiApi.getCoinMetadata(coinType) } returns
-            SuiCoinMetadata(decimals = 9, symbol = "WIDGET", iconUrl = "https://example.com/w.png")
+            SuiCoinMetadata(
+                decimals = 9,
+                symbol = "WIDGET",
+                iconUrl = "https://example.com/w.png",
+                name = " Widget Coin ",
+            )
 
         val result = useCase(coinType)
 
         assertEquals("WIDGET", result?.coin?.ticker)
+        assertEquals("Widget Coin", result?.coin?.name)
         assertEquals("https://example.com/w.png", result?.coin?.logo)
         assertEquals(BigDecimal.ZERO, result?.price)
     }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinderTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/usecases/SuiTokenFinderTest.kt
@@ -34,12 +34,13 @@ internal class SuiTokenFinderTest {
     fun `discovers a held coin type the curated catalog does not list`() = runTest {
         stubHeld(heldObject(GOLD_TYPE))
         coEvery { suiApi.getCoinMetadata(GOLD_TYPE) } returns
-            SuiCoinMetadata(decimals = 6, symbol = "GOLD", iconUrl = GOLD_ICON)
+            SuiCoinMetadata(decimals = 6, symbol = "GOLD", iconUrl = GOLD_ICON, name = "Gold Coin")
 
         val discovered = finder.find(ADDRESS).single()
 
         assertEquals(Chain.Sui, discovered.chain)
         assertEquals("GOLD", discovered.ticker)
+        assertEquals("Gold Coin", discovered.name)
         assertEquals(6, discovered.decimal)
         assertEquals(GOLD_TYPE, discovered.contractAddress)
         assertEquals(GOLD_ICON, discovered.logo)


### PR DESCRIPTION
Closes #5653

Asset search matched the ticker only, so typing an asset's name found nothing — most visibly on the EVM L2s, where the native asset is `ETH` and a user looking for it types `ethereum`.

<img src="https://i.imgur.com/7uTGcF8.png" width="320" />

*Swap asset picker on Robinhood, query `apple` — AAPL surfaces on its name; before, only `aapl` would.*

## Summary

- **`Coin.name` + one shared matcher.** `Coin.matchesSearch(query)` matches ticker, name or contract address, case-insensitively. Every asset search now goes through it: the asset picker (`SelectAssetViewModel`), manage tokens (`TokenSelectionViewModel`), the chain-detail token list, the referral payout picker and the history asset filter. Contract matching keeps what the asset picker already had through `Coin.id` and mirrors the extension's address search.
- **Catalogue named.** All 331 `Coins.kt` entries carry a name. No sibling platform had names to copy — iOS `CoinMeta`, the SDK's `CoinMetadata` and the extension's `Coin` are ticker-only — so they are authored here. The Robinhood stock names are read from each contract's on-chain `name()` (`"Apple • Robinhood Token"` → `Apple`), which is also what resolved the tickers not on any exchange (`P` = Everpure, `SKHY` = SK hynix, `XNDU` = Xanadu Quantum, `SPCX` = SpaceX). `CoinsNameTest` fails if a future entry lands nameless.
- **Persistence = the `logo` precedent.** `CoinEntity.name`, `MIGRATION_44_45` (`ADD COLUMN name TEXT NOT NULL DEFAULT ""`, DB v45), and `VaultRepository` fills a blank name from the catalogue on read — an already-added ETH on Base is searchable by name from first launch, with no backfill tying the migration to definitions that are free to change.
- **Discovery passes names through** where the indexer reports one: 1inch (`OneInchToCoinsUseCase`, `EvmCoinFinder`), SPL/Jupiter, CW20, TON jetton, Sui metadata, Cosmos bank and THORChain denom metadata. Anything else discovered gets the curated name in `getRefreshTokens` (`Coins.withCuratedName`) — the one funnel `TokenRefreshWorker` and `GetChainTokensUseCase` read — and secured assets borrow the underlying L1 coin's name, so `bitcoin` on THORChain lands on `BTC.BTC`.
- **Search-only.** Nothing renders the name; no UI change.

Left as ticker-only on purpose: Tron `SearchTronTokenUseCase` and the ERC-20 `getEVMTokenByContract` custom lookups (each needs an extra `name()` RPC), and XRPL trust lines (no name exists).

## Test plan

- [x] `:data` 3669 / `:app` 2483 unit tests green — new: `CoinMatchesSearchTest`, `CoinsNameTest` (every entry named, L2 natives named "Ethereum", `withCuratedName` fills/keeps/skips), `TokenRepositoryImplTest` (`getRefreshTokens` names a bare denom from the catalogue, keeps a node-reported name), `EvmCoinFinderTest` (1inch name pass-through), `SelectAssetViewModelTest` (`ethereum` on Base → ETH; `usd coin` → unheld USDC), new `TokenSelectionViewModelTest`
- [x] root `assembleDebug` + `compileDebugAndroidTestKotlin`, ktfmt
- [x] On device: Swap → asset picker → Robinhood → `apple` (screenshot above)
- [ ] Upgrade path: install on a vault created before this build, open the asset picker on Base and type `ethereum` — ETH should appear without re-adding it (migration 44→45 + read-time fallback)
- [ ] Manage tokens on Arbitrum → `usd coin` lists USDC and USDC.e; THORChain asset picker → `bitcoin` lists the BTC secured asset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added coin and token names across supported networks using curated or network-provided metadata.
  - Improved asset search to match names, tickers, contract addresses, and chains.
  - Transaction history and referral asset searches now support name-based matching.
  - Added support for displaying names from additional token metadata sources.

- **Bug Fixes**
  - Preserved token names when refreshing balances and loading discovered assets.
  - Existing wallet data is upgraded to store coin names without losing compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->