### PR TITLE
fix(utxo): display the spendable UTXO balance, not Blockchair aggregate

### DIFF
--- a/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/AppDatabase.kt
@@ -17,6 +17,7 @@ import com.vultisig.wallet.data.db.dao.StakingDetailsDao
 import com.vultisig.wallet.data.db.dao.TokenPriceDao
 import com.vultisig.wallet.data.db.dao.TokenValueDao
 import com.vultisig.wallet.data.db.dao.TransactionHistoryDao
+import com.vultisig.wallet.data.db.dao.UtxoInFlightOutpointDao
 import com.vultisig.wallet.data.db.dao.VaultDao
 import com.vultisig.wallet.data.db.dao.VaultMetadataDao
 import com.vultisig.wallet.data.db.dao.VaultNotificationSettingsDao
@@ -36,6 +37,7 @@ import com.vultisig.wallet.data.db.models.StakingDetailsEntity
 import com.vultisig.wallet.data.db.models.TokenPriceEntity
 import com.vultisig.wallet.data.db.models.TokenValueEntity
 import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
+import com.vultisig.wallet.data.db.models.UtxoInFlightOutpointEntity
 import com.vultisig.wallet.data.db.models.VaultEntity
 import com.vultisig.wallet.data.db.models.VaultMetadataEntity
 import com.vultisig.wallet.data.db.models.VaultNotificationSettingsEntity
@@ -63,8 +65,9 @@ import com.vultisig.wallet.data.db.models.VaultOrderEntity
             VaultNotificationSettingsEntity::class,
             TransactionHistoryEntity::class,
             PendingLimitOrderEntity::class,
+            UtxoInFlightOutpointEntity::class,
         ],
-    version = 45,
+    version = 46,
     exportSchema = false,
 )
 @TypeConverters(
@@ -102,4 +105,6 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun transactionHistoryDao(): TransactionHistoryDao
 
     abstract fun pendingLimitOrderDao(): PendingLimitOrderDao
+
+    abstract fun utxoInFlightOutpointDao(): UtxoInFlightOutpointDao
 }

--- a/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/DatabaseModule.kt
@@ -12,6 +12,7 @@ import com.vultisig.wallet.data.db.dao.StakingDetailsDao
 import com.vultisig.wallet.data.db.dao.TokenPriceDao
 import com.vultisig.wallet.data.db.dao.TokenValueDao
 import com.vultisig.wallet.data.db.dao.TransactionHistoryDao
+import com.vultisig.wallet.data.db.dao.UtxoInFlightOutpointDao
 import com.vultisig.wallet.data.db.dao.VaultDao
 import com.vultisig.wallet.data.db.dao.VaultMetadataDao
 import com.vultisig.wallet.data.db.dao.VaultNotificationSettingsDao
@@ -54,6 +55,7 @@ import com.vultisig.wallet.data.db.migrations.MIGRATION_41_42
 import com.vultisig.wallet.data.db.migrations.MIGRATION_42_43
 import com.vultisig.wallet.data.db.migrations.MIGRATION_43_44
 import com.vultisig.wallet.data.db.migrations.MIGRATION_44_45
+import com.vultisig.wallet.data.db.migrations.MIGRATION_45_46
 import com.vultisig.wallet.data.db.migrations.MIGRATION_4_5
 import com.vultisig.wallet.data.db.migrations.MIGRATION_5_6
 import com.vultisig.wallet.data.db.migrations.MIGRATION_6_7
@@ -127,6 +129,7 @@ internal interface DatabaseModule {
                     MIGRATION_42_43,
                     MIGRATION_43_44,
                     MIGRATION_44_45,
+                    MIGRATION_45_46,
                 )
                 .build()
 
@@ -200,5 +203,10 @@ internal interface DatabaseModule {
         @Singleton
         fun providePendingLimitOrderDao(appDatabase: AppDatabase): PendingLimitOrderDao =
             appDatabase.pendingLimitOrderDao()
+
+        @Provides
+        @Singleton
+        fun provideUtxoInFlightOutpointDao(appDatabase: AppDatabase): UtxoInFlightOutpointDao =
+            appDatabase.utxoInFlightOutpointDao()
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/db/migrations/MIGRATIONS.kt
@@ -1276,3 +1276,31 @@ internal val MIGRATION_44_45 =
             )
         }
     }
+
+// Adds utxo_inflight_outpoint: the wallet's own record of what each recent UTXO-chain broadcast
+// consumed and paid back to the sender (#5867). Blockchair serves the address dashboard from a
+// 60–120 s cache, so a send made right after another was funded from a snapshot that still listed
+// the first send's inputs and was rejected with `bad-txns-inputs-missingorspent`. Coin selection
+// and the displayed balance now replay these rows over the provider snapshot. One row per outpoint
+// so the table needs no converter; rows expire on age, so nothing here is ever migrated forward.
+internal val MIGRATION_45_46 =
+    object : Migration(45, 46) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+            CREATE TABLE IF NOT EXISTS `utxo_inflight_outpoint` (
+                `chain` TEXT NOT NULL,
+                `address` TEXT NOT NULL,
+                `tx_hash` TEXT NOT NULL,
+                `broadcast_at` INTEGER NOT NULL,
+                `kind` TEXT NOT NULL,
+                `hash` TEXT NOT NULL,
+                `idx` INTEGER NOT NULL,
+                `amount` INTEGER NOT NULL,
+                PRIMARY KEY(`chain`, `tx_hash`, `kind`, `hash`, `idx`)
+            )
+            """
+                    .trimIndent()
+            )
+        }
+    }

--- a/app/src/main/java/com/vultisig/wallet/data/usecases/BroadcastKeysignUseCase.kt
+++ b/app/src/main/java/com/vultisig/wallet/data/usecases/BroadcastKeysignUseCase.kt
@@ -3,13 +3,16 @@ package com.vultisig.wallet.data.usecases
 import com.vultisig.wallet.data.api.EvmApiFactory
 import com.vultisig.wallet.data.chains.helpers.SigningHelper
 import com.vultisig.wallet.data.chains.helpers.THORChainSwaps
+import com.vultisig.wallet.data.chains.helpers.UtxoHelper
 import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.getEcdsaSigningKey
 import com.vultisig.wallet.data.models.getEddsaSigningKey
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.repositories.BalanceRepository
 import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
+import com.vultisig.wallet.data.repositories.UtxoInFlightRepository
 import java.math.BigInteger
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
@@ -78,6 +81,7 @@ constructor(
     private val explorerLinkRepository: ExplorerLinkRepository,
     private val evmApiFactory: EvmApiFactory,
     private val balanceRepository: BalanceRepository,
+    private val utxoInFlightRepository: UtxoInFlightRepository,
 ) {
 
     /**
@@ -178,6 +182,10 @@ constructor(
             txLink = explorerLinkRepository.getTransactionLink(chain, txHash)
             swapProgressLink =
                 explorerLinkRepository.getSwapProgressLink(txHash, payload.swapPayload)
+            // Before the balance is invalidated: the refresh that follows reads the provider,
+            // whose snapshot may not reflect this broadcast for minutes, and reconciles against
+            // this record.
+            recordUtxoSpend(vault, payload, txHash)
             runCatching { balanceRepository.invalidateBalance(payload.coin.address, payload.coin) }
                 .onFailure { Timber.e(it, "Failed to invalidate balance cache after broadcast") }
             runCatching {
@@ -204,5 +212,33 @@ constructor(
                 else "",
             additionalTxHashes = txHashes.drop(1).filterNotNull(),
         )
+    }
+
+    /**
+     * Writes what a UTXO-chain broadcast consumed and paid back to the sender, so the next coin
+     * selection and balance read do not trust a provider snapshot that predates it (#5867). A
+     * joined co-signer records it too: its broadcast races the initiator's and either may win, and
+     * its own next send is funded from the same address. Best-effort — a failed write costs the
+     * ledger, never the keysign.
+     */
+    private suspend fun recordUtxoSpend(vault: Vault, payload: KeysignPayload, txHash: String) {
+        val coin = payload.coin
+        if (coin.chain.standard != TokenStandard.UTXO || coin.chain == Chain.Cardano) return
+        try {
+            val effects =
+                UtxoHelper.getHelper(vault, coin.coinType).getSpendEffects(payload, txHash)
+                    ?: return
+            utxoInFlightRepository.record(
+                chain = coin.chain,
+                address = coin.address,
+                txHash = txHash,
+                spent = effects.spent,
+                created = effects.created,
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to record the outputs spent by %s", txHash)
+        }
     }
 }

--- a/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
+++ b/app/src/main/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModel.kt
@@ -42,6 +42,7 @@ import com.vultisig.wallet.data.repositories.ExplorerLinkRepository
 import com.vultisig.wallet.data.repositories.InAppReviewRepository
 import com.vultisig.wallet.data.repositories.PendingLimitOrderRepository
 import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
+import com.vultisig.wallet.data.repositories.UtxoInFlightRepository
 import com.vultisig.wallet.data.repositories.VaultRepository
 import com.vultisig.wallet.data.services.KeysignTxStatusPoller
 import com.vultisig.wallet.data.services.TxStatusPollOutcome
@@ -352,6 +353,7 @@ constructor(
     private val gasFeeToEstimatedFee: GasFeeToEstimatedFeeUseCase,
     private val inAppReviewRepository: InAppReviewRepository,
     private val pendingLimitOrderRepository: PendingLimitOrderRepository,
+    private val utxoInFlightRepository: UtxoInFlightRepository,
     private val doneTransactionPresentation: DoneTransactionPresentation,
     /**
      * Injected so the two reads this view model starts at construction stay on the caller's
@@ -428,6 +430,7 @@ constructor(
             explorerLinkRepository = explorerLinkRepository,
             evmApiFactory = evmApiFactory,
             balanceRepository = balanceRepository,
+            utxoInFlightRepository = utxoInFlightRepository,
         )
 
     init {

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/BroadcastKeysignBatchTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/BroadcastKeysignBatchTest.kt
@@ -172,5 +172,6 @@ internal class BroadcastKeysignBatchTest {
             explorerLinkRepository = mockk(relaxed = true),
             evmApiFactory = mockk(relaxed = true),
             balanceRepository = mockk(relaxed = true),
+            utxoInFlightRepository = mockk(relaxed = true),
         )
 }

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelApplyBroadcastResultTest.kt
@@ -273,6 +273,7 @@ internal class KeysignViewModelApplyBroadcastResultTest {
             inAppReviewRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
+            utxoInFlightRepository = mockk(relaxed = true),
             doneTransactionPresentation = mockk(relaxed = true),
             ioDispatcher = testDispatcher,
             awaitApprovalConfirmation = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelInAppReviewTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelInAppReviewTest.kt
@@ -164,6 +164,7 @@ internal class KeysignViewModelInAppReviewTest {
             inAppReviewRepository = inAppReviewRepository,
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
+            utxoInFlightRepository = mockk(relaxed = true),
             doneTransactionPresentation = mockk(relaxed = true),
             ioDispatcher = testDispatcher,
             awaitApprovalConfirmation = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelSaveTransactionHistoryTest.kt
@@ -105,6 +105,7 @@ internal class KeysignViewModelSaveTransactionHistoryTest {
             inAppReviewRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = mockk(relaxed = true),
             pendingLimitOrderRepository = mockk(relaxed = true),
+            utxoInFlightRepository = mockk(relaxed = true),
             doneTransactionPresentation = mockk(relaxed = true),
             ioDispatcher = testDispatcher,
             awaitApprovalConfirmation = mockk(relaxed = true),

--- a/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateEvmActualFeeTest.kt
+++ b/app/src/test/java/com/vultisig/wallet/ui/models/keysign/KeysignViewModelTryUpdateEvmActualFeeTest.kt
@@ -147,6 +147,7 @@ internal class KeysignViewModelTryUpdateEvmActualFeeTest {
             inAppReviewRepository = mockk(relaxed = true),
             gasFeeToEstimatedFee = gasFeeToEstimatedFee,
             pendingLimitOrderRepository = mockk(relaxed = true),
+            utxoInFlightRepository = mockk(relaxed = true),
             doneTransactionPresentation = mockk(relaxed = true),
             ioDispatcher = testDispatcher,
             awaitApprovalConfirmation = mockk(relaxed = true),

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/SpendableUtxos.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/SpendableUtxos.kt
@@ -80,15 +80,28 @@ object SpendableUtxos {
     /**
      * The balance of exactly the set [select] admits, in the chain's smallest unit. Defined in
      * terms of [select] rather than alongside it so the two cannot drift.
+     *
+     * Unlike [select], a row that cannot name an outpoint fails the read rather than being dropped:
+     * this number gets persisted over the cached balance, and an understated balance written to the
+     * cache is worse than a stale one kept. Coin selection can afford to drop the row — fewer
+     * inputs can only under-fund a send, never overspend.
      */
     fun balance(
         rows: List<BlockChairUtxoInfo>,
         dustThreshold: Long,
         ownUnconfirmedTxHashes: Set<String>,
-    ): BigInteger =
-        select(rows, dustThreshold, ownUnconfirmedTxHashes).fold(BigInteger.ZERO) { total, utxo ->
+    ): BigInteger {
+        val unusable = rows.count { !it.isUsable }
+        check(unusable == 0) {
+            "$unusable of ${rows.size} Blockchair UTXO rows have no usable transaction_hash/index" +
+                " — refusing to persist an understated balance"
+        }
+        return select(rows, dustThreshold, ownUnconfirmedTxHashes).fold(BigInteger.ZERO) {
+            total,
+            utxo ->
             total + BigInteger.valueOf(utxo.amount)
         }
+    }
 
     private val BlockChairUtxoInfo.isUsable: Boolean
         get() = transactionHash.isNotBlank() && index >= 0

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/SpendableUtxos.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/SpendableUtxos.kt
@@ -1,0 +1,95 @@
+package com.vultisig.wallet.data.blockchain.utxo
+
+import com.vultisig.wallet.data.api.models.BlockChairUtxoInfo
+import com.vultisig.wallet.data.models.payload.UtxoInfo
+import java.math.BigInteger
+import timber.log.Timber
+
+/**
+ * The single definition of which of an address's unspent outputs this wallet treats as its own
+ * spendable money on the Blockchair-backed UTXO chains.
+ *
+ * Both numbers the user meets come from here: the balance on the wallet screen
+ * ([com.vultisig.wallet.data.repositories.BalanceRepository]) and the candidate set a transaction
+ * is funded from ([com.vultisig.wallet.data.repositories.BlockChainSpecificRepository]). They used
+ * to be derived independently — the balance from Blockchair's `address.balance`, the inputs from a
+ * separately filtered `utxo` array — and everything in the gap between them was money the wallet
+ * displayed and then refused to spend: a send cleared the balance check and failed at input
+ * selection, and send-max drained less than the screen showed. One predicate with two callers is
+ * what keeps that gap shut (#5867; iOS closed the same gap in vultisig-ios#4978).
+ */
+object SpendableUtxos {
+
+    /**
+     * Narrows Blockchair's rows to the outputs that may fund a transaction, smallest first.
+     * - **Not explicitly unspendable.** `is_spendable` is absent from Blockchair's Bitcoin
+     *   responses, so absent means spendable and only an explicit `false` disqualifies an output.
+     * - **Confirmed, or unconfirmed and ours.** Blockchair reports mempool outputs with `block_id
+     *   == -1` and counts them in `address.balance`. Zero-conf someone else controls can be
+     *   replaced or evicted at will, and the MPC pairing window leaves minutes for that between
+     *   selection and broadcast. Zero-conf produced by a transaction this wallet broadcast is
+     *   different: only this wallet can spend that parent's inputs, so nobody else can replace it.
+     *   Withholding it would blank the wallet for a block after every send, because the input
+     *   leaves the UTXO set the moment the parent reaches the mempool while the change arrives
+     *   unconfirmed.
+     * - **At or above the chain's dust threshold** (`>=`, matching iOS so both platforms spend the
+     *   same outputs).
+     *
+     * [ownUnconfirmedTxHashes] can only ever rescue a row, never add one: every candidate was
+     * returned by the provider as part of the address's current unspent set, so a parent that was
+     * dropped or never propagated contributes nothing to spend in the first place. An empty set
+     * collapses the predicate back to confirmed-only.
+     *
+     * Rows that cannot name an outpoint (negative index, blank hash) are dropped and counted in the
+     * log rather than failing the whole set: unlike the policy exclusions above there is no
+     * legitimate reason for one to exist, and silently dropping it would understate the balance
+     * with nothing anywhere failing.
+     */
+    fun select(
+        rows: List<BlockChairUtxoInfo>,
+        dustThreshold: Long,
+        ownUnconfirmedTxHashes: Set<String>,
+    ): List<UtxoInfo> {
+        // Blockchair lower-cases transaction hashes, but the stored hash can come back from a
+        // broadcast proxy, so neither side's casing is guaranteed.
+        val ownHashes = ownUnconfirmedTxHashes.mapTo(HashSet()) { it.lowercase() }
+
+        val unusable = rows.count { !it.isUsable }
+        if (unusable > 0) {
+            Timber.e(
+                "Dropped %d of %d Blockchair UTXO rows with no usable transaction_hash/index — " +
+                    "the balance understates this address by whatever they held",
+                unusable,
+                rows.size,
+            )
+        }
+
+        return rows
+            .filter { row ->
+                row.isUsable &&
+                    row.isSpendable != false &&
+                    row.value >= dustThreshold &&
+                    (row.blockId > 0 || row.transactionHash.lowercase() in ownHashes)
+            }
+            .map {
+                UtxoInfo(hash = it.transactionHash, amount = it.value, index = it.index.toUInt())
+            }
+            .sortedBy(UtxoInfo::amount)
+    }
+
+    /**
+     * The balance of exactly the set [select] admits, in the chain's smallest unit. Defined in
+     * terms of [select] rather than alongside it so the two cannot drift.
+     */
+    fun balance(
+        rows: List<BlockChairUtxoInfo>,
+        dustThreshold: Long,
+        ownUnconfirmedTxHashes: Set<String>,
+    ): BigInteger =
+        select(rows, dustThreshold, ownUnconfirmedTxHashes).fold(BigInteger.ZERO) { total, utxo ->
+            total + BigInteger.valueOf(utxo.amount)
+        }
+
+    private val BlockChairUtxoInfo.isUsable: Boolean
+        get() = transactionHash.isNotBlank() && index >= 0
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/SpendableUtxos.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/SpendableUtxos.kt
@@ -44,11 +44,16 @@ object SpendableUtxos {
      * log rather than failing the whole set: unlike the policy exclusions above there is no
      * legitimate reason for one to exist, and silently dropping it would understate the balance
      * with nothing anywhere failing.
+     *
+     * [inFlight] is then replayed over the result — see [reconcile] — so a provider snapshot that
+     * predates this wallet's own recent broadcasts cannot offer up an input the wallet already
+     * spent.
      */
     fun select(
         rows: List<BlockChairUtxoInfo>,
         dustThreshold: Long,
         ownUnconfirmedTxHashes: Set<String>,
+        inFlight: List<UtxoInFlightTx> = emptyList(),
     ): List<UtxoInfo> {
         // Blockchair lower-cases transaction hashes, but the stored hash can come back from a
         // broadcast proxy, so neither side's casing is guaranteed.
@@ -74,8 +79,61 @@ object SpendableUtxos {
             .map {
                 UtxoInfo(hash = it.transactionHash, amount = it.value, index = it.index.toUInt())
             }
-            .sortedBy(UtxoInfo::amount)
+            .reconcile(inFlight, dustThreshold)
     }
+
+    /**
+     * Replays this wallet's own recent broadcasts over a provider snapshot, smallest output first
+     * in the result.
+     *
+     * Blockchair serves the address dashboard from a 60–120 s cache and ingests our broadcast into
+     * its mempool view with its own lag, so right after a send the snapshot can still list the
+     * inputs that send consumed and not yet the change it paid back. The wallet knows both
+     * ([UtxoInFlightTx]), and it is the only party that can: nobody else can spend these outputs.
+     *
+     * Each in-flight transaction, oldest first, is applied only when the snapshot still lists at
+     * least one input it spent — the evidence that the snapshot predates it. Then those inputs are
+     * removed and the outputs it paid back are added. A transaction none of whose inputs are listed
+     * is skipped: either the provider has already caught up, in which case its own view of that
+     * transaction's outputs (present as `block_id -1` and admitted through
+     * `ownUnconfirmedTxHashes`, or absent) is authoritative — or the transaction was evicted from
+     * the mempool and its inputs are free again, in which case injecting its outputs would build on
+     * nothing. That gate is what keeps the ledger from ever overriding a provider that already
+     * knows better. Oldest-first ordering is what lets a chain of sends work: the second send's
+     * input is the first send's injected change, present only because the first was replayed.
+     *
+     * Injected outputs go through the same dust threshold as provider rows; a sub-dust change
+     * output is money this wallet will not spend after it confirms either.
+     */
+    private fun List<UtxoInfo>.reconcile(
+        inFlight: List<UtxoInFlightTx>,
+        dustThreshold: Long,
+    ): List<UtxoInfo> {
+        if (inFlight.isEmpty()) return sortedBy(UtxoInfo::amount)
+
+        val candidates = LinkedHashMap<OutPointKey, UtxoInfo>()
+        for (utxo in this) candidates[utxo.outPointKey] = utxo
+
+        for (tx in inFlight.sortedBy(UtxoInFlightTx::broadcastAt)) {
+            val spentKeys = tx.spent.map { it.outPointKey }
+            if (spentKeys.none { it in candidates }) continue
+
+            spentKeys.forEach(candidates::remove)
+            tx.created
+                .filter { it.amount >= dustThreshold }
+                .forEach { candidates.putIfAbsent(it.outPointKey, it) }
+        }
+        return candidates.values.sortedBy(UtxoInfo::amount)
+    }
+
+    /**
+     * Hash casing is normalised for the same reason as in [select]: the stored hash can come from a
+     * broadcast proxy, Blockchair's is lower-case.
+     */
+    private data class OutPointKey(val hash: String, val index: UInt)
+
+    private val UtxoInfo.outPointKey: OutPointKey
+        get() = OutPointKey(hash.lowercase(), index)
 
     /**
      * The balance of exactly the set [select] admits, in the chain's smallest unit. Defined in
@@ -90,18 +148,30 @@ object SpendableUtxos {
         rows: List<BlockChairUtxoInfo>,
         dustThreshold: Long,
         ownUnconfirmedTxHashes: Set<String>,
+        inFlight: List<UtxoInFlightTx> = emptyList(),
     ): BigInteger {
         val unusable = rows.count { !it.isUsable }
         check(unusable == 0) {
             "$unusable of ${rows.size} Blockchair UTXO rows have no usable transaction_hash/index" +
                 " — refusing to persist an understated balance"
         }
-        return select(rows, dustThreshold, ownUnconfirmedTxHashes).fold(BigInteger.ZERO) {
-            total,
-            utxo ->
+        return select(rows, dustThreshold, ownUnconfirmedTxHashes, inFlight).fold(
+            BigInteger.ZERO
+        ) { total, utxo ->
             total + BigInteger.valueOf(utxo.amount)
         }
     }
+
+    /**
+     * [reconcile] for a UTXO set that did not come from Blockchair — Dash's own address index,
+     * which is built from connected blocks and blind to the mempool in both directions, so it keeps
+     * listing a spent input until the spending transaction confirms.
+     */
+    fun reconcile(
+        candidates: List<UtxoInfo>,
+        dustThreshold: Long,
+        inFlight: List<UtxoInFlightTx>,
+    ): List<UtxoInfo> = candidates.reconcile(inFlight, dustThreshold)
 
     private val BlockChairUtxoInfo.isUsable: Boolean
         get() = transactionHash.isNotBlank() && index >= 0

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/SpendableUtxos.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/SpendableUtxos.kt
@@ -91,16 +91,29 @@ object SpendableUtxos {
      * inputs that send consumed and not yet the change it paid back. The wallet knows both
      * ([UtxoInFlightTx]), and it is the only party that can: nobody else can spend these outputs.
      *
-     * Each in-flight transaction, oldest first, is applied only when the snapshot still lists at
-     * least one input it spent — the evidence that the snapshot predates it. Then those inputs are
-     * removed and the outputs it paid back are added. A transaction none of whose inputs are listed
-     * is skipped: either the provider has already caught up, in which case its own view of that
-     * transaction's outputs (present as `block_id -1` and admitted through
-     * `ownUnconfirmedTxHashes`, or absent) is authoritative — or the transaction was evicted from
-     * the mempool and its inputs are free again, in which case injecting its outputs would build on
-     * nothing. That gate is what keeps the ledger from ever overriding a provider that already
-     * knows better. Oldest-first ordering is what lets a chain of sends work: the second send's
-     * input is the first send's injected change, present only because the first was replayed.
+     * An in-flight transaction is applied only when the snapshot still lists at least one input it
+     * spent — the evidence that the snapshot predates it. Then those inputs are removed and the
+     * outputs it paid back are added. A transaction none of whose inputs are listed is left alone:
+     * the provider has already caught up, and its own view of that transaction's outputs (present
+     * as `block_id -1` and admitted through `ownUnconfirmedTxHashes`, or absent) is authoritative.
+     * That gate is what keeps the ledger from overriding a provider that already knows better.
+     *
+     * Replay runs to a fixpoint rather than in recorded order: a pass applies every transaction
+     * whose inputs are present, and passes repeat until one applies nothing. A chain of sends
+     * therefore works regardless of how its entries are ordered — the second send's input is the
+     * first send's change, absent from the snapshot until the first is applied, so the second is
+     * skipped in that pass and applied in the next. Ordering by recorded time alone would let a
+     * clock adjustment between two sends put the child first, skip it for good, and then have the
+     * parent re-offer the very output the child spent. Within a pass, entries go in recorded order
+     * so the result is deterministic.
+     *
+     * The gate has one blind spot, accepted and bounded rather than closed: a transaction the
+     * mempool evicted frees its inputs, and a snapshot listing them again is indistinguishable from
+     * a stale one. Until its entry expires, replay would then re-spend outputs that no longer
+     * exist, and the child is rejected at broadcast — one failed broadcast, no money, the same
+     * outcome iOS accepts for a child built on an evicted parent. Nothing local can tell the two
+     * apart (no UTXO status ever becomes `FAILED` on eviction), so the exposure is bounded by how
+     * long an entry is replayed at all: see `UtxoInFlightRepositoryImpl.REPLAY_WINDOW_MS`.
      *
      * Injected outputs go through the same dust threshold as provider rows; a sub-dust change
      * output is money this wallet will not spend after it confirms either.
@@ -114,15 +127,24 @@ object SpendableUtxos {
         val candidates = LinkedHashMap<OutPointKey, UtxoInfo>()
         for (utxo in this) candidates[utxo.outPointKey] = utxo
 
-        for (tx in inFlight.sortedBy(UtxoInFlightTx::broadcastAt)) {
-            val spentKeys = tx.spent.map { it.outPointKey }
-            if (spentKeys.none { it in candidates }) continue
+        val pending = inFlight.sortedBy(UtxoInFlightTx::broadcastAt).toMutableList()
+        do {
+            var applied = false
+            val iterator = pending.iterator()
+            while (iterator.hasNext()) {
+                val tx = iterator.next()
+                val spentKeys = tx.spent.map { it.outPointKey }
+                if (spentKeys.none { it in candidates }) continue
 
-            spentKeys.forEach(candidates::remove)
-            tx.created
-                .filter { it.amount >= dustThreshold }
-                .forEach { candidates.putIfAbsent(it.outPointKey, it) }
-        }
+                spentKeys.forEach(candidates::remove)
+                tx.created
+                    .filter { it.amount >= dustThreshold }
+                    .forEach { candidates.putIfAbsent(it.outPointKey, it) }
+                iterator.remove()
+                applied = true
+            }
+        } while (applied && pending.isNotEmpty())
+
         return candidates.values.sortedBy(UtxoInfo::amount)
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/UtxoInFlightTx.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/utxo/UtxoInFlightTx.kt
@@ -1,0 +1,24 @@
+package com.vultisig.wallet.data.blockchain.utxo
+
+import com.vultisig.wallet.data.models.payload.UtxoInfo
+
+/**
+ * What one transaction this wallet broadcast did to the sending address's UTXO set: the outpoints
+ * it consumed and the outputs it paid back to that same address (change, or a self-send).
+ *
+ * Recorded at broadcast and read back by [SpendableUtxos] so the wallet's own recent spending is
+ * applied on top of whatever snapshot the provider hands back. Blockchair serves the address
+ * dashboard from a 60–120 s cache and its mempool view lags behind our broadcast, so for a couple
+ * of minutes after every send the provider still lists the inputs that send consumed and not yet
+ * the change it created. Fed that snapshot verbatim, the next send picks an input the network
+ * already saw spent and dies at broadcast with `bad-txns-inputs-missingorspent` (#5867).
+ */
+data class UtxoInFlightTx(
+    val txHash: String,
+    /** Wall-clock millis at broadcast; the reconciliation replays transactions in this order. */
+    val broadcastAt: Long,
+    /** Inputs the transaction spent. */
+    val spent: List<UtxoInfo>,
+    /** Outputs paid back to the sending address, keyed by this transaction's hash. */
+    val created: List<UtxoInfo>,
+)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -1,12 +1,14 @@
 package com.vultisig.wallet.data.chains.helpers
 
 import com.google.protobuf.ByteString
+import com.vultisig.wallet.data.blockchain.utxo.UtxoInFlightTx
 import com.vultisig.wallet.data.crypto.checkError
 import com.vultisig.wallet.data.models.SignedTransactionResult
 import com.vultisig.wallet.data.models.Vault
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.models.payload.KeysignPayload
 import com.vultisig.wallet.data.models.payload.SwapPayload
+import com.vultisig.wallet.data.models.payload.UtxoInfo
 import com.vultisig.wallet.data.utils.Numeric
 import com.vultisig.wallet.data.utils.getDustThreshold
 import java.io.ByteArrayOutputStream
@@ -176,11 +178,17 @@ class UtxoHelper(
         return input.build()
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
     fun getSigningInputData(
         keysignPayload: KeysignPayload,
         signingInput: Bitcoin.SigningInput.Builder,
-    ): ByteArray {
+    ): ByteArray = buildSigningInput(keysignPayload, signingInput).toByteArray()
+
+    /** [signingInput] with the payload's UTXOs, their scripts, and the resulting plan attached. */
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun buildSigningInput(
+        keysignPayload: KeysignPayload,
+        signingInput: Bitcoin.SigningInput.Builder,
+    ): Bitcoin.SigningInput {
         val utxo = keysignPayload.blockChainSpecific as BlockChainSpecific.UTXO
         signingInput
             .setHashType(BitcoinScript.hashTypeForCoin(coinType))
@@ -235,7 +243,7 @@ class UtxoHelper(
 
         val plan = planTransaction(signingInput)
         signingInput.setPlan(plan)
-        return signingInput.build().toByteArray()
+        return signingInput.build()
     }
 
     @OptIn(ExperimentalStdlibApi::class)
@@ -497,6 +505,69 @@ class UtxoHelper(
         }
         val signingInput = getBitcoinSigningInput(keysignPayload)
         return planTransaction(signingInput)
+    }
+
+    /**
+     * What broadcasting [keysignPayload] as [txHash] does to the sending address's UTXO set, for
+     * the in-flight ledger [com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos] replays over
+     * the provider's next snapshot — or null for a payload whose inputs never went through the
+     * planner (a SwapKit or dApp PSBT), which the ledger then simply does not cover.
+     *
+     * Re-plans the payload the way signing did, along the same route signing took (a THORChain swap
+     * plans a different input than a send): the plan is a pure function of the payload, so the
+     * inputs it names are exactly the ones the signed transaction spends. Outputs follow
+     * WalletCore's fixed layout, the one [serializeUnsignedTransaction] mirrors — the destination
+     * at index 0, change at index 1 when there is any — so an output is ours when it is the change
+     * or when the destination is the sending address itself (a consolidation / self-send).
+     */
+    fun getSpendEffects(keysignPayload: KeysignPayload, txHash: String): UtxoInFlightTx? {
+        if (keysignPayload.signBitcoin != null) return null
+        val address = keysignPayload.coin.address
+
+        val plan: Bitcoin.TransactionPlan
+        val toAddress: String
+        when (val swapPayload = keysignPayload.swapPayload) {
+            is SwapPayload.ThorChain -> {
+                plan =
+                    buildSigningInput(
+                            keysignPayload,
+                            getSwapPreSigningInputData(keysignPayload).toBuilder(),
+                        )
+                        .plan
+                toAddress = swapPayload.data.vaultAddress
+            }
+            is SwapPayload.SwapKit -> return null
+            else -> {
+                plan = getBitcoinTransactionPlan(keysignPayload)
+                toAddress = keysignPayload.toAddress
+            }
+        }
+
+        val spent =
+            plan.utxosList.map {
+                UtxoInfo(
+                    // The planner carries the outpoint hash in wire (reversed) byte order; the
+                    // ledger and the provider both speak display order.
+                    hash =
+                        Numeric.toHexStringNoPrefix(it.outPoint.hash.toByteArray().reversedArray()),
+                    amount = it.amount,
+                    index = it.outPoint.index.toUInt(),
+                )
+            }
+        val created = buildList {
+            if (toAddress == address) {
+                add(UtxoInfo(hash = txHash, amount = plan.amount, index = 0u))
+            }
+            if (plan.change > 0) {
+                add(UtxoInfo(hash = txHash, amount = plan.change, index = 1u))
+            }
+        }
+        return UtxoInFlightTx(
+            txHash = txHash,
+            broadcastAt = System.currentTimeMillis(),
+            spent = spent,
+            created = created,
+        )
     }
 
     /**

--- a/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/chains/helpers/UtxoHelper.kt
@@ -416,6 +416,11 @@ class UtxoHelper(
         )
     }
 
+    private fun isSameLockScript(a: String, b: String): Boolean =
+        BitcoinScript.lockScriptForAddress(a, coinType)
+            .data()
+            .contentEquals(BitcoinScript.lockScriptForAddress(b, coinType).data())
+
     private fun requireLockScript(address: String): ByteArray =
         BitcoinScript.lockScriptForAddress(address, coinType).data().also {
             require(it.isNotEmpty()) {
@@ -518,7 +523,9 @@ class UtxoHelper(
      * inputs it names are exactly the ones the signed transaction spends. Outputs follow
      * WalletCore's fixed layout, the one [serializeUnsignedTransaction] mirrors — the destination
      * at index 0, change at index 1 when there is any — so an output is ours when it is the change
-     * or when the destination is the sending address itself (a consolidation / self-send).
+     * or when the destination is the sending address itself (a consolidation / self-send). "Itself"
+     * is decided on the locking script, not the string: a Bech32 address is valid in either case
+     * and WalletCore locks both spellings to the same script.
      */
     fun getSpendEffects(keysignPayload: KeysignPayload, txHash: String): UtxoInFlightTx? {
         if (keysignPayload.signBitcoin != null) return null
@@ -555,7 +562,7 @@ class UtxoHelper(
                 )
             }
         val created = buildList {
-            if (toAddress == address) {
+            if (isSameLockScript(toAddress, address)) {
                 add(UtxoInfo(hash = txHash, amount = plan.amount, index = 0u))
             }
             if (plan.change > 0) {

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/TransactionDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/TransactionDao.kt
@@ -84,6 +84,24 @@ abstract class TransactionHistoryDao {
     abstract suspend fun getAllPendingTransactions(): List<TransactionHistoryEntity>
 
     /**
+     * In-flight rows for one chain across every vault on this device; the caller narrows to the
+     * sending address (see
+     * [com.vultisig.wallet.data.repositories.TransactionHistoryRepository.getUnconfirmedTxHashes]).
+     * [chain] is the source chain in [com.vultisig.wallet.data.models.Chain.raw] form, as the
+     * keysign flow records it.
+     */
+    @Query(
+        """
+        SELECT * FROM transaction_history
+        WHERE chain = :chain
+        AND status IN ('BROADCASTED', 'PENDING', 'NotFound')
+    """
+    )
+    abstract suspend fun getPendingTransactionsByChain(
+        chain: String
+    ): List<TransactionHistoryEntity>
+
+    /**
      * CONFIRMED, FAILED, and REFUNDED are terminal — the WHERE guard prevents stale writers from
      * downgrading a finalised row. retryCount resets on every successful API response (including
      * NotFound) so backoff only accumulates on network errors. All mutating queries key on the

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/UtxoInFlightOutpointDao.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/dao/UtxoInFlightOutpointDao.kt
@@ -1,0 +1,31 @@
+package com.vultisig.wallet.data.db.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.vultisig.wallet.data.db.models.UtxoInFlightOutpointEntity
+
+@Dao
+interface UtxoInFlightOutpointDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(rows: List<UtxoInFlightOutpointEntity>)
+
+    /** Rows for one sending address broadcast at or after [since], oldest transaction first. */
+    @Query(
+        """
+        SELECT * FROM utxo_inflight_outpoint
+        WHERE chain = :chain AND address = :address AND broadcast_at >= :since
+        ORDER BY broadcast_at ASC
+        """
+    )
+    suspend fun getSince(
+        chain: String,
+        address: String,
+        since: Long,
+    ): List<UtxoInFlightOutpointEntity>
+
+    @Query("DELETE FROM utxo_inflight_outpoint WHERE broadcast_at < :before")
+    suspend fun deleteBroadcastBefore(before: Long)
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/db/models/UtxoInFlightOutpointEntity.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/db/models/UtxoInFlightOutpointEntity.kt
@@ -1,0 +1,38 @@
+package com.vultisig.wallet.data.db.models
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+
+/**
+ * One outpoint a transaction this wallet broadcast either consumed or paid back to the sending
+ * address — the per-row form of [com.vultisig.wallet.data.blockchain.utxo.UtxoInFlightTx].
+ *
+ * Kept as plain rows rather than a serialized list per transaction so the table needs no converter
+ * and can be queried by address directly. Rows are short-lived: the provider catches up with a
+ * broadcast within minutes, after which they change nothing, and the repository prunes them on a
+ * fixed age (see [com.vultisig.wallet.data.repositories.UtxoInFlightRepository]).
+ */
+@Entity(
+    tableName = "utxo_inflight_outpoint",
+    primaryKeys = ["chain", "tx_hash", "kind", "hash", "idx"],
+)
+data class UtxoInFlightOutpointEntity(
+    /**
+     * [com.vultisig.wallet.data.models.Chain.raw] of the chain the transaction was broadcast to.
+     */
+    @ColumnInfo(name = "chain") val chain: String,
+    /** The address the transaction was sent from — the address whose UTXO set this row amends. */
+    @ColumnInfo(name = "address") val address: String,
+    @ColumnInfo(name = "tx_hash") val txHash: String,
+    @ColumnInfo(name = "broadcast_at") val broadcastAt: Long,
+    /** [KIND_SPENT] for an input the transaction consumed, [KIND_CREATED] for an output it made. */
+    @ColumnInfo(name = "kind") val kind: String,
+    @ColumnInfo(name = "hash") val hash: String,
+    @ColumnInfo(name = "idx") val index: Long,
+    @ColumnInfo(name = "amount") val amount: Long,
+) {
+    companion object {
+        const val KIND_SPENT = "spent"
+        const val KIND_CREATED = "created"
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -179,6 +179,7 @@ constructor(
     private val cosmosStakingDeFiBalanceService: CosmosStakingDeFiBalanceService,
     private val solanaDeFiBalanceService: SolanaDeFiBalanceService,
     private val transactionHistoryRepository: TransactionHistoryRepository,
+    private val utxoInFlightRepository: UtxoInFlightRepository,
 ) : BalanceRepository {
 
     private val defiBalanceCache = SimpleCache<String, List<DeFiBalance>>(12 * 1000)
@@ -664,6 +665,7 @@ constructor(
             dustThreshold = chain.getDustThreshold.toLong(),
             ownUnconfirmedTxHashes =
                 transactionHistoryRepository.getUnconfirmedTxHashes(chain, address),
+            inFlight = utxoInFlightRepository.getInFlight(chain, address),
         )
     }
 

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BalanceRepository.kt
@@ -24,6 +24,7 @@ import com.vultisig.wallet.data.blockchain.solana.SolanaDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.thorchain.ThorchainDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.ton.TonDeFiBalanceService
 import com.vultisig.wallet.data.blockchain.tron.TronDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos
 import com.vultisig.wallet.data.db.dao.TokenValueDao
 import com.vultisig.wallet.data.db.models.TokenValueEntity
 import com.vultisig.wallet.data.models.Chain
@@ -68,6 +69,7 @@ import com.vultisig.wallet.data.models.TokenBalanceWrapped
 import com.vultisig.wallet.data.models.TokenId
 import com.vultisig.wallet.data.models.TokenStandard
 import com.vultisig.wallet.data.models.TokenValue
+import com.vultisig.wallet.data.models.getDustThreshold
 import com.vultisig.wallet.data.utils.SimpleCache
 import com.vultisig.wallet.data.utils.runCatchingCancellable
 import com.vultisig.wallet.data.utils.scaledFor
@@ -176,6 +178,7 @@ constructor(
     private val tonDeFiBalanceService: TonDeFiBalanceService,
     private val cosmosStakingDeFiBalanceService: CosmosStakingDeFiBalanceService,
     private val solanaDeFiBalanceService: SolanaDeFiBalanceService,
+    private val transactionHistoryRepository: TransactionHistoryRepository,
 ) : BalanceRepository {
 
     private val defiBalanceCache = SimpleCache<String, List<DeFiBalance>>(12 * 1000)
@@ -500,8 +503,16 @@ constructor(
                             BitcoinCash,
                             Litecoin,
                             Dogecoin,
-                            Dash,
-                            Zcash -> {
+                            Zcash -> spendableUtxoBalance(coin.chain, address)
+
+                            // Dash is the one UTXO chain whose spendable set does not come from
+                            // Blockchair: coin selection reads a node's address index
+                            // (`getaddressutxos`), which is built from connected blocks and
+                            // blind to the mempool in both directions, so summing it here would
+                            // keep showing an input a pending send had already consumed.
+                            // Blockchair's aggregate is mempool-aware and stays the better number
+                            // to display.
+                            Dash -> {
                                 val balance =
                                     blockchairApi
                                         .getAddressInfo(coin.chain, address)
@@ -629,6 +640,32 @@ constructor(
                     )
                 )
             }
+
+    /**
+     * The sum of exactly the outputs coin selection will fund a send from, so the number on the
+     * screen is one a send can actually spend (#5867). Reads the paginated UTXO set rather than
+     * `getAddressInfo`, which is capped near 100 entries and would understate a wallet holding
+     * more.
+     *
+     * An address the provider says holds a balance but returns no unspent outputs for is
+     * contradicting itself: throw, and the failed-read path keeps the cached value rather than
+     * persisting a zero (#5788 / #5831). An address whose outputs are all present and all filtered
+     * out is a different case entirely and legitimately reads zero.
+     */
+    private suspend fun spendableUtxoBalance(chain: Chain, address: String): BigInteger {
+        val info = blockchairApi.getAllUtxos(chain, address)
+        val reportedBalance = info.address.balance
+        check(info.utxos.isNotEmpty() || reportedBalance <= 0) {
+            "Blockchair reported a balance of $reportedBalance for $chain with no unspent " +
+                "outputs — refusing to zero the balance"
+        }
+        return SpendableUtxos.balance(
+            rows = info.utxos,
+            dustThreshold = chain.getDustThreshold.toLong(),
+            ownUnconfirmedTxHashes =
+                transactionHistoryRepository.getUnconfirmedTxHashes(chain, address),
+        )
+    }
 
     override suspend fun getBalanceOrNull(address: String, coin: Coin): BigInteger? =
         // Solana native is the only read that reports failure as a value rather than as a throw

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -16,7 +16,6 @@ import com.vultisig.wallet.data.api.ZcashApi
 import com.vultisig.wallet.data.api.chains.SuiApi
 import com.vultisig.wallet.data.api.chains.ton.TonApi
 import com.vultisig.wallet.data.api.chains.ton.tonUserFriendlyAddress
-import com.vultisig.wallet.data.api.models.BlockChairUtxoInfo
 import com.vultisig.wallet.data.blockchain.FeeService
 import com.vultisig.wallet.data.blockchain.FeeServiceComposite
 import com.vultisig.wallet.data.blockchain.TronFee
@@ -31,6 +30,7 @@ import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.TronFees
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
+import com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos
 import com.vultisig.wallet.data.chains.helpers.CardanoHelper
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
@@ -113,6 +113,7 @@ constructor(
     private val cardanoApi: CardanoApi,
     private val feeServiceComposite: FeeServiceComposite,
     @TronFee private val tronFeeService: FeeService,
+    private val transactionHistoryRepository: TransactionHistoryRepository,
 ) : BlockChainSpecificRepository {
 
     override suspend fun getSpecific(
@@ -331,19 +332,10 @@ constructor(
                                 byteFee = gasFee.value,
                                 sendMaxAmount = isMaxAmountEnabled,
                             ),
-                        utxos =
-                            dashUtxos?.excludingDust(chain)
-                                ?: blockChairApi
-                                    .getAllUtxos(chain = chain, address = address)
-                                    .utxos
-                                    .toSpendableUtxos(chain),
+                        utxos = dashUtxos?.excludingDust(chain) ?: spendableUtxos(chain, address),
                     )
                 } else {
-                    val utxos =
-                        blockChairApi
-                            .getAllUtxos(chain = chain, address = address)
-                            .utxos
-                            .toSpendableUtxos(chain)
+                    val utxos = spendableUtxos(chain, address)
 
                     BlockChainSpecificAndUtxo(
                         blockChainSpecific =
@@ -768,22 +760,27 @@ constructor(
             }
         }
 
-    /** Shared by every UTXO-chain data source, Blockchair or Dash's own RPC. */
+    /**
+     * Dash's own RPC index only. Blockchair-sourced sets go through [SpendableUtxos], whose dust
+     * boundary is inclusive; this one is left as it was so Dash UTXO sourcing stays untouched.
+     */
     private fun List<UtxoInfo>.excludingDust(chain: Chain): List<UtxoInfo> {
         val dustThreshold = chain.getDustThreshold.toLong()
         return filter { it.amount > dustThreshold }.sortedBy(UtxoInfo::amount)
     }
 
     /**
-     * Matches the SDK's spendable-UTXO filter (parity with iOS/Windows) so coin selection can't
-     * pick an input that looks present in Blockchair's list but isn't actually usable yet.
+     * The same predicate [BalanceRepository] sums for the displayed balance, so coin selection
+     * can't pick an input that looks present in Blockchair's list but isn't usable yet — and,
+     * conversely, can fund every amount the screen said was there (#5867).
      */
-    private fun List<BlockChairUtxoInfo>.toSpendableUtxos(chain: Chain): List<UtxoInfo> =
-        filter { it.isSpendable != false && it.blockId > 0 && it.index >= 0 }
-            .map {
-                UtxoInfo(hash = it.transactionHash, amount = it.value, index = it.index.toUInt())
-            }
-            .excludingDust(chain)
+    private suspend fun spendableUtxos(chain: Chain, address: String): List<UtxoInfo> =
+        SpendableUtxos.select(
+            rows = blockChairApi.getAllUtxos(chain = chain, address = address).utxos,
+            dustThreshold = chain.getDustThreshold.toLong(),
+            ownUnconfirmedTxHashes =
+                transactionHistoryRepository.getUnconfirmedTxHashes(chain, address),
+        )
 
     private fun isThorchainRouterChain(chain: Chain): Boolean =
         chain == Chain.Ethereum ||

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepository.kt
@@ -114,6 +114,7 @@ constructor(
     private val feeServiceComposite: FeeServiceComposite,
     @TronFee private val tronFeeService: FeeService,
     private val transactionHistoryRepository: TransactionHistoryRepository,
+    private val utxoInFlightRepository: UtxoInFlightRepository,
 ) : BlockChainSpecificRepository {
 
     override suspend fun getSpecific(
@@ -332,7 +333,14 @@ constructor(
                                 byteFee = gasFee.value,
                                 sendMaxAmount = isMaxAmountEnabled,
                             ),
-                        utxos = dashUtxos?.excludingDust(chain) ?: spendableUtxos(chain, address),
+                        utxos =
+                            dashUtxos?.excludingDust(chain)?.let {
+                                SpendableUtxos.reconcile(
+                                    candidates = it,
+                                    dustThreshold = chain.getDustThreshold.toLong(),
+                                    inFlight = utxoInFlightRepository.getInFlight(chain, address),
+                                )
+                            } ?: spendableUtxos(chain, address),
                     )
                 } else {
                     val utxos = spendableUtxos(chain, address)
@@ -762,7 +770,10 @@ constructor(
 
     /**
      * Dash's own RPC index only. Blockchair-sourced sets go through [SpendableUtxos], whose dust
-     * boundary is inclusive; this one is left as it was so Dash UTXO sourcing stays untouched.
+     * boundary is inclusive; this one is left as it was so Dash UTXO sourcing stays untouched. The
+     * in-flight ledger is still replayed over it at the call site: that index is built from
+     * connected blocks, so it keeps offering an input a pending send consumed until that send
+     * confirms.
      */
     private fun List<UtxoInfo>.excludingDust(chain: Chain): List<UtxoInfo> {
         val dustThreshold = chain.getDustThreshold.toLong()
@@ -780,6 +791,7 @@ constructor(
             dustThreshold = chain.getDustThreshold.toLong(),
             ownUnconfirmedTxHashes =
                 transactionHistoryRepository.getUnconfirmedTxHashes(chain, address),
+            inFlight = utxoInFlightRepository.getInFlight(chain, address),
         )
 
     private fun isThorchainRouterChain(chain: Chain): Boolean =

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/RepositoriesModule.kt
@@ -368,6 +368,10 @@ internal interface RepositoriesModule {
 
     @Binds
     @Singleton
+    fun bindUtxoInFlightRepository(impl: UtxoInFlightRepositoryImpl): UtxoInFlightRepository
+
+    @Binds
+    @Singleton
     fun bindPreventScreenshotsRepository(
         impl: PreventScreenshotsRepositoryImpl
     ): PreventScreenshotsRepository

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionHistoryRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/TransactionHistoryRepository.kt
@@ -3,8 +3,12 @@ package com.vultisig.wallet.data.repositories
 import com.vultisig.wallet.data.db.dao.TransactionHistoryDao
 import com.vultisig.wallet.data.db.models.TransactionHistoryEntity
 import com.vultisig.wallet.data.db.models.TransactionStatus
+import com.vultisig.wallet.data.models.Chain
 import com.vultisig.wallet.data.models.CommonTransactionHistoryData
+import com.vultisig.wallet.data.models.SendTransactionHistoryData
+import com.vultisig.wallet.data.models.SwapTransactionHistoryData
 import com.vultisig.wallet.data.models.TransactionHistoryData
+import com.vultisig.wallet.data.models.UnknownTransactionHistoryData
 import com.vultisig.wallet.data.models.buildTransactionHistoryId
 import com.vultisig.wallet.data.models.toEntity
 import com.vultisig.wallet.data.usecases.txstatus.TransactionResult
@@ -33,6 +37,20 @@ interface TransactionHistoryRepository {
     suspend fun getPendingTransactions(vaultId: String): List<TransactionHistoryEntity>
 
     suspend fun getAllPendingTransactions(): List<TransactionHistoryEntity>
+
+    /**
+     * Hashes of the transactions this wallet broadcast from [address] on [chain] that have not
+     * reached a terminal state — the parents whose unconfirmed change
+     * [com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos] may admit.
+     *
+     * Scoped by sending address rather than vault id because on a UTXO chain the two name the same
+     * wallet — the address is derived from the vault's key — and the balance and coin-selection
+     * readers only hold the address. A pending transaction only vouches for the outputs of the
+     * wallet that signed it: another vault's zero-conf payment into this one is still someone
+     * else's, even when both vaults live on this device, and a row recorded without a sending
+     * address (legacy swaps) vouches for nothing.
+     */
+    suspend fun getUnconfirmedTxHashes(chain: Chain, address: String): Set<String>
 
     /** Merge backfill data with existing rows without wiping local metadata. */
     suspend fun upsertFromBackfill(entity: TransactionHistoryEntity)
@@ -106,6 +124,19 @@ class TransactionHistoryRepositoryImpl @Inject constructor(private val dao: Tran
 
     override suspend fun getAllPendingTransactions(): List<TransactionHistoryEntity> =
         dao.getAllPendingTransactions()
+
+    override suspend fun getUnconfirmedTxHashes(chain: Chain, address: String): Set<String> =
+        dao.getPendingTransactionsByChain(chain.raw)
+            .filter { it.payload.fromAddressOrNull == address }
+            .mapTo(HashSet()) { it.txHash }
+
+    private val TransactionHistoryData.fromAddressOrNull: String?
+        get() =
+            when (this) {
+                is SendTransactionHistoryData -> fromAddress
+                is SwapTransactionHistoryData -> fromAddress.takeIf { it.isNotEmpty() }
+                is UnknownTransactionHistoryData -> null
+            }
 
     override suspend fun upsertFromBackfill(entity: TransactionHistoryEntity) =
         dao.upsertFromBackfill(entity)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/UtxoInFlightRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/UtxoInFlightRepository.kt
@@ -1,0 +1,93 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.blockchain.utxo.UtxoInFlightTx
+import com.vultisig.wallet.data.db.dao.UtxoInFlightOutpointDao
+import com.vultisig.wallet.data.db.models.UtxoInFlightOutpointEntity
+import com.vultisig.wallet.data.db.models.UtxoInFlightOutpointEntity.Companion.KIND_CREATED
+import com.vultisig.wallet.data.db.models.UtxoInFlightOutpointEntity.Companion.KIND_SPENT
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.payload.UtxoInfo
+import javax.inject.Inject
+
+/**
+ * The wallet's own record of what its recent UTXO-chain broadcasts did to the sending address — the
+ * [UtxoInFlightTx] ledger that [com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos] replays
+ * over the provider's snapshot.
+ *
+ * Entries expire on age alone, [TTL_MS] after broadcast. The ledger only ever matters while the
+ * provider's snapshot predates the broadcast (see `SpendableUtxos.reconcile`), and Blockchair's
+ * cache plus mempool ingest lag is measured in minutes, so an hour is generous cover. It is also
+ * the bound on the one way the ledger can be wrong: a transaction evicted from the mempool frees
+ * its inputs, and until its entry expires a snapshot listing those inputs again would be
+ * "corrected" by re-spending outputs that no longer exist. That costs one rejected broadcast and no
+ * money — the same outcome iOS accepts for a child built on an evicted parent — and is far rarer
+ * than the provider lag the ledger exists for.
+ */
+interface UtxoInFlightRepository {
+
+    /**
+     * Records that [txHash], broadcast from [address] on [chain], consumed [spent] and paid
+     * [created] back to [address]. Persistence failures propagate; the caller records best-effort.
+     */
+    suspend fun record(
+        chain: Chain,
+        address: String,
+        txHash: String,
+        spent: List<UtxoInfo>,
+        created: List<UtxoInfo>,
+    )
+
+    /** Unexpired entries for [address] on [chain], oldest broadcast first. */
+    suspend fun getInFlight(chain: Chain, address: String): List<UtxoInFlightTx>
+}
+
+internal class UtxoInFlightRepositoryImpl
+@Inject
+constructor(private val dao: UtxoInFlightOutpointDao) : UtxoInFlightRepository {
+
+    override suspend fun record(
+        chain: Chain,
+        address: String,
+        txHash: String,
+        spent: List<UtxoInfo>,
+        created: List<UtxoInfo>,
+    ) {
+        val now = System.currentTimeMillis()
+        dao.deleteBroadcastBefore(now - TTL_MS)
+
+        fun rows(kind: String, utxos: List<UtxoInfo>) =
+            utxos.map {
+                UtxoInFlightOutpointEntity(
+                    chain = chain.raw,
+                    address = address,
+                    txHash = txHash,
+                    broadcastAt = now,
+                    kind = kind,
+                    hash = it.hash,
+                    index = it.index.toLong(),
+                    amount = it.amount,
+                )
+            }
+        dao.insertAll(rows(KIND_SPENT, spent) + rows(KIND_CREATED, created))
+    }
+
+    override suspend fun getInFlight(chain: Chain, address: String): List<UtxoInFlightTx> =
+        dao.getSince(chain.raw, address, since = System.currentTimeMillis() - TTL_MS)
+            .groupBy { it.txHash }
+            .map { (txHash, rows) ->
+                UtxoInFlightTx(
+                    txHash = txHash,
+                    broadcastAt = rows.first().broadcastAt,
+                    spent = rows.filter { it.kind == KIND_SPENT }.map { it.toUtxoInfo() },
+                    created = rows.filter { it.kind == KIND_CREATED }.map { it.toUtxoInfo() },
+                )
+            }
+            .sortedBy(UtxoInFlightTx::broadcastAt)
+
+    private fun UtxoInFlightOutpointEntity.toUtxoInfo() =
+        UtxoInfo(hash = hash, amount = amount, index = index.toUInt())
+
+    private companion object {
+        const val TTL_MS = 60L * 60 * 1000
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/repositories/UtxoInFlightRepository.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/repositories/UtxoInFlightRepository.kt
@@ -14,14 +14,16 @@ import javax.inject.Inject
  * [UtxoInFlightTx] ledger that [com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos] replays
  * over the provider's snapshot.
  *
- * Entries expire on age alone, [TTL_MS] after broadcast. The ledger only ever matters while the
- * provider's snapshot predates the broadcast (see `SpendableUtxos.reconcile`), and Blockchair's
- * cache plus mempool ingest lag is measured in minutes, so an hour is generous cover. It is also
- * the bound on the one way the ledger can be wrong: a transaction evicted from the mempool frees
- * its inputs, and until its entry expires a snapshot listing those inputs again would be
- * "corrected" by re-spending outputs that no longer exist. That costs one rejected broadcast and no
- * money — the same outcome iOS accepts for a child built on an evicted parent — and is far rarer
- * than the provider lag the ledger exists for.
+ * Entries are replayed for [UtxoInFlightRepositoryImpl.REPLAY_WINDOW_MS] after broadcast and then
+ * dropped. The ledger only matters while the provider's snapshot predates the broadcast (see
+ * [com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos]), and Blockchair's cache plus mempool
+ * ingest lag is measured in minutes, so ten of them is generous cover. The window is also the bound
+ * on the one way the ledger can be wrong — a transaction the mempool evicted frees its inputs, and
+ * until its entry expires a snapshot listing them again would be "corrected" by re-spending outputs
+ * that no longer exist. Nothing local can distinguish that from a stale snapshot (a UTXO history
+ * row never becomes `FAILED` on eviction), so the window is kept as short as the lag it exists to
+ * cover: an eviction inside it costs one rejected broadcast and no money, the outcome iOS accepts
+ * for a child built on an evicted parent.
  */
 interface UtxoInFlightRepository {
 
@@ -37,7 +39,7 @@ interface UtxoInFlightRepository {
         created: List<UtxoInfo>,
     )
 
-    /** Unexpired entries for [address] on [chain], oldest broadcast first. */
+    /** Entries for [address] on [chain] still inside the replay window, oldest broadcast first. */
     suspend fun getInFlight(chain: Chain, address: String): List<UtxoInFlightTx>
 }
 
@@ -53,7 +55,7 @@ constructor(private val dao: UtxoInFlightOutpointDao) : UtxoInFlightRepository {
         created: List<UtxoInfo>,
     ) {
         val now = System.currentTimeMillis()
-        dao.deleteBroadcastBefore(now - TTL_MS)
+        dao.deleteBroadcastBefore(now - REPLAY_WINDOW_MS)
 
         fun rows(kind: String, utxos: List<UtxoInfo>) =
             utxos.map {
@@ -72,7 +74,7 @@ constructor(private val dao: UtxoInFlightOutpointDao) : UtxoInFlightRepository {
     }
 
     override suspend fun getInFlight(chain: Chain, address: String): List<UtxoInFlightTx> =
-        dao.getSince(chain.raw, address, since = System.currentTimeMillis() - TTL_MS)
+        dao.getSince(chain.raw, address, since = System.currentTimeMillis() - REPLAY_WINDOW_MS)
             .groupBy { it.txHash }
             .map { (txHash, rows) ->
                 UtxoInFlightTx(
@@ -87,7 +89,7 @@ constructor(private val dao: UtxoInFlightOutpointDao) : UtxoInFlightRepository {
     private fun UtxoInFlightOutpointEntity.toUtxoInfo() =
         UtxoInfo(hash = hash, amount = amount, index = index.toUInt())
 
-    private companion object {
-        const val TTL_MS = 60L * 60 * 1000
+    companion object {
+        const val REPLAY_WINDOW_MS = 10L * 60 * 1000
     }
 }

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
@@ -32,6 +32,7 @@ import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepositoryImpl
 import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
+import com.vultisig.wallet.data.repositories.UtxoInFlightRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -276,6 +277,7 @@ internal class TronFeeReconciliationTest {
             feeServiceComposite = mockk<FeeServiceComposite>(relaxed = true),
             tronFeeService = feeService,
             transactionHistoryRepository = mockk<TransactionHistoryRepository>(relaxed = true),
+            utxoInFlightRepository = mockk<UtxoInFlightRepository>(relaxed = true),
         )
 
     private fun trc20Transfer(to: String = RECIPIENT) =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/blockchain/tron/TronFeeReconciliationTest.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.data.models.Coin
 import com.vultisig.wallet.data.models.TokenValue
 import com.vultisig.wallet.data.models.payload.BlockChainSpecific
 import com.vultisig.wallet.data.repositories.BlockChainSpecificRepositoryImpl
+import com.vultisig.wallet.data.repositories.TransactionHistoryRepository
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -274,6 +275,7 @@ internal class TronFeeReconciliationTest {
             cardanoApi = mockk<CardanoApi>(relaxed = true),
             feeServiceComposite = mockk<FeeServiceComposite>(relaxed = true),
             tronFeeService = feeService,
+            transactionHistoryRepository = mockk<TransactionHistoryRepository>(relaxed = true),
         )
 
     private fun trc20Transfer(to: String = RECIPIENT) =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryBalanceOrNullTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryBalanceOrNullTest.kt
@@ -81,6 +81,7 @@ class BalanceRepositoryBalanceOrNullTest {
                 mockk<CosmosStakingDeFiBalanceService>(relaxed = true),
             solanaDeFiBalanceService = mockk<SolanaDeFiBalanceService>(relaxed = true),
             transactionHistoryRepository = mockk<TransactionHistoryRepository>(relaxed = true),
+            utxoInFlightRepository = mockk<UtxoInFlightRepository>(relaxed = true),
         )
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryBalanceOrNullTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryBalanceOrNullTest.kt
@@ -80,6 +80,7 @@ class BalanceRepositoryBalanceOrNullTest {
             cosmosStakingDeFiBalanceService =
                 mockk<CosmosStakingDeFiBalanceService>(relaxed = true),
             solanaDeFiBalanceService = mockk<SolanaDeFiBalanceService>(relaxed = true),
+            transactionHistoryRepository = mockk<TransactionHistoryRepository>(relaxed = true),
         )
 
     @Test
@@ -119,7 +120,7 @@ class BalanceRepositoryBalanceOrNullTest {
 
     @Test
     fun `a Blockchair balance failure propagates and is not persisted as zero`() = runTest {
-        coEvery { blockchairApi.getAddressInfo(Coins.Bitcoin.BTC.chain, ADDRESS) } throws
+        coEvery { blockchairApi.getAllUtxos(Coins.Bitcoin.BTC.chain, ADDRESS) } throws
             IllegalStateException("blockchair down")
 
         assertThrows<IllegalStateException> {
@@ -129,11 +130,12 @@ class BalanceRepositoryBalanceOrNullTest {
         coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
     }
 
+    /** Dash still reads the unpaged aggregate, where an absent address decodes to null. */
     @Test
     fun `a Blockchair absent address response persists a genuine zero`() = runTest {
-        coEvery { blockchairApi.getAddressInfo(Coins.Bitcoin.BTC.chain, ADDRESS) } returns null
+        coEvery { blockchairApi.getAddressInfo(Coins.Dash.DASH.chain, ADDRESS) } returns null
 
-        repository.getTokenValue(ADDRESS, Coins.Bitcoin.BTC).first().value shouldBe BigInteger.ZERO
+        repository.getTokenValue(ADDRESS, Coins.Dash.DASH).first().value shouldBe BigInteger.ZERO
 
         coVerify(exactly = 1) {
             tokenValueDao.insertTokenValue(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryUtxoSpendableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryUtxoSpendableTest.kt
@@ -173,6 +173,26 @@ class BalanceRepositoryUtxoSpendableTest {
         coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
     }
 
+    /**
+     * A row with no usable outpoint is a decode defect, not a policy exclusion; summing around it
+     * would persist an understated balance over the cached one.
+     */
+    @Test
+    fun `a row that cannot name an outpoint is a failed read, not a partial sum`() = runTest {
+        givenUtxos(
+            Chain.Bitcoin,
+            reportedBalance = 90_000,
+            confirmed("a", 50_000),
+            confirmed("malformed", 40_000).copy(index = -1),
+        )
+
+        assertThrows<IllegalStateException> {
+            repository.getTokenValue(ADDRESS, Coins.Bitcoin.BTC).first()
+        }
+
+        coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
+    }
+
     @Test
     fun `outputs that are all present and all filtered out are a genuine zero`() = runTest {
         givenUtxos(

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryUtxoSpendableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryUtxoSpendableTest.kt
@@ -52,6 +52,8 @@ class BalanceRepositoryUtxoSpendableTest {
         mockk<TransactionHistoryRepository> {
             coEvery { getUnconfirmedTxHashes(any(), any()) } returns emptySet()
         }
+    private val utxoInFlightRepository =
+        mockk<UtxoInFlightRepository> { coEvery { getInFlight(any(), any()) } returns emptyList() }
 
     private val repository =
         BalanceRepositoryImpl(
@@ -82,6 +84,7 @@ class BalanceRepositoryUtxoSpendableTest {
                 mockk<CosmosStakingDeFiBalanceService>(relaxed = true),
             solanaDeFiBalanceService = mockk<SolanaDeFiBalanceService>(relaxed = true),
             transactionHistoryRepository = transactionHistoryRepository,
+            utxoInFlightRepository = utxoInFlightRepository,
         )
 
     @Test

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryUtxoSpendableTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BalanceRepositoryUtxoSpendableTest.kt
@@ -1,0 +1,225 @@
+package com.vultisig.wallet.data.repositories
+
+import com.vultisig.wallet.data.api.BittensorApi
+import com.vultisig.wallet.data.api.BlockChairApi
+import com.vultisig.wallet.data.api.CardanoApi
+import com.vultisig.wallet.data.api.CosmosApiFactory
+import com.vultisig.wallet.data.api.EvmApiFactory
+import com.vultisig.wallet.data.api.MayaChainApi
+import com.vultisig.wallet.data.api.PolkadotApi
+import com.vultisig.wallet.data.api.RippleApi
+import com.vultisig.wallet.data.api.SolanaApi
+import com.vultisig.wallet.data.api.ThorChainApi
+import com.vultisig.wallet.data.api.TronApi
+import com.vultisig.wallet.data.api.chains.SuiApi
+import com.vultisig.wallet.data.api.chains.ton.TonApi
+import com.vultisig.wallet.data.api.models.BlockChairAddress
+import com.vultisig.wallet.data.api.models.BlockChairInfo
+import com.vultisig.wallet.data.api.models.BlockChairUtxoInfo
+import com.vultisig.wallet.data.blockchain.cosmos.staking.CosmosStakingDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.ethereum.CircleDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.maya.MayaDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.solana.SolanaDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.thorchain.ThorchainDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.ton.TonDeFiBalanceService
+import com.vultisig.wallet.data.blockchain.tron.TronDeFiBalanceService
+import com.vultisig.wallet.data.db.dao.TokenValueDao
+import com.vultisig.wallet.data.db.models.TokenValueEntity
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.Coin
+import com.vultisig.wallet.data.models.Coins
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import java.math.BigInteger
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Pins the displayed native balance of the Blockchair-backed UTXO chains to the sum of the outputs
+ * coin selection will actually spend (#5867), rather than Blockchair's `address.balance`, which
+ * also counts a stranger's zero-conf, explicitly unspendable outputs and dust — money the wallet
+ * showed and then refused to send.
+ */
+class BalanceRepositoryUtxoSpendableTest {
+
+    private val blockchairApi = mockk<BlockChairApi>()
+    private val tokenValueDao = mockk<TokenValueDao>(relaxed = true)
+    private val transactionHistoryRepository =
+        mockk<TransactionHistoryRepository> {
+            coEvery { getUnconfirmedTxHashes(any(), any()) } returns emptySet()
+        }
+
+    private val repository =
+        BalanceRepositoryImpl(
+            thorChainApi = mockk<ThorChainApi>(relaxed = true),
+            blockchairApi = blockchairApi,
+            evmApiFactory = mockk<EvmApiFactory>(relaxed = true),
+            mayaChainApi = mockk<MayaChainApi>(relaxed = true),
+            cosmosApiFactory = mockk<CosmosApiFactory>(relaxed = true),
+            solanaApi = mockk<SolanaApi>(relaxed = true),
+            splTokenRepository = mockk<SplTokenRepository>(relaxed = true),
+            tokenPriceRepository = mockk<TokenPriceRepository>(relaxed = true),
+            appCurrencyRepository = mockk<AppCurrencyRepository>(relaxed = true),
+            tronResourceDataSource = mockk<TronResourceDataSource>(relaxed = true),
+            polkadotApi = mockk<PolkadotApi>(relaxed = true),
+            bittensorApi = mockk<BittensorApi>(relaxed = true),
+            suiApi = mockk<SuiApi>(relaxed = true),
+            tonApi = mockk<TonApi>(relaxed = true),
+            rippleApi = mockk<RippleApi>(relaxed = true),
+            tronApi = mockk<TronApi>(relaxed = true),
+            cardanoApi = mockk<CardanoApi>(relaxed = true),
+            tokenValueDao = tokenValueDao,
+            thorchainDeFiBalanceService = mockk<ThorchainDeFiBalanceService>(relaxed = true),
+            circleDeFiBalanceService = mockk<CircleDeFiBalanceService>(relaxed = true),
+            mayaDeFiBalanceService = mockk<MayaDeFiBalanceService>(relaxed = true),
+            tronDeFiBalanceService = mockk<TronDeFiBalanceService>(relaxed = true),
+            tonDeFiBalanceService = mockk<TonDeFiBalanceService>(relaxed = true),
+            cosmosStakingDeFiBalanceService =
+                mockk<CosmosStakingDeFiBalanceService>(relaxed = true),
+            solanaDeFiBalanceService = mockk<SolanaDeFiBalanceService>(relaxed = true),
+            transactionHistoryRepository = transactionHistoryRepository,
+        )
+
+    @Test
+    fun `balance is the sum of confirmed spendable outputs, not the Blockchair aggregate`() =
+        runTest {
+            givenUtxos(
+                Chain.Bitcoin,
+                reportedBalance = 120_000,
+                confirmed("a", 50_000),
+                confirmed("b", 70_000),
+            )
+
+            balanceOf(Coins.Bitcoin.BTC) shouldBe BigInteger.valueOf(120_000)
+        }
+
+    @Test
+    fun `a stranger's unconfirmed inbound output is not counted`() = runTest {
+        givenUtxos(
+            Chain.Bitcoin,
+            reportedBalance = 90_000,
+            confirmed("a", 50_000),
+            unconfirmed("inbound-from-stranger", 40_000),
+        )
+
+        balanceOf(Coins.Bitcoin.BTC) shouldBe BigInteger.valueOf(50_000)
+    }
+
+    @Test
+    fun `own unconfirmed change is counted`() = runTest {
+        coEvery {
+            transactionHistoryRepository.getUnconfirmedTxHashes(Chain.Bitcoin, ADDRESS)
+        } returns setOf("OWN-SEND")
+        givenUtxos(
+            Chain.Bitcoin,
+            reportedBalance = 90_000,
+            confirmed("a", 50_000),
+            unconfirmed("own-send", 40_000),
+        )
+
+        balanceOf(Coins.Bitcoin.BTC) shouldBe BigInteger.valueOf(90_000)
+    }
+
+    @Test
+    fun `an explicitly unspendable output is not counted`() = runTest {
+        givenUtxos(
+            Chain.Bitcoin,
+            reportedBalance = 70_000,
+            confirmed("a", 50_000),
+            confirmed("frozen", 20_000).copy(isSpendable = false),
+        )
+
+        balanceOf(Coins.Bitcoin.BTC) shouldBe BigInteger.valueOf(50_000)
+    }
+
+    /** Bitcoin's dust threshold is 546 sats; the boundary is inclusive, as on iOS. */
+    @Test
+    fun `dust is not counted but an output exactly at the threshold is`() = runTest {
+        givenUtxos(
+            Chain.Bitcoin,
+            reportedBalance = 51_091,
+            confirmed("a", 50_000),
+            confirmed("dust", 545),
+            confirmed("at-threshold", 546),
+        )
+
+        balanceOf(Coins.Bitcoin.BTC) shouldBe BigInteger.valueOf(50_546)
+    }
+
+    @Test
+    fun `Zcash is read from the same spendable set`() = runTest {
+        givenUtxos(
+            Chain.Zcash,
+            reportedBalance = 90_000,
+            confirmed("a", 50_000),
+            unconfirmed("inbound-from-stranger", 40_000),
+        )
+
+        balanceOf(Coins.Zcash.ZEC) shouldBe BigInteger.valueOf(50_000)
+    }
+
+    @Test
+    fun `a reported balance with no unspent outputs is a failed read, not a zero`() = runTest {
+        givenUtxos(Chain.Bitcoin, reportedBalance = 50_000)
+
+        assertThrows<IllegalStateException> {
+            repository.getTokenValue(ADDRESS, Coins.Bitcoin.BTC).first()
+        }
+
+        coVerify(exactly = 0) { tokenValueDao.insertTokenValue(any<TokenValueEntity>()) }
+    }
+
+    @Test
+    fun `outputs that are all present and all filtered out are a genuine zero`() = runTest {
+        givenUtxos(
+            Chain.Bitcoin,
+            reportedBalance = 40_000,
+            unconfirmed("inbound-from-stranger", 40_000),
+        )
+
+        balanceOf(Coins.Bitcoin.BTC) shouldBe BigInteger.ZERO
+        coVerify(exactly = 1) {
+            tokenValueDao.insertTokenValue(
+                match<TokenValueEntity> { it.tokenValue == BigInteger.ZERO.toString() }
+            )
+        }
+    }
+
+    @Test
+    fun `Dash still reads the Blockchair aggregate`() = runTest {
+        coEvery { blockchairApi.getAddressInfo(Chain.Dash, ADDRESS) } returns
+            BlockChairInfo(
+                address = BlockChairAddress(balance = 90_000, unspentOutputCount = 2),
+                utxos = listOf(confirmed("a", 50_000), unconfirmed("inbound-from-stranger", 40_000)),
+            )
+
+        balanceOf(Coins.Dash.DASH) shouldBe BigInteger.valueOf(90_000)
+        coVerify(exactly = 0) { blockchairApi.getAllUtxos(any(), any()) }
+    }
+
+    private suspend fun balanceOf(coin: Coin): BigInteger =
+        repository.getTokenValue(ADDRESS, coin).first().value
+
+    private fun givenUtxos(chain: Chain, reportedBalance: Long, vararg utxos: BlockChairUtxoInfo) {
+        coEvery { blockchairApi.getAllUtxos(chain, ADDRESS) } returns
+            BlockChairInfo(
+                address =
+                    BlockChairAddress(balance = reportedBalance, unspentOutputCount = utxos.size),
+                utxos = utxos.toList(),
+            )
+    }
+
+    private fun confirmed(hash: String, value: Long) =
+        BlockChairUtxoInfo(transactionHash = hash, index = 0, value = value, blockId = 800_000)
+
+    private fun unconfirmed(hash: String, value: Long) =
+        BlockChairUtxoInfo(transactionHash = hash, index = 1, value = value, blockId = -1)
+
+    private companion object {
+        const val ADDRESS = "bc1qexampleaddress"
+    }
+}

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -297,6 +297,10 @@ internal class BlockChainSpecificRepositoryImplTest {
      * list its change, and the third was rejected with `bad-txns-inputs-missingorspent`. The ledger
      * of this wallet's own broadcasts is replayed over the snapshot: the consumed input is gone,
      * the change is there to spend, and a chained second send builds on that change.
+     *
+     * The child is recorded with an *earlier* timestamp than its parent — a clock adjustment
+     * between the two sends — so this also pins that replay order comes from the dependency, not
+     * the timestamp: skipped while its input is absent, applied once the parent injects it.
      */
     @Test
     fun `Bitcoin UTXO selection replays own in-flight sends over a stale provider snapshot`() =
@@ -326,10 +330,9 @@ internal class BlockChainSpecificRepositoryImplTest {
                 mockk<UtxoInFlightRepository> {
                     coEvery { getInFlight(Chain.Bitcoin, SOURCE_ADDRESS) } returns
                         listOf(
-                            // Second send, listed first: replay order comes from broadcastAt.
                             UtxoInFlightTx(
                                 txHash = "send-c",
-                                broadcastAt = 2_000,
+                                broadcastAt = 500,
                                 spent =
                                     listOf(UtxoInfo(hash = "send-b", amount = 60_000, index = 1u)),
                                 created =

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -31,6 +31,7 @@ import com.vultisig.wallet.data.blockchain.model.GasFees
 import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
+import com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.crypto.SuiHelper
@@ -217,6 +218,72 @@ internal class BlockChainSpecificRepositoryImplTest {
             assertEquals(
                 listOf(
                     UtxoInfo(hash = "tx-confirmed-small", amount = 10_000, index = 0u),
+                    UtxoInfo(hash = "tx-confirmed-large", amount = 50_000, index = 0u),
+                ),
+                result.utxos,
+            )
+        }
+
+    /**
+     * The change of a send this wallet broadcast leaves the parent's inputs the moment it reaches
+     * the mempool; withholding it until it confirms would blank the wallet for a block after every
+     * send. A stranger's zero-conf stays out — only the hash the pending history vouches for is
+     * rescued.
+     */
+    @Test
+    fun `Bitcoin UTXO selection admits own unconfirmed change but not a stranger's zero-conf`() =
+        runTest {
+            val coin = bitcoinCoin()
+            val blockChairApi =
+                mockk<BlockChairApi> {
+                    coEvery { getAllUtxos(Chain.Bitcoin, SOURCE_ADDRESS) } returns
+                        blockChairInfo(
+                            listOf(
+                                BlockChairUtxoInfo(
+                                    transactionHash = "own-send",
+                                    index = 1,
+                                    value = 40_000,
+                                    blockId = -1,
+                                ),
+                                BlockChairUtxoInfo(
+                                    transactionHash = "inbound-from-stranger",
+                                    index = 0,
+                                    value = 30_000,
+                                    blockId = -1,
+                                ),
+                                BlockChairUtxoInfo(
+                                    transactionHash = "tx-confirmed-large",
+                                    index = 0,
+                                    value = 50_000,
+                                    blockId = 800_000,
+                                ),
+                            )
+                        )
+                }
+            val transactionHistoryRepository =
+                mockk<TransactionHistoryRepository> {
+                    coEvery { getUnconfirmedTxHashes(Chain.Bitcoin, SOURCE_ADDRESS) } returns
+                        setOf("OWN-SEND")
+                }
+
+            val result =
+                repository(
+                        blockChairApi = blockChairApi,
+                        transactionHistoryRepository = transactionHistoryRepository,
+                    )
+                    .getSpecific(
+                        chain = Chain.Bitcoin,
+                        address = SOURCE_ADDRESS,
+                        token = coin,
+                        gasFee = TokenValue(BigInteger.ONE, coin),
+                        isSwap = false,
+                        isMaxAmountEnabled = false,
+                        isDeposit = false,
+                    )
+
+            assertEquals(
+                listOf(
+                    UtxoInfo(hash = "own-send", amount = 40_000, index = 1u),
                     UtxoInfo(hash = "tx-confirmed-large", amount = 50_000, index = 0u),
                 ),
                 result.utxos,
@@ -941,8 +1008,8 @@ internal class BlockChainSpecificRepositoryImplTest {
 
     /**
      * A dust entry, an unconfirmed entry, and an explicitly non-spendable entry — all excluded by
-     * [toSpendableUtxos] — alongside two valid entries whose values (10_000 / 50_000 sats) clear
-     * every UTXO chain's dust threshold, so the fixture is safe to reuse across chains.
+     * [SpendableUtxos.select] — alongside two valid entries whose values (10_000 / 50_000 sats)
+     * clear every UTXO chain's dust threshold, so the fixture is safe to reuse across chains.
      */
     private fun rawUtxoFixture(): List<BlockChairUtxoInfo> =
         listOf(
@@ -1081,6 +1148,10 @@ internal class BlockChainSpecificRepositoryImplTest {
         zcashApi: ZcashApi = mockk<ZcashApi>(relaxed = true),
         solanaApi: SolanaApi = mockk<SolanaApi>(relaxed = true),
         tonApi: TonApi = mockk<TonApi>(relaxed = true),
+        transactionHistoryRepository: TransactionHistoryRepository =
+            mockk<TransactionHistoryRepository> {
+                coEvery { getUnconfirmedTxHashes(any(), any()) } returns emptySet()
+            },
     ): BlockChainSpecificRepositoryImpl {
         val evmApiFactory =
             object : EvmApiFactory {
@@ -1119,6 +1190,7 @@ internal class BlockChainSpecificRepositoryImplTest {
                     cosmosFeeService = NoOpFeeService,
                     utxoFeeService = NoOpFeeService,
                 ),
+            transactionHistoryRepository = transactionHistoryRepository,
         )
     }
 

--- a/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
+++ b/data/src/test/kotlin/com/vultisig/wallet/data/repositories/BlockChainSpecificRepositoryImplTest.kt
@@ -32,6 +32,7 @@ import com.vultisig.wallet.data.blockchain.model.Transfer
 import com.vultisig.wallet.data.blockchain.model.VaultData
 import com.vultisig.wallet.data.blockchain.sui.SuiFeeService.Companion.SUI_DEFAULT_GAS_BUDGET
 import com.vultisig.wallet.data.blockchain.utxo.SpendableUtxos
+import com.vultisig.wallet.data.blockchain.utxo.UtxoInFlightTx
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_LIMIT
 import com.vultisig.wallet.data.chains.helpers.SOLANA_PRIORITY_FEE_PRICE
 import com.vultisig.wallet.data.crypto.SuiHelper
@@ -289,6 +290,199 @@ internal class BlockChainSpecificRepositoryImplTest {
                 result.utxos,
             )
         }
+
+    /**
+     * The three-sends-in-a-row failure behind #5867's follow-up: Blockchair served the third send a
+     * 60 s-cached snapshot that still listed the input the second send had consumed and did not yet
+     * list its change, and the third was rejected with `bad-txns-inputs-missingorspent`. The ledger
+     * of this wallet's own broadcasts is replayed over the snapshot: the consumed input is gone,
+     * the change is there to spend, and a chained second send builds on that change.
+     */
+    @Test
+    fun `Bitcoin UTXO selection replays own in-flight sends over a stale provider snapshot`() =
+        runTest {
+            val coin = bitcoinCoin()
+            val blockChairApi =
+                mockk<BlockChairApi> {
+                    coEvery { getAllUtxos(Chain.Bitcoin, SOURCE_ADDRESS) } returns
+                        blockChairInfo(
+                            listOf(
+                                BlockChairUtxoInfo(
+                                    transactionHash = "confirmed-a",
+                                    index = 0,
+                                    value = 100_000,
+                                    blockId = 800_000,
+                                ),
+                                BlockChairUtxoInfo(
+                                    transactionHash = "confirmed-untouched",
+                                    index = 3,
+                                    value = 20_000,
+                                    blockId = 800_000,
+                                ),
+                            )
+                        )
+                }
+            val utxoInFlightRepository =
+                mockk<UtxoInFlightRepository> {
+                    coEvery { getInFlight(Chain.Bitcoin, SOURCE_ADDRESS) } returns
+                        listOf(
+                            // Second send, listed first: replay order comes from broadcastAt.
+                            UtxoInFlightTx(
+                                txHash = "send-c",
+                                broadcastAt = 2_000,
+                                spent =
+                                    listOf(UtxoInfo(hash = "send-b", amount = 60_000, index = 1u)),
+                                created =
+                                    listOf(UtxoInfo(hash = "send-c", amount = 45_000, index = 1u)),
+                            ),
+                            UtxoInFlightTx(
+                                txHash = "send-b",
+                                broadcastAt = 1_000,
+                                spent =
+                                    listOf(
+                                        UtxoInfo(hash = "CONFIRMED-A", amount = 100_000, index = 0u)
+                                    ),
+                                created =
+                                    listOf(UtxoInfo(hash = "send-b", amount = 60_000, index = 1u)),
+                            ),
+                        )
+                }
+
+            val result =
+                repository(
+                        blockChairApi = blockChairApi,
+                        utxoInFlightRepository = utxoInFlightRepository,
+                    )
+                    .getSpecific(
+                        chain = Chain.Bitcoin,
+                        address = SOURCE_ADDRESS,
+                        token = coin,
+                        gasFee = TokenValue(BigInteger.ONE, coin),
+                        isSwap = false,
+                        isMaxAmountEnabled = false,
+                        isDeposit = false,
+                    )
+
+            assertEquals(
+                listOf(
+                    UtxoInfo(hash = "confirmed-untouched", amount = 20_000, index = 3u),
+                    UtxoInfo(hash = "send-c", amount = 45_000, index = 1u),
+                ),
+                result.utxos,
+            )
+        }
+
+    /**
+     * Once the provider has caught up — the consumed input is gone and the change is listed as our
+     * own zero-conf — the ledger changes nothing: an entry none of whose inputs the snapshot still
+     * lists is skipped, so the provider's view of that send's outputs stays authoritative and a
+     * mempool-evicted send can never be rebuilt from the ledger alone.
+     */
+    @Test
+    fun `Bitcoin UTXO selection leaves a caught-up provider snapshot alone`() = runTest {
+        val coin = bitcoinCoin()
+        val blockChairApi =
+            mockk<BlockChairApi> {
+                coEvery { getAllUtxos(Chain.Bitcoin, SOURCE_ADDRESS) } returns
+                    blockChairInfo(
+                        listOf(
+                            BlockChairUtxoInfo(
+                                transactionHash = "send-b",
+                                index = 1,
+                                value = 60_000,
+                                blockId = -1,
+                            )
+                        )
+                    )
+            }
+        val transactionHistoryRepository =
+            mockk<TransactionHistoryRepository> {
+                coEvery { getUnconfirmedTxHashes(Chain.Bitcoin, SOURCE_ADDRESS) } returns
+                    setOf("send-b")
+            }
+        val utxoInFlightRepository =
+            mockk<UtxoInFlightRepository> {
+                coEvery { getInFlight(Chain.Bitcoin, SOURCE_ADDRESS) } returns
+                    listOf(
+                        UtxoInFlightTx(
+                            txHash = "send-b",
+                            broadcastAt = 1_000,
+                            spent =
+                                listOf(
+                                    UtxoInfo(hash = "confirmed-a", amount = 100_000, index = 0u)
+                                ),
+                            // Deliberately disagrees with the provider's 60_000: must not win.
+                            created = listOf(UtxoInfo(hash = "send-b", amount = 1, index = 1u)),
+                        ),
+                        // Evicted from the mempool: its input never comes back in the snapshot,
+                        // so its change is never offered.
+                        UtxoInFlightTx(
+                            txHash = "evicted",
+                            broadcastAt = 500,
+                            spent = listOf(UtxoInfo(hash = "gone", amount = 5_000, index = 0u)),
+                            created = listOf(UtxoInfo(hash = "evicted", amount = 4_000, index = 1u)),
+                        ),
+                    )
+            }
+
+        val result =
+            repository(
+                    blockChairApi = blockChairApi,
+                    transactionHistoryRepository = transactionHistoryRepository,
+                    utxoInFlightRepository = utxoInFlightRepository,
+                )
+                .getSpecific(
+                    chain = Chain.Bitcoin,
+                    address = SOURCE_ADDRESS,
+                    token = coin,
+                    gasFee = TokenValue(BigInteger.ONE, coin),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                )
+
+        assertEquals(listOf(UtxoInfo(hash = "send-b", amount = 60_000, index = 1u)), result.utxos)
+    }
+
+    /**
+     * Dash's own address index is built from connected blocks, so it keeps listing a pending send's
+     * input until that send confirms and never lists its change — the same replay applies.
+     */
+    @Test
+    fun `Dash RPC path replays own in-flight sends over the mempool-blind index`() = runTest {
+        val dashApi =
+            mockk<DashApi> {
+                coEvery { getAddressUtxos(SOURCE_ADDRESS) } returns
+                    listOf(UtxoInfo(hash = "confirmed-a", amount = 50_000, index = 0u))
+            }
+        val utxoInFlightRepository =
+            mockk<UtxoInFlightRepository> {
+                coEvery { getInFlight(Chain.Dash, SOURCE_ADDRESS) } returns
+                    listOf(
+                        UtxoInFlightTx(
+                            txHash = "send-b",
+                            broadcastAt = 1_000,
+                            spent =
+                                listOf(UtxoInfo(hash = "confirmed-a", amount = 50_000, index = 0u)),
+                            created = listOf(UtxoInfo(hash = "send-b", amount = 30_000, index = 1u)),
+                        )
+                    )
+            }
+
+        val result =
+            repository(dashApi = dashApi, utxoInFlightRepository = utxoInFlightRepository)
+                .getSpecific(
+                    chain = Chain.Dash,
+                    address = SOURCE_ADDRESS,
+                    token = dashCoin(),
+                    gasFee = TokenValue(BigInteger.ONE, dashCoin()),
+                    isSwap = false,
+                    isMaxAmountEnabled = false,
+                    isDeposit = false,
+                )
+
+        assertEquals(listOf(UtxoInfo(hash = "send-b", amount = 30_000, index = 1u)), result.utxos)
+    }
 
     @Test
     fun `Dash-Blockchair-fallback and the generic UTXO branch apply the identical spendable filter`() =
@@ -1152,6 +1346,10 @@ internal class BlockChainSpecificRepositoryImplTest {
             mockk<TransactionHistoryRepository> {
                 coEvery { getUnconfirmedTxHashes(any(), any()) } returns emptySet()
             },
+        utxoInFlightRepository: UtxoInFlightRepository =
+            mockk<UtxoInFlightRepository> {
+                coEvery { getInFlight(any(), any()) } returns emptyList()
+            },
     ): BlockChainSpecificRepositoryImpl {
         val evmApiFactory =
             object : EvmApiFactory {
@@ -1191,6 +1389,7 @@ internal class BlockChainSpecificRepositoryImplTest {
                     utxoFeeService = NoOpFeeService,
                 ),
             transactionHistoryRepository = transactionHistoryRepository,
+            utxoInFlightRepository = utxoInFlightRepository,
         )
     }
 


### PR DESCRIPTION
Closes #5867

## Summary

Two halves. The first makes the displayed balance and coin selection agree; the second makes both immune to a provider snapshot that predates the wallet's own last broadcast — the actual cause of `bad-txns-inputs-missingorspent` on back-to-back sends.

### 1. One spendable predicate for display and coin selection

- BTC / BCH / LTC / DOGE / ZEC displayed balance is now the sum of the **paginated** spendable UTXO set (`getAllUtxos`), not Blockchair `address.balance`. The number on the screen is the number a send can fund.
- New `SpendableUtxos` (port of the iOS `SpendableUtxos` invariant from vultisig-ios#4978) is the single predicate for both display (`BalanceRepository`) and coin selection (`BlockChainSpecificRepository`): not explicitly `is_spendable=false`, confirmed **or** unconfirmed-and-ours, `>=` dust threshold (was `>`; now matches iOS).
- Own unconfirmed change is admitted via the pending transaction history (`BROADCASTED` / `PENDING` / `NotFound`), scoped to chain + sending address. Address rather than vault id because the balance and coin-selection readers only hold the address, and on a UTXO chain the address *is* the vault's identity — another vault's zero-conf into this address is still a stranger's.
- Fail closed: `address.balance > 0` with `utxo: []` throws, so the existing failed-read path keeps the cached value instead of persisting zero. All outputs present and all filtered out is a genuine zero.
- Dash display is unchanged: still `getAddressInfo().address.balance`, still `dashApi.getAddressUtxos` (with its existing `>` dust filter) for inputs.

### 2. The wallet remembers what it just spent

Testing the above on Litecoin, three sends in a row: the third was rejected with `bad-txns-inputs-missingorspent` because it re-spent the input the second send had consumed (`0940e39e…:0`, spent by `e0110f83…`). The predicate never saw that: Blockchair serves the address dashboard from a 60–120 s cache (`context.cache.live=false` on the second hit through `api.vultisig.com/blockchair`), so the third send was funded from a snapshot that still listed the consumed input and did not yet list the new change. Nothing in the app remembered what it had itself just broadcast — iOS has the same hole and its `SpendableUtxos` documents "a rejected broadcast" as an accepted cost.

- At broadcast, `BroadcastKeysignUseCase` records what the transaction did to the sender's UTXO set (`UtxoHelper.getSpendEffects`): the outpoints it consumed and the outputs it paid back (change at index 1, or index 0 for a self-send — WalletCore's fixed layout, the one `serializeUnsignedTransaction` already mirrors). The payload is re-planned the same way signing did, along the same route (THORChain swaps plan through `getSwapPreSigningInputData`), so the inputs are exactly the signed ones. Recorded on the initiator and the joined co-signer alike, since either broadcast may win and both fund their next send from the same address.
- Persisted in a new Room table `utxo_inflight_outpoint` (one row per outpoint, migration 45→46) behind `UtxoInFlightRepository`; entries are replayed for ten minutes after broadcast and then dropped — the ledger only matters for as long as the provider lags, and that window is also the bound on its one blind spot (a mempool-evicted transaction re-listing its inputs is indistinguishable from a stale snapshot; an eviction inside the window costs one rejected broadcast, no funds).
- `SpendableUtxos.reconcile` replays the entries over the provider snapshot in both coin selection and the displayed balance. An entry is applied **only while the snapshot still lists an input it spent** — the evidence that the snapshot predates it — so a provider that has caught up is never overridden. Replay runs to a fixpoint rather than in recorded order: a child skipped while its input is absent is applied once its parent injects it, so a chain of sends funds each from the previous one's change regardless of timestamps.
- Dash's own address index is built from connected blocks and mempool-blind in both directions, so the same replay is applied over it.
- Not covered: SwapKit PSBT swaps and dApp `signBitcoin` payloads, whose inputs never go through the planner (`getSpendEffects` returns null). Their inputs are parsable from the PSBT via `SwapKitPsbtParser` if a follow-up wants them.

## Test plan

- [x] `./gradlew assembleDebug`
- [x] `./gradlew :data:testDebugUnitTest` — `BalanceRepository*`, `BlockChainSpecificRepositoryImplTest`, `TronFeeReconciliationTest`; `:app:testDebugUnitTest` — `BroadcastKeysign*`, `KeysignViewModel*`: 85 tests, 0 failures
- [x] `BalanceRepositoryUtxoSpendableTest`: confirmed-only sum; stranger zero-conf excluded; own unconfirmed change included; `is_spendable=false` excluded; dust excluded / exact-threshold included; ZEC on the same path; balance>0 + empty utxo does not zero the cache; all-filtered-out is a real zero; Dash still reads the aggregate
- [x] `BlockChainSpecificRepositoryImplTest`: coin selection admits own unconfirmed change and not a stranger's; a stale snapshot is reconciled against two chained in-flight sends recorded out of order (the consumed input is gone, the second send's change is offered); a caught-up snapshot is left alone and an evicted send's change is never offered; the same replay on Dash's RPC index
- [x] Lint clean
- [ ] On device: three LTC sends within two minutes of each other, all three broadcast
- [ ] On device: hold a ZEC/BTC address with an unconfirmed inbound; the wallet shows only the confirmed amount, and send-max of that amount succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHEjf3tYmuZFJvZfkrh5pc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved spendable balance calculations for supported UTXO chains.
  - Excludes dust, unspendable outputs, and unrelated unconfirmed funds.
  - Includes eligible unconfirmed change from pending transactions.
  - Reconciles recent transactions when blockchain data is delayed or incomplete.
  - Reports malformed or inconsistent data instead of showing an incorrect zero or partial balance.
  - Preserves Dash’s aggregate-balance behavior.

- **Reliability**
  - Tracks recently broadcast UTXO transactions to improve balance accuracy during confirmation delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->