### PR TITLE
docs(wallet-core): TransactionUtil.calcTxHash is null off-registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,6 +363,9 @@ When deleting a screen, go through this checklist:
 - Follow OWASP Mobile security best practices
 - Biometric authentication for sensitive operations
 
+### Wallet Core
+- `wallet.core.jni.TransactionUtil.calcTxHash` returns null for coins outside Wallet Core's Rust registry (Cardano, Tron, THORChain/Maya, Ripple, Zcash) and its JNI type is a bare `String` — read it into a `String?` and see [docs/wallet-core-calc-tx-hash.md](docs/wallet-core-calc-tx-hash.md) before using it
+
 ### Performance
 - Use lazy loading for large lists
 - Optimize Compose recompositions

--- a/data/src/androidTest/kotlin/com/vultisig/wallet/data/crypto/WalletCoreCalcTxHashTest.kt
+++ b/data/src/androidTest/kotlin/com/vultisig/wallet/data/crypto/WalletCoreCalcTxHashTest.kt
@@ -1,0 +1,65 @@
+package com.vultisig.wallet.data.crypto
+
+import com.vultisig.wallet.data.WalletCoreNative
+import com.vultisig.wallet.data.models.CosmoSignature
+import com.vultisig.wallet.data.models.transactionHash
+import java.util.Base64
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import wallet.core.jni.CoinType
+import wallet.core.jni.TransactionUtil
+
+/**
+ * Pins which of our locally computed transaction ids WalletCore's `TransactionUtil.calcTxHash`
+ * could and could not replace.
+ *
+ * The JNI binding declares a bare `String`, but the native returns null for every coin without a
+ * `TransactionUtil` in WalletCore's Rust registry — and for a supported coin whose input it cannot
+ * parse. Read it into a declared `String?` and null-check; letting it flow as a platform type turns
+ * the null into an NPE at the first non-null use.
+ *
+ * If a WalletCore bump makes one of the null cases start returning a hash, that coin's hand-rolled
+ * hash in `CardanoUtils` / `CosmoSignature.transactionHash` becomes a candidate for removal.
+ */
+class WalletCoreCalcTxHashTest {
+
+    @Before
+    fun loadWalletCore() {
+        WalletCoreNative.ensureLoaded()
+    }
+
+    @Test
+    fun cardano_is_not_in_the_registry() {
+        val hash: String? = TransactionUtil.calcTxHash(CoinType.CARDANO, signedCardanoEnvelopeHex)
+        assertNull(hash)
+    }
+
+    @Test
+    fun thorchain_is_not_in_the_registry() {
+        val hash: String? = TransactionUtil.calcTxHash(CoinType.THORCHAIN, cosmosTxBytesBase64)
+        assertNull(hash)
+    }
+
+    @Test
+    fun cosmos_matches_the_local_sha256_over_tx_bytes() {
+        val local = CosmoSignature(mode = "BROADCAST_MODE_SYNC", txBytes = cosmosTxBytesBase64)
+        val hash: String? = TransactionUtil.calcTxHash(CoinType.COSMOS, cosmosTxBytesBase64)
+        assertEquals(local.transactionHash().uppercase(), hash)
+    }
+
+    // Real signed 3-element envelope [body, witness_set, auxiliary_data] from a native ADA send.
+    private val signedCardanoEnvelopeHex =
+        "83a4008182582052e86a3e604ef6600f45d1cdb434eacbbaeffc763b02dd6d83bdbd8c825a01d2" +
+            "01018282581d61df45a39eb0282d2f6d0c1e46ea30452ba18eb86723739cdfbede9cbb1a001e8480" +
+            "82581d6150574c50e2c665f998457296a5d7ea1d789949d5e4e25adeee1a18251a026723d2021a00" +
+            "028900031a0b736d01a1008182582075be85178816db3bc71a4f3e64e5c89866d8b7daae827ba9cf" +
+            "4ecd1ed9e645d55840f802b0a258b5af9c78dd5cc062bfb8d7984a432af1808a0dd7282051613ed1" +
+            "fc62d7e1953443177354137b29d6bf34bd6cf10c7eee442d1a448e3b497f12b00bf6"
+
+    // Any bytes do: the Cosmos util is sha256 over the base64-decoded input, and the unsupported
+    // check runs before the input is looked at.
+    private val cosmosTxBytesBase64: String =
+        Base64.getEncoder().encodeToString(ByteArray(64) { it.toByte() })
+}

--- a/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/crypto/CardanoUtils.kt
@@ -107,6 +107,11 @@ object CardanoUtils {
         }
     }
 
+    /**
+     * Local txid: blake2b-256 over the body element of the signed envelope. WalletCore's
+     * `TransactionUtil.calcTxHash` cannot replace this — Cardano is not in its registry, so it
+     * returns null (an NPE at the Kotlin boundary) for every input.
+     */
     fun calculateCardanoTransactionHash(transactionData: ByteArray): String {
         return try {
             val transactionBodyData = extractCardanoTransactionBody(transactionData)

--- a/data/src/main/kotlin/com/vultisig/wallet/data/models/CosmoSignature.kt
+++ b/data/src/main/kotlin/com/vultisig/wallet/data/models/CosmoSignature.kt
@@ -12,6 +12,11 @@ data class CosmoSignature(
     @SerialName("tx_bytes") val txBytes: String,
 )
 
+/**
+ * SHA-256 over the broadcast bytes. Kept local rather than delegating to WalletCore's
+ * `TransactionUtil.calcTxHash`: that returns null for `CoinType.THORCHAIN`, which the THORChain and
+ * MayaChain helpers reach this through.
+ */
 fun CosmoSignature.transactionHash(): String {
     val decodedBytes = txBytes.decodeBase64Bytes()
     val digest = MessageDigest.getInstance("SHA-256").digest(decodedBytes)

--- a/docs/wallet-core-calc-tx-hash.md
+++ b/docs/wallet-core-calc-tx-hash.md
@@ -1,0 +1,69 @@
+# `TransactionUtil.calcTxHash` returns null for unsupported coins
+
+`wallet.core.jni.TransactionUtil.calcTxHash(coinType, encodedTx)` looks like a drop-in
+replacement for the transaction ids we compute locally. It is not one for every chain: the
+native returns **null** when the coin has no `TransactionUtil` in Wallet Core's Rust registry,
+and also when the input is not in the encoding that coin's implementation decodes. The two
+cases are indistinguishable from the caller's side.
+
+## Why it surfaces as an NPE
+
+The JNI binding is declared without a nullability annotation:
+
+```java
+public static native String calcTxHash(CoinType coinType, String encodedTx);
+```
+
+Kotlin sees a platform type (`String!`). Nothing fails at the call itself — the null becomes
+`NullPointerException: calcTxHash(...) must not be null` at the first place the value is used
+as non-null, typically when it is returned from a function declared `: String`.
+
+Read it into a declared nullable and handle the null where it is produced:
+
+```kotlin
+val hash: String? = TransactionUtil.calcTxHash(coinType, encodedTx)
+    ?: return null
+```
+
+## Which of our chains it supports (Wallet Core 4.8.0)
+
+Dispatch is `CoinType` → `registry.json` blockchain type → Rust `CoinEntry` → its
+`transaction_util()`. An entry that declares `NoTransactionUtil` returns `Error_not_supported`;
+a chain still implemented in the C++ tree never reaches an entry at all. Both come back as null.
+
+| Chains | Blockchain type | `calcTxHash` | Input it decodes → result |
+|---|---|---|---|
+| Bitcoin, Litecoin, Dogecoin, Dash | `Bitcoin` | yes | hex signed tx → txid, RPC byte order |
+| Bitcoin Cash | `BitcoinCash` | yes | hex signed tx → txid, RPC byte order |
+| Ethereum and every EVM chain | `Ethereum` | yes | hex signed tx → `0x` keccak256 |
+| Solana | `Solana` | yes | base64 signed tx → first signature |
+| Sui | `Sui` | yes | base64 `TransactionData` → blake2b digest |
+| TON | `TheOpenNetwork` | yes | base64 BoC → root-cell hash (the message hash, not the on-chain tx hash) |
+| Polkadot, Bittensor | `Polkadot` | yes | hex extrinsic → `0x` blake2b-256 |
+| Cosmos, dYdX, Osmosis, Terra, Terra Classic, Noble, Akash | `Cosmos` | yes | base64 `tx_bytes` → uppercase SHA-256 |
+| THORChain, MayaChain | `Thorchain` | **null** | entry declares `NoTransactionUtil` |
+| Ripple | `Ripple` | **null** | entry declares `NoTransactionUtil` |
+| Zcash | `Zcash` | **null** | entry declares `NoTransactionUtil` |
+| Cardano | — | **null** | no Rust entry (C++ implementation) |
+| Tron | — | **null** | no Rust entry (C++ implementation) |
+
+Derived from `rust/tw_coin_registry/src/dispatcher.rs` and each
+`rust/chains/*/src/entry.rs` at the `4.8.0` tag; Cardano is also measured on device.
+
+## Where we hash locally, and why that stays
+
+- `data/.../crypto/CardanoUtils.kt` `calculateCardanoTransactionHash` — blake2b-256 over the
+  CBOR body. Cardano is unsupported above, and the function fails closed to `""` on a parse
+  error on purpose: a hash over the wrong bytes would be a txid that never exists on-chain, and
+  duplicate-broadcast recovery would report it as an untrackable success.
+- `data/.../models/CosmoSignature.kt` `transactionHash()` — SHA-256 over the broadcast bytes.
+  Identical to what Wallet Core computes for the `Cosmos` type, but the same function serves the
+  THORChain and MayaChain helpers, for which `calcTxHash` returns null.
+
+## Re-checking after a Wallet Core bump
+
+`data/src/androidTest/.../crypto/WalletCoreCalcTxHashTest.kt` pins the three rows above that
+matter to our code (Cardano null, THORChain null, Cosmos equal to the local digest) and runs in
+CI's `data:connectedDebugAndroidTest`. If a bump flips a null row, the matching local hash is a
+candidate for removal. For any other coin, check `type TransactionUtil` in its `entry.rs` at the
+new tag, then confirm on a device or emulator — the natives do not load on the host JVM.


### PR DESCRIPTION
Closes #5874.

## Summary

`wallet.core.jni.TransactionUtil.calcTxHash(coinType, encodedTx)` looks like a drop-in for the transaction ids we compute locally. The native returns **null** for every coin without a `TransactionUtil` in Wallet Core's Rust registry (and for a supported coin's unparseable input), and the JNI binding is an unannotated `String`, so Kotlin surfaces that null as `NullPointerException: calcTxHash(...) must not be null` at the first non-null use rather than as something you can check.

Nothing calls it today. This records the trap where the next person would run into it, and pins it so a Wallet Core bump that changes the answer shows up in CI:

- **KDoc** on `CardanoUtils.calculateCardanoTransactionHash` and `CosmoSignature.transactionHash()` — the two local hashes someone would try to replace, and why each stays local.
- **`docs/wallet-core-calc-tx-hash.md`** — the mechanism, the safe idiom (`val hash: String? = …`; no cast needed, the binding has no nullability annotation), and a per-Vultisig-chain support table for Wallet Core 4.8.0 derived from `rust/tw_coin_registry/src/dispatcher.rs` and each `rust/chains/*/src/entry.rs` at the tag.
- **`CLAUDE.md`** — one pointer under Important Notes, same pattern as `docs/network-error-handling.md`.
- **`WalletCoreCalcTxHashTest`** (`:data` androidTest, runs in the existing `data:connectedDebugAndroidTest` job) — Cardano → null on a real signed envelope, THORChain → null, Cosmos → equal to our local SHA-256. If a bump flips a null row, the matching local hash is a candidate for removal.

## What the source says (4.8.0)

| `calcTxHash` | Vultisig chains |
|---|---|
| works | Bitcoin, Litecoin, Dogecoin, Dash, Bitcoin Cash, Ethereum + every EVM chain, Solana, Sui, TON, Polkadot, Bittensor, Cosmos, dYdX, Osmosis, Terra, Terra Classic, Noble, Akash |
| null — entry declares `NoTransactionUtil` | THORChain, MayaChain, Ripple, Zcash |
| null — no Rust entry (C++ implementation) | Cardano, Tron |

The live trap is THORChain/MayaChain rather than Cardano: `CosmoSignature.transactionHash()` is shared by `ThorChainHelper`, so swapping it for `calcTxHash` would work for every Cosmos-family chain and NPE for THOR/Maya.

## Test plan

- [x] `./gradlew :data:ktfmtCheck` clean
- [x] `./gradlew :data:compileDebugAndroidTestKotlin` succeeds
- [x] `./gradlew :data:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.vultisig.wallet.data.crypto.WalletCoreCalcTxHashTest` on `Medium_Phone` (API 36): `tests="3" failures="0" errors="0"`
- [x] No production code changed — main-source diff is two KDoc blocks
