### PR TITLE
feat(swap): carry THORChain price impact to the co-signer

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
@@ -39,6 +39,7 @@ import com.vultisig.wallet.ui.models.mappers.SwapTransactionToHistoryDataMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
 import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
 import com.vultisig.wallet.ui.models.swap.LimitOrderLabels
+import com.vultisig.wallet.ui.models.swap.PriceImpactDisplay
 import com.vultisig.wallet.ui.models.swap.SwapDiscountBps
 import com.vultisig.wallet.ui.models.swap.SwapFeeRow
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
@@ -46,6 +47,7 @@ import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.models.swap.evmSwapDisplayGasLimit
 import com.vultisig.wallet.ui.models.swap.formatAffiliatePercent
+import com.vultisig.wallet.ui.models.swap.formatPriceImpact
 import com.vultisig.wallet.ui.models.swap.formatSwapKitProviderLabel
 import com.vultisig.wallet.ui.models.swap.resolveExternalSwapRecipient
 import com.vultisig.wallet.ui.models.swap.signedLimitOrder
@@ -447,6 +449,7 @@ constructor(
                             ),
                         feeProvider = SwapProvider.THORCHAIN,
                         vultBps = thorVultBps,
+                        priceImpact = formatPriceImpact(swapPayload.data.priceImpact),
                     )
                 JoinKeysignVerifyResult(
                     verifyUiModel =
@@ -529,6 +532,7 @@ constructor(
                             ),
                         feeProvider = SwapProvider.MAYA,
                         vultBps = mayaVultBps,
+                        priceImpact = formatPriceImpact(swapPayload.data.priceImpact),
                     )
                 JoinKeysignVerifyResult(
                     verifyUiModel =
@@ -640,6 +644,10 @@ constructor(
         // cost), which leaves the row exactly as it was: the charged fee, claiming no rate.
         feeProvider: SwapProvider? = null,
         vultBps: Int? = null,
+        // Price impact read off the wire, never re-quoted: pools move between initiating and
+        // joining, so a fresh figure would make this the one row the two devices disagree on.
+        // Null hides the row.
+        priceImpact: PriceImpactDisplay? = null,
     ): SwapTransactionUiModel {
         val estimatedFee = convertTokenValueToFiat(providerFeeToken, providerFee, currency)
 
@@ -724,6 +732,8 @@ constructor(
             isLimitOrder = isLimitOrder,
             limitTargetPriceLabel = limitOrderLabels?.targetPriceLabel,
             limitExpiryLabel = limitOrderLabels?.expiryLabel,
+            priceImpactPercent = priceImpact?.percent,
+            priceImpactLevel = priceImpact?.level,
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -146,6 +146,7 @@ constructor(
                                         .inWholeSeconds
                                         .toULong(),
                                 isAffiliate = isAffiliate,
+                                slippageBps = quote.data.fees.slippageBps,
                             )
                         ),
                 )
@@ -229,6 +230,7 @@ constructor(
                                         .inWholeSeconds
                                         .toULong(),
                                 isAffiliate = isAffiliate,
+                                slippageBps = quote.data.fees.slippageBps,
                             )
                         ),
                 )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinSwapPriceImpactTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinSwapPriceImpactTest.kt
@@ -1,0 +1,321 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.api.models.quotes.Fees
+import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EstimatedGasFee
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.models.THORChainSwapPayload
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.SwapQuoteRepository
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.repositories.swap.SwapQuoteResult
+import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.models.mappers.SwapTransactionToHistoryDataMapper
+import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
+import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
+import com.vultisig.wallet.ui.models.swap.PriceImpactLevel
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.Instant
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+
+/**
+ * The co-signer's Price Impact row comes off the payload's `slippage_bps`, never off the quote it
+ * re-fetches for the fee rows: pools move between initiating and joining, so a fresh figure would
+ * make this the one row the two devices legitimately disagree on. The re-fetched quote below
+ * deliberately carries a different `slippage_bps` than the payload to prove which one wins.
+ */
+internal class JoinSwapPriceImpactTest {
+
+    private val tokenRepository: TokenRepository = mockk()
+    private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase = mockk()
+    private val fiatValueToStringMapper: FiatValueToStringMapper = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val getDiscountBps: GetDiscountBpsUseCase = mockk()
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper = mockk()
+    private val mapSwapTransactionToHistoryData: SwapTransactionToHistoryDataMapper = mockk()
+    private val swapQuoteRepository: SwapQuoteRepository = mockk()
+
+    private fun builder() =
+        JoinSwapUiModelBuilder(
+            tokenRepository = tokenRepository,
+            chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
+            feeServiceComposite = mockk(relaxed = true),
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            convertTokenValueToFiat = convertTokenValueToFiat,
+            fiatValueToStringMapper = fiatValueToStringMapper,
+            mapTokenValueToDecimalUiString = mapTokenValueToDecimalUiString,
+            swapQuoteRepository = swapQuoteRepository,
+            mapSwapTransactionToHistoryData = mapSwapTransactionToHistoryData,
+            formatLimitOrderLabels = FormatLimitOrderLabelsUseCase(),
+            getDiscountBps = getDiscountBps,
+        )
+
+    @Test
+    fun `renders the payload's price impact, not the re-fetched quote's`() = runTest {
+        stub(SwapProvider.THORCHAIN, refetchedSlippageBps = 900)
+
+        val tx =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.ThorChain(thorPayload(slippageBps = 133)),
+                    vault,
+                    AppCurrency.USD,
+                )
+
+        val swap = tx.transactionTypeUiModel as TransactionTypeUiModel.Swap
+        // 133 bps, negated for display like the initiator's row, in the Average band.
+        swap.swapTransactionUiModel.priceImpactPercent shouldBe "-1.33%"
+        swap.swapTransactionUiModel.priceImpactLevel shouldBe PriceImpactLevel.AVERAGE
+    }
+
+    @Test
+    fun `bands the payload's figure the way the initiator does`() = runTest {
+        stub(SwapProvider.THORCHAIN, refetchedSlippageBps = null)
+
+        val good =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.ThorChain(thorPayload(slippageBps = 19)),
+                    vault,
+                    AppCurrency.USD,
+                )
+        val high =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.ThorChain(thorPayload(slippageBps = 450)),
+                    vault,
+                    AppCurrency.USD,
+                )
+
+        (good.transactionTypeUiModel as TransactionTypeUiModel.Swap).swapTransactionUiModel.let {
+            it.priceImpactPercent shouldBe "-0.19%"
+            it.priceImpactLevel shouldBe PriceImpactLevel.GOOD
+        }
+        (high.transactionTypeUiModel as TransactionTypeUiModel.Swap).swapTransactionUiModel.let {
+            it.priceImpactPercent shouldBe "-4.50%"
+            it.priceImpactLevel shouldBe PriceImpactLevel.HIGH
+        }
+    }
+
+    @Test
+    fun `hides the row for a payload without the field, even when the re-fetched quote has one`() =
+        runTest {
+            stub(SwapProvider.THORCHAIN, refetchedSlippageBps = 19)
+
+            val tx =
+                builder()
+                    .build(
+                        payload(),
+                        SwapPayload.ThorChain(thorPayload(slippageBps = null)),
+                        vault,
+                        AppCurrency.USD,
+                    )
+
+            val swap = tx.transactionTypeUiModel as TransactionTypeUiModel.Swap
+            swap.swapTransactionUiModel.priceImpactPercent shouldBe null
+            swap.swapTransactionUiModel.priceImpactLevel shouldBe null
+        }
+
+    @Test
+    fun `renders a zero-impact payload as zero, distinct from an absent one`() = runTest {
+        stub(SwapProvider.THORCHAIN, refetchedSlippageBps = null)
+
+        val tx =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.ThorChain(thorPayload(slippageBps = 0)),
+                    vault,
+                    AppCurrency.USD,
+                )
+
+        val swap = tx.transactionTypeUiModel as TransactionTypeUiModel.Swap
+        swap.swapTransactionUiModel.priceImpactPercent shouldBe "+0.00%"
+        swap.swapTransactionUiModel.priceImpactLevel shouldBe PriceImpactLevel.GOOD
+    }
+
+    @Test
+    fun `mayachain payload renders its price impact too`() = runTest {
+        stub(SwapProvider.MAYA, refetchedSlippageBps = null)
+
+        val tx =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.MayaChain(thorPayload(slippageBps = 250)),
+                    vault,
+                    AppCurrency.USD,
+                )
+
+        val swap = tx.transactionTypeUiModel as TransactionTypeUiModel.Swap
+        swap.swapTransactionUiModel.priceImpactPercent shouldBe "-2.50%"
+        swap.swapTransactionUiModel.priceImpactLevel shouldBe PriceImpactLevel.AVERAGE
+    }
+
+    private fun stub(provider: SwapProvider, refetchedSlippageBps: Int?) {
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        every { mapSwapTransactionToHistoryData(any()) } returns mockk(relaxed = true)
+        coEvery { getDiscountBps(vault.id, provider) } returns 0
+        coEvery { tokenRepository.getNativeToken(Chain.ThorChain.id) } returns rune
+        coEvery { swapQuoteRepository.getQuote(provider, any()) } returns
+            SwapQuoteResult.Native(quote(provider, refetchedSlippageBps))
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns usd("0")
+        coEvery { fiatValueToStringMapper(any(), any()) } returns "0.00"
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedTokenValue = "0.02 RUNE",
+                formattedFiatValue = "$0.20",
+                tokenValue = TokenValue(BigInteger.valueOf(2_000_000L), rune),
+                fiatValue = usd("0.20"),
+            )
+    }
+
+    private fun quote(provider: SwapProvider, slippageBps: Int?): SwapQuote {
+        val dst = TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), eth)
+        val data =
+            THORChainSwapQuote(
+                dustThreshold = null,
+                expectedAmountOut = "1",
+                expiry = BigInteger.ZERO,
+                fees =
+                    Fees(
+                        affiliate = "60000000",
+                        asset = "0",
+                        outbound = "10000000",
+                        total = "70000000",
+                        slippageBps = slippageBps,
+                    ),
+                inboundAddress = "inbound",
+                inboundConfirmationBlocks = null,
+                inboundConfirmationSeconds = null,
+                maxStreamingQuantity = 0,
+                memo = "=:ETH.ETH:0xdst",
+                notes = "",
+                outboundDelayBlocks = BigInteger.ZERO,
+                outboundDelaySeconds = BigInteger.ZERO,
+                recommendedMinAmountIn = "0",
+                streamingSwapBlocks = BigInteger.ZERO,
+                totalSwapSeconds = 0L,
+                warning = "",
+                router = null,
+                error = null,
+            )
+        val expiry = Instant.now().plus(5.minutes.toJavaDuration())
+        val zero = TokenValue(BigInteger.ZERO, eth)
+        return if (provider == SwapProvider.MAYA) {
+            SwapQuote.MayaChain(
+                expectedDstValue = dst,
+                fees = zero,
+                expiredAt = expiry,
+                recommendedMinTokenValue = zero,
+                data = data,
+            )
+        } else {
+            SwapQuote.ThorChain(
+                expectedDstValue = dst,
+                fees = zero,
+                expiredAt = expiry,
+                recommendedMinTokenValue = zero,
+                data = data,
+            )
+        }
+    }
+
+    private fun payload() =
+        KeysignPayload(
+            coin = rune,
+            toAddress = "thorInbound",
+            toAmount = srcValue.value,
+            memo = "=:ETH.ETH:0xdst",
+            blockChainSpecific =
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.valueOf(2_000_000L),
+                    isDeposit = false,
+                    transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "party",
+            libType = null,
+            wasmExecuteContractPayload = null,
+        )
+
+    private val rune =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUNE",
+            logo = "",
+            address = "thorsrc",
+            decimal = 8,
+            hexPublicKey = "pub",
+            priceProviderID = "thorchain",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val eth =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xdst",
+            decimal = 18,
+            hexPublicKey = "pub",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val srcValue = TokenValue(BigInteger.valueOf(100_000_000L), rune)
+
+    private fun thorPayload(slippageBps: Int?) =
+        THORChainSwapPayload(
+            fromAddress = "thorsrc",
+            fromCoin = rune,
+            toCoin = eth,
+            vaultAddress = "thorInbound",
+            routerAddress = null,
+            fromAmount = srcValue.value,
+            toAmountDecimal = BigDecimal.ONE,
+            toAmountLimit = "0",
+            streamingInterval = "0",
+            streamingQuantity = "0",
+            expirationTime = 0UL,
+            isAffiliate = true,
+            slippageBps = slippageBps,
+        )
+
+    private fun usd(amount: String) = FiatValue(BigDecimal(amount), "USD")
+
+    private val vault =
+        Vault(id = "vault-1", name = "Main", pubKeyECDSA = "pub", pubKeyEDDSA = "pubed")
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/THORChainSwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/THORChainSwapQuote.kt
@@ -41,9 +41,6 @@ data class THORChainSwapQuote(
     @SerialName("warning") val warning: String,
     @SerialName("router") val router: String?,
     @SerialName("error") val error: String?,
-    // Price impact of the swap in basis points (100 == 1%), as reported by the node. Drives the
-    // Price Impact row in the fee breakdown (iOS parity). Null when the node omits it.
-    @SerialName("slippage_bps") val slippageBps: Int? = null,
 )
 
 @Serializable
@@ -52,4 +49,8 @@ data class Fees(
     @SerialName("asset") val asset: String,
     @SerialName("outbound") val outbound: String,
     @SerialName("total") val total: String,
+    // Price impact of the swap in basis points (100 == 1%). THORNode and MayaNode report it here,
+    // inside `fees`, never at the top level of the quote. Drives the Price Impact row and rides
+    // the keysign payload to the co-signer. Null when the node omits it.
+    @SerialName("slippage_bps") val slippageBps: Int? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -377,5 +377,6 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
             streamingQuantity = streamingQuantity,
             expirationTime = expirationTime,
             isAffiliate = isAffiliate,
+            slippageBps = slippageBps?.takeIf { it <= Int.MAX_VALUE.toUInt() }?.toInt(),
         )
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -194,6 +194,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         streamingQuantity = from.streamingQuantity,
                         expirationTime = from.expirationTime,
                         isAffiliate = from.isAffiliate,
+                        slippageBps = from.slippageBps?.takeIf { it >= 0 }?.toUInt(),
                     )
                 } else null,
             mayachainSwapPayload =
@@ -212,6 +213,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         streamingQuantity = from.streamingQuantity,
                         expirationTime = from.expirationTime,
                         isAffiliate = from.isAffiliate,
+                        slippageBps = from.slippageBps?.takeIf { it >= 0 }?.toUInt(),
                     )
                 } else null,
             oneinchSwapPayload =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -48,7 +48,7 @@ sealed class SwapQuote {
         val data: THORChainSwapQuote,
     ) : SwapQuote() {
         override val priceImpact: BigDecimal?
-            get() = data.slippageBps.toPriceImpactFraction()
+            get() = data.fees.slippageBps.toPriceImpactFraction()
     }
 
     data class MayaChain(
@@ -59,7 +59,7 @@ sealed class SwapQuote {
         val data: THORChainSwapQuote,
     ) : SwapQuote() {
         override val priceImpact: BigDecimal?
-            get() = data.slippageBps.toPriceImpactFraction()
+            get() = data.fees.slippageBps.toPriceImpactFraction()
     }
 
     /**
@@ -82,5 +82,4 @@ sealed class SwapQuote {
 }
 
 /** Converts a basis-point slippage value (100 == 1%) into the fractional price impact (0.01). */
-private fun Int?.toPriceImpactFraction(): BigDecimal? =
-    this?.let { BigDecimal(it).movePointLeft(4) }
+fun Int?.toPriceImpactFraction(): BigDecimal? = this?.let { BigDecimal(it).movePointLeft(4) }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/THORChainSwapPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/THORChainSwapPayload.kt
@@ -17,9 +17,22 @@ data class THORChainSwapPayload(
     val streamingQuantity: String,
     val expirationTime: ULong,
     val isAffiliate: Boolean,
+    /**
+     * Price impact the quote reported (`fees.slippage_bps`), carried so a co-signer shows the
+     * figure the initiator approved rather than re-pricing a pool that has since moved. Null when
+     * the sender predates the field or the route had no quote (limit orders); the row then hides.
+     */
+    val slippageBps: Int? = null,
 ) {
     val toAddress: String
         get() = toCoin.address
+
+    /**
+     * Fractional price impact (`0.0133` == 1.33%) of [slippageBps], the same shape
+     * [SwapQuote.priceImpact] exposes.
+     */
+    val priceImpact: BigDecimal?
+        get() = slippageBps.toPriceImpactFraction()
 
     val fromAsset: Asset
         get() = swapAsset(fromCoin, true)

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperNativeSwapSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperNativeSwapSlippageTest.kt
@@ -1,0 +1,221 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.THORChainSwapPayload
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.proto.v1.CoinProto
+import com.vultisig.wallet.data.models.proto.v1.KeysignPayloadProto
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.THORChainSpecific
+import vultisig.keysign.v1.THORChainSwapPayload as ThorChainSwapPayloadProto
+import vultisig.keysign.v1.TransactionType
+
+/**
+ * Pins `slippage_bps` on the THORChain / MayaChain swap payload in both proto directions. The field
+ * is `optional`, so absence and zero are different values on the wire: a sender that predates it
+ * must read back as null (row hidden), not as a zero-impact route.
+ */
+class KeysignPayloadProtoMapperNativeSwapSlippageTest {
+
+    private val mapper = KeysignPayloadProtoMapperImpl()
+    private val outboundMapper = PayloadToProtoMapperImpl()
+
+    @Test
+    fun `thorchain payload round-trips slippage_bps domain to proto to domain`() {
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(swapPayload = SwapPayload.ThorChain(thorPayload(slippageBps = 19)))
+
+        val proto = requireNotNull(outboundMapper.invoke(domain))
+        assertEquals(19u, requireNotNull(proto.thorchainSwapPayload).slippageBps)
+        assertNull(proto.mayachainSwapPayload)
+
+        val back = mapper.invoke(basePayload(thorchainSwapPayload = proto.thorchainSwapPayload))
+        val payload = assertInstanceOf(SwapPayload.ThorChain::class.java, back.swapPayload)
+        assertEquals(19, payload.data.slippageBps)
+        assertEquals(BigDecimal("0.0019"), payload.data.priceImpact)
+    }
+
+    @Test
+    fun `mayachain payload round-trips slippage_bps too`() {
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(swapPayload = SwapPayload.MayaChain(thorPayload(slippageBps = 250)))
+
+        val proto = requireNotNull(outboundMapper.invoke(domain))
+        assertEquals(250u, requireNotNull(proto.mayachainSwapPayload).slippageBps)
+        assertNull(proto.thorchainSwapPayload)
+
+        val back = mapper.invoke(basePayload(mayachainSwapPayload = proto.mayachainSwapPayload))
+        val payload = assertInstanceOf(SwapPayload.MayaChain::class.java, back.swapPayload)
+        assertEquals(250, payload.data.slippageBps)
+    }
+
+    @Test
+    fun `proto without slippage_bps reads back as null, not zero`() {
+        val back = mapper.invoke(basePayload(thorchainSwapPayload = thorProto(slippageBps = null)))
+        val payload = assertInstanceOf(SwapPayload.ThorChain::class.java, back.swapPayload)
+
+        assertNull(payload.data.slippageBps)
+        assertNull(payload.data.priceImpact)
+    }
+
+    @Test
+    fun `proto with slippage_bps of zero reads back as zero`() {
+        val back = mapper.invoke(basePayload(thorchainSwapPayload = thorProto(slippageBps = 0u)))
+        val payload = assertInstanceOf(SwapPayload.ThorChain::class.java, back.swapPayload)
+
+        assertEquals(0, payload.data.slippageBps)
+        assertEquals(0, BigDecimal.ZERO.compareTo(payload.data.priceImpact))
+    }
+
+    @Test
+    fun `domain payload without slippage leaves the proto field unset`() {
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(swapPayload = SwapPayload.ThorChain(thorPayload(slippageBps = null)))
+
+        val proto = requireNotNull(outboundMapper.invoke(domain))
+        assertNull(requireNotNull(proto.thorchainSwapPayload).slippageBps)
+    }
+
+    @Test
+    fun `a negative domain value is never written to the unsigned proto field`() {
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(swapPayload = SwapPayload.ThorChain(thorPayload(slippageBps = -1)))
+
+        val proto = requireNotNull(outboundMapper.invoke(domain))
+        assertNull(requireNotNull(proto.thorchainSwapPayload).slippageBps)
+    }
+
+    @Test
+    fun `a proto value beyond Int range reads back as absent rather than wrapping negative`() {
+        val back =
+            mapper.invoke(
+                basePayload(thorchainSwapPayload = thorProto(slippageBps = UInt.MAX_VALUE))
+            )
+        val payload = assertInstanceOf(SwapPayload.ThorChain::class.java, back.swapPayload)
+
+        assertNull(payload.data.slippageBps)
+    }
+
+    private fun thorPayload(slippageBps: Int?) =
+        THORChainSwapPayload(
+            fromAddress = "thorsrc",
+            fromCoin = runeDomainCoin(),
+            toCoin = ethDomainCoin(),
+            vaultAddress = "thorInbound",
+            routerAddress = null,
+            fromAmount = BigInteger.valueOf(100_000_000L),
+            toAmountDecimal = BigDecimal("0.05"),
+            toAmountLimit = "0",
+            streamingInterval = "1",
+            streamingQuantity = "0",
+            expirationTime = 1_700_000_000uL,
+            isAffiliate = true,
+            slippageBps = slippageBps,
+        )
+
+    private fun thorProto(slippageBps: UInt?) =
+        ThorChainSwapPayloadProto(
+            fromAddress = "thorsrc",
+            fromCoin = RUNE_COIN,
+            toCoin = ETH_COIN,
+            vaultAddress = "thorInbound",
+            routerAddress = null,
+            fromAmount = "100000000",
+            toAmountDecimal = "0.05",
+            toAmountLimit = "0",
+            streamingInterval = "1",
+            streamingQuantity = "0",
+            expirationTime = 1_700_000_000uL,
+            isAffiliate = true,
+            slippageBps = slippageBps,
+        )
+
+    private fun runeDomainCoin() =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUNE",
+            logo = "",
+            address = "thorsrc",
+            decimal = 8,
+            hexPublicKey = "pubkey",
+            priceProviderID = "thorchain",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun ethDomainCoin() =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xuser",
+            decimal = 18,
+            hexPublicKey = "pubkey",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun basePayload(
+        thorchainSwapPayload: ThorChainSwapPayloadProto? = null,
+        mayachainSwapPayload: ThorChainSwapPayloadProto? = null,
+    ) =
+        KeysignPayloadProto(
+            coin = RUNE_COIN,
+            toAddress = "thorInbound",
+            toAmount = "100000000",
+            vaultPublicKeyEcdsa = "pubkey",
+            vaultLocalPartyId = "party-1",
+            thorchainSpecific =
+                THORChainSpecific(
+                    accountNumber = 1uL,
+                    sequence = 0uL,
+                    fee = 2_000_000uL,
+                    isDeposit = false,
+                    transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            thorchainSwapPayload = thorchainSwapPayload,
+            mayachainSwapPayload = mayachainSwapPayload,
+        )
+
+    companion object {
+        private val RUNE_COIN =
+            CoinProto(
+                chain = "THORChain",
+                ticker = "RUNE",
+                address = "thorsrc",
+                contractAddress = "",
+                decimals = 8,
+                priceProviderId = "thorchain",
+                isNativeToken = true,
+                hexPublicKey = "pubkey",
+                logo = "",
+            )
+        private val ETH_COIN =
+            CoinProto(
+                chain = "Ethereum",
+                ticker = "ETH",
+                address = "0xuser",
+                contractAddress = "",
+                decimals = 18,
+                priceProviderId = "ethereum",
+                isNativeToken = true,
+                hexPublicKey = "pubkey",
+                logo = "",
+            )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/SwapQuotePriceImpactTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/SwapQuotePriceImpactTest.kt
@@ -2,11 +2,15 @@ package com.vultisig.wallet.data.models
 
 import com.vultisig.wallet.data.api.models.quotes.Fees
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
+import com.vultisig.wallet.data.utils.BigIntegerSerializerImpl
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import org.junit.jupiter.api.Test
 
 /**
@@ -15,6 +19,56 @@ import org.junit.jupiter.api.Test
  * row.
  */
 internal class SwapQuotePriceImpactTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        serializersModule = SerializersModule { contextual(BigIntegerSerializerImpl()) }
+    }
+
+    @Test
+    fun `thorchain reads slippage_bps from inside fees, where the node sends it`() {
+        // Trimmed from a live `ETH.ETH -> BTC.BTC` thornode quote: the figure lives in `fees` and
+        // nowhere else. Reading it off the top level parsed clean and never rendered a row.
+        val body =
+            """
+            {
+              "dust_threshold": "10000",
+              "expected_amount_out": "3157340",
+              "expiry": 1788000000,
+              "fees": {
+                "asset": "BTC.BTC",
+                "affiliate": "0",
+                "outbound": "1161",
+                "liquidity": "6382",
+                "total": "7543",
+                "slippage_bps": 19,
+                "total_bps": 23
+              },
+              "inbound_address": "0xinbound",
+              "max_streaming_quantity": 0,
+              "notes": "",
+              "outbound_delay_blocks": 0,
+              "outbound_delay_seconds": 0,
+              "recommended_min_amount_in": "1",
+              "streaming_swap_blocks": 0,
+              "warning": ""
+            }
+            """
+                .trimIndent()
+
+        val quote =
+            SwapQuote.ThorChain(
+                expectedDstValue = mockk(),
+                fees = mockk(),
+                expiredAt = mockk(),
+                recommendedMinTokenValue = mockk(),
+                data = json.decodeFromString<THORChainSwapQuote>(body),
+            )
+
+        assertEquals(19, quote.data.fees.slippageBps)
+        assertEquals(BigDecimal("0.0019"), quote.priceImpact)
+    }
 
     @Test
     fun `thorchain derives fractional price impact from slippage_bps`() {
@@ -81,7 +135,14 @@ internal class SwapQuotePriceImpactTest {
             dustThreshold = null,
             expectedAmountOut = "9950",
             expiry = BigInteger.valueOf(9_999_999),
-            fees = Fees(affiliate = "0", asset = "50", outbound = "0", total = "50"),
+            fees =
+                Fees(
+                    affiliate = "0",
+                    asset = "50",
+                    outbound = "0",
+                    total = "50",
+                    slippageBps = slippageBps,
+                ),
             inboundAddress = "thorInbound",
             inboundConfirmationBlocks = null,
             inboundConfirmationSeconds = null,
@@ -96,6 +157,5 @@ internal class SwapQuotePriceImpactTest {
             warning = "",
             router = null,
             error = null,
-            slippageBps = slippageBps,
         )
 }


### PR DESCRIPTION
Closes #5865

## Summary

A device joining a keysign builds its swap verify screen from the `KeysignPayload` alone — it holds no quote — so price impact never reached it. This carries the quote's `fees.slippage_bps` on the wire (`THORChainSwapPayload.slippage_bps`, vultisig/commondata#104) and renders it on the joiner, for both THORChain and MayaChain.

- **commondata pin** `63a65c37` → `4064d473`. The intervening proto diff, all additive:

  | commit | file | change |
  |---|---|---|
  | `882cf313` | `thorchain_swap_payload.proto` | `optional uint32 slippage_bps = 14` — **this PR** |
  | `d782a4b1` | `swapkit_swap_payload.proto` | `swap_fee` + `swap_fee_chain` / `swap_fee_token_id` / `swap_fee_decimals` (12–15) — #5864, next PR |
  | `4ccedcbb` | `1inch_swap_payload.proto` | `sub_provider = 7` — unused |
  | `d1566e4f` | `blockchain_specific.proto` | `TRANSACTION_TYPE_RIPPLE_PAYMENT = 11` — unused |

- **Initiator**: `SwapTransactionBuilder` populates `slippageBps` from `quote.data.fees.slippageBps` for both native chains. The limit-order builder has no quote and leaves it unset.
- **Mappers**: `PayloadToProtoMapper` / `KeysignPayloadProtoMapper` carry it both ways. The proto type is `UInt?`, so a negative is never written and a value beyond `Int` range reads back as absent rather than wrapping.
- **Joiner**: `JoinSwapUiModelBuilder` derives the `PriceImpactRow` from the payload through the same `formatPriceImpact` helper the initiator uses. It deliberately does **not** use the quote it re-fetches for the fee rows: pools move between initiating and joining, so a fresh figure would make this the one row the two devices legitimately disagree on. `null` hides the row; `0` renders as `+0.00%`.

### The initiator's own row was dead too

The issue parks this as "related, out of scope", but it can't be: THORNode and MayaNode send `slippage_bps` **inside `fees`**, never at the top level where `THORChainSwapQuote` read it. Verified through the gateway the app uses:

```
GET https://gateway.liquify.com/chain/thorchain_api/thorchain/quote/swap?from_asset=ETH.ETH&to_asset=BTC.BTC&amount=100000000
fees: { asset: "BTC.BTC", affiliate: "0", outbound: "1161", liquidity: "6382", total: "7543", slippage_bps: 19, total_bps: 23 }
top-level slippage_bps: absent
```

So `SwapQuote.ThorChain.priceImpact` has been `null` since #5075 and the Price Impact row never rendered for either chain on the initiator. Populating the wire from `fees` while leaving that read alone would have shown the co-signer a row the initiator doesn't — the inverse of the issue. The field moves into `Fees` (one line in `SwapQuote.kt`), and the existing `SwapQuotePriceImpactTest` fixture moves with it, plus a new test that decodes a trimmed live THORNode body.

## Verified on device

Extension on `main` (`f8192639a`, core-mpc 3.2.2), Android on this branch, 2-of-2 vault.

**Android initiates (RUNE → BTC), extension joins** — `-0.08% (Good)` on both, and every fee row reconciles (Max. Total Fee $0.91 on both):

| Android verify | Extension join |
|---|---|
| <img src="https://i.imgur.com/cLLP66b.png" width="320" /> | <img src="https://i.imgur.com/eUjiItm.png" width="360" /> |

**Extension initiates (10 RUNE → BTC), Android joins** — the Android join screen shows `-0.08% (Good)` read from the payload; it has no other source for the row:

<img src="https://i.imgur.com/qFQBnxA.png" width="320" />

## Tests

- `KeysignPayloadProtoMapperNativeSwapSlippageTest` (new, :data, 7): domain → proto → domain for THORChain and MayaChain; proto without the field → `null` (not `0`); `slippage_bps = 0` → `0`; the two `UInt` boundary guards.
- `SwapQuotePriceImpactTest` (:data, 6): fixture moved into `Fees`, plus the live-shape deserialization test above.
- `JoinSwapPriceImpactTest` (new, :app, 5): the re-fetched quote is given a *different* `slippage_bps` than the payload to prove the payload wins; Good/Average/High banding; absent hides; zero renders; MayaChain.
- Root `assembleDebug`, `:app:ktfmtCheck`, `:data:ktfmtCheck`, `:app:compileDebugAndroidTestKotlin` all pass.

## Test plan

- [ ] Android → Swap → RUNE → BTC → fee breakdown and verify screen show `Price Impact` (was missing before)
- [ ] Sign, join from extension → its join screen shows the same value and band
- [ ] Extension → Swap → THORChain pair → Sign; join from Android → Android verify screen shows the same `Price Impact`
- [ ] Join a swap from an older Android build → no Price Impact row, no `0.00%`
- [ ] Repeat with a MayaChain pair (CACAO → BTC)

## Out of scope

- `THORChainSwapPayload.fee` (field 13) is still unset by Android; iOS shipped it in vultisig/vultisig-ios#5352. Follow-up.
- SwapKit `swap_fee` (#5864) — next PR, stacked on this one.

Sibling implementations: vultisig/vultisig-sdk#2330 (populate), vultisig/vultisig-windows#4836 (render on join), vultisig/vultisig-ios#5360 (both).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Swap verification now displays formatted price-impact percentages and severity for THORChain and MayaChain routes.
  - Swap transactions now preserve quote slippage information for more accurate verification and price-impact calculations.
  - Slippage values are handled safely, including zero, missing, negative, and out-of-range values.
- **Bug Fixes**
  - Corrected quote processing when slippage is provided within fee details, improving displayed price-impact accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->