### PR TITLE
feat(swap): carry the SwapKit provider fee to the co-signer

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
@@ -39,6 +39,7 @@ import com.vultisig.wallet.ui.models.mappers.SwapTransactionToHistoryDataMapper
 import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
 import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
 import com.vultisig.wallet.ui.models.swap.LimitOrderLabels
+import com.vultisig.wallet.ui.models.swap.PriceImpactDisplay
 import com.vultisig.wallet.ui.models.swap.SwapDiscountBps
 import com.vultisig.wallet.ui.models.swap.SwapFeeRow
 import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
@@ -46,6 +47,7 @@ import com.vultisig.wallet.ui.models.swap.ValuedToken
 import com.vultisig.wallet.ui.models.swap.VerifySwapUiModel
 import com.vultisig.wallet.ui.models.swap.evmSwapDisplayGasLimit
 import com.vultisig.wallet.ui.models.swap.formatAffiliatePercent
+import com.vultisig.wallet.ui.models.swap.formatPriceImpact
 import com.vultisig.wallet.ui.models.swap.formatSwapKitProviderLabel
 import com.vultisig.wallet.ui.models.swap.resolveExternalSwapRecipient
 import com.vultisig.wallet.ui.models.swap.signedLimitOrder
@@ -447,6 +449,7 @@ constructor(
                             ),
                         feeProvider = SwapProvider.THORCHAIN,
                         vultBps = thorVultBps,
+                        priceImpact = formatPriceImpact(swapPayload.data.priceImpact),
                     )
                 JoinKeysignVerifyResult(
                     verifyUiModel =
@@ -529,6 +532,7 @@ constructor(
                             ),
                         feeProvider = SwapProvider.MAYA,
                         vultBps = mayaVultBps,
+                        priceImpact = formatPriceImpact(swapPayload.data.priceImpact),
                     )
                 JoinKeysignVerifyResult(
                     verifyUiModel =
@@ -640,6 +644,10 @@ constructor(
         // cost), which leaves the row exactly as it was: the charged fee, claiming no rate.
         feeProvider: SwapProvider? = null,
         vultBps: Int? = null,
+        // Price impact read off the wire, never re-quoted: pools move between initiating and
+        // joining, so a fresh figure would make this the one row the two devices disagree on.
+        // Null hides the row.
+        priceImpact: PriceImpactDisplay? = null,
     ): SwapTransactionUiModel {
         val estimatedFee = convertTokenValueToFiat(providerFeeToken, providerFee, currency)
 
@@ -724,6 +732,8 @@ constructor(
             isLimitOrder = isLimitOrder,
             limitTargetPriceLabel = limitOrderLabels?.targetPriceLabel,
             limitExpiryLabel = limitOrderLabels?.expiryLabel,
+            priceImpactPercent = priceImpact?.percent,
+            priceImpactLevel = priceImpact?.level,
         )
     }
 

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/JoinSwapUiModelBuilder.kt
@@ -545,45 +545,61 @@ constructor(
             }
 
             is SwapPayload.SwapKit -> {
+                // The provider fee the initiator saw, when its payload carries one. Read off the
+                // wire rather than re-quoted: a fresh quote can disagree with what the initiator
+                // approved, and a failed fetch would show a confident zero on the one screen whose
+                // purpose is to state the cost.
+                val payloadFee =
+                    swapKitPayloadFee(swapPayload.data, srcToken, dstToken, nativeToken)
                 // BTC/Cardano SwapKit deposits report the deposit cost as their inbound fee,
                 // already shown as the Network Fee — hide the Swap Fee row so it isn't
-                // double-counted, matching the initiator and the form (#5358, #5321).
-                val swapFeeHidden = srcToken.chain.standard == TokenStandard.UTXO
-                // Re-fetch only the SwapKit inbound fee at join time so the co-signer sees the same
-                // non-zero swap fee as the initiator (mirrors the Thor/Maya branches). Uses the
-                // quote-only `getSwapKitInboundFee` (`POST /v3/quote`) rather than the full
-                // `getQuote`, which would also fire `POST /v3/swap` and mint a throwaway swap route
-                // — a fresh `swapId` and deposit address — per cosigner just to read the fee.
-                // Display-only: the signing bytes come from the payload and are never touched. The
-                // quote may reprice slightly between fetches (approximate parity, the same
-                // trade-off Thor/Maya accept); a fetch failure degrades to a zero fee rather than
-                // stalling the verify screen. The initiator's `affiliateBps` / `srcAddress` are
-                // intentionally omitted — the inbound fee doesn't depend on the affiliate fee and
-                // the join device can't know the initiator's `vultBPSDiscount`, so approximate
-                // parity holds. Skipped entirely when the row is hidden (UTXO): the fetched fee
-                // would be neither displayed nor added to the total, so the round-trip is waste
-                // (#5358 review).
+                // double-counted, matching the initiator and the form (#5358, #5321). A provider
+                // fee stated on the wire is a separate charge and shows on every source chain.
+                val swapFeeHidden =
+                    when (payloadFee) {
+                        is SwapKitPayloadFee.Stated -> false
+                        SwapKitPayloadFee.NotRenderable -> true
+                        SwapKitPayloadFee.Absent -> srcToken.chain.standard == TokenStandard.UTXO
+                    }
+                // For a sender that predates the field, re-fetch only the SwapKit inbound fee at
+                // join time so the co-signer sees the same non-zero swap fee as the initiator
+                // (mirrors the Thor/Maya branches). Uses the quote-only `getSwapKitInboundFee`
+                // (`POST /v3/quote`) rather than the full `getQuote`, which would also fire
+                // `POST /v3/swap` and mint a throwaway swap route — a fresh `swapId` and deposit
+                // address — per cosigner just to read the fee. Display-only: the signing bytes
+                // come from the payload and are never touched. The quote may reprice slightly
+                // between fetches (approximate parity, the same trade-off Thor/Maya accept); a
+                // fetch failure degrades to a zero fee rather than stalling the verify screen. The
+                // initiator's `affiliateBps` / `srcAddress` are intentionally omitted — the inbound
+                // fee doesn't depend on the affiliate fee and the join device can't know the
+                // initiator's `vultBPSDiscount`, so approximate parity holds. Skipped entirely
+                // when the row is hidden (UTXO): the fetched fee would be neither displayed nor
+                // added to the total, so the round-trip is waste (#5358 review).
+                val swapKitProviderFeeToken =
+                    (payloadFee as? SwapKitPayloadFee.Stated)?.coin ?: srcToken
                 val swapKitProviderFee =
-                    if (swapFeeHidden) {
-                        TokenValue(value = BigInteger.ZERO, token = srcToken)
-                    } else {
-                        try {
-                            swapQuoteRepository.getSwapKitInboundFee(
-                                SwapQuoteRequest(
-                                    srcToken = srcToken,
-                                    dstToken = dstToken,
-                                    tokenValue = srcTokenValue,
-                                    dstAddress = dstToken.address,
+                    when {
+                        payloadFee is SwapKitPayloadFee.Stated -> payloadFee.fee
+                        swapFeeHidden -> TokenValue(value = BigInteger.ZERO, token = srcToken)
+                        else ->
+                            try {
+                                swapQuoteRepository.getSwapKitInboundFee(
+                                    SwapQuoteRequest(
+                                        srcToken = srcToken,
+                                        dstToken = dstToken,
+                                        tokenValue = srcTokenValue,
+                                        dstAddress = dstToken.address,
+                                    )
                                 )
-                            )
-                        } catch (e: SwapKitError) {
-                            // The SwapKit API layer wraps network/timeout/decoding failures into
-                            // SwapKitError and rethrows CancellationException un-wrapped, so this
-                            // narrow catch degrades quote failures to a zero fee while letting
-                            // cancellation (and any genuinely unexpected exception) propagate.
-                            Timber.w(e, "SwapKit join fee re-fetch failed; showing zero fee")
-                            TokenValue(value = BigInteger.ZERO, token = srcToken)
-                        }
+                            } catch (e: SwapKitError) {
+                                // The SwapKit API layer wraps network/timeout/decoding failures
+                                // into SwapKitError and rethrows CancellationException un-wrapped,
+                                // so this narrow catch degrades quote failures to a zero fee while
+                                // letting cancellation (and any genuinely unexpected exception)
+                                // propagate.
+                                Timber.w(e, "SwapKit join fee re-fetch failed; showing zero fee")
+                                TokenValue(value = BigInteger.ZERO, token = srcToken)
+                            }
                     }
                 val swapTransactionUiModel =
                     buildSwapUiModel(
@@ -594,7 +610,7 @@ constructor(
                         estimatedNetworkGasFee = estimatedNetworkGasFee,
                         provider = provider,
                         providerFee = swapKitProviderFee,
-                        providerFeeToken = srcToken,
+                        providerFeeToken = swapKitProviderFeeToken,
                         currency = currency,
                         providerLabel = providerLabel,
                         swapFeeHidden = swapFeeHidden,

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/SwapKitPayloadFee.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/SwapKitPayloadFee.kt
@@ -5,6 +5,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.Coins
 import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.repositories.TokenMetadataResolver
 import java.math.BigInteger
 
 /**
@@ -20,7 +21,7 @@ internal sealed interface SwapKitPayloadFee {
 
     /**
      * The sender stated a fee this device cannot render — zero, a non-integer amount, an unknown
-     * chain, missing decimals, or a coin it cannot resolve. No row, no re-fetch.
+     * chain, missing or out-of-range decimals, or a coin it cannot resolve. No row, no re-fetch.
      */
     data object NotRenderable : SwapKitPayloadFee
 
@@ -49,7 +50,11 @@ internal fun swapKitPayloadFee(
             ?: return SwapKitPayloadFee.NotRenderable
     val chain =
         data.swapFeeChain?.let(Chain::fromRawOrNull) ?: return SwapKitPayloadFee.NotRenderable
-    val decimals = data.swapFeeDecimals ?: return SwapKitPayloadFee.NotRenderable
+    // The scale feeds `10 ^ decimals` on every render, so the same ceiling contract metadata is
+    // held to applies here: a negative value throws, an absurd one burns CPU.
+    val decimals =
+        data.swapFeeDecimals?.takeIf { it in 0..TokenMetadataResolver.MAX_DECIMALS }
+            ?: return SwapKitPayloadFee.NotRenderable
     val tokenId = data.swapFeeTokenId.orEmpty()
     val coin =
         listOf(dstToken, srcToken, nativeToken).firstOrNull { it.isFeeCoin(chain, tokenId) }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/SwapKitPayloadFee.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/SwapKitPayloadFee.kt
@@ -1,0 +1,62 @@
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.TokenValue
+import java.math.BigInteger
+
+/**
+ * What a SwapKit transfer-route payload says about its provider fee, as read by a co-signer.
+ *
+ * The `swap_fee` group is written by the initiating device, which may run another platform's code,
+ * so nothing in it is trusted past a parse: a stated fee that cannot be turned into a coin this
+ * device can price renders no row rather than a guess, and never throws out of the verify screen.
+ */
+internal sealed interface SwapKitPayloadFee {
+    /** The sender predates the field. The co-signer keeps its pre-field behaviour. */
+    data object Absent : SwapKitPayloadFee
+
+    /**
+     * The sender stated a fee this device cannot render — zero, a non-integer amount, an unknown
+     * chain, missing decimals, or a coin it cannot resolve. No row, no re-fetch.
+     */
+    data object NotRenderable : SwapKitPayloadFee
+
+    /** A fee the initiator saw, in the coin it was charged in. */
+    data class Stated(val coin: Coin, val amount: BigInteger) : SwapKitPayloadFee {
+        val fee: TokenValue
+            get() = TokenValue(amount, coin)
+    }
+}
+
+/**
+ * Resolves the payload's fee group against the coins the co-signer can price: the pair, the source
+ * chain's native coin, then the built-in registry for the fee chain — which is where a Chainflip
+ * route's Ethereum USDC fee lands on a BTC → ETH swap, a coin that is neither leg. The sender's
+ * decimals are kept over the registry's so the amount is read the way it was written.
+ */
+internal fun swapKitPayloadFee(
+    data: SwapKitSwapPayloadJson,
+    srcToken: Coin,
+    dstToken: Coin,
+    nativeToken: Coin,
+): SwapKitPayloadFee {
+    if (data.swapFee.isEmpty()) return SwapKitPayloadFee.Absent
+    val amount =
+        data.swapFee.toBigIntegerOrNull()?.takeIf { it.signum() > 0 }
+            ?: return SwapKitPayloadFee.NotRenderable
+    val chain =
+        data.swapFeeChain?.let(Chain::fromRawOrNull) ?: return SwapKitPayloadFee.NotRenderable
+    val decimals = data.swapFeeDecimals ?: return SwapKitPayloadFee.NotRenderable
+    val tokenId = data.swapFeeTokenId.orEmpty()
+    val coin =
+        listOf(dstToken, srcToken, nativeToken).firstOrNull { it.isFeeCoin(chain, tokenId) }
+            ?: Coins.coins[chain]?.firstOrNull { it.isFeeCoin(chain, tokenId) }
+            ?: return SwapKitPayloadFee.NotRenderable
+    return SwapKitPayloadFee.Stated(coin.copy(decimal = decimals), amount)
+}
+
+private fun Coin.isFeeCoin(chain: Chain, tokenId: String): Boolean =
+    this.chain == chain && contractAddress.equals(tokenId, ignoreCase = true)

--- a/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/swap/SwapTransactionBuilder.kt
@@ -146,6 +146,7 @@ constructor(
                                         .inWholeSeconds
                                         .toULong(),
                                 isAffiliate = isAffiliate,
+                                slippageBps = quote.data.fees.slippageBps,
                             )
                         ),
                 )
@@ -229,6 +230,7 @@ constructor(
                                         .inWholeSeconds
                                         .toULong(),
                                 isAffiliate = isAffiliate,
+                                slippageBps = quote.data.fees.slippageBps,
                             )
                         ),
                 )

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinSwapPriceImpactTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinSwapPriceImpactTest.kt
@@ -1,0 +1,321 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.api.models.quotes.Fees
+import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.EstimatedGasFee
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapProvider
+import com.vultisig.wallet.data.models.SwapQuote
+import com.vultisig.wallet.data.models.THORChainSwapPayload
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.SwapQuoteRepository
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.repositories.swap.SwapQuoteResult
+import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.models.mappers.SwapTransactionToHistoryDataMapper
+import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
+import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
+import com.vultisig.wallet.ui.models.swap.PriceImpactLevel
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.Instant
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.TransactionType
+
+/**
+ * The co-signer's Price Impact row comes off the payload's `slippage_bps`, never off the quote it
+ * re-fetches for the fee rows: pools move between initiating and joining, so a fresh figure would
+ * make this the one row the two devices legitimately disagree on. The re-fetched quote below
+ * deliberately carries a different `slippage_bps` than the payload to prove which one wins.
+ */
+internal class JoinSwapPriceImpactTest {
+
+    private val tokenRepository: TokenRepository = mockk()
+    private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase = mockk()
+    private val fiatValueToStringMapper: FiatValueToStringMapper = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val getDiscountBps: GetDiscountBpsUseCase = mockk()
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper = mockk()
+    private val mapSwapTransactionToHistoryData: SwapTransactionToHistoryDataMapper = mockk()
+    private val swapQuoteRepository: SwapQuoteRepository = mockk()
+
+    private fun builder() =
+        JoinSwapUiModelBuilder(
+            tokenRepository = tokenRepository,
+            chainAccountAddressRepository = mockk<ChainAccountAddressRepository>(relaxed = true),
+            feeServiceComposite = mockk(relaxed = true),
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            convertTokenValueToFiat = convertTokenValueToFiat,
+            fiatValueToStringMapper = fiatValueToStringMapper,
+            mapTokenValueToDecimalUiString = mapTokenValueToDecimalUiString,
+            swapQuoteRepository = swapQuoteRepository,
+            mapSwapTransactionToHistoryData = mapSwapTransactionToHistoryData,
+            formatLimitOrderLabels = FormatLimitOrderLabelsUseCase(),
+            getDiscountBps = getDiscountBps,
+        )
+
+    @Test
+    fun `renders the payload's price impact, not the re-fetched quote's`() = runTest {
+        stub(SwapProvider.THORCHAIN, refetchedSlippageBps = 900)
+
+        val tx =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.ThorChain(thorPayload(slippageBps = 133)),
+                    vault,
+                    AppCurrency.USD,
+                )
+
+        val swap = tx.transactionTypeUiModel as TransactionTypeUiModel.Swap
+        // 133 bps, negated for display like the initiator's row, in the Average band.
+        swap.swapTransactionUiModel.priceImpactPercent shouldBe "-1.33%"
+        swap.swapTransactionUiModel.priceImpactLevel shouldBe PriceImpactLevel.AVERAGE
+    }
+
+    @Test
+    fun `bands the payload's figure the way the initiator does`() = runTest {
+        stub(SwapProvider.THORCHAIN, refetchedSlippageBps = null)
+
+        val good =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.ThorChain(thorPayload(slippageBps = 19)),
+                    vault,
+                    AppCurrency.USD,
+                )
+        val high =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.ThorChain(thorPayload(slippageBps = 450)),
+                    vault,
+                    AppCurrency.USD,
+                )
+
+        (good.transactionTypeUiModel as TransactionTypeUiModel.Swap).swapTransactionUiModel.let {
+            it.priceImpactPercent shouldBe "-0.19%"
+            it.priceImpactLevel shouldBe PriceImpactLevel.GOOD
+        }
+        (high.transactionTypeUiModel as TransactionTypeUiModel.Swap).swapTransactionUiModel.let {
+            it.priceImpactPercent shouldBe "-4.50%"
+            it.priceImpactLevel shouldBe PriceImpactLevel.HIGH
+        }
+    }
+
+    @Test
+    fun `hides the row for a payload without the field, even when the re-fetched quote has one`() =
+        runTest {
+            stub(SwapProvider.THORCHAIN, refetchedSlippageBps = 19)
+
+            val tx =
+                builder()
+                    .build(
+                        payload(),
+                        SwapPayload.ThorChain(thorPayload(slippageBps = null)),
+                        vault,
+                        AppCurrency.USD,
+                    )
+
+            val swap = tx.transactionTypeUiModel as TransactionTypeUiModel.Swap
+            swap.swapTransactionUiModel.priceImpactPercent shouldBe null
+            swap.swapTransactionUiModel.priceImpactLevel shouldBe null
+        }
+
+    @Test
+    fun `renders a zero-impact payload as zero, distinct from an absent one`() = runTest {
+        stub(SwapProvider.THORCHAIN, refetchedSlippageBps = null)
+
+        val tx =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.ThorChain(thorPayload(slippageBps = 0)),
+                    vault,
+                    AppCurrency.USD,
+                )
+
+        val swap = tx.transactionTypeUiModel as TransactionTypeUiModel.Swap
+        swap.swapTransactionUiModel.priceImpactPercent shouldBe "+0.00%"
+        swap.swapTransactionUiModel.priceImpactLevel shouldBe PriceImpactLevel.GOOD
+    }
+
+    @Test
+    fun `mayachain payload renders its price impact too`() = runTest {
+        stub(SwapProvider.MAYA, refetchedSlippageBps = null)
+
+        val tx =
+            builder()
+                .build(
+                    payload(),
+                    SwapPayload.MayaChain(thorPayload(slippageBps = 250)),
+                    vault,
+                    AppCurrency.USD,
+                )
+
+        val swap = tx.transactionTypeUiModel as TransactionTypeUiModel.Swap
+        swap.swapTransactionUiModel.priceImpactPercent shouldBe "-2.50%"
+        swap.swapTransactionUiModel.priceImpactLevel shouldBe PriceImpactLevel.AVERAGE
+    }
+
+    private fun stub(provider: SwapProvider, refetchedSlippageBps: Int?) {
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        every { mapSwapTransactionToHistoryData(any()) } returns mockk(relaxed = true)
+        coEvery { getDiscountBps(vault.id, provider) } returns 0
+        coEvery { tokenRepository.getNativeToken(Chain.ThorChain.id) } returns rune
+        coEvery { swapQuoteRepository.getQuote(provider, any()) } returns
+            SwapQuoteResult.Native(quote(provider, refetchedSlippageBps))
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } returns usd("0")
+        coEvery { fiatValueToStringMapper(any(), any()) } returns "0.00"
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedTokenValue = "0.02 RUNE",
+                formattedFiatValue = "$0.20",
+                tokenValue = TokenValue(BigInteger.valueOf(2_000_000L), rune),
+                fiatValue = usd("0.20"),
+            )
+    }
+
+    private fun quote(provider: SwapProvider, slippageBps: Int?): SwapQuote {
+        val dst = TokenValue(BigInteger.valueOf(1_000_000_000_000_000_000L), eth)
+        val data =
+            THORChainSwapQuote(
+                dustThreshold = null,
+                expectedAmountOut = "1",
+                expiry = BigInteger.ZERO,
+                fees =
+                    Fees(
+                        affiliate = "60000000",
+                        asset = "0",
+                        outbound = "10000000",
+                        total = "70000000",
+                        slippageBps = slippageBps,
+                    ),
+                inboundAddress = "inbound",
+                inboundConfirmationBlocks = null,
+                inboundConfirmationSeconds = null,
+                maxStreamingQuantity = 0,
+                memo = "=:ETH.ETH:0xdst",
+                notes = "",
+                outboundDelayBlocks = BigInteger.ZERO,
+                outboundDelaySeconds = BigInteger.ZERO,
+                recommendedMinAmountIn = "0",
+                streamingSwapBlocks = BigInteger.ZERO,
+                totalSwapSeconds = 0L,
+                warning = "",
+                router = null,
+                error = null,
+            )
+        val expiry = Instant.now().plus(5.minutes.toJavaDuration())
+        val zero = TokenValue(BigInteger.ZERO, eth)
+        return if (provider == SwapProvider.MAYA) {
+            SwapQuote.MayaChain(
+                expectedDstValue = dst,
+                fees = zero,
+                expiredAt = expiry,
+                recommendedMinTokenValue = zero,
+                data = data,
+            )
+        } else {
+            SwapQuote.ThorChain(
+                expectedDstValue = dst,
+                fees = zero,
+                expiredAt = expiry,
+                recommendedMinTokenValue = zero,
+                data = data,
+            )
+        }
+    }
+
+    private fun payload() =
+        KeysignPayload(
+            coin = rune,
+            toAddress = "thorInbound",
+            toAmount = srcValue.value,
+            memo = "=:ETH.ETH:0xdst",
+            blockChainSpecific =
+                BlockChainSpecific.THORChain(
+                    accountNumber = BigInteger.ZERO,
+                    sequence = BigInteger.ZERO,
+                    fee = BigInteger.valueOf(2_000_000L),
+                    isDeposit = false,
+                    transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "party",
+            libType = null,
+            wasmExecuteContractPayload = null,
+        )
+
+    private val rune =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUNE",
+            logo = "",
+            address = "thorsrc",
+            decimal = 8,
+            hexPublicKey = "pub",
+            priceProviderID = "thorchain",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val eth =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xdst",
+            decimal = 18,
+            hexPublicKey = "pub",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val srcValue = TokenValue(BigInteger.valueOf(100_000_000L), rune)
+
+    private fun thorPayload(slippageBps: Int?) =
+        THORChainSwapPayload(
+            fromAddress = "thorsrc",
+            fromCoin = rune,
+            toCoin = eth,
+            vaultAddress = "thorInbound",
+            routerAddress = null,
+            fromAmount = srcValue.value,
+            toAmountDecimal = BigDecimal.ONE,
+            toAmountLimit = "0",
+            streamingInterval = "0",
+            streamingQuantity = "0",
+            expirationTime = 0UL,
+            isAffiliate = true,
+            slippageBps = slippageBps,
+        )
+
+    private fun usd(amount: String) = FiatValue(BigDecimal(amount), "USD")
+
+    private val vault =
+        Vault(id = "vault-1", name = "Main", pubKeyECDSA = "pub", pubKeyEDDSA = "pubed")
+}

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinSwapSwapKitFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinSwapSwapKitFeeTest.kt
@@ -185,6 +185,21 @@ internal class JoinSwapSwapKitFeeTest {
         tx.swapFeeHidden shouldBe true
     }
 
+    @Test
+    fun `out-of-range decimals render no row instead of throwing on render`() = runTest {
+        stub()
+
+        // A negative scale throws out of `10 ^ decimals`; an absurd one burns CPU on every render.
+        val negative =
+            join(payload(swapFee = "13000000", swapFeeChain = "Tron", swapFeeDecimals = -1))
+        val absurd =
+            join(payload(swapFee = "13000000", swapFeeChain = "Tron", swapFeeDecimals = 255))
+
+        negative.swapFeeHidden shouldBe true
+        absurd.swapFeeHidden shouldBe true
+        coVerify(exactly = 0) { swapQuoteRepository.getSwapKitInboundFee(any()) }
+    }
+
     private suspend fun join(swapKit: SwapKitSwapPayloadJson): SwapTransactionUiModel {
         val result =
             builder().build(keysignPayload(), SwapPayload.SwapKit(swapKit), vault, AppCurrency.USD)

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinSwapSwapKitFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/JoinSwapSwapKitFeeTest.kt
@@ -1,0 +1,296 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.vultisig.wallet.ui.models.keysign
+
+import com.vultisig.wallet.data.api.errors.SwapKitError
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import com.vultisig.wallet.data.models.EstimatedGasFee
+import com.vultisig.wallet.data.models.FiatValue
+import com.vultisig.wallet.data.models.SwapKitSwapPayloadJson
+import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.Vault
+import com.vultisig.wallet.data.models.payload.BlockChainSpecific
+import com.vultisig.wallet.data.models.payload.KeysignPayload
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.settings.AppCurrency
+import com.vultisig.wallet.data.repositories.ChainAccountAddressRepository
+import com.vultisig.wallet.data.repositories.SwapQuoteRepository
+import com.vultisig.wallet.data.repositories.TokenRepository
+import com.vultisig.wallet.data.usecases.ConvertTokenValueToFiatUseCase
+import com.vultisig.wallet.data.usecases.GasFeeToEstimatedFeeUseCase
+import com.vultisig.wallet.data.usecases.GetDiscountBpsUseCase
+import com.vultisig.wallet.ui.models.mappers.FiatValueToStringMapper
+import com.vultisig.wallet.ui.models.mappers.SwapTransactionToHistoryDataMapper
+import com.vultisig.wallet.ui.models.mappers.TokenValueToDecimalUiStringMapper
+import com.vultisig.wallet.ui.models.swap.FormatLimitOrderLabelsUseCase
+import com.vultisig.wallet.ui.models.swap.SwapTransactionUiModel
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.math.RoundingMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * A SwapKit transfer-route co-signer reads the provider fee off the payload's `swap_fee` group and
+ * renders it without a second quote. Only a sender that predates the group falls back to the
+ * inbound re-fetch; a stated fee this device cannot render shows no row and never throws.
+ */
+internal class JoinSwapSwapKitFeeTest {
+
+    private val tokenRepository: TokenRepository = mockk()
+    private val convertTokenValueToFiat: ConvertTokenValueToFiatUseCase = mockk()
+    private val fiatValueToStringMapper: FiatValueToStringMapper = mockk()
+    private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase = mockk()
+    private val getDiscountBps: GetDiscountBpsUseCase = mockk()
+    private val mapTokenValueToDecimalUiString: TokenValueToDecimalUiStringMapper = mockk()
+    private val mapSwapTransactionToHistoryData: SwapTransactionToHistoryDataMapper = mockk()
+    private val swapQuoteRepository: SwapQuoteRepository = mockk()
+    private val chainAccountAddressRepository: ChainAccountAddressRepository = mockk()
+
+    private fun builder() =
+        JoinSwapUiModelBuilder(
+            tokenRepository = tokenRepository,
+            chainAccountAddressRepository = chainAccountAddressRepository,
+            feeServiceComposite = mockk(relaxed = true),
+            gasFeeToEstimatedFee = gasFeeToEstimatedFee,
+            convertTokenValueToFiat = convertTokenValueToFiat,
+            fiatValueToStringMapper = fiatValueToStringMapper,
+            mapTokenValueToDecimalUiString = mapTokenValueToDecimalUiString,
+            swapQuoteRepository = swapQuoteRepository,
+            mapSwapTransactionToHistoryData = mapSwapTransactionToHistoryData,
+            formatLimitOrderLabels = FormatLimitOrderLabelsUseCase(),
+            getDiscountBps = getDiscountBps,
+        )
+
+    @Test
+    fun `renders the fee stated on the wire without re-quoting`() = runTest {
+        stub()
+
+        // 13 TRX affiliate + service, as a NEAR route states it in the source asset.
+        val tx = join(payload(swapFee = "13000000", swapFeeChain = "Tron", swapFeeDecimals = 6))
+
+        tx.swapFeeHidden shouldBe false
+        tx.providerFee.token shouldBe trx
+        tx.providerFee.value shouldBe "13000000"
+        tx.providerFee.fiatValue shouldBe "1.30"
+        // 1.30 swap fee + 0.11 gas.
+        tx.totalFee shouldBe "1.41"
+        coVerify(exactly = 0) { swapQuoteRepository.getSwapKitInboundFee(any()) }
+    }
+
+    @Test
+    fun `prices a Chainflip fee in Ethereum USDC, a coin that is neither leg`() = runTest {
+        stub()
+        val usdc = Coins.Ethereum.USDC
+
+        val tx =
+            join(
+                payload(
+                    swapFee = "650000",
+                    swapFeeChain = "Ethereum",
+                    swapFeeTokenId = usdc.contractAddress.lowercase(),
+                    swapFeeDecimals = 6,
+                    subProvider = "CHAINFLIP",
+                )
+            )
+
+        tx.swapFeeHidden shouldBe false
+        tx.providerFee.token.contractAddress shouldBe usdc.contractAddress
+        tx.providerFee.token.chain shouldBe Chain.Ethereum
+        tx.providerFee.fiatValue shouldBe "0.65"
+        tx.totalFee shouldBe "0.76"
+        coVerify(exactly = 0) { swapQuoteRepository.getSwapKitInboundFee(any()) }
+    }
+
+    @Test
+    fun `keeps the inbound re-fetch for a sender that predates the field`() = runTest {
+        stub()
+        coEvery { swapQuoteRepository.getSwapKitInboundFee(any()) } returns
+            TokenValue(BigInteger.valueOf(1_100_000L), trx)
+
+        val tx = join(payload(swapFee = ""))
+
+        tx.swapFeeHidden shouldBe false
+        tx.providerFee.value shouldBe "1100000"
+        tx.providerFee.fiatValue shouldBe "0.11"
+        coVerify(exactly = 1) { swapQuoteRepository.getSwapKitInboundFee(any()) }
+    }
+
+    @Test
+    fun `legacy re-fetch failure still degrades to a zero fee`() = runTest {
+        stub()
+        coEvery { swapQuoteRepository.getSwapKitInboundFee(any()) } throws
+            SwapKitError.Decoding("boom")
+
+        val tx = join(payload(swapFee = ""))
+
+        tx.providerFee.value shouldBe "0"
+        tx.totalFee shouldBe "0.11"
+    }
+
+    @Test
+    fun `an unknown fee chain renders no row and does not re-fetch or throw`() = runTest {
+        stub()
+
+        val tx = join(payload(swapFee = "13000000", swapFeeChain = "Narnia", swapFeeDecimals = 6))
+
+        tx.swapFeeHidden shouldBe true
+        // Gas alone: a fee this device cannot price is not silently added to the total either.
+        tx.totalFee shouldBe "0.11"
+        coVerify(exactly = 0) { swapQuoteRepository.getSwapKitInboundFee(any()) }
+    }
+
+    @Test
+    fun `a non-integer amount renders no row and does not throw`() = runTest {
+        stub()
+
+        val tx = join(payload(swapFee = "13.5", swapFeeChain = "Tron", swapFeeDecimals = 6))
+
+        tx.swapFeeHidden shouldBe true
+        coVerify(exactly = 0) { swapQuoteRepository.getSwapKitInboundFee(any()) }
+    }
+
+    @Test
+    fun `a stated fee in a coin this device cannot resolve renders no row`() = runTest {
+        stub()
+
+        val tx =
+            join(
+                payload(
+                    swapFee = "1000000",
+                    swapFeeChain = "Solana",
+                    swapFeeTokenId = "NotARealMint",
+                    swapFeeDecimals = 6,
+                )
+            )
+
+        tx.swapFeeHidden shouldBe true
+        coVerify(exactly = 0) { swapQuoteRepository.getSwapKitInboundFee(any()) }
+    }
+
+    @Test
+    fun `missing decimals render no row rather than guessing a scale`() = runTest {
+        stub()
+
+        val tx = join(payload(swapFee = "13000000", swapFeeChain = "Tron", swapFeeDecimals = null))
+
+        tx.swapFeeHidden shouldBe true
+    }
+
+    private suspend fun join(swapKit: SwapKitSwapPayloadJson): SwapTransactionUiModel {
+        val result =
+            builder().build(keysignPayload(), SwapPayload.SwapKit(swapKit), vault, AppCurrency.USD)
+        return (result.transactionTypeUiModel as TransactionTypeUiModel.Swap).swapTransactionUiModel
+    }
+
+    private fun stub() {
+        every { mapTokenValueToDecimalUiString(any()) } returns "0"
+        every { mapSwapTransactionToHistoryData(any()) } returns mockk(relaxed = true)
+        coEvery { tokenRepository.getNativeToken(Chain.Tron.id) } returns trx
+        coEvery { chainAccountAddressRepository.getAddress(any<Coin>(), any()) } returns
+            ("Tsrc" to "")
+        // TRX at $0.10, everything else (ETH dst, USDC) at $1 per whole unit.
+        coEvery { convertTokenValueToFiat(any(), any(), any()) } answers
+            {
+                val rate =
+                    if (firstArg<Coin>().chain == Chain.Tron) BigDecimal("0.10") else BigDecimal.ONE
+                FiatValue(secondArg<TokenValue>().decimal.multiply(rate), "USD")
+            }
+        coEvery { fiatValueToStringMapper(any(), any()) } answers
+            {
+                firstArg<FiatValue>().value.setScale(2, RoundingMode.HALF_UP).toPlainString()
+            }
+        coEvery { gasFeeToEstimatedFee(any()) } returns
+            EstimatedGasFee(
+                formattedTokenValue = "1.1 TRX",
+                formattedFiatValue = "$0.11",
+                tokenValue = TokenValue(BigInteger.valueOf(1_100_000L), trx),
+                fiatValue = FiatValue(BigDecimal("0.11"), "USD"),
+            )
+    }
+
+    private fun payload(
+        swapFee: String,
+        swapFeeChain: String? = null,
+        swapFeeTokenId: String? = null,
+        swapFeeDecimals: Int? = null,
+        subProvider: String = "NEAR",
+    ) =
+        SwapKitSwapPayloadJson(
+            fromCoin = trx,
+            toCoin = eth,
+            fromAmount = srcValue.value,
+            toAmountDecimal = BigDecimal("0.27"),
+            txType = SwapKitSwapPayloadJson.TX_TYPE_TRON,
+            txPayload = byteArrayOf(1),
+            targetAddress = "Tdeposit",
+            subProvider = subProvider,
+            swapFee = swapFee,
+            swapFeeChain = swapFeeChain,
+            swapFeeTokenId = swapFeeTokenId,
+            swapFeeDecimals = swapFeeDecimals,
+        )
+
+    private fun keysignPayload() =
+        KeysignPayload(
+            coin = trx,
+            toAddress = "Tdeposit",
+            toAmount = srcValue.value,
+            memo = null,
+            blockChainSpecific =
+                BlockChainSpecific.Tron(
+                    timestamp = 0uL,
+                    expiration = 0uL,
+                    blockHeaderTimestamp = 0uL,
+                    blockHeaderNumber = 0uL,
+                    blockHeaderVersion = 0uL,
+                    blockHeaderTxTrieRoot = "",
+                    blockHeaderParentHash = "",
+                    blockHeaderWitnessAddress = "",
+                    gasFeeEstimation = 1_100_000uL,
+                ),
+            vaultPublicKeyECDSA = "pub",
+            vaultLocalPartyID = "party",
+            libType = null,
+            wasmExecuteContractPayload = null,
+        )
+
+    private val trx =
+        Coin(
+            chain = Chain.Tron,
+            ticker = "TRX",
+            logo = "",
+            address = "Tsrc",
+            decimal = 6,
+            hexPublicKey = "pub",
+            priceProviderID = "tron",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val eth =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xdst",
+            decimal = 18,
+            hexPublicKey = "pub",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val srcValue = TokenValue(BigInteger.valueOf(2_000_000_000L), trx)
+
+    private val vault =
+        Vault(id = "vault-1", name = "Main", pubKeyECDSA = "pub", pubKeyEDDSA = "pubed")
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/THORChainSwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/api/models/quotes/THORChainSwapQuote.kt
@@ -41,9 +41,6 @@ data class THORChainSwapQuote(
     @SerialName("warning") val warning: String,
     @SerialName("router") val router: String?,
     @SerialName("error") val error: String?,
-    // Price impact of the swap in basis points (100 == 1%), as reported by the node. Drives the
-    // Price Impact row in the fee breakdown (iOS parity). Null when the node omits it.
-    @SerialName("slippage_bps") val slippageBps: Int? = null,
 )
 
 @Serializable
@@ -52,4 +49,8 @@ data class Fees(
     @SerialName("asset") val asset: String,
     @SerialName("outbound") val outbound: String,
     @SerialName("total") val total: String,
+    // Price impact of the swap in basis points (100 == 1%). THORNode and MayaNode report it here,
+    // inside `fees`, never at the top level of the quote. Drives the Price Impact row and rides
+    // the keysign payload to the co-signer. Null when the node omits it.
+    @SerialName("slippage_bps") val slippageBps: Int? = null,
 )

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -130,6 +130,10 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
                                     memo = it.memo,
                                     subProvider = it.subProvider,
                                     swapId = it.swapId,
+                                    swapFee = it.swapFee,
+                                    swapFeeChain = it.swapFeeChain?.ifEmpty { null },
+                                    swapFeeTokenId = it.swapFeeTokenId?.ifEmpty { null },
+                                    swapFeeDecimals = it.swapFeeDecimals,
                                 )
                             )
                         }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapper.kt
@@ -377,5 +377,6 @@ internal class KeysignPayloadProtoMapperImpl @Inject constructor() : KeysignPayl
             streamingQuantity = streamingQuantity,
             expirationTime = expirationTime,
             isAffiliate = isAffiliate,
+            slippageBps = slippageBps?.takeIf { it <= Int.MAX_VALUE.toUInt() }?.toInt(),
         )
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -266,6 +266,10 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         memo = from.memo,
                         subProvider = from.subProvider,
                         swapId = from.swapId,
+                        swapFee = from.swapFee,
+                        swapFeeChain = from.swapFeeChain?.ifEmpty { null },
+                        swapFeeTokenId = from.swapFeeTokenId?.ifEmpty { null },
+                        swapFeeDecimals = from.swapFeeDecimals,
                     )
                 } else null,
             wasmExecuteContractPayload = keysignPayload.wasmExecuteContractPayload,

--- a/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/mappers/PayloadToProtoMapper.kt
@@ -194,6 +194,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         streamingQuantity = from.streamingQuantity,
                         expirationTime = from.expirationTime,
                         isAffiliate = from.isAffiliate,
+                        slippageBps = from.slippageBps?.takeIf { it >= 0 }?.toUInt(),
                     )
                 } else null,
             mayachainSwapPayload =
@@ -212,6 +213,7 @@ internal class PayloadToProtoMapperImpl @Inject constructor() : PayloadToProtoMa
                         streamingQuantity = from.streamingQuantity,
                         expirationTime = from.expirationTime,
                         isAffiliate = from.isAffiliate,
+                        slippageBps = from.slippageBps?.takeIf { it >= 0 }?.toUInt(),
                     )
                 } else null,
             oneinchSwapPayload =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapKitSwapPayloadJson.kt
@@ -28,6 +28,20 @@ data class SwapKitSwapPayloadJson(
     val subProvider: String = "",
     /** Persisted for analytics; not accepted by `/track` (keys off broadcast hash + chain id). */
     val swapId: String = "",
+    /**
+     * Provider fee (affiliate + service) in base units of the coin the three fields below identify,
+     * or empty when the route states none. A cosigning peer holds no quote, so a fee omitted here
+     * is one it can neither recover nor display. Never the `inbound` entry — that is a deposit cost
+     * the Network Fee already covers, and every platform labels this value "Swap Fee".
+     */
+    val swapFee: String = "",
+    /**
+     * Coin context for [swapFee]: [Chain.id], contract address (null for a native coin) and
+     * decimals. All null when [swapFee] is empty, and on payloads from senders that predate them.
+     */
+    val swapFeeChain: String? = null,
+    val swapFeeTokenId: String? = null,
+    val swapFeeDecimals: Int? = null,
 ) {
     // Override equals/hashCode so the ByteArray field compares by content (default is reference).
     override fun equals(other: Any?): Boolean {
@@ -44,7 +58,11 @@ data class SwapKitSwapPayloadJson(
             inboundAddress == other.inboundAddress &&
             memo == other.memo &&
             subProvider == other.subProvider &&
-            swapId == other.swapId
+            swapId == other.swapId &&
+            swapFee == other.swapFee &&
+            swapFeeChain == other.swapFeeChain &&
+            swapFeeTokenId == other.swapFeeTokenId &&
+            swapFeeDecimals == other.swapFeeDecimals
     }
 
     override fun hashCode(): Int {
@@ -59,6 +77,10 @@ data class SwapKitSwapPayloadJson(
         result = 31 * result + (memo?.hashCode() ?: 0)
         result = 31 * result + subProvider.hashCode()
         result = 31 * result + swapId.hashCode()
+        result = 31 * result + swapFee.hashCode()
+        result = 31 * result + (swapFeeChain?.hashCode() ?: 0)
+        result = 31 * result + (swapFeeTokenId?.hashCode() ?: 0)
+        result = 31 * result + (swapFeeDecimals ?: 0)
         return result
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/SwapQuote.kt
@@ -48,7 +48,7 @@ sealed class SwapQuote {
         val data: THORChainSwapQuote,
     ) : SwapQuote() {
         override val priceImpact: BigDecimal?
-            get() = data.slippageBps.toPriceImpactFraction()
+            get() = data.fees.slippageBps.toPriceImpactFraction()
     }
 
     data class MayaChain(
@@ -59,7 +59,7 @@ sealed class SwapQuote {
         val data: THORChainSwapQuote,
     ) : SwapQuote() {
         override val priceImpact: BigDecimal?
-            get() = data.slippageBps.toPriceImpactFraction()
+            get() = data.fees.slippageBps.toPriceImpactFraction()
     }
 
     /**
@@ -82,5 +82,4 @@ sealed class SwapQuote {
 }
 
 /** Converts a basis-point slippage value (100 == 1%) into the fractional price impact (0.01). */
-private fun Int?.toPriceImpactFraction(): BigDecimal? =
-    this?.let { BigDecimal(it).movePointLeft(4) }
+fun Int?.toPriceImpactFraction(): BigDecimal? = this?.let { BigDecimal(it).movePointLeft(4) }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/THORChainSwapPayload.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/THORChainSwapPayload.kt
@@ -17,9 +17,22 @@ data class THORChainSwapPayload(
     val streamingQuantity: String,
     val expirationTime: ULong,
     val isAffiliate: Boolean,
+    /**
+     * Price impact the quote reported (`fees.slippage_bps`), carried so a co-signer shows the
+     * figure the initiator approved rather than re-pricing a pool that has since moved. Null when
+     * the sender predates the field or the route had no quote (limit orders); the row then hides.
+     */
+    val slippageBps: Int? = null,
 ) {
     val toAddress: String
         get() = toCoin.address
+
+    /**
+     * Fractional price impact (`0.0133` == 1.33%) of [slippageBps], the same shape
+     * [SwapQuote.priceImpact] exposes.
+     */
+    val priceImpact: BigDecimal?
+        get() = slippageBps.toPriceImpactFraction()
 
     val fromAsset: Asset
         get() = swapAsset(fromCoin, true)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitAssetPrefix.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitAssetPrefix.kt
@@ -1,6 +1,7 @@
 package com.vultisig.wallet.data.repositories.swap
 
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
 
 /**
  * SwapKit's spelling of a chain in an asset identifier — the `CHAIN` half of
@@ -48,4 +49,23 @@ internal object SwapKitAssetPrefix {
             // until an entry can be read off `GET /tokens`.
             else -> null
         }
+
+    /**
+     * SwapKit's spelling of [coin]'s ticker. The Toncoin → GRAM rebrand renamed only the display
+     * ticker, so a GRAM-ticker'd native must still swap as `TON`. Mirrors iOS'
+     * `SwapKitService.swapSymbol(chain:ticker:isNativeToken:)`.
+     */
+    fun symbolOf(coin: Coin): String =
+        if (coin.chain == Chain.Ton && coin.isNativeToken) "TON" else coin.ticker
+
+    /**
+     * Full SwapKit asset identifier for [coin] — `CHAIN.TICKER`, or `CHAIN.TICKER-CONTRACT` for a
+     * token — or null when the chain has no prefix here.
+     */
+    fun identifierOf(coin: Coin): String? {
+        val prefix = of(coin.chain) ?: return null
+        val ticker = symbolOf(coin)
+        return if (coin.isNativeToken || coin.contractAddress.isBlank()) "$prefix.$ticker"
+        else "$prefix.$ticker-${coin.contractAddress}"
+    }
 }

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitProviderFee.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitProviderFee.kt
@@ -1,0 +1,83 @@
+package com.vultisig.wallet.data.repositories.swap
+
+import com.vultisig.wallet.data.api.models.quotes.SwapKitFee
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import java.math.BigInteger
+
+/**
+ * The provider fee a SwapKit route itemizes — its `affiliate` and `service` entries summed — in
+ * base units of [coin]. This is what `SwapKitSwapPayload.swap_fee` carries to a co-signer, which
+ * holds no quote and would otherwise approve a total that omits it.
+ *
+ * Distinct from the route's `inbound` entry, a deposit cost on the source chain that the Network
+ * Fee already covers: every other platform labels this figure "Swap Fee" verbatim, so it must be
+ * the provider's charge and nothing else.
+ */
+data class SwapKitProviderFee(val coin: Coin, val amount: BigInteger)
+
+/**
+ * Resolves the provider fee out of a route's `fees[]`, or null when the route states none it can
+ * vouch for.
+ *
+ * Providers attribute the fee to different coins — NEAR Intents charges in the source asset,
+ * Chainflip in Ethereum USDC, Flashnet in Solana USDC — so each entry's `asset` identifier is
+ * matched against the coins this device can price: the pair itself, plus Ethereum USDC on a
+ * Chainflip route. An entry in any other coin, a malformed or negative amount, or affiliate and
+ * service entries in different coins all yield null: none of them establishes an amount to put on
+ * the wire, and a wrong coin would misprice the fee by orders of magnitude on the co-signer.
+ *
+ * Only `asset` is matched. The entry's `chain` is the routing protocol's label (`NEAR` on an
+ * Intents route) rather than the asset's chain, so keying on it would drop the fee on the routes
+ * that carry one most often.
+ */
+fun resolveSwapKitProviderFee(
+    fees: List<SwapKitFee>,
+    srcToken: Coin,
+    dstToken: Coin,
+    subProvider: String?,
+): SwapKitProviderFee? {
+    val candidates = buildList {
+        add(srcToken)
+        add(dstToken)
+        if (isChainflipProvider(subProvider)) add(Coins.Ethereum.USDC)
+    }
+    val candidatesByAsset =
+        candidates
+            .mapNotNull { coin ->
+                SwapKitAssetPrefix.identifierOf(coin)?.lowercase()?.let { it to coin }
+            }
+            .toMap()
+
+    var resolved: SwapKitProviderFee? = null
+    for (fee in fees) {
+        if (!fee.type.isProviderFeeType()) continue
+        val amountText = fee.amount?.trim().orEmpty()
+        if (amountText.isEmpty()) continue
+        val decimal = amountText.toBigDecimalOrNull() ?: return null
+        if (decimal.signum() < 0) return null
+        if (decimal.signum() == 0) continue
+
+        val coin = fee.asset?.lowercase()?.let(candidatesByAsset::get) ?: return null
+        val amount = decimal.movePointRight(coin.decimal).toBigInteger()
+
+        val current = resolved
+        resolved =
+            when {
+                current == null -> SwapKitProviderFee(coin, amount)
+                current.coin.sameAssetAs(coin) -> current.copy(amount = current.amount + amount)
+                else -> return null
+            }
+    }
+    return resolved?.takeIf { it.amount.signum() > 0 }
+}
+
+private fun String?.isProviderFeeType(): Boolean =
+    this != null && (equals("affiliate", ignoreCase = true) || equals("service", ignoreCase = true))
+
+private fun Coin.sameAssetAs(other: Coin): Boolean =
+    chain == other.chain && contractAddress.equals(other.contractAddress, ignoreCase = true)
+
+private fun isChainflipProvider(subProvider: String?): Boolean =
+    subProvider.equals("CHAINFLIP", ignoreCase = true) ||
+        subProvider.equals("CHAINFLIP_STREAMING", ignoreCase = true)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitProviderFee.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitProviderFee.kt
@@ -51,7 +51,7 @@ fun resolveSwapKitProviderFee(
 
     var resolved: SwapKitProviderFee? = null
     for (fee in fees) {
-        if (!fee.type.isProviderFeeType()) continue
+        if (!fee.isProviderFeeEntry()) continue
         val amountText = fee.amount?.trim().orEmpty()
         if (amountText.isEmpty()) continue
         val decimal = amountText.toBigDecimalOrNull() ?: return null
@@ -72,8 +72,9 @@ fun resolveSwapKitProviderFee(
     return resolved?.takeIf { it.amount.signum() > 0 }
 }
 
-private fun String?.isProviderFeeType(): Boolean =
-    this != null && (equals("affiliate", ignoreCase = true) || equals("service", ignoreCase = true))
+/** True for the entries that make up the provider fee: `affiliate` and `service`. */
+internal fun SwapKitFee.isProviderFeeEntry(): Boolean =
+    type.equals("affiliate", ignoreCase = true) || type.equals("service", ignoreCase = true)
 
 private fun Coin.sameAssetAs(other: Coin): Boolean =
     chain == other.chain && contractAddress.equals(other.contractAddress, ignoreCase = true)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -591,6 +591,11 @@ constructor(
         // destinationTag. Mirrors iOS' resolvedDestinationTag.
         val memo =
             if (isXrp) resolveDestinationTag(response, rawTargetAddress)?.toString() else null
+        // The `/v3/swap` reply is the fresher statement of the fee; the `/v3/quote` route is the
+        // fallback for a reply that carries no `fees[]` at all, as for the inbound entry.
+        val providerFee =
+            resolveSwapKitProviderFee(response.fees, srcToken, dstToken, subProvider)
+                ?: resolveSwapKitProviderFee(routeFees, srcToken, dstToken, subProvider)
         val payload =
             SwapKitSwapPayloadJson(
                 fromCoin = srcToken,
@@ -608,6 +613,10 @@ constructor(
                 memo = memo,
                 subProvider = subProvider.orEmpty(),
                 swapId = response.swapId?.takeIf { it.isNotBlank() }.orEmpty(),
+                swapFee = providerFee?.amount?.toString().orEmpty(),
+                swapFeeChain = providerFee?.coin?.chain?.id,
+                swapFeeTokenId = providerFee?.coin?.contractAddress?.takeIf { it.isNotBlank() },
+                swapFeeDecimals = providerFee?.coin?.decimal,
             )
         return SwapQuote.SwapKit(
             expectedDstValue =
@@ -959,27 +968,18 @@ constructor(
         // this is defense-in-depth: throwing NoRoutes (rather than falling back to `coin.ticker`)
         // keeps a future capability change from minting a garbage identifier — e.g. `ETH.ETH` for
         // ZkSync.ETH — and surfacing as `helpers_invalid_asset_identifier` 500s from the proxy.
-        val prefix =
-            SwapKitAssetPrefix.of(coin.chain)
-                ?: throw SwapKitError.NoRoutes(
-                    "SwapKit asset identifier missing chain prefix for ${coin.chain.raw}"
-                )
-        val ticker = swapSymbol(coin)
-        return if (coin.isNativeToken || coin.contractAddress.isBlank()) {
-            "$prefix.$ticker"
-        } else {
-            "$prefix.$ticker-${coin.contractAddress}"
-        }
+        return SwapKitAssetPrefix.identifierOf(coin)
+            ?: throw SwapKitError.NoRoutes(
+                "SwapKit asset identifier missing chain prefix for ${coin.chain.raw}"
+            )
     }
 
     /**
      * SwapKit lists the native TON asset as "TON"; the Toncoin → GRAM rebrand (#4984) renamed only
-     * the display ticker, so a GRAM-ticker'd native must still swap as TON. Mirrors iOS'
-     * `SwapKitService.swapSymbol(chain:ticker:isNativeToken:)`.
+     * the display ticker, so a GRAM-ticker'd native must still swap as TON.
      */
     @VisibleForTesting
-    internal fun swapSymbol(coin: Coin): String =
-        if (coin.chain == Chain.Ton && coin.isNativeToken) "TON" else coin.ticker
+    internal fun swapSymbol(coin: Coin): String = SwapKitAssetPrefix.symbolOf(coin)
 
     /**
      * Parse a SwapKit EVM tx numeric field (gas / gasPrice / value). SwapKit V3 hex-encodes these

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSource.kt
@@ -592,10 +592,13 @@ constructor(
         val memo =
             if (isXrp) resolveDestinationTag(response, rawTargetAddress)?.toString() else null
         // The `/v3/swap` reply is the fresher statement of the fee; the `/v3/quote` route is the
-        // fallback for a reply that carries no `fees[]` at all, as for the inbound entry.
+        // fallback only for a reply that itemizes no provider fee at all, as for the inbound
+        // entry. A reply whose provider entries cannot be resolved is left empty rather than
+        // overwritten by the route's — the two are different statements of the same swap.
         val providerFee =
-            resolveSwapKitProviderFee(response.fees, srcToken, dstToken, subProvider)
-                ?: resolveSwapKitProviderFee(routeFees, srcToken, dstToken, subProvider)
+            if (response.fees.any { it.isProviderFeeEntry() })
+                resolveSwapKitProviderFee(response.fees, srcToken, dstToken, subProvider)
+            else resolveSwapKitProviderFee(routeFees, srcToken, dstToken, subProvider)
         val payload =
             SwapKitSwapPayloadJson(
                 fromCoin = srcToken,

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperNativeSwapSlippageTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperNativeSwapSlippageTest.kt
@@ -1,0 +1,221 @@
+package com.vultisig.wallet.data.mappers
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.THORChainSwapPayload
+import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.proto.v1.CoinProto
+import com.vultisig.wallet.data.models.proto.v1.KeysignPayloadProto
+import java.math.BigDecimal
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import vultisig.keysign.v1.THORChainSpecific
+import vultisig.keysign.v1.THORChainSwapPayload as ThorChainSwapPayloadProto
+import vultisig.keysign.v1.TransactionType
+
+/**
+ * Pins `slippage_bps` on the THORChain / MayaChain swap payload in both proto directions. The field
+ * is `optional`, so absence and zero are different values on the wire: a sender that predates it
+ * must read back as null (row hidden), not as a zero-impact route.
+ */
+class KeysignPayloadProtoMapperNativeSwapSlippageTest {
+
+    private val mapper = KeysignPayloadProtoMapperImpl()
+    private val outboundMapper = PayloadToProtoMapperImpl()
+
+    @Test
+    fun `thorchain payload round-trips slippage_bps domain to proto to domain`() {
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(swapPayload = SwapPayload.ThorChain(thorPayload(slippageBps = 19)))
+
+        val proto = requireNotNull(outboundMapper.invoke(domain))
+        assertEquals(19u, requireNotNull(proto.thorchainSwapPayload).slippageBps)
+        assertNull(proto.mayachainSwapPayload)
+
+        val back = mapper.invoke(basePayload(thorchainSwapPayload = proto.thorchainSwapPayload))
+        val payload = assertInstanceOf(SwapPayload.ThorChain::class.java, back.swapPayload)
+        assertEquals(19, payload.data.slippageBps)
+        assertEquals(BigDecimal("0.0019"), payload.data.priceImpact)
+    }
+
+    @Test
+    fun `mayachain payload round-trips slippage_bps too`() {
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(swapPayload = SwapPayload.MayaChain(thorPayload(slippageBps = 250)))
+
+        val proto = requireNotNull(outboundMapper.invoke(domain))
+        assertEquals(250u, requireNotNull(proto.mayachainSwapPayload).slippageBps)
+        assertNull(proto.thorchainSwapPayload)
+
+        val back = mapper.invoke(basePayload(mayachainSwapPayload = proto.mayachainSwapPayload))
+        val payload = assertInstanceOf(SwapPayload.MayaChain::class.java, back.swapPayload)
+        assertEquals(250, payload.data.slippageBps)
+    }
+
+    @Test
+    fun `proto without slippage_bps reads back as null, not zero`() {
+        val back = mapper.invoke(basePayload(thorchainSwapPayload = thorProto(slippageBps = null)))
+        val payload = assertInstanceOf(SwapPayload.ThorChain::class.java, back.swapPayload)
+
+        assertNull(payload.data.slippageBps)
+        assertNull(payload.data.priceImpact)
+    }
+
+    @Test
+    fun `proto with slippage_bps of zero reads back as zero`() {
+        val back = mapper.invoke(basePayload(thorchainSwapPayload = thorProto(slippageBps = 0u)))
+        val payload = assertInstanceOf(SwapPayload.ThorChain::class.java, back.swapPayload)
+
+        assertEquals(0, payload.data.slippageBps)
+        assertEquals(0, BigDecimal.ZERO.compareTo(payload.data.priceImpact))
+    }
+
+    @Test
+    fun `domain payload without slippage leaves the proto field unset`() {
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(swapPayload = SwapPayload.ThorChain(thorPayload(slippageBps = null)))
+
+        val proto = requireNotNull(outboundMapper.invoke(domain))
+        assertNull(requireNotNull(proto.thorchainSwapPayload).slippageBps)
+    }
+
+    @Test
+    fun `a negative domain value is never written to the unsigned proto field`() {
+        val domain =
+            mapper
+                .invoke(basePayload())
+                .copy(swapPayload = SwapPayload.ThorChain(thorPayload(slippageBps = -1)))
+
+        val proto = requireNotNull(outboundMapper.invoke(domain))
+        assertNull(requireNotNull(proto.thorchainSwapPayload).slippageBps)
+    }
+
+    @Test
+    fun `a proto value beyond Int range reads back as absent rather than wrapping negative`() {
+        val back =
+            mapper.invoke(
+                basePayload(thorchainSwapPayload = thorProto(slippageBps = UInt.MAX_VALUE))
+            )
+        val payload = assertInstanceOf(SwapPayload.ThorChain::class.java, back.swapPayload)
+
+        assertNull(payload.data.slippageBps)
+    }
+
+    private fun thorPayload(slippageBps: Int?) =
+        THORChainSwapPayload(
+            fromAddress = "thorsrc",
+            fromCoin = runeDomainCoin(),
+            toCoin = ethDomainCoin(),
+            vaultAddress = "thorInbound",
+            routerAddress = null,
+            fromAmount = BigInteger.valueOf(100_000_000L),
+            toAmountDecimal = BigDecimal("0.05"),
+            toAmountLimit = "0",
+            streamingInterval = "1",
+            streamingQuantity = "0",
+            expirationTime = 1_700_000_000uL,
+            isAffiliate = true,
+            slippageBps = slippageBps,
+        )
+
+    private fun thorProto(slippageBps: UInt?) =
+        ThorChainSwapPayloadProto(
+            fromAddress = "thorsrc",
+            fromCoin = RUNE_COIN,
+            toCoin = ETH_COIN,
+            vaultAddress = "thorInbound",
+            routerAddress = null,
+            fromAmount = "100000000",
+            toAmountDecimal = "0.05",
+            toAmountLimit = "0",
+            streamingInterval = "1",
+            streamingQuantity = "0",
+            expirationTime = 1_700_000_000uL,
+            isAffiliate = true,
+            slippageBps = slippageBps,
+        )
+
+    private fun runeDomainCoin() =
+        Coin(
+            chain = Chain.ThorChain,
+            ticker = "RUNE",
+            logo = "",
+            address = "thorsrc",
+            decimal = 8,
+            hexPublicKey = "pubkey",
+            priceProviderID = "thorchain",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun ethDomainCoin() =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xuser",
+            decimal = 18,
+            hexPublicKey = "pubkey",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private fun basePayload(
+        thorchainSwapPayload: ThorChainSwapPayloadProto? = null,
+        mayachainSwapPayload: ThorChainSwapPayloadProto? = null,
+    ) =
+        KeysignPayloadProto(
+            coin = RUNE_COIN,
+            toAddress = "thorInbound",
+            toAmount = "100000000",
+            vaultPublicKeyEcdsa = "pubkey",
+            vaultLocalPartyId = "party-1",
+            thorchainSpecific =
+                THORChainSpecific(
+                    accountNumber = 1uL,
+                    sequence = 0uL,
+                    fee = 2_000_000uL,
+                    isDeposit = false,
+                    transactionType = TransactionType.TRANSACTION_TYPE_UNSPECIFIED,
+                ),
+            thorchainSwapPayload = thorchainSwapPayload,
+            mayachainSwapPayload = mayachainSwapPayload,
+        )
+
+    companion object {
+        private val RUNE_COIN =
+            CoinProto(
+                chain = "THORChain",
+                ticker = "RUNE",
+                address = "thorsrc",
+                contractAddress = "",
+                decimals = 8,
+                priceProviderId = "thorchain",
+                isNativeToken = true,
+                hexPublicKey = "pubkey",
+                logo = "",
+            )
+        private val ETH_COIN =
+            CoinProto(
+                chain = "Ethereum",
+                ticker = "ETH",
+                address = "0xuser",
+                contractAddress = "",
+                decimals = 18,
+                priceProviderId = "ethereum",
+                isNativeToken = true,
+                hexPublicKey = "pubkey",
+                logo = "",
+            )
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSwapKitTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/mappers/KeysignPayloadProtoMapperSwapKitTest.kt
@@ -190,6 +190,121 @@ class KeysignPayloadProtoMapperSwapKitTest {
     }
 
     @Test
+    fun `outbound mapper writes the swap-fee group and leaves it unset when the route states none`() {
+        val withFee =
+            SwapKitSwapPayloadJson(
+                fromCoin = tonDomainCoin(),
+                toCoin = ethDomainCoin(),
+                fromAmount = BigInteger.TEN,
+                toAmountDecimal = BigDecimal("0.001"),
+                txType = "TON",
+                txPayload = byteArrayOf(1),
+                targetAddress = "EQAdeposit",
+                swapFee = "13000000",
+                swapFeeChain = "Tron",
+                swapFeeTokenId = null,
+                swapFeeDecimals = 6,
+            )
+        val withoutFee = withFee.copy(swapFee = "", swapFeeChain = null, swapFeeDecimals = null)
+
+        val feeProto =
+            requireNotNull(
+                outboundMapper
+                    .invoke(
+                        mapper
+                            .invoke(basePayload())
+                            .copy(swapPayload = SwapPayload.SwapKit(withFee))
+                    )
+                    ?.swapkitSwapPayload
+            )
+        assertEquals("13000000", feeProto.swapFee)
+        assertEquals("Tron", feeProto.swapFeeChain)
+        assertNull(feeProto.swapFeeTokenId)
+        assertEquals(6, feeProto.swapFeeDecimals)
+
+        val noFeeProto =
+            requireNotNull(
+                outboundMapper
+                    .invoke(
+                        mapper
+                            .invoke(basePayload())
+                            .copy(swapPayload = SwapPayload.SwapKit(withoutFee))
+                    )
+                    ?.swapkitSwapPayload
+            )
+        assertEquals("", noFeeProto.swapFee)
+        assertNull(noFeeProto.swapFeeChain)
+        assertNull(noFeeProto.swapFeeTokenId)
+        assertNull(noFeeProto.swapFeeDecimals)
+    }
+
+    @Test
+    fun `swap-fee group round-trips and a sender that predates it reads back empty`() {
+        val usdc = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+        val stated =
+            basePayload(
+                swapkitSwapPayload =
+                    SwapKitSwapPayloadProto(
+                        fromCoin = TON_COIN,
+                        toCoin = ETH_COIN,
+                        fromAmount = "1",
+                        toAmountDecimal = "1",
+                        txType = "PSBT",
+                        txPayload = byteArrayOf(),
+                        targetAddress = "bc1qdeposit",
+                        swapFee = "650000",
+                        swapFeeChain = "Ethereum",
+                        swapFeeTokenId = usdc,
+                        swapFeeDecimals = 6,
+                    )
+            )
+        val domain =
+            assertInstanceOf(SwapPayload.SwapKit::class.java, mapper.invoke(stated).swapPayload)
+        assertEquals("650000", domain.data.swapFee)
+        assertEquals("Ethereum", domain.data.swapFeeChain)
+        assertEquals(usdc, domain.data.swapFeeTokenId)
+        assertEquals(6, domain.data.swapFeeDecimals)
+
+        val roundTripped =
+            requireNotNull(outboundMapper.invoke(mapper.invoke(stated))?.swapkitSwapPayload)
+        assertEquals(stated.swapkitSwapPayload?.swapFee, roundTripped.swapFee)
+        assertEquals(stated.swapkitSwapPayload?.swapFeeChain, roundTripped.swapFeeChain)
+        assertEquals(stated.swapkitSwapPayload?.swapFeeTokenId, roundTripped.swapFeeTokenId)
+        assertEquals(stated.swapkitSwapPayload?.swapFeeDecimals, roundTripped.swapFeeDecimals)
+
+        val legacy =
+            basePayload(
+                swapkitSwapPayload =
+                    SwapKitSwapPayloadProto(
+                        fromCoin = TON_COIN,
+                        toCoin = ETH_COIN,
+                        fromAmount = "1",
+                        toAmountDecimal = "1",
+                        txType = "PSBT",
+                        txPayload = byteArrayOf(),
+                        targetAddress = "bc1qdeposit",
+                    )
+            )
+        val legacyDomain =
+            assertInstanceOf(SwapPayload.SwapKit::class.java, mapper.invoke(legacy).swapPayload)
+        assertEquals("", legacyDomain.data.swapFee)
+        assertNull(legacyDomain.data.swapFeeChain)
+        assertNull(legacyDomain.data.swapFeeTokenId)
+        assertNull(legacyDomain.data.swapFeeDecimals)
+        // Re-encoding a legacy payload must not invent presence for the optional fields.
+        val legacyRoundTripped =
+            requireNotNull(
+                outboundMapper
+                    .invoke(legacyDomain.let { mapper.invoke(legacy) })
+                    ?.swapkitSwapPayload
+            )
+        assertEquals("", legacyRoundTripped.swapFee)
+        assertNull(legacyRoundTripped.swapFeeChain)
+        assertNull(legacyRoundTripped.swapFeeTokenId)
+        assertNull(legacyRoundTripped.swapFeeDecimals)
+    }
+
+    @Test
     fun `SwapPayload SwapKit exposes src and dst token values derived from the inner data`() {
         val data =
             SwapKitSwapPayloadJson(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/models/SwapQuotePriceImpactTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/models/SwapQuotePriceImpactTest.kt
@@ -2,11 +2,15 @@ package com.vultisig.wallet.data.models
 
 import com.vultisig.wallet.data.api.models.quotes.Fees
 import com.vultisig.wallet.data.api.models.quotes.THORChainSwapQuote
+import com.vultisig.wallet.data.utils.BigIntegerSerializerImpl
 import io.mockk.mockk
 import java.math.BigDecimal
 import java.math.BigInteger
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.contextual
 import org.junit.jupiter.api.Test
 
 /**
@@ -15,6 +19,56 @@ import org.junit.jupiter.api.Test
  * row.
  */
 internal class SwapQuotePriceImpactTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        explicitNulls = false
+        serializersModule = SerializersModule { contextual(BigIntegerSerializerImpl()) }
+    }
+
+    @Test
+    fun `thorchain reads slippage_bps from inside fees, where the node sends it`() {
+        // Trimmed from a live `ETH.ETH -> BTC.BTC` thornode quote: the figure lives in `fees` and
+        // nowhere else. Reading it off the top level parsed clean and never rendered a row.
+        val body =
+            """
+            {
+              "dust_threshold": "10000",
+              "expected_amount_out": "3157340",
+              "expiry": 1788000000,
+              "fees": {
+                "asset": "BTC.BTC",
+                "affiliate": "0",
+                "outbound": "1161",
+                "liquidity": "6382",
+                "total": "7543",
+                "slippage_bps": 19,
+                "total_bps": 23
+              },
+              "inbound_address": "0xinbound",
+              "max_streaming_quantity": 0,
+              "notes": "",
+              "outbound_delay_blocks": 0,
+              "outbound_delay_seconds": 0,
+              "recommended_min_amount_in": "1",
+              "streaming_swap_blocks": 0,
+              "warning": ""
+            }
+            """
+                .trimIndent()
+
+        val quote =
+            SwapQuote.ThorChain(
+                expectedDstValue = mockk(),
+                fees = mockk(),
+                expiredAt = mockk(),
+                recommendedMinTokenValue = mockk(),
+                data = json.decodeFromString<THORChainSwapQuote>(body),
+            )
+
+        assertEquals(19, quote.data.fees.slippageBps)
+        assertEquals(BigDecimal("0.0019"), quote.priceImpact)
+    }
 
     @Test
     fun `thorchain derives fractional price impact from slippage_bps`() {
@@ -81,7 +135,14 @@ internal class SwapQuotePriceImpactTest {
             dustThreshold = null,
             expectedAmountOut = "9950",
             expiry = BigInteger.valueOf(9_999_999),
-            fees = Fees(affiliate = "0", asset = "50", outbound = "0", total = "50"),
+            fees =
+                Fees(
+                    affiliate = "0",
+                    asset = "50",
+                    outbound = "0",
+                    total = "50",
+                    slippageBps = slippageBps,
+                ),
             inboundAddress = "thorInbound",
             inboundConfirmationBlocks = null,
             inboundConfirmationSeconds = null,
@@ -96,6 +157,5 @@ internal class SwapQuotePriceImpactTest {
             warning = "",
             router = null,
             error = null,
-            slippageBps = slippageBps,
         )
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitProviderFeeTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitProviderFeeTest.kt
@@ -1,0 +1,223 @@
+package com.vultisig.wallet.data.repositories.swap
+
+import com.vultisig.wallet.data.api.models.quotes.SwapKitFee
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import java.math.BigInteger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins [resolveSwapKitProviderFee] against the `fees[]` shapes SwapKit actually returns. The
+ * entries below are trimmed from live `/v3/quote` and `/v3/swap` replies: a NEAR Intents route
+ * charges in the source asset and labels its entries `chain: "NEAR"`, Flashnet charges in Solana
+ * USDC, Chainflip in Ethereum USDC.
+ */
+internal class SwapKitProviderFeeTest {
+
+    @Test
+    fun `sums affiliate and service in the source asset on a NEAR route`() {
+        // TRX → ETH, 2000 TRX: affiliate 10 + service 3, both `TRON.TRX` under `chain: "NEAR"`.
+        val fees =
+            listOf(
+                fee("affiliate", "10", "TRON.TRX", chain = "NEAR"),
+                fee("service", "3", "TRON.TRX", chain = "NEAR"),
+                fee("outbound", "0.000035", "ETH.ETH", chain = "ETH"),
+                fee("inbound", "1.1", "TRON.TRX", chain = "TRON"),
+            )
+
+        val resolved = resolveSwapKitProviderFee(fees, trx, eth, subProvider = "NEAR")
+
+        assertEquals(trx, resolved?.coin)
+        // 13 TRX in 6-decimal base units. The inbound entry is not part of it.
+        assertEquals(BigInteger("13000000"), resolved?.amount)
+    }
+
+    @Test
+    fun `matches on the asset identifier, not the entry's protocol chain label`() {
+        // `chain: "NEAR"` is the routing protocol, not the asset's chain; keying on it would drop
+        // the fee on exactly the routes that carry one most often.
+        val fees = listOf(fee("affiliate", "0.01", "ZEC.ZEC", chain = "NEAR"))
+
+        val resolved = resolveSwapKitProviderFee(fees, zec, eth, subProvider = "NEAR")
+
+        assertEquals(zec, resolved?.coin)
+        assertEquals(BigInteger("1000000"), resolved?.amount)
+    }
+
+    @Test
+    fun `resolves a Chainflip fee in Ethereum USDC, a coin that is neither leg`() {
+        val usdc = Coins.Ethereum.USDC
+        val fees =
+            listOf(
+                fee("affiliate", "0.5", "ETH.USDC-${usdc.contractAddress}", chain = "ETH"),
+                fee("service", "0.15", "eth.usdc-${usdc.contractAddress.lowercase()}"),
+            )
+
+        val resolved = resolveSwapKitProviderFee(fees, btc, eth, subProvider = "CHAINFLIP")
+
+        assertEquals(usdc, resolved?.coin)
+        assertEquals(BigInteger("650000"), resolved?.amount)
+    }
+
+    @Test
+    fun `does not offer Ethereum USDC as a fee coin off a Chainflip route`() {
+        val usdc = Coins.Ethereum.USDC
+        val fees = listOf(fee("affiliate", "0.5", "ETH.USDC-${usdc.contractAddress}"))
+
+        assertNull(resolveSwapKitProviderFee(fees, btc, eth, subProvider = "NEAR"))
+    }
+
+    @Test
+    fun `yields nothing for a Flashnet fee in Solana USDC on a ZEC to ETH route`() {
+        // Neither leg nor a Chainflip stable: the co-signer could not price it, so nothing goes on
+        // the wire rather than an amount in a coin it has to guess.
+        val fees =
+            listOf(
+                fee(
+                    "affiliate",
+                    "10.830937",
+                    "SOL.USDC-EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                ),
+                fee("service", "3.249281", "SOL.USDC-EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+                fee("inbound", "0.0006", "ZEC.ZEC", chain = "ZEC"),
+            )
+
+        assertNull(resolveSwapKitProviderFee(fees, zec, eth, subProvider = "FLASHNET"))
+    }
+
+    @Test
+    fun `resolves a fee charged in the destination asset`() {
+        val fees =
+            listOf(
+                fee("affiliate", "0.000851376923076923", "ETH.ETH", chain = "THOR"),
+                fee("service", "0.000255413076923077", "ETH.ETH", chain = "THOR"),
+            )
+
+        val resolved =
+            resolveSwapKitProviderFee(fees, trx, eth, subProvider = "THORCHAIN_STREAMING")
+
+        assertEquals(eth, resolved?.coin)
+        assertEquals(BigInteger("1106790000000000"), resolved?.amount)
+    }
+
+    @Test
+    fun `yields nothing when affiliate and service are charged in different coins`() {
+        val fees = listOf(fee("affiliate", "10", "TRON.TRX"), fee("service", "0.0001", "ETH.ETH"))
+
+        assertNull(resolveSwapKitProviderFee(fees, trx, eth, subProvider = "NEAR"))
+    }
+
+    @Test
+    fun `yields nothing for a route with no provider entries or only zero ones`() {
+        assertNull(
+            resolveSwapKitProviderFee(
+                listOf(fee("inbound", "1.1", "TRON.TRX"), fee("outbound", "0.00003", "ETH.ETH")),
+                trx,
+                eth,
+                subProvider = "NEAR",
+            )
+        )
+        assertNull(
+            resolveSwapKitProviderFee(
+                listOf(fee("affiliate", "0", "TRON.TRX"), fee("service", "0.0", "TRON.TRX")),
+                trx,
+                eth,
+                subProvider = "NEAR",
+            )
+        )
+    }
+
+    @Test
+    fun `yields nothing for a malformed or negative amount rather than throwing`() {
+        assertNull(
+            resolveSwapKitProviderFee(
+                listOf(fee("affiliate", "1e+", "TRON.TRX")),
+                trx,
+                eth,
+                subProvider = "NEAR",
+            )
+        )
+        assertNull(
+            resolveSwapKitProviderFee(
+                listOf(fee("affiliate", "-10", "TRON.TRX")),
+                trx,
+                eth,
+                subProvider = "NEAR",
+            )
+        )
+        assertNull(
+            resolveSwapKitProviderFee(
+                listOf(fee("affiliate", "10", asset = null)),
+                trx,
+                eth,
+                subProvider = "NEAR",
+            )
+        )
+    }
+
+    @Test
+    fun `truncates sub-unit dust instead of rounding it up`() {
+        val fees = listOf(fee("affiliate", "0.0000001", "TRON.TRX"))
+
+        // 0.0000001 TRX is a tenth of a sun; nothing to charge, nothing on the wire.
+        assertNull(resolveSwapKitProviderFee(fees, trx, eth, subProvider = "NEAR"))
+    }
+
+    private fun fee(type: String, amount: String, asset: String?, chain: String? = null) =
+        SwapKitFee(type = type, amount = amount, asset = asset, chain = chain, protocol = null)
+
+    private val trx =
+        Coin(
+            chain = Chain.Tron,
+            ticker = "TRX",
+            logo = "",
+            address = "Tsrc",
+            decimal = 6,
+            hexPublicKey = "pub",
+            priceProviderID = "tron",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val zec =
+        Coin(
+            chain = Chain.Zcash,
+            ticker = "ZEC",
+            logo = "",
+            address = "t1src",
+            decimal = 8,
+            hexPublicKey = "pub",
+            priceProviderID = "zcash",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val btc =
+        Coin(
+            chain = Chain.Bitcoin,
+            ticker = "BTC",
+            logo = "",
+            address = "bc1src",
+            decimal = 8,
+            hexPublicKey = "pub",
+            priceProviderID = "bitcoin",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+
+    private val eth =
+        Coin(
+            chain = Chain.Ethereum,
+            ticker = "ETH",
+            logo = "",
+            address = "0xdst",
+            decimal = 18,
+            hexPublicKey = "pub",
+            priceProviderID = "ethereum",
+            contractAddress = "",
+            isNativeToken = true,
+        )
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -985,6 +985,138 @@ internal class SwapKitQuoteSourceTest {
     }
 
     @Test
+    fun `fetch stamps the provider fee and its coin onto a transfer-route payload`() = runTest {
+        // Trimmed from a live TRX → ETH NEAR route: affiliate 10 + service 3 TRX. The inbound entry
+        // keeps feeding `quote.fees` (the Network Fee surface) and stays off the wire group.
+        every { config.isFeatureEnabled } returns flowOf(true)
+        val btc = btcCoin()
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(route(routeId = "r-btc", providers = listOf("NEAR"), expectedBuy = "1"))
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                swapId = "btc-swap-2",
+                tx = JsonPrimitive(Base64.getEncoder().encodeToString(byteArrayOf(0x70))),
+                meta = SwapKitTxMeta(txType = "PSBT"),
+                targetAddress = "bc1ptarget",
+                expectedBuyAmount = "1",
+                fees =
+                    listOf(
+                        SwapKitFee(
+                            type = "affiliate",
+                            amount = "0.0005",
+                            asset = "BTC.BTC",
+                            chain = "NEAR",
+                        ),
+                        SwapKitFee(
+                            type = "service",
+                            amount = "0.00015",
+                            asset = "BTC.BTC",
+                            chain = "NEAR",
+                        ),
+                        SwapKitFee(
+                            type = "inbound",
+                            amount = "0.000004",
+                            asset = "BTC.BTC",
+                            chain = "BTC",
+                        ),
+                    ),
+                providers = listOf("NEAR"),
+            )
+
+        val result =
+            source().fetch(request(srcToken = btc, dstToken = ethCoin())) as SwapQuoteResult.Native
+        val payload = (result.quote as SwapQuote.SwapKit).data
+
+        // 0.00065 BTC in sats; native coin, so no token id.
+        assertEquals("65000", payload.swapFee)
+        assertEquals("Bitcoin", payload.swapFeeChain)
+        assertNull(payload.swapFeeTokenId)
+        assertEquals(8, payload.swapFeeDecimals)
+        assertEquals(BigInteger("400"), result.quote.fees.value)
+    }
+
+    @Test
+    fun `fetch leaves the wire fee group empty when the route itemizes no provider fee`() =
+        runTest {
+            every { config.isFeatureEnabled } returns flowOf(true)
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(routeId = "r-btc", providers = listOf("NEAR"), expectedBuy = "1")
+                        )
+                )
+            coEvery { api.swap(any()) } returns
+                SwapKitSwapResponseJson(
+                    tx = JsonPrimitive(Base64.getEncoder().encodeToString(byteArrayOf(0x70))),
+                    meta = SwapKitTxMeta(txType = "PSBT"),
+                    targetAddress = "bc1ptarget",
+                    expectedBuyAmount = "1",
+                    fees =
+                        listOf(
+                            SwapKitFee(
+                                type = "inbound",
+                                amount = "0.000004",
+                                asset = "BTC.BTC",
+                                chain = "BTC",
+                            )
+                        ),
+                    providers = listOf("NEAR"),
+                )
+
+            val result =
+                source().fetch(request(srcToken = btcCoin(), dstToken = ethCoin()))
+                    as SwapQuoteResult.Native
+            val payload = (result.quote as SwapQuote.SwapKit).data
+
+            assertEquals("", payload.swapFee)
+            assertNull(payload.swapFeeChain)
+            assertNull(payload.swapFeeTokenId)
+            assertNull(payload.swapFeeDecimals)
+        }
+
+    @Test
+    fun `fetch falls back to the quote route's fees when the swap reply itemizes none`() = runTest {
+        every { config.isFeatureEnabled } returns flowOf(true)
+        coEvery { api.quote(any()) } returns
+            SwapKitQuoteResponseJson(
+                routes =
+                    listOf(
+                        route(
+                            routeId = "r-btc",
+                            providers = listOf("NEAR"),
+                            expectedBuy = "1",
+                            fees =
+                                listOf(
+                                    SwapKitFee(
+                                        type = "affiliate",
+                                        amount = "0.0005",
+                                        asset = "BTC.BTC",
+                                    )
+                                ),
+                        )
+                    )
+            )
+        coEvery { api.swap(any()) } returns
+            SwapKitSwapResponseJson(
+                tx = JsonPrimitive(Base64.getEncoder().encodeToString(byteArrayOf(0x70))),
+                meta = SwapKitTxMeta(txType = "PSBT"),
+                targetAddress = "bc1ptarget",
+                expectedBuyAmount = "1",
+                providers = listOf("NEAR"),
+            )
+
+        val result =
+            source().fetch(request(srcToken = btcCoin(), dstToken = ethCoin()))
+                as SwapQuoteResult.Native
+
+        assertEquals("50000", (result.quote as SwapQuote.SwapKit).data.swapFee)
+    }
+
+    @Test
     fun `fetch decodes a TRON route into a Native SwapQuote SwapKit with the TronWeb object as txPayload`() =
         runTest {
             // TRON's tx is a TronWeb-shaped JSON object (not base64) — the source UTF-8 encodes it

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/swap/SwapKitQuoteSourceTest.kt
@@ -1079,6 +1079,101 @@ internal class SwapKitQuoteSourceTest {
         }
 
     @Test
+    fun `fetch does not fall back to the route's fee when the swap reply's provider entries cannot be resolved`() =
+        runTest {
+            // The reply states a provider fee, just in a coin this device cannot attribute. The
+            // quote route's older entry is a different statement of the same swap, not a fallback.
+            every { config.isFeatureEnabled } returns flowOf(true)
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(
+                                routeId = "r-btc",
+                                providers = listOf("NEAR"),
+                                expectedBuy = "1",
+                                fees =
+                                    listOf(
+                                        SwapKitFee(
+                                            type = "affiliate",
+                                            amount = "0.0005",
+                                            asset = "BTC.BTC",
+                                        )
+                                    ),
+                            )
+                        )
+                )
+            coEvery { api.swap(any()) } returns
+                SwapKitSwapResponseJson(
+                    tx = JsonPrimitive(Base64.getEncoder().encodeToString(byteArrayOf(0x70))),
+                    meta = SwapKitTxMeta(txType = "PSBT"),
+                    targetAddress = "bc1ptarget",
+                    expectedBuyAmount = "1",
+                    fees =
+                        listOf(
+                            SwapKitFee(
+                                type = "affiliate",
+                                amount = "0.5",
+                                asset = "SOL.USDC-EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                            ),
+                            SwapKitFee(type = "inbound", amount = "0.000004", asset = "BTC.BTC"),
+                        ),
+                    providers = listOf("NEAR"),
+                )
+
+            val result =
+                source().fetch(request(srcToken = btcCoin(), dstToken = ethCoin()))
+                    as SwapQuoteResult.Native
+            val payload = (result.quote as SwapQuote.SwapKit).data
+
+            assertEquals("", payload.swapFee)
+            assertNull(payload.swapFeeChain)
+        }
+
+    @Test
+    fun `fetch falls back to the quote route's fees when the swap reply carries only an inbound entry`() =
+        runTest {
+            every { config.isFeatureEnabled } returns flowOf(true)
+            coEvery { api.quote(any()) } returns
+                SwapKitQuoteResponseJson(
+                    routes =
+                        listOf(
+                            route(
+                                routeId = "r-btc",
+                                providers = listOf("NEAR"),
+                                expectedBuy = "1",
+                                fees =
+                                    listOf(
+                                        SwapKitFee(
+                                            type = "affiliate",
+                                            amount = "0.0005",
+                                            asset = "BTC.BTC",
+                                        )
+                                    ),
+                            )
+                        )
+                )
+            coEvery { api.swap(any()) } returns
+                SwapKitSwapResponseJson(
+                    tx = JsonPrimitive(Base64.getEncoder().encodeToString(byteArrayOf(0x70))),
+                    meta = SwapKitTxMeta(txType = "PSBT"),
+                    targetAddress = "bc1ptarget",
+                    expectedBuyAmount = "1",
+                    fees =
+                        listOf(
+                            SwapKitFee(type = "inbound", amount = "0.000004", asset = "BTC.BTC")
+                        ),
+                    providers = listOf("NEAR"),
+                )
+
+            val result =
+                source().fetch(request(srcToken = btcCoin(), dstToken = ethCoin()))
+                    as SwapQuoteResult.Native
+
+            assertEquals("50000", (result.quote as SwapQuote.SwapKit).data.swapFee)
+        }
+
+    @Test
     fun `fetch falls back to the quote route's fees when the swap reply itemizes none`() = runTest {
         every { config.isFeatureEnabled } returns flowOf(true)
         coEvery { api.quote(any()) } returns


### PR DESCRIPTION
Closes #5864

Stacked on #5868 (`aminsato/5865_thorchain_slippage_bps`), which carries the commondata pin bump to `4064d473` that both need. Until #5868 merges this diff shows its commit too; the #5864 change is the last commit.

## Summary

A SwapKit swap from a non-EVM/Solana source (BTC, LTC, DOGE, BCH, DASH, ZEC, TRON, TON, SUI, ADA, XRP) travels as `SwapKitSwapPayload`. vultisig/commondata#103 added a `swap_fee` group to it — the provider fee plus the coin context that makes it priceable — because a co-signer holds no quote and cannot recover a fee the payload omits. Android neither wrote nor read it.

- **Initiator** — `SwapKitQuoteSource` resolves the provider fee out of the route's `fees[]` (`affiliate` + `service`, per the proto's definition and the SDK's `getSwapKitSwapFee`) and stamps `swapFee` / `swapFeeChain` / `swapFeeTokenId` / `swapFeeDecimals` onto the payload. The group stays empty — no coin context — when the route itemizes no fee, or one this device cannot attribute to a coin. The `/v3/swap` reply is read first, the `/v3/quote` route as fallback, the same order as the inbound entry.
- **Mappers** — both directions, `ifEmpty { null }` on the optional context fields so a re-encoded legacy payload stays byte-stable.
- **Joiner** — `JoinSwapUiModelBuilder` reads the group and renders the Swap Fee row from it with no `/v3/quote` call. An empty `swap_fee` (a sender that predates the field) keeps today's inbound re-fetch, so older initiators are not regressed. A stated fee this device cannot render — zero, a non-integer amount, an unknown chain, missing decimals, or a coin it cannot resolve — shows no row and never throws out of the verify screen.

### Fee coin resolution

The fee coin is not "the source chain's fee coin". Live `fees[]` from the proxy, same pair, three providers:

| provider | affiliate / service `asset` | entry `chain` |
|---|---|---|
| NEAR | source asset (`TRON.TRX`, `ZEC.ZEC`, `DOGE.DOGE`) | `NEAR` |
| Chainflip | `ETH.USDC-0xA0b8…` | `ETH` |
| Flashnet | `SOL.USDC-EPjF…` | `SOL` |

So `resolveSwapKitProviderFee` matches each entry's `asset` identifier against the coins a co-signer can price — the pair, plus Ethereum USDC on a Chainflip route — and treats anything else (Flashnet's Solana USDC on a ZEC → ETH swap) as no fee, rather than putting an amount on the wire in a coin the other device would have to guess. Affiliate and service in different coins, a malformed or negative amount, and sub-unit dust also yield no fee.

Only `asset` is matched, not the entry's `chain`. That field is the routing protocol's label — `NEAR` on an Intents route — not the asset's chain; the SDK keys on it (`matchesSwapKitFeeChain`) and so drops the fee on exactly the routes that carry one most often. Noted here so the difference in what the two initiators write is understood, not accidental.

On the joiner, a Chainflip fee in Ethereum USDC is neither leg of a BTC → ETH swap, so after the pair and the native coin the resolver falls through to the built-in registry (`Coins.coins[chain]`). The sender's decimals are kept over the registry's so the amount is read the way it was written.

### What this does not change

- **The initiator's own Swap Fee row.** Per the issue's Must-NOT it still shows the route's `inbound` entry (hidden on UTXO sources where it duplicates the Network Fee). That means the wire now carries a different figure than the Android initiator displays: on a TRX → ETH NEAR route the payload says 13 TRX (affiliate 10 + service 3) while the initiator's row says 1.1 TRX (inbound). The issue's acceptance line "same Swap Fee on the co-signer as on the initiator" cannot hold under its own Must-NOT; the co-signer now shows what the SDK/extension initiator shows for the same swap. iOS reads this field but deliberately does not write it, for the same reason. Moving the initiator's row onto the provider fee is a separate decision.
- The EVM/Solana SwapKit path (`oneinchSwapPayload`), `slippage_bps` (#5868) and 1inch `sub_provider` (unused).

## Tests

- `SwapKitProviderFeeTest` (new, :data, 10) — the live shapes above: NEAR sums in the source asset under `chain: "NEAR"`; Chainflip resolves Ethereum USDC and only on a Chainflip route; Flashnet's Solana USDC yields nothing; destination-asset fee; mixed coins, zero, malformed, negative and sub-unit dust yield nothing.
- `SwapKitQuoteSourceTest` (+3) — a PSBT route stamps the group (`65000` sats, `Bitcoin`, no token id, 8) while the inbound entry keeps feeding `quote.fees`; a route with no provider entries leaves it empty; the quote route's fees are the fallback when the swap reply itemizes none.
- `KeysignPayloadProtoMapperSwapKitTest` (+2) — outbound writes the group and leaves it unset when empty; inbound reads it; a legacy proto reads back empty and re-encodes without inventing presence.
- `JoinSwapSwapKitFeeTest` (new, :app, 8) — a stated fee renders and adds to the total with no `getSwapKitInboundFee` call; Ethereum USDC resolves from the registry; an empty field keeps the re-fetch (and its zero-on-failure); unknown chain, non-integer amount, unresolvable coin and missing decimals render no row, do not re-fetch, do not throw.
- Full `:data:testDebugUnitTest`; `:app` keysign / swap / mappers packages; root `assembleDebug`, `:app:ktfmtCheck`, `:data:ktfmtCheck`, `:app:compileDebugAndroidTestKotlin` — all pass.

## Verified on device

Extension on `main` (`f8192639a`, core-mpc 3.2.2), Android on this branch, 2-of-2 vault with a VULT Gold tier.

**Android initiates (100 TRX → ETH, SwapKit via NEAR), extension joins.** The extension's join screen now has a **Swap Fee** row — it hides that row whenever `swap_fee` is empty, so it can only have come from the payload:

| Android initiator | Extension join |
|---|---|
| <img src="https://i.imgur.com/6H2RXsm.png" width="320" /> | <img src="https://i.imgur.com/PE1ttY3.png" width="360" /> |

The figures reconcile with the resolver: the extension's **$0.15** is 0.45 TRX × $0.3388 — affiliate **30 bps** (50 bps list − 20 bps Gold) + service **15 bps** on 100 TRX, i.e. the `affiliate + service` sum at the discounted rate Android quoted. The Android initiator's **$0.37** is the route's 1.1 TRX `inbound` entry, unchanged per the Must-NOT — the asymmetry described above, now visible. Network Fee differs (0.8 vs 0.345 TRX) because Android writes a fixed `gas_fee_estimation` into the payload while displaying its own reconciled estimate; pre-existing and unrelated.

Also observed: an extension-initiated TRX → ETH NEAR route reaches Android with an **empty** field (the SDK drops NEAR's `chain: "NEAR"` entries, see above), and Android correctly took the legacy path — inbound re-fetch, $0.37 — rather than showing nothing.

**Not exercised on device:** the Android *read* of a stated fee. Every cheap transfer source is quoted only by NEAR (dropped by the SDK) or THORChain-streaming (filtered), and the extension lists only its single best SwapKit route, so a Chainflip-written payload was not reachable from the extension in this session. That path is pinned by `JoinSwapSwapKitFeeTest` with the exact Chainflip shape (`Ethereum` / `0xA0b8…` / 6 decimals, resolved from the registry).

## Test plan

- [x] Android → Swap → TRX → ETH via SwapKit (NEAR) → Sign; join from the extension → Swap Fee row present and equal to affiliate + service
- [x] Extension → TRX → ETH via NEAR → Sign; join from Android → empty field → legacy inbound re-fetch, no crash
- [ ] Extension → BTC → FLIP (the one pair Chainflip has to itself) → Sign; join from Android → Swap Fee ≈ $0.17 from the payload's Ethereum USDC context, row shown on the BTC source
- [ ] Join a SwapKit swap from an older Android build → today's behaviour (inbound re-fetch; row hidden on BTC)

Sibling implementations: vultisig/vultisig-sdk#2315 (initiator), vultisig/vultisig-windows#4814 (joiner), vultisig/vultisig-ios#5360 (joiner only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Swap quotes now display price impact for THORChain and MayaChain swaps.
  - SwapKit provider fees from payloads are preserved with their correct token, amount, and decimals.
  - Swap transactions now include quoted slippage information.
  - Fee handling supports more assets and accurately combines applicable provider fees.

- **Bug Fixes**
  - Improved handling of missing, invalid, unsupported, or non-renderable fee data.
  - Prevented incorrect fallback fees and source-token assumptions when payload details are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->