### PR TITLE
feat(keysign): decode TRON resource transactions

### DIFF
--- a/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronTransactionDecoder.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/blockchain/tron/TronTransactionDecoder.kt
@@ -1,0 +1,88 @@
+package com.vultisig.wallet.data.blockchain.tron
+
+import com.vultisig.wallet.data.models.Chain
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedAsset
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedEvidence
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedOperation
+import com.vultisig.wallet.data.models.transaction_decoding.DecodedTransaction
+import com.vultisig.wallet.data.models.transaction_decoding.MemoPrecedence
+import com.vultisig.wallet.data.models.transaction_decoding.SignedAmount
+import com.vultisig.wallet.data.models.transaction_decoding.SignedTransactionContent
+import com.vultisig.wallet.data.models.transaction_decoding.TransactionContentDecoder
+import java.math.BigInteger
+import javax.inject.Inject
+
+/**
+ * Decodes TRON Stake 2.0 resource operations from the routing memo the signer dispatches on.
+ *
+ * A freeze or unfreeze is a self-addressed native TRX payload whose memo is `FREEZE:<RESOURCE>` or
+ * `UNFREEZE:<RESOURCE>`; `TronHelper` turns that into a `FreezeBalanceV2Contract` or
+ * `UnfreezeBalanceV2Contract` and the memo itself never reaches the chain. The grammar is
+ * [TRON_STAKING_MEMO_REGEX] — the signer's own table — matched exactly, because the signer rejects
+ * any other spelling and a reader that trimmed or case-folded would title a payload the signer
+ * refuses to build.
+ *
+ * Mirrors the iOS `TronTransactionDecoder`, with one deliberate gate it does not have: this app's
+ * signer routes a staking memo to the contract builders only on a native coin sent to the vault's
+ * own address, and builds a plain or TRC20 transfer otherwise. iOS dispatches on the memo prefix
+ * alone. The reader has to agree with the signer beside it, so a token-dressed or third-party
+ * addressed payload is a transfer here, whatever its memo says.
+ */
+class TronTransactionDecoder @Inject constructor() : TransactionContentDecoder {
+
+    /** The memo grammar is meaningful only on TRON. */
+    override val handles: Set<Chain> = setOf(Chain.Tron)
+
+    override fun decode(tx: SignedTransactionContent): DecodedTransaction? {
+        // Typed dApp contracts outrank the memo in `memoIsOutranked`; an earlier approve or swap
+        // route makes it inert. Both withhold `corroborated` or the memo.
+        val content = tx.corroborated ?: return null
+        val memo = content.memo(MEMO_PRECEDENCE) ?: return null
+
+        // The same gate `TronHelper` dispatches on: anything else with this memo is built as a
+        // transfer, or refused outright when the memo names an operation the payload cannot be.
+        if (!tx.isNativeCoin || content.toAddress != tx.signerAddress) return null
+
+        val match = TRON_STAKING_MEMO_REGEX.matchEntire(memo) ?: return null
+        val operation =
+            when (match.groupValues[OPERATION_GROUP]) {
+                TronStakingOperation.FREEZE.memoPrefix -> DecodedOperation.Stake
+                TronStakingOperation.UNFREEZE.memoPrefix -> DecodedOperation.Unstake
+                else -> return null
+            }
+
+        return DecodedTransaction(
+            operation = operation,
+            amount = committed(content.amount),
+            counterparty = null,
+            evidence = DecodedEvidence.Memo,
+        )
+    }
+
+    private companion object {
+        /** An earlier approve or swap route makes the sidecar memo inert. */
+        val MEMO_PRECEDENCE = MemoPrecedence.MemoIsInertWhenRoutedEarlier
+
+        /** Capture group of the `OP:RESOURCE` grammar that names the operation. */
+        const val OPERATION_GROUP = 1
+
+        /** The widest balance the contract's `int64` field can carry. */
+        val INT64_MAX: BigInteger = BigInteger.valueOf(Long.MAX_VALUE)
+
+        /**
+         * A freeze or unfreeze moves chain-native TRX. Only a positive amount the wire can encode
+         * is stated: the contract's balance field is an `int64`, so a wider figure would name a
+         * balance the signed contract never carries.
+         */
+        fun committed(signed: SignedAmount): DecodedAmount =
+            when (signed) {
+                is SignedAmount.Committed ->
+                    if (signed.value.signum() > 0 && signed.value <= INT64_MAX)
+                        DecodedAmount.Units(signed.value, DecodedAsset.ChainNative)
+                    else DecodedAmount.Unstated
+
+                SignedAmount.ComputedAtSigning -> DecodedAmount.Unstated
+            }
+    }
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/transaction_decoding/TransactionDecodingModule.kt
@@ -6,6 +6,7 @@ import com.vultisig.wallet.data.blockchain.maya.MayaChainTransactionDecoder
 import com.vultisig.wallet.data.blockchain.solana.staking.SolanaTransactionDecoder
 import com.vultisig.wallet.data.blockchain.thorchain.THORChainTransactionDecoder
 import com.vultisig.wallet.data.blockchain.ton.TonTransactionDecoder
+import com.vultisig.wallet.data.blockchain.tron.TronTransactionDecoder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -33,6 +34,7 @@ internal object TransactionDecodingModule {
         cosmos: CosmosTransactionDecoder,
         maya: MayaChainTransactionDecoder,
         ton: TonTransactionDecoder,
+        tron: TronTransactionDecoder,
     ): SignedTransactionDecoder =
         SignedTransactionDecoder().apply {
             register(solana)
@@ -49,5 +51,6 @@ internal object TransactionDecodingModule {
             register(cosmos)
             register(maya)
             register(ton)
+            register(tron)
         }
 }


### PR DESCRIPTION
## Summary

Android mirror of vultisig-ios#5219. Adds the TRON resource-operation reader and registers it in the decoder registry — the last chain reader missing from the iOS stack (Cosmos, Maya, Solana, THORChain and TON are already on `main`).

- `FREEZE:<RESOURCE>` reads as **staking**, `UNFREEZE:<RESOURCE>` as **unstaking**, with the committed TRX amount as chain-native units and `Memo` evidence
- the grammar is `TRON_STAKING_MEMO_REGEX` — the signer's own table — matched exactly, so the reader cannot accept a spelling `TronHelper` refuses to build
- initiator and co-signer read the same payload through the same `SignedTransactionContent` path, so both devices name the transaction identically
- amounts wider than the contract's `int64` field, or non-positive, are left unstated rather than named
- refused: a staking memo beside a dApp contract payload (`memoIsOutranked`), beside a swap or approve route, on any other chain, or with an unknown / inexact resource

No presentation changes were needed: `VerifyTransactionViewModel`, `JoinKeysignViewModel` and `KeysignViewModel` already apply the decoded hero. On the initiator Send verify the decoded "You're staking" hero now displaces the hand-rolled "Freeze TRON" header — the same visible change iOS made.

## Reviewer contract

1. **What proves the operation?** A native TRX payload addressed to the vault's own address whose memo matches `^(FREEZE|UNFREEZE):(BANDWIDTH|ENERGY)$`.
2. **Which surfaces can reach it?** Initiator Send verify, co-signer verify, and Done for both devices, through the shared registry.
3. **What is deliberately refused?** Wrong-chain payloads, dApp contract payloads, swap/approve-routed payloads, malformed or inexact memos, token-dressed coins, third-party destinations.
4. **What hero appears?** "You're staking / unstaking" (Verify) or "Staked / Unstaked" (Done) with the signed TRX amount when the wire can carry it; otherwise verb-only.

## Deliberate divergence from iOS

The Android reader additionally requires `isNativeCoin && toAddress == signerAddress`. `TronHelper.getPreSignedInputData` builds `FreezeBalanceV2` / `UnfreezeBalanceV2` only under exactly those conditions and otherwise builds a plain or TRC20 transfer (or throws on a foreign destination). The iOS signer dispatches on the memo prefix alone, so its reader accepts a token-dressed payload as a stake. A reader must agree with the signer beside it, so this one mirrors ours.

`WITHDRAW_EXPIRE_UNFREEZE` is intentionally not decoded, matching iOS #5219; its Verify header still comes from `TransactionToUiModelMapper`.

## Test plan

- [x] Full iOS test matrix exercised locally against the registry (both resources, initiator/co-signer parity, dApp transfer and trigger payload refusal, malformed memos, off-chain, swap sidecar, int64 overflow / zero / exact max, token-dressed, foreign destination) — all green
- [x] `:data` decoder + TRON unit suites green (100 tests)
- [x] `:app:compileDebugKotlin` (Hilt wiring) and ktfmt clean

Part of #5657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZwuKuqA9tDJasniTuTp4H


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decoding TRON Stake 2.0 freeze and unfreeze transactions.
  * Recognizes valid native TRX staking and unstaking transactions sent to the signer’s own address.
  * Reports supported staking amounts while ignoring invalid, unsupported, or non-positive transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->